### PR TITLE
[test] Regenerate linux test manifests

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,14 +3,14 @@ import XCTest
 import LanguageServerProtocolJSONRPCTests
 import LanguageServerProtocolTests
 import SKCoreTests
-import SourceKitTests
 import SKSupportTests
+import SourceKitTests
 
 var tests = [XCTestCaseEntry]()
 tests += LanguageServerProtocolJSONRPCTests.__allTests()
 tests += LanguageServerProtocolTests.__allTests()
 tests += SKCoreTests.__allTests()
-tests += SourceKitTests.__allTests()
 tests += SKSupportTests.__allTests()
+tests += SourceKitTests.__allTests()
 
 XCTMain(tests)

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -29,6 +29,7 @@ extension ToolchainRegistryTests {
         ("testSearchExplicitEnv", testSearchExplicitEnv),
         ("testSearchPATH", testSearchPATH),
         ("testSubDirs", testSubDirs),
+        ("testUnknownPlatform", testUnknownPlatform),
     ]
 }
 

--- a/Tests/SKSupportTests/XCTestManifests.swift
+++ b/Tests/SKSupportTests/XCTestManifests.swift
@@ -11,6 +11,7 @@ extension SupportTests {
         ("testLineTable", testLineTable),
         ("testLineTableAppendPerf", testLineTableAppendPerf),
         ("testLineTableEditing", testLineTableEditing),
+        ("testLineTableLinePositionTranslation", testLineTableLinePositionTranslation),
         ("testLineTableSingleCharEditPerf", testLineTableSingleCharEditPerf),
         ("testLogging", testLogging),
         ("testResultEquality", testResultEquality),


### PR DESCRIPTION
We were missing a couple of the newer tests.