### PR TITLE
[SKCore] If 'Platform.currentPlatform' is nil use 'so' as library extension

### DIFF
--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -86,7 +86,8 @@ public final class Toolchain {
       foundAny = true
     }
 
-    let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? "dylib"
+    // If 'currentPlatform' is nil it's most likely an unknown linux flavor.
+    let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? "so"
 
     let sourcekitdPath = libPath.appending(components: "sourcekitd.framework", "sourcekitd")
     if fs.isFile(sourcekitdPath) {

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -47,7 +47,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainID)
   }
 
-  func testUnknownLinux() {
+  func testUnknownPlatform() {
     let prevPlatform = Platform.currentPlatform
     defer { Platform.currentPlatform = prevPlatform }
     Platform.currentPlatform = nil
@@ -298,6 +298,7 @@ final class ToolchainRegistryTests: XCTestCase {
   static var allTests = [
     ("testDefaultBasic", testDefaultBasic),
     ("testDefaultDarwin", testDefaultDarwin),
+    ("testUnknownPlatform", testUnknownPlatform),
     ("testSearchDarwin", testSearchDarwin),
     ("testSearchPATH", testSearchPATH),
     ("testFromDirectory", testFromDirectory),


### PR DESCRIPTION
Platform only detects the 'debian' linux flavor so if it is nil it's most likely an unknown linux flavor