### PR TITLE
[Folding nit] Ignore the structure stack after the limit

### DIFF
--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -588,7 +588,7 @@ extension SwiftLanguageServer {
       }
 
       var structureStack: [SKResponseArray] = [substructure]
-      while let substructure = structureStack.popLast(), !hasReachedLimit {
+      while !hasReachedLimit, let substructure = structureStack.popLast() {
         substructure.forEach { _, value in
           if let offset: Int = value[self.keys.bodyoffset],
              let length: Int = value[self.keys.bodylength],
@@ -596,7 +596,6 @@ extension SwiftLanguageServer {
           {
             self.addFoldingRange(offset: offset, length: length, in: snapshot, toArray: &ranges)
             if hasReachedLimit {
-              structureStack = []
               return false
             }
           }


### PR DESCRIPTION
Just a little cleanup, with the limit being checked on the loop we don't have to kill the stack anymore. Should make the logic easier to read.