### PR TITLE
Improve logging of errors getting build settings

### DIFF
--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -58,13 +58,10 @@ public protocol CompilationDatabase {
 /// Loads the compilation database located in `directory`, if any.
 public func tryLoadCompilationDatabase(
   directory: AbsolutePath,
-  fileSystem: FileSystem = localFileSystem
+  _ fileSystem: FileSystem = localFileSystem
 ) -> CompilationDatabase? {
-
-  return orLog("could not open compilation database for \(directory.asString)", level: .error) {
-    try JSONCompilationDatabase(directory: directory, fileSystem: fileSystem)
-  }
   // TODO: Support fixed compilation database (compile_flags.txt).
+  return try? JSONCompilationDatabase(directory: directory, fileSystem)
 }
 
 /// The JSON clang-compatible compilation database.
@@ -128,7 +125,7 @@ extension JSONCompilationDatabase: Codable {
 }
 
 extension JSONCompilationDatabase {
-  public init(directory: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {
+  public init(directory: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
     let path = directory.appending(component: "compile_commands.json")
     let bytes = try fileSystem.readFileContents(path)
     try bytes.withUnsafeData { data in

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
 import Basic
 import LanguageServerProtocol
 
@@ -27,7 +28,7 @@ public final class CompilationDatabaseBuildSystem: BuildSettingsProvider {
   public init(projectRoot: AbsolutePath? = nil, fileSystem: FileSystem = localFileSystem) {
     self.fileSystem = fileSystem
     if let path = projectRoot {
-      self.compdb = tryLoadCompilationDatabase(directory: path, fileSystem: fileSystem)
+      self.compdb = tryLoadCompilationDatabase(directory: path, fileSystem)
     }
   }
 
@@ -53,12 +54,17 @@ public final class CompilationDatabaseBuildSystem: BuildSettingsProvider {
       var dir = path
       while !dir.isRoot {
         dir = dir.parentDirectory
-        if let db = tryLoadCompilationDatabase(directory: dir, fileSystem: fileSystem) {
+        if let db = tryLoadCompilationDatabase(directory: dir, fileSystem) {
           compdb = db
           break
         }
       }
     }
+
+    if compdb == nil {
+      log("could not open compilation database for \(path.asString)", level: .warning)
+    }
+
     return compdb
   }
 }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -129,8 +129,9 @@ public final class SwiftPMWorkspace {
 
     // FIXME: the rest of this should be done asynchronously.
 
-    // FIXME: connect to logging?
-    let diags = DiagnosticsEngine()
+    let diags = DiagnosticsEngine(handlers: [{ diag in
+      log(diag.localizedDescription, level: diag.behavior.asLogLevel)
+    }])
 
     self.packageGraph = self.workspace.loadPackageGraph(root: PackageGraphRootInput(packages: [packageRoot]), diagnostics: diags)
 
@@ -397,5 +398,15 @@ public final class BuildSettingProviderWorkspaceDelegate: WorkspaceDelegate {
   }
 
   public func managedDependenciesDidUpdate(_ dependencies: AnySequence<ManagedDependency>) {
+  }
+}
+
+extension Basic.Diagnostic.Behavior {
+  var asLogLevel: LogLevel {
+    switch self {
+    case .error: return .error
+    case .warning: return .warning
+    default: return .info
+    }
   }
 }

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -169,7 +169,7 @@ final class CompilationDatabaseTests: XCTestCase {
   func testJSONCompilationDatabaseFromDirectory() {
     let fs = InMemoryFileSystem()
     try! fs.createDirectory(AbsolutePath("/a"))
-    XCTAssertNil(tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fileSystem: fs))
+    XCTAssertNil(tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fs))
 
     try! fs.writeFileContents(AbsolutePath("/a/compile_commands.json"), bytes: """
       [
@@ -181,7 +181,7 @@ final class CompilationDatabaseTests: XCTestCase {
       ]
       """)
 
-    XCTAssertNotNil(tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fileSystem: fs))
+    XCTAssertNotNil(tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fs))
   }
 
   func testCompilationDatabaseBuildSystem() {


### PR DESCRIPTION
* Add logging of swiftpm diagnostics (e.g. manifest doesn't parse)
* Reduce redundant logging when a compilation database isn't found