### PR TITLE
Add setting `trace.server` to vscode extension

### DIFF
--- a/Editors/README.md
+++ b/Editors/README.md
@@ -13,6 +13,7 @@ After installing the extension, settings for SourceKit-LSP can be found in `Pref
 
 * `sourcekit-lsp.serverPath`: The path to sourcekit-lsp executable
 * `sourcekit-lsp.toolchainPath`: The path to the swift toolchain (sets `SOURCEKIT_TOOLCHAIN_PATH`)
+* `sourcekit-lsp.tracing.server`: Traces the communication between VS Code and the SourceKit-LSP language server
 
 ## Sublime Text
 

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -56,6 +56,7 @@
                     "default": "off",
                     "enum": [
                         "off",
+                        "messages",
                         "verbose"
                     ],
                     "description": "Traces the communication between VS Code and the SourceKit-LSP language server."

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -50,6 +50,15 @@
                     "type": "string",
                     "default": "",
                     "description": "The path of the swift toolchain"
+                },
+                "sourcekit-lsp.trace.server": {
+                    "type": "string",
+                    "default": "off",
+                    "enum": [
+                        "off",
+                        "verbose"
+                    ],
+                    "description": "Traces the communication between VS Code and the SourceKit-LSP language server."
                 }
             }
         }

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
         synchronize: undefined
     };
 
-    const client = new langclient.LanguageClient('SourceKit Language Server', serverOptions, clientOptions);
+    const client = new langclient.LanguageClient('sourcekit-lsp', 'SourceKit Language Server', serverOptions, clientOptions);
 
     context.subscriptions.push(client.start());
 


### PR DESCRIPTION
So that LSP inspector or other tools can be used to visualize communication between vscode extension and the SourceKit Language Server.