### PR TITLE
[clangd] Save the server capabilities and use it to avoid unsupported request

### DIFF
--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -120,4 +120,25 @@ final class LocalClangTests: XCTestCase {
       XCTAssertEqual(resp.count, 0)
     }
   }
+
+  func testFoldingRange() {
+    guard haveClangd else { return }
+    let url = URL(fileURLWithPath: "/a.cpp")
+    sk.allowUnexpectedNotification = true
+
+    sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
+      url: url,
+      language: .cpp,
+      version: 1,
+      text: """
+      struct S {
+        void foo() {
+          int local = 1;
+        }
+      };
+      """)))
+
+    let resp = try! sk.sendSync(FoldingRangeRequest(textDocument: TextDocumentIdentifier(url)))
+    XCTAssertNil(resp)
+  }
 }

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -18,6 +18,7 @@ extension LocalClangTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__LocalClangTests = [
+        ("testFoldingRange", testFoldingRange),
         ("testSymbolInfo", testSymbolInfo),
     ]
 }


### PR DESCRIPTION
While the server supports foldingRange in general, clangd may not
support it, so add a mechanism for capturing the server capabilities and
using them to avoid unsupported requests to clangd (instead, return
nil). This avoids interruptions due to "method not found" errors that
get surfaced very noisily in the IDE.