### PR TITLE
[WIP] Add support for code action quick fixes

### DIFF
--- a/Sources/LanguageServerProtocol/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/CodeAction.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public struct CodeAction: Codable, Hashable {
+  public var title: String
+
+  public var kind: CodeActionKind
+
+  public var edit: WorkspaceEdit
+
+  public init(title: String, kind: CodeActionKind = CodeActionKind.quickFix, edit: WorkspaceEdit) {
+    self.title = title
+    self.kind = kind
+    self.edit = edit
+  }
+}
+
+extension CodeAction: ResponseType {}

--- a/Sources/LanguageServerProtocol/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/CodeAction.swift
@@ -10,7 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct CodeAction: Codable, Hashable {
+public struct CodeActionRequest: TextDocumentRequest, Hashable {
+    public static let method: String = "textDocument/codeAction"
+    public typealias Response = [CodeAction]?
+
+    public var textDocument: TextDocumentIdentifier
+
+    /// The range at which this code action should be applied.
+    public var range: PositionRange
+
+    public var context: CodeActionContext
+}
+
+public struct CodeActionContext: Codable, Hashable {
+
+    public var diagnostics: [Diagnostic]
+}
+
+public struct CodeAction: Codable, Hashable, ResponseType {
   public var title: String
 
   public var kind: CodeActionKind
@@ -23,5 +40,3 @@ public struct CodeAction: Codable, Hashable {
     self.edit = edit
   }
 }
-
-extension CodeAction: ResponseType {}

--- a/Sources/LanguageServerProtocol/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/Diagnostic.swift
@@ -49,7 +49,7 @@ public struct Diagnostic: Codable, Hashable {
   public var fixits: [DiagnosticFixit]?
 
   public init(range: Range<Position>, severity: DiagnosticSeverity?, code: DiagnosticCode? = nil, source: String?, message: String, relatedInformation: [DiagnosticRelatedInformation]? = nil, diagnosticFixits: [DiagnosticFixit]? = nil) {
-    self.range = range
+    self.range = PositionRange(range)
     self.severity = severity
     self.code = code
     self.source = source
@@ -75,12 +75,12 @@ public struct DiagnosticRelatedInformation: Codable, Hashable {
 /// A code suggestion that can be automatically applied to fix a compile error.
 public struct DiagnosticFixit: Codable, Hashable {
 
-  public var range: Range<Position>
+  public var range: PositionRange
 
   public var fixit: String
 
   public init(range: Range<Position>, fixit: String) {
-    self.range = range
+    self.range = PositionRange(range)
     self.fixit = fixit
   }
 }

--- a/Sources/LanguageServerProtocol/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/Diagnostic.swift
@@ -46,24 +46,20 @@ public struct Diagnostic: Codable, Hashable {
   /// Related diagnostic notes.
   public var relatedInformation: [DiagnosticRelatedInformation]?
 
-  public init(
-    range: Range<Position>,
-    severity: DiagnosticSeverity?,
-    code: DiagnosticCode? = nil,
-    source: String?,
-    message: String,
-    relatedInformation: [DiagnosticRelatedInformation]? = nil)
-  {
-    self.range = PositionRange(range)
+  public var fixits: [DiagnosticFixit]?
+
+  public init(range: Range<Position>, severity: DiagnosticSeverity?, code: DiagnosticCode? = nil, source: String?, message: String, relatedInformation: [DiagnosticRelatedInformation]? = nil, diagnosticFixits: [DiagnosticFixit]? = nil) {
+    self.range = range
     self.severity = severity
     self.code = code
     self.source = source
     self.message = message
     self.relatedInformation = relatedInformation
+    self.fixits = diagnosticFixits
   }
 }
 
-/// A 'note' diagnostic attached to a primary diagonstic that provides additional information.
+/// A 'note' diagnostic attached to a primary diagnostic that provides additional information.
 public struct DiagnosticRelatedInformation: Codable, Hashable {
 
   public var location: Position
@@ -73,6 +69,19 @@ public struct DiagnosticRelatedInformation: Codable, Hashable {
   public init(location: Position, message: String) {
     self.location = location
     self.message = message
+  }
+}
+
+/// A code suggestion that can be automatically applied to fix a compile error.
+public struct DiagnosticFixit: Codable, Hashable {
+
+  public var range: Range<Position>
+
+  public var fixit: String
+
+  public init(range: Range<Position>, fixit: String) {
+    self.range = range
+    self.fixit = fixit
   }
 }
 

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -30,6 +30,7 @@ public let builtinRequests: [_RequestType.Type] = [
   DocumentRangeFormatting.self,
   DocumentOnTypeFormatting.self,
   FoldingRangeRequest.self,
+  CodeActionRequest.self,
 
   // MARK: LSP Extension Requests
 

--- a/Sources/LanguageServerProtocol/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ServerCapabilities.swift
@@ -42,6 +42,9 @@ public struct ServerCapabilities: Codable, Hashable {
   /// Whether the server provides "textDocument/foldingRange".
   public var foldingRangeProvider: Bool?
 
+  /// Whether the server provides "textDocument/codeAction".
+  public var codeActionProvider: [CodeActionKind]?
+
   // TODO: fill-in the rest.
 
   public init(
@@ -55,6 +58,7 @@ public struct ServerCapabilities: Codable, Hashable {
     documentRangeFormattingProvider: Bool? = nil,
     documentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions? = nil,
     foldingRangeProvider: Bool? = nil
+    codeActionProvider: [CodeActionKind]? = nil
     )
   {
     self.textDocumentSync = textDocumentSync
@@ -67,6 +71,7 @@ public struct ServerCapabilities: Codable, Hashable {
     self.documentRangeFormattingProvider = documentRangeFormattingProvider
     self.documentOnTypeFormattingProvider = documentOnTypeFormattingProvider
     self.foldingRangeProvider = foldingRangeProvider
+    self.codeActionProvider = codeActionProvider
   }
 
   public init(from decoder: Decoder) throws {

--- a/Sources/LanguageServerProtocol/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ServerCapabilities.swift
@@ -57,7 +57,7 @@ public struct ServerCapabilities: Codable, Hashable {
     documentFormattingProvider: Bool? = nil,
     documentRangeFormattingProvider: Bool? = nil,
     documentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions? = nil,
-    foldingRangeProvider: Bool? = nil
+    foldingRangeProvider: Bool? = nil,
     codeActionProvider: [CodeActionKind]? = nil
     )
   {

--- a/Sources/LanguageServerProtocol/TextDocumentEdit.swift
+++ b/Sources/LanguageServerProtocol/TextDocumentEdit.swift
@@ -13,7 +13,7 @@
 /// Edit within a particular document.
 ///
 /// For an edit where the document is implied, use `TextEdit`.
-public struct TextDocumentEdit: Hashable, Codable {
+public struct TextDocumentEdit: Hashable, Codable, ResponseType {
 
   /// The potentially versioned document to which these edits apply.
   public var textDocument: VersionedTextDocumentIdentifier
@@ -26,8 +26,3 @@ public struct TextDocumentEdit: Hashable, Codable {
     self.edits = edits
   }
 }
-
-extension TextDocumentEdit: Equatable {}
-extension TextDocumentEdit: Hashable {}
-extension TextDocumentEdit: Codable {}
-extension TextDocumentEdit: ResponseType {}

--- a/Sources/LanguageServerProtocol/TextDocumentEdit.swift
+++ b/Sources/LanguageServerProtocol/TextDocumentEdit.swift
@@ -26,3 +26,8 @@ public struct TextDocumentEdit: Hashable, Codable {
     self.edits = edits
   }
 }
+
+extension TextDocumentEdit: Equatable {}
+extension TextDocumentEdit: Hashable {}
+extension TextDocumentEdit: Codable {}
+extension TextDocumentEdit: ResponseType {}

--- a/Sources/LanguageServerProtocol/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/WorkspaceEdit.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A workspace edit represents changes to many resources managed in the workspace.
+/// The edit should either provide changes or documentChanges. If the client can handle versioned document
+/// edits and if documentChanges are present, the latter are preferred over changes.
+public struct WorkspaceEdit : Codable, Hashable {
+  /// The edits to be applied, which must be non-overlapping.
+  public var changes: [TextEdit]?
+
+  public var documentChanges: [TextDocumentEdit]?
+
+  public init(changes: [TextEdit]) {
+    self.changes = changes
+  }
+
+  public init(documentChanges: [TextDocumentEdit]) {
+    self.documentChanges = documentChanges
+  }
+}

--- a/Sources/SourceKit/DocumentManager.swift
+++ b/Sources/SourceKit/DocumentManager.swift
@@ -36,6 +36,7 @@ public final class Document {
   public let language: Language
   var latestVersion: Int
   var latestLineTable: LineTable
+  var diagnostics: [Diagnostic]?
 
   init(url: URL, language: Language, version: Int, text: String) {
     self.url = url

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -69,6 +69,7 @@ public final class SourceKitServer: LanguageServer {
     registerWorkspaceRequest(SourceKitServer.documentSymbolHighlight)
     registerWorkspaceRequest(SourceKitServer.foldingRange)
     registerWorkspaceRequest(SourceKitServer.symbolInfo)
+    registerWorkspaceRequest(SourceKitServer.codeAction)
   }
 
   func registerWorkspaceRequest<R>(
@@ -330,6 +331,10 @@ extension SourceKitServer {
   }
 
   func foldingRange(_ req: Request<FoldingRangeRequest>, workspace: Workspace) {
+    toolchainTextDocumentRequest(req, workspace: workspace, fallback: nil)
+  }
+
+  func codeAction(_ req: Request<CodeActionRequest>, workspace: Workspace) {
     toolchainTextDocumentRequest(req, workspace: workspace, fallback: nil)
   }
 

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -253,6 +253,7 @@ extension SourceKitServer {
       referencesProvider: true,
       documentHighlightProvider: true,
       foldingRangeProvider: true
+      codeActionProvider: [CodeActionKind.quickFix]
     )))
   }
 

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -252,7 +252,7 @@ extension SourceKitServer {
       definitionProvider: true,
       referencesProvider: true,
       documentHighlightProvider: true,
-      foldingRangeProvider: true
+      foldingRangeProvider: true,
       codeActionProvider: [CodeActionKind.quickFix]
     )))
   }

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -684,14 +684,17 @@ extension SwiftLanguageServer {
     }
     var codeActions: [CodeAction] = []
     diagnostics.forEach { diagnostic in
-      if let fixits = diagnostic.fixits {
+      if let fixits = diagnostic.fixits, !fixits.isEmpty {
         var textEdits: [TextEdit] = []
         fixits.forEach { fixit in
           textEdits.append(TextEdit(range: fixit.range, newText: fixit.fixit))
         }
-        let textDocumentEdit = TextDocumentEdit(textDocument: VersionedTextDocumentIdentifier(url: req.params.textDocument.url, version: nil), edits: textEdits)
-        let workspaceEdit = WorkspaceEdit(documentChanges: [textDocumentEdit])
-        codeActions.append(CodeAction(title: "Fix \(diagnostic.message)", kind: CodeActionKind.quickFix, edit: workspaceEdit))
+        // If there are no text edits, we can return an empty list to the client.
+        if !textEdits.isEmpty {
+          let textDocumentEdit = TextDocumentEdit(textDocument: VersionedTextDocumentIdentifier(url: req.params.textDocument.url, version: nil), edits: textEdits)
+          let workspaceEdit = WorkspaceEdit(documentChanges: [textDocumentEdit])
+          codeActions.append(CodeAction(title: "Fix \(diagnostic.message)", kind: CodeActionKind.quickFix, edit: workspaceEdit))
+        }
       }
     }
     req.reply(codeActions)

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -217,7 +217,7 @@ extension SwiftLanguageServer {
       definitionProvider: nil,
       referencesProvider: nil,
       documentHighlightProvider: true,
-      foldingRangeProvider: true
+      foldingRangeProvider: true,
       codeActionProvider: [CodeActionKind.quickFix]
       )))
   }
@@ -687,11 +687,11 @@ extension SwiftLanguageServer {
       if let fixits = diagnostic.fixits, !fixits.isEmpty {
         var textEdits: [TextEdit] = []
         fixits.forEach { fixit in
-          textEdits.append(TextEdit(range: fixit.range, newText: fixit.fixit))
+          textEdits.append(TextEdit(range: fixit.range.asRange, newText: fixit.fixit))
         }
         // If there are no text edits, we can return an empty list to the client.
         if !textEdits.isEmpty {
-          let textDocumentEdit = TextDocumentEdit(textDocument: VersionedTextDocumentIdentifier(url: req.params.textDocument.url, version: nil), edits: textEdits)
+          let textDocumentEdit = TextDocumentEdit(textDocument: VersionedTextDocumentIdentifier(req.params.textDocument.url, version: nil), edits: textEdits)
           let workspaceEdit = WorkspaceEdit(documentChanges: [textDocumentEdit])
           codeActions.append(CodeAction(title: "Fix \(diagnostic.message)", kind: CodeActionKind.quickFix, edit: workspaceEdit))
         }

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -200,6 +200,7 @@ struct sourcekitd_keys {
   let kind: sourcekitd_uid_t
   let notification: sourcekitd_uid_t
   let diagnostics: sourcekitd_uid_t
+  let fixits: sourcekitd_uid_t
   let severity: sourcekitd_uid_t
   let line: sourcekitd_uid_t
   let column: sourcekitd_uid_t
@@ -227,6 +228,7 @@ struct sourcekitd_keys {
     kind = api.uid_get_from_cstr("key.kind")!
     notification = api.uid_get_from_cstr("key.notification")!
     diagnostics = api.uid_get_from_cstr("key.diagnostics")!
+    fixits = api.uid_get_from_cstr("key.fixits")!
     severity = api.uid_get_from_cstr("key.severity")!
     line = api.uid_get_from_cstr("key.line")!
     column = api.uid_get_from_cstr("key.column")!


### PR DESCRIPTION
[Still WIP]

**Screenshot (VSCode):**

<img width="611" alt="screen shot 2018-11-26 at 9 59 06 pm" src="https://user-images.githubusercontent.com/1573717/49041809-8dd27a00-f1c6-11e8-94f6-6cf9c7083dba.png">

This PR adds support for the `textDocument/codeAction` LSP method, so that Swift diagnostics that carry a quick fix can be applied from the LSP client with a keystroke.