### PR TITLE
Update recommended toolchain to 2018-11-25-a

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SourceKit-LSP is an implementation of the [Language Server Protocol](https://mic
 
 SourceKit-LSP is under heavy development! The best way to try it out is to build it from source. You will also need a Swift development toolchain and an editor that supports LSP.
 
-1. Install the `swift-DEVELOPMENT-SNAPSHOT-2018-11-01-a` toolchain snapshot from https://swift.org/download/. Set the environment variable `SOURCEKIT_TOOLCHAIN_PATH` to the absolute path to the toolchain or otherwise configure your editor to use this toolchain. See [Toolchains](#toolchains) for more information.
+1. Install the `swift-DEVELOPMENT-SNAPSHOT-2018-11-25-a` toolchain snapshot from https://swift.org/download/#snapshots. Set the environment variable `SOURCEKIT_TOOLCHAIN_PATH` to the absolute path to the toolchain or otherwise configure your editor to use this toolchain. See [Toolchains](#toolchains) for more information.
 
 2. Build the language server executable `sourcekit-lsp` using `swift build`. See [Building](#building-sourcekit-lsp) for more information.
 
@@ -51,7 +51,7 @@ SourceKit-LSP depends on tools such as `sourcekitd` and `clangd`, which it loads
 
 ### Recommended Toolchain
 
-Use the `swift-DEVELOPMENT-SNAPSHOT-2018-11-01-a` toolchain snapshot from https://swift.org/download/#snapshots. It can be found under "Older Snapshots" as "November 1, 2018".  SourceKit-LSP is still early in its development and we are actively adding functionality to the toolchain to support it.
+Use the `swift-DEVELOPMENT-SNAPSHOT-2018-11-25-a` toolchain snapshot from https://swift.org/download/#snapshots. SourceKit-LSP is still early in its development and we are actively adding functionality to the toolchain to support it.
 
 ### Selecting the Toolchain
 
@@ -93,9 +93,6 @@ SourceKit-LSP is still in early development, so you may run into rough edges wit
 
 
 ### Caveats
-
-* Indexing does not work on Linux (jump-to-definition, find references)
-	* Should be fixed in the next Swift snapshot by [swift-clang#219](https://github.com/apple/swift-clang/pull/219)
 
 * SwiftPM build settings are not updated automatically after files are added/removed.
 	* **Workaround**: close and reopen the project after adding/removing files


### PR DESCRIPTION
This also means indexing is now working on Linux!

This change just updates us from 11-01 to 11-25. Once this project is
tested in Swift CI we should be able to just recommend using whatever
the latest snapshot is instead of listing a specific version.