### PR TITLE
Expand docs

### DIFF
--- a/Editors/README.md
+++ b/Editors/README.md
@@ -68,6 +68,10 @@ You will need the path to the `sourcekit-lsp` executable and the Swift toolchain
 }
 ```
 
+## Emacs
+
+There is an Emacs client for SourceKit-LSP in the [main Emacs LSP repository](https://github.com/emacs-lsp/lsp-sourcekit).
+
 ## Other Editors
 
 SourceKit-LSP should work with any editor that supports the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ SourceKit-LSP as soon as you open a Swift file:
 
 
 ```sh
-(lldb) process attach --name sourcekit-lsp --waitfor
+$ lldb -w -n sourcekit-lsp
 ```
 
 If you are using the Xcode project, go to Debug, Attach to Process by PID or Name.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ $ swift package generate-xcodeproj --xcconfig-overrides overrides.xcconfig
 $ open SourceKitLSP.xcodeproj
 ```
 
+## Debugging
+
+You can attach LLDB to SourceKit-LSP and set breakpoints to debug. You may want to instruct LLDB to wait for the sourcekit-lsp process to launch and then start your editor, which will typically launch
+SourceKit-LSP as soon as you open a Swift file:
+
+
+```sh
+(lldb) process attach --name sourcekit-lsp --waitfor
+```
+
+If you are using the Xcode project, go to Debug, Attach to Process by PID or Name.
+
+### Print SourceKit Logs
+
+You can configure SourceKit-LSP to print log information from SourceKit to stdout by setting the following environment variable:
+
+```sh
+SOURCEKIT_LOGGING="N"
+```
+
+Where "N" configures the log verbosity and is one of the following numbers: 0 (error), 1 (warning), 2 (info), or 3 (debug).
+
 ## Toolchains
 
 SourceKit-LSP depends on tools such as `sourcekitd` and `clangd`, which it loads at runtime from an installed toolchain.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you are using the Xcode project, go to Debug, Attach to Process by PID or Nam
 
 ### Print SourceKit Logs
 
-You can configure SourceKit-LSP to print log information from SourceKit to stdout by setting the following environment variable:
+You can configure SourceKit-LSP to print log information from SourceKit to stderr by setting the following environment variable:
 
 ```sh
 SOURCEKIT_LOGGING="N"


### PR DESCRIPTION
This PR expands the documentation a little bit:

- Mentions the Emacs client.
- Adds some information about how to debug SourceKit-LSP and how to configure SourceKit logging to stdout.