### PR TITLE
[swiftpm] Stop hard-coding the index store path

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -172,7 +172,7 @@ extension SwiftPMWorkspace: ExternalWorkspace, BuildSettingsProvider {
   }
 
   public var indexStorePath: AbsolutePath? {
-    return buildPath.appending(components: "index", "store")
+    return buildParameters.indexStoreMode == .off ? nil : buildParameters.indexStore
   }
 
   public var indexDatabasePath: AbsolutePath? {


### PR DESCRIPTION
Now that we are using a new enough libSwiftPM, get the path from the API instead of hard-coding it.