### PR TITLE
[test] Remove defunct `static var allTests` everywhere

### DIFF
--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -209,11 +209,6 @@ final class CodingTests: XCTestCase {
     {"jsonrpc":"2.0","id":2,"result":{}}
     """, userInfo: info)
   }
-
-  static var allTests = [
-    ("testMessageCoding", testMessageCoding),
-    ("testMessageDecodingError", testMessageDecodingError),
-    ]
 }
 
 private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Request: RequestType & Equatable {

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionPerfTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionPerfTests.swift
@@ -68,10 +68,4 @@ class ConnectionPerfTests: XCTestCase {
       }
     }
   }
-
-  static var allTests = [
-    ("testEcho1", testEcho1),
-    ("testEcho100Latency", testEcho100Latency),
-    ("testEcho100Throughput", testEcho100Throughput),
-  ]
 }

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -251,18 +251,4 @@ class ConnectionTests: XCTestCase {
     wait(for: [closedServer], timeout: 10)
 #endif
   }
-
-  static var allTests = [
-    ("testRound", testRound),
-    ("testEcho", testEcho),
-    ("testMessageBuffer", testMessageBuffer),
-    ("testEchoError", testEchoError),
-    ("testEchoNote", testEchoNote),
-    ("testUnknownRequest", testUnknownRequest),
-    ("testUnknownNotification", testUnknownNotification),
-    ("testUnexpectedResponse", testUnexpectedResponse),
-    ("testSendAfterClose", testSendAfterClose),
-    //("testCloseClientFD", testCloseClientFD),
-    //("testCloseServerFD", testCloseServerFD),
-    ]
 }

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -145,10 +145,4 @@ final class MessageParsingTests: XCTestCase {
 
     checkError("C\r\n", MessageDecodingError.parseError("expected ':' in message header"))
   }
-
-  static var allTests = [
-    ("testSplitMessage", testSplitMessage),
-    ("testParseHeader", testParseHeader),
-    ("testParseHeaderField", testParseHeaderField),
-  ]
 }

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -197,10 +197,6 @@ final class CodingTests: XCTestCase {
     checkCoding(RequestID.number(100), json: "100")
     checkCoding(RequestID.string("100"), json: "\"100\"")
   }
-
-  static var allTests = [
-    ("testValueCoding", testValueCoding),
-    ]
 }
 
 func with<T>(_ value: T, mutate: (inout T) -> ()) -> T {

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -72,10 +72,4 @@ class ConnectionTests: XCTestCase {
 
     waitForExpectations(timeout: 10)
   }
-
-  static var allTests = [
-    ("testEcho", testEcho),
-    ("testEchoError", testEchoError),
-    ("testEchoNote", testEchoNote),
-    ]
 }

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -294,15 +294,6 @@ final class ToolchainRegistryTests: XCTestCase {
     makeToolchain(binPath: AbsolutePath("/t3/bin"), fs, sourcekitd: true)
     XCTAssertNotNil(Toolchain(AbsolutePath("/t3"), fs))
   }
-
-  static var allTests = [
-    ("testDefaultBasic", testDefaultBasic),
-    ("testDefaultDarwin", testDefaultDarwin),
-    ("testUnknownPlatform", testUnknownPlatform),
-    ("testSearchDarwin", testSearchDarwin),
-    ("testSearchPATH", testSearchPATH),
-    ("testFromDirectory", testFromDirectory),
-    ]
 }
 
 #if os(macOS)

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -525,12 +525,4 @@ final class SupportTests: XCTestCase {
     XCTAssertNotEqual(AbsolutePath(expandingTilde: "~/foo").parentDirectory, .root)
     XCTAssertEqual(AbsolutePath(expandingTilde: "/foo"), AbsolutePath("/foo"))
   }
-
-  static var allTests = [
-    ("testResultEquality", testResultEquality),
-    ("testResultProjection", testResultProjection),
-    ("testIntFromAscii", testIntFromAscii),
-    ("testFindSubsequence", testFindSubsequence),
-    ("testLogging", testLogging),
-    ]
 }

--- a/Tests/SourceKitTests/SourceKitTests.swift
+++ b/Tests/SourceKitTests/SourceKitTests.swift
@@ -52,9 +52,4 @@ final class SKTests: XCTestCase {
       XCTAssertEqual(initResult.capabilities.textDocumentSync?.openClose, true)
       XCTAssertNotNil(initResult.capabilities.completionProvider)
     }
-
-    static var allTests = [
-        ("testInitLocal", testInitLocal),
-        ("testInitJSON", testInitJSON),
-    ]
 }


### PR DESCRIPTION
When we started managing the Linux test lists with the
`--generate-linuxmain` option to swiftpm, these all became dead code.