### PR TITLE
[core] Refactor Toolchain and ToolchainRegistry

### DIFF
--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -10,47 +10,111 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
 import Basic
 import Utility
 
+/// A Toolchain is a collection of related compilers and libraries meant to be used together to
+/// build and edit source code.
+///
+/// This can be an explicit toolchain, such as an xctoolchain directory on Darwin, or an implicit
+/// toolchain, such as the contents from `/usr/bin`.
 public final class Toolchain {
 
+  /// The unique toolchain identifer.
+  ///
+  /// For an xctoolchain, this is a reverse domain name e.g. "com.apple.dt.toolchain.XcodeDefault".
+  /// Otherwise, it is typically derived from `path`.
   public var identifier: String
+
+  /// The human-readable name for the toolchain.
   public var displayName: String
+
+  /// The path to this toolchain, if applicable.
+  ///
+  /// For example, this may be the path to an ".xctoolchain" directory.
   public var path: AbsolutePath? = nil
 
+  // MARK: Tool Paths
+
+  /// The path to the Clang compiler if available.
   public var clang: AbsolutePath?
+
+  /// The path to the Swift compiler if available.
   public var swiftc: AbsolutePath?
+
+  /// The path to the clangd language server if available.
   public var clangd: AbsolutePath?
+
+  /// The path to the Swift language server if available.
   public var sourcekitd: AbsolutePath?
+
+  /// The path to the indexstore library if available.
   public var libIndexStore: AbsolutePath?
 
-  public init(identifier: String, displayName: String, path: AbsolutePath?) {
+  public init(
+    identifier: String,
+    displayName: String,
+    path: AbsolutePath? = nil,
+    clang: AbsolutePath? = nil,
+    swiftc: AbsolutePath? = nil,
+    clangd: AbsolutePath? = nil,
+    sourcekitd: AbsolutePath? = nil,
+    libIndexStore: AbsolutePath? = nil)
+  {
     self.identifier = identifier
     self.displayName = displayName
     self.path = path
+    self.clang = clang
+    self.swiftc = swiftc
+    self.clangd = clangd
+    self.sourcekitd = sourcekitd
+    self.libIndexStore = libIndexStore
   }
+}
 
-  public convenience init?(
-    identifier: String,
-    displayName: String,
-    searchForTools path: AbsolutePath,
-    fileSystem fs: FileSystem = localFileSystem)
-  {
-    self.init(identifier: identifier, displayName: displayName, path: path)
-    if !searchForTools(path: path, fileSystem: fs) {
+extension Toolchain {
+
+  /// Create a toolchain for the given path, if it contains at least one tool, otherwise return nil.
+  ///
+  /// This initializer looks for a toolchain using the following basic layout:
+  ///
+  /// ```
+  /// bin/clang
+  ///    /clangd
+  ///    /swiftc
+  /// lib/sourcekitd.framework/sourcekitd
+  ///    /libsourcekitdInProc.{so,dylib}
+  ///    /libIndexStore.{so,dylib}
+  /// ```
+  ///
+  /// The above directory layout can found relative to `path` in the following ways:
+  /// * `path` (=bin), `path/../lib`
+  /// * `path/bin`, `path/lib`
+  /// * `path/usr/bin`, `path/usr/lib`
+  ///
+  /// If `path` has an ".xctoolchain" extension, we try to read an Info.plist file to provide the
+  /// toolchain identifier, etc.  Otherwise this information is derived from the path.
+  convenience public init?(path: AbsolutePath, fileSystem: FileSystem = localFileSystem) {
+    if path.extension == "xctoolchain",
+       let infoPlist = orLog("", {
+         try XCToolchainPlist(fromDirectory: path, fileSystem: fileSystem) })
+    {
+      self.init(
+        identifier: infoPlist.identifier,
+        displayName:
+          infoPlist.displayName ?? String(path.basename.dropLast(path.suffix?.count ?? 0)),
+        path: path)
+    } else {
+      self.init(
+        identifier: path.asString,
+        displayName: path.basename,
+        path: path)
+    }
+
+    if !searchForTools(path: path, fileSystem: fileSystem) {
       return nil
     }
-  }
-
-  public convenience init(
-    identifier: String,
-    displayName: String,
-    xctoolchainPath path: AbsolutePath,
-    fileSystem fs: FileSystem = localFileSystem
-  ) {
-    self.init(identifier: identifier, displayName: displayName, path: path)
-    _  = searchForTools(path: path, fileSystem: fs)
   }
 
   /// Search `path` for tools, returning true if any are found.

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -110,12 +110,3 @@ public final class Toolchain {
     return foundAny
   }
 }
-
-extension Platform {
-  var dynamicLibraryExtension: String {
-    switch self {
-    case .darwin: return "dylib"
-    case .linux(_): return "so"
-    }
-  }
-}

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -95,10 +95,10 @@ extension Toolchain {
   ///
   /// If `path` has an ".xctoolchain" extension, we try to read an Info.plist file to provide the
   /// toolchain identifier, etc.  Otherwise this information is derived from the path.
-  convenience public init?(path: AbsolutePath, fileSystem: FileSystem = localFileSystem) {
+  convenience public init?(_ path: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) {
     if path.extension == "xctoolchain",
        let infoPlist = orLog("", {
-         try XCToolchainPlist(fromDirectory: path, fileSystem: fileSystem) })
+         try XCToolchainPlist(fromDirectory: path, fileSystem) })
     {
       self.init(
         identifier: infoPlist.identifier,
@@ -112,13 +112,13 @@ extension Toolchain {
         path: path)
     }
 
-    if !searchForTools(path: path, fileSystem: fileSystem) {
+    if !searchForTools(path, fileSystem) {
       return nil
     }
   }
 
   /// Search `path` for tools, returning true if any are found.
-  func searchForTools(path: AbsolutePath, fileSystem fs: FileSystem = localFileSystem) -> Bool {
+  func searchForTools(_ path: AbsolutePath, _ fs: FileSystem = localFileSystem) -> Bool {
     return
       searchForTools(binPath: path, fs) ||
       searchForTools(binPath: path.appending(components: "bin"), fs) ||

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -87,7 +87,7 @@ public final class ToolchainRegistry {
 
   @discardableResult
   func scanForToolchain(path: AbsolutePath) -> Toolchain? {
-    if let toolchain = Toolchain(path: path, fileSystem: fs) {
+    if let toolchain = Toolchain(path, fs) {
       registerToolchain(toolchain)
       return toolchain
     }
@@ -160,7 +160,7 @@ extension ToolchainRegistry {
     }
     for name in contents {
       let path = toolchains.appending(component: name)
-      if path.extension == "xctoolchain", let toolchain = Toolchain(path: path, fileSystem: fs) {
+      if path.extension == "xctoolchain", let toolchain = Toolchain(path, fs) {
         registerToolchain(toolchain)
       }
     }

--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -34,7 +34,7 @@ extension XCToolchainPlist {
   ///
   /// - parameter path: The directory to search.
   /// - throws: If there is not plist file or it cannot be read.
-  init(fromDirectory path: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {
+  init(fromDirectory path: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
 #if os(macOS)
     let plistNames = [
       RelativePath("ToolchainInfo.plist"), // Xcode
@@ -43,7 +43,7 @@ extension XCToolchainPlist {
 
     for plistPath in plistNames.lazy.map({ path.appending($0) }) {
       if fileSystem.isFile(plistPath) {
-        try self.init(path: plistPath, fileSystem: fileSystem)
+        try self.init(path: plistPath, fileSystem)
         return
       }
     }
@@ -57,7 +57,7 @@ extension XCToolchainPlist {
   /// Returns the plist contents from the xctoolchain at `path`.
   ///
   /// - parameter path: The directory to search.
-  init(path: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {
+  init(path: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
 #if os(macOS)
     let bytes = try fileSystem.readFileContents(path)
     self = try bytes.withUnsafeData { data in

--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basic
+import Foundation
+
+/// A helper type for decoding the Info.plist or ToolchainInfo.plist file from an .xctoolchain.
+struct XCToolchainPlist {
+
+  /// The toolchain identifer e.g. "com.apple.dt.toolchain.XcodeDefault".
+  var identifier: String
+
+  /// The toolchain's human-readable name.
+  var displayName: String?
+}
+
+extension XCToolchainPlist {
+
+  enum Error: Swift.Error {
+    case unsupportedPlatform
+  }
+
+  /// Returns the plist contents from the xctoolchain in the given directory, either Info.plist or
+  /// ToolchainInfo.plist.
+  ///
+  /// - parameter path: The directory to search.
+  /// - throws: If there is not plist file or it cannot be read.
+  init(fromDirectory path: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {
+#if os(macOS)
+    let plistNames = [
+      RelativePath("ToolchainInfo.plist"), // Xcode
+      RelativePath("Info.plist"), // Swift.org
+    ]
+
+    for plistPath in plistNames.lazy.map({ path.appending($0) }) {
+      if fileSystem.isFile(plistPath) {
+        try self.init(path: plistPath, fileSystem: fileSystem)
+        return
+      }
+    }
+
+    throw FileSystemError.noEntry
+#else
+    throw Error.unsupportedPlatform
+#endif
+  }
+
+  /// Returns the plist contents from the xctoolchain at `path`.
+  ///
+  /// - parameter path: The directory to search.
+  init(path: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {
+#if os(macOS)
+    let bytes = try fileSystem.readFileContents(path)
+    self = try bytes.withUnsafeData { data in
+      let decoder = PropertyListDecoder()
+      var format = PropertyListSerialization.PropertyListFormat.binary
+      return try decoder.decode(XCToolchainPlist.self, from: data, format: &format)
+    }
+#else
+    throw Error.unsupportedPlatform
+#endif
+  }
+}
+
+extension XCToolchainPlist: Codable {
+
+  private enum CodingKeys: String, CodingKey {
+    case Identifier
+    case CFBundleIdentifier
+    case DisplayName
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    if let identifier = try container.decodeIfPresent(String.self, forKey: .Identifier) {
+      self.identifier = identifier
+    } else {
+      self.identifier = try container.decode(String.self, forKey: .CFBundleIdentifier)
+    }
+    self.displayName = try container.decodeIfPresent(String.self, forKey: .DisplayName)
+  }
+
+  /// Encode the info plist. **For testing**.
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    if identifier.starts(with: "com.apple") {
+      try container.encode(identifier, forKey: .Identifier)
+    } else {
+      try container.encode(identifier, forKey: .CFBundleIdentifier)
+    }
+    try container.encodeIfPresent(displayName, forKey: .DisplayName)
+  }
+}

--- a/Sources/SKSupport/Logging.swift
+++ b/Sources/SKSupport/Logging.swift
@@ -54,7 +54,7 @@ public func logAsync(level: LogLevel = .default, messageProducer: @escaping (_ c
 }
 
 /// Like `try?`, but logs the error on failure.
-public func orLog<R>(_ prefix: String = "", level: LogLevel = .default, block: () throws -> R?) -> R? {
+public func orLog<R>(_ prefix: String = "", level: LogLevel = .default, _ block: () throws -> R?) -> R? {
   do {
     return try block()
   } catch {

--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Utility
+
+extension Platform {
+
+  /// The file extension used for a dynamic library on this platform.
+  public var dynamicLibraryExtension: String {
+    switch self {
+    case .darwin: return "dylib"
+    case .linux(_): return "so"
+    }
+  }
+}

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -348,7 +348,7 @@ extension ToolchainRegistry {
       return nil
     }
 
-    guard let clang = base.clang ?? toolchains.values.first(where: { $0.clang != nil })?.clang else { return nil }
+    guard let clang = base.clang ?? toolchains.first(where: { $0.clang != nil })?.clang else { return nil }
 
     return SwiftPMToolchain(
       swiftCompiler: base.swiftc!,

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -358,13 +358,7 @@ extension ToolchainRegistry {
       extraCCFlags: [],
       extraSwiftCFlags: [],
       extraCPPFlags: [],
-      dynamicLibraryExtension: {
-        if case .darwin? = Platform.currentPlatform {
-          return "dylib"
-        } else {
-          return "so"
-        }
-      }()
+      dynamicLibraryExtension: Platform.currentPlatform?.dynamicLibraryExtension ?? "so"
     )
   }
 }

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -63,7 +63,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let binPath = AbsolutePath("/foo/bar/my_toolchain/bin")
     makeToolchain(binPath)
 
-    guard let t = Toolchain(identifier: "a", displayName: "b", searchForTools: binPath, fileSystem: fs) else {
+    guard let t = Toolchain(path: binPath, fileSystem: fs) else {
       XCTFail("could not find any tools")
       return
     }
@@ -137,6 +137,12 @@ final class ToolchainRegistryTests: XCTestCase {
 
     tr.scanForToolchains()
     XCTAssertEqual(tr.toolchains.count, 5)
+
+    let path = toolchains.appending(component: "Explicit.xctoolchain")
+    makeToolchain("org.fake.explicit", false, path)
+    let tc = Toolchain(path: path, fileSystem: fs)
+    XCTAssertNotNil(tc)
+    XCTAssertEqual(tc?.identifier, "org.fake.explicit")
 #endif
   }
 
@@ -226,7 +232,7 @@ final class ToolchainRegistryTests: XCTestCase {
     try! fs.writeFileContents(path.appending(components: "bin", "other") , bytes: "")
     try! fs.writeFileContents(path.appending(components: "lib", "sourcekitd.framework", "sourcekitd") , bytes: "")
 
-    let t1 = Toolchain(identifier: "a", displayName: "b", xctoolchainPath: path.parentDirectory, fileSystem: fs)
+    let t1 = Toolchain(path: path.parentDirectory, fileSystem: fs)!
     XCTAssertNotNil(t1.sourcekitd)
     XCTAssertNil(t1.clang)
     XCTAssertNil(t1.clangd)
@@ -241,7 +247,7 @@ final class ToolchainRegistryTests: XCTestCase {
     chmodRX(path.appending(components: "bin", "swiftc"))
     chmodRX(path.appending(components: "bin", "other"))
 
-    let t2 = Toolchain(identifier: "a", displayName: "b", xctoolchainPath: path.parentDirectory, fileSystem: fs)
+    let t2 = Toolchain(path: path.parentDirectory, fileSystem: fs)!
     XCTAssertNotNil(t2.sourcekitd)
     XCTAssertNotNil(t2.clang)
     XCTAssertNotNil(t2.clangd)
@@ -263,7 +269,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let binPath = AbsolutePath("/foo/bar/my_toolchain/bin")
     makeToolchain(binPath)
 
-    guard let t = Toolchain(identifier: "a", displayName: "b", searchForTools: binPath, fileSystem: fs) else {
+    guard let t = Toolchain(path: binPath, fileSystem: fs) else {
       XCTFail("could not find any tools")
       return
     }
@@ -283,16 +289,16 @@ final class ToolchainRegistryTests: XCTestCase {
     makeToolchain(AbsolutePath("/t1/bin"))
     makeToolchain(AbsolutePath("/t2/usr/bin"))
 
-    XCTAssertNotNil(Toolchain(identifier: "a", displayName: "b", searchForTools: AbsolutePath("/t1"), fileSystem: fs))
-    XCTAssertNotNil(Toolchain(identifier: "a", displayName: "b", searchForTools: AbsolutePath("/t1/bin"), fileSystem: fs))
-    XCTAssertNotNil(Toolchain(identifier: "a", displayName: "b", searchForTools: AbsolutePath("/t2"), fileSystem: fs))
+    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t1"), fileSystem: fs))
+    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t1/bin"), fileSystem: fs))
+    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t2"), fileSystem: fs))
 
-    XCTAssertNil(Toolchain(identifier: "a", displayName: "b", searchForTools: AbsolutePath("/t3"), fileSystem: fs))
+    XCTAssertNil(Toolchain(path: AbsolutePath("/t3"), fileSystem: fs))
     try! fs.createDirectory(AbsolutePath("/t3/bin"), recursive: true)
     try! fs.createDirectory(AbsolutePath("/t3/lib/sourcekitd.framework"), recursive: true)
-    XCTAssertNil(Toolchain(identifier: "a", displayName: "b", searchForTools: AbsolutePath("/t3"), fileSystem: fs))
+    XCTAssertNil(Toolchain(path: AbsolutePath("/t3"), fileSystem: fs))
     makeToolchain(AbsolutePath("/t3/bin"))
-    XCTAssertNotNil(Toolchain(identifier: "a", displayName: "b", searchForTools: AbsolutePath("/t3"), fileSystem: fs))
+    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t3"), fileSystem: fs))
   }
 
   static var allTests = [

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -54,9 +54,9 @@ final class ToolchainRegistryTests: XCTestCase {
 
     let fs = InMemoryFileSystem()
     let binPath = AbsolutePath("/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fileSystem: fs, sourcekitdInProc: true)
+    makeToolchain(binPath: binPath, fs, sourcekitdInProc: true)
 
-    guard let t = Toolchain(path: binPath, fileSystem: fs) else {
+    guard let t = Toolchain(binPath, fs) else {
       XCTFail("could not find any tools")
       return
     }
@@ -75,8 +75,7 @@ final class ToolchainRegistryTests: XCTestCase {
     makeXCToolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainID,
       opensource: false,
-      path: toolchains.appending(component: "XcodeDefault.xctoolchain"),
-      fileSystem: fs,
+      toolchains.appending(component: "XcodeDefault.xctoolchain"), fs,
       sourcekitd: true)
 
     XCTAssertNil(tr.default)
@@ -100,14 +99,12 @@ final class ToolchainRegistryTests: XCTestCase {
     makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
-      path: toolchains.appending(component: "A.xctoolchain"),
-      fileSystem: fs,
+      toolchains.appending(component: "A.xctoolchain"), fs,
       sourcekitd: true)
     makeXCToolchain(
       identifier: "com.apple.fake.B",
       opensource: false,
-      path: toolchains.appending(component: "B.xctoolchain"),
-      fileSystem: fs,
+      toolchains.appending(component: "B.xctoolchain"), fs,
       sourcekitd: true)
 
     tr.scanForToolchains()
@@ -116,14 +113,12 @@ final class ToolchainRegistryTests: XCTestCase {
     makeXCToolchain(
       identifier: "com.apple.fake.C",
       opensource: false,
-      path: toolchains.appending(component: "C.wrong_extension"),
-      fileSystem: fs,
+      toolchains.appending(component: "C.wrong_extension"), fs,
       sourcekitd: true)
     makeXCToolchain(
       identifier: "com.apple.fake.D",
       opensource: false,
-      path: toolchains.appending(component: "D_no_extension"),
-      fileSystem: fs,
+      toolchains.appending(component: "D_no_extension"), fs,
       sourcekitd: true)
 
     tr.scanForToolchains()
@@ -132,8 +127,7 @@ final class ToolchainRegistryTests: XCTestCase {
     makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
-      path: toolchains.appending(component: "E.xctoolchain"),
-      fileSystem: fs,
+      toolchains.appending(component: "E.xctoolchain"), fs,
       sourcekitd: true)
 
     tr.scanForToolchains()
@@ -142,14 +136,12 @@ final class ToolchainRegistryTests: XCTestCase {
     makeXCToolchain(
       identifier: "org.fake.global.A",
       opensource: true,
-      path: AbsolutePath("/Library/Developer/Toolchains/A.xctoolchain"),
-      fileSystem: fs,
+      AbsolutePath("/Library/Developer/Toolchains/A.xctoolchain"), fs,
       sourcekitd: true)
     makeXCToolchain(
       identifier: "org.fake.global.B",
       opensource: true,
-      path: AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"),
-      fileSystem: fs,
+      AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"), fs,
       sourcekitd: true)
 
     tr.scanForToolchains()
@@ -159,11 +151,10 @@ final class ToolchainRegistryTests: XCTestCase {
     makeXCToolchain(
       identifier: "org.fake.explicit",
       opensource: false,
-      path: toolchains.appending(component: "Explicit.xctoolchain"),
-      fileSystem: fs,
+      toolchains.appending(component: "Explicit.xctoolchain"), fs,
       sourcekitd: true)
 
-    let tc = Toolchain(path: path, fileSystem: fs)
+    let tc = Toolchain(path, fs)
     XCTAssertNotNil(tc)
     XCTAssertEqual(tc?.identifier, "org.fake.explicit")
 #endif
@@ -173,7 +164,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = InMemoryFileSystem()
     let tr = ToolchainRegistry(fileSystem: fs)
     let binPath = AbsolutePath("/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fileSystem: fs, sourcekitd: true)
+    makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
@@ -201,7 +192,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = InMemoryFileSystem()
     let tr = ToolchainRegistry(fileSystem: fs)
     let binPath = AbsolutePath("/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fileSystem: fs, sourcekitd: true)
+    makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
@@ -232,8 +223,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
     let path = tempDir.path.appending(components: "A.xctoolchain", "usr")
     makeToolchain(
-      binPath: path.appending(component: "bin"),
-      fileSystem: fs,
+      binPath: path.appending(component: "bin"), fs,
       clang: true,
       clangd: true,
       swiftc: true,
@@ -242,7 +232,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
     try! fs.writeFileContents(path.appending(components: "bin", "other") , bytes: "")
 
-    let t1 = Toolchain(path: path.parentDirectory, fileSystem: fs)!
+    let t1 = Toolchain(path.parentDirectory, fs)!
     XCTAssertNotNil(t1.sourcekitd)
     XCTAssertNil(t1.clang)
     XCTAssertNil(t1.clangd)
@@ -257,7 +247,7 @@ final class ToolchainRegistryTests: XCTestCase {
     chmodRX(path.appending(components: "bin", "swiftc"))
     chmodRX(path.appending(components: "bin", "other"))
 
-    let t2 = Toolchain(path: path.parentDirectory, fileSystem: fs)!
+    let t2 = Toolchain(path.parentDirectory, fs)!
     XCTAssertNotNil(t2.sourcekitd)
     XCTAssertNotNil(t2.clang)
     XCTAssertNotNil(t2.clangd)
@@ -267,8 +257,8 @@ final class ToolchainRegistryTests: XCTestCase {
   func testDylibNames() {
     let fs = InMemoryFileSystem()
     let binPath = AbsolutePath("/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fileSystem: fs, sourcekitdInProc: true, libIndexStore: true)
-    guard let t = Toolchain(path: binPath, fileSystem: fs) else {
+    makeToolchain(binPath: binPath, fs, sourcekitdInProc: true, libIndexStore: true)
+    guard let t = Toolchain(binPath, fs) else {
       XCTFail("could not find any tools")
       return
     }
@@ -278,19 +268,19 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testSubDirs() {
     let fs = InMemoryFileSystem()
-    makeToolchain(binPath: AbsolutePath("/t1/bin"), fileSystem: fs, sourcekitd: true)
-    makeToolchain(binPath: AbsolutePath("/t2/usr/bin"), fileSystem: fs, sourcekitd: true)
+    makeToolchain(binPath: AbsolutePath("/t1/bin"), fs, sourcekitd: true)
+    makeToolchain(binPath: AbsolutePath("/t2/usr/bin"), fs, sourcekitd: true)
 
-    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t1"), fileSystem: fs))
-    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t1/bin"), fileSystem: fs))
-    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t2"), fileSystem: fs))
+    XCTAssertNotNil(Toolchain(AbsolutePath("/t1"), fs))
+    XCTAssertNotNil(Toolchain(AbsolutePath("/t1/bin"), fs))
+    XCTAssertNotNil(Toolchain(AbsolutePath("/t2"), fs))
 
-    XCTAssertNil(Toolchain(path: AbsolutePath("/t3"), fileSystem: fs))
+    XCTAssertNil(Toolchain(AbsolutePath("/t3"), fs))
     try! fs.createDirectory(AbsolutePath("/t3/bin"), recursive: true)
     try! fs.createDirectory(AbsolutePath("/t3/lib/sourcekitd.framework"), recursive: true)
-    XCTAssertNil(Toolchain(path: AbsolutePath("/t3"), fileSystem: fs))
-    makeToolchain(binPath: AbsolutePath("/t3/bin"), fileSystem: fs, sourcekitd: true)
-    XCTAssertNotNil(Toolchain(path: AbsolutePath("/t3"), fileSystem: fs))
+    XCTAssertNil(Toolchain(AbsolutePath("/t3"), fs))
+    makeToolchain(binPath: AbsolutePath("/t3/bin"), fs, sourcekitd: true)
+    XCTAssertNotNil(Toolchain(AbsolutePath("/t3"), fs))
   }
 
   static var allTests = [
@@ -307,8 +297,8 @@ final class ToolchainRegistryTests: XCTestCase {
 private func makeXCToolchain(
   identifier: String,
   opensource: Bool,
-  path: AbsolutePath,
-  fileSystem fs: FileSystem,
+  _ path: AbsolutePath,
+  _ fs: FileSystem,
   clang: Bool = false,
   clangd: Bool = false,
   swiftc: Bool = false,
@@ -327,7 +317,7 @@ private func makeXCToolchain(
 
   makeToolchain(
     binPath: path.appending(components: "usr", "bin"),
-    fileSystem: fs,
+    fs,
     clang: clang,
     clangd: clangd,
     swiftc: swiftc,
@@ -340,7 +330,7 @@ private func makeXCToolchain(
 
 private func makeToolchain(
   binPath: AbsolutePath,
-  fileSystem fs: FileSystem,
+  _ fs: FileSystem,
   clang: Bool = false,
   clangd: Bool = false,
   swiftc: Bool = false,


### PR DESCRIPTION
This rewrites most of the functions for scanning for and constructing toolchains to be single-purpose and factors the configuration (e.g. specific directories and environment variable names) to only the highest level API. Clients can now generally use the shared toolchain registry and ignore all the scanning logic. Incidentally switches the toolchain registry to keep toolchains in order of registration to avoid non-determinism.

Along the way, add documentation comments to most of the public API in the toolchain code.