### PR TITLE
[build] Fix warnings about Foundation.Process on Linux

### DIFF
--- a/Sources/SKSupport/Path.swift
+++ b/Sources/SKSupport/Path.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basic
+import Foundation
+
+extension AbsolutePath {
+
+  /// File URL created from the normalized string representation of the path.
+  public var asURL: URL {
+    return URL(fileURLWithPath: asString)
+  }
+}

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -106,7 +106,13 @@ func makeJSONRPCClangServer(client: MessageHandler, clangd: AbsolutePath, buildS
   connection.start(receiveHandler: shim)
 
   let process = Foundation.Process()
-  process.launchPath = clangd.asString
+
+  if #available(OSX 10.13, *) {
+    process.executableURL = clangd.asURL
+  } else {
+    process.launchPath = clangd.asString
+  }
+
   process.arguments = [
     "-compile_args_from=lsp", // Provide compiler args programmatically.
   ]
@@ -117,7 +123,11 @@ func makeJSONRPCClangServer(client: MessageHandler, clangd: AbsolutePath, buildS
     connection.close()
   }
 
-  process.launch()
+  if #available(OSX 10.13, *) {
+    try process.run()
+  } else {
+    process.launch()
+  }
 
   return connectionToShim
 }


### PR DESCRIPTION
launchPath and launch are deprecated. Use exectuableURL and run() when
available.