### PR TITLE
[SKSupport.LineTable] Fix UTF16 offset calculation

### DIFF
--- a/Sources/SourceKit/DocumentManager.swift
+++ b/Sources/SourceKit/DocumentManager.swift
@@ -27,11 +27,7 @@ public struct DocumentSnapshot {
   }
 
   func index(of pos: Position) -> String.Index? {
-    // FIXME: TEST ME
-    guard pos.line < lineTable.count else { return nil }
-    let lineData = lineTable[pos.line]
-    let utf16Offset = lineData.utf16Offset + pos.utf16index
-    return String.Index(encodedOffset: utf16Offset)
+    return lineTable.stringIndexOf(line: pos.line, utf16Column: pos.utf16index)
   }
 }
 

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -552,31 +552,19 @@ extension SwiftLanguageServer {
 extension DocumentSnapshot {
 
   func utf8Offset(of pos: Position) -> Int? {
-    // FIXME: TEST ME
-    guard pos.line < lineTable.count else { return nil }
-    let lineData = lineTable[pos.line]
-    let utf16Offset = lineData.utf16Offset + pos.utf16index
-    let index = String.Index(encodedOffset: utf16Offset)
-    guard index <= lineData.content.endIndex else { return nil }
-    return lineData.utf8Offset + lineData.content.prefix(upTo: index).utf8.count
+    return lineTable.utf8OffsetOf(line: pos.line, utf16Column: pos.utf16index)
   }
 
   func positionOf(utf8Offset: Int) -> Position? {
-    // FIXME: TEST ME
-    let line = lineTable[utf8Offset: utf8Offset]
-    let column = utf8Offset - line.utf8Offset
-    return positionOf(zeroBasedLine: line.index, utf8Column: column)
+    return lineTable.lineAndUTF16ColumnOf(utf8Offset: utf8Offset).map {
+      Position(line: $0.line, utf16index: $0.utf16Column)
+    }
   }
 
   func positionOf(zeroBasedLine: Int, utf8Column: Int) -> Position? {
-    // FIXME: TEST ME
-    guard zeroBasedLine < lineTable.count else { return nil }
-    let lineData = lineTable[zeroBasedLine]
-    let index = lineData.content.dropFirst(utf8Column).startIndex
-    return Position(
-      line: zeroBasedLine,
-      utf16index: index.encodedOffset - lineData.utf16Offset
-    )
+    return lineTable.utf16ColumnAt(line: zeroBasedLine, utf8Column: utf8Column).map {
+      Position(line: zeroBasedLine, utf16index: $0)
+    }
   }
 }
 


### PR DESCRIPTION
Rework `LineTable`. Now that, `LineTable` is just a collection of `Substring`s. Derive UTF16/UTF8 offset from corresponding view of the content String.
Added several methods to translate between line/UTF(8|16)column and UTF8 offset.

Resolves: https://bugs.swift.org/browse/SR-9311