### PR TITLE
Correct location property of DiagnosticRelatedInformation

### DIFF
--- a/Sources/LanguageServerProtocol/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/Diagnostic.swift
@@ -66,11 +66,11 @@ public struct Diagnostic: Codable, Hashable {
 /// A 'note' diagnostic attached to a primary diagonstic that provides additional information.
 public struct DiagnosticRelatedInformation: Codable, Hashable {
 
-  public var location: Position
+  public var location: Location
 
   public var message: String
 
-  public init(location: Position, message: String) {
+  public init(location: Location, message: String) {
     self.location = location
     self.message = message
   }

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -100,7 +100,7 @@ public final class SwiftLanguageServer: LanguageServer {
       sknotes.forEach { (_, sknote) -> Bool in
         guard let note = getDiagnostic(sknote, for: snapshot) else { return true }
         notes?.append(DiagnosticRelatedInformation(
-          location: note.range.lowerBound,
+          location: Location(url: snapshot.document.url, range: note.range.asRange),
           message: note.message
         ))
         return true


### PR DESCRIPTION
In the [protocol spec](https://microsoft.github.io/language-server-protocol/specification), `DiagnosticRelatedInformation`'s `location` property is a `Location` structure, not a `Position`. This change corrects the implementation to match.

I'm not 100% sure that the location's `range` is correct here, but it does at least emit the correct JSON and stop client parsers from erroring out when handing the location field.

Before:
```json
{
  "jsonrpc": "2.0",
  "method": "textDocument/publishDiagnostics",
  "params": {
    "uri": "file:///Users/firehed/dev/reader-backend/Sources/App/Models/Todo.swift",
    "diagnostics": [
      {
        "range": {
          "start": {
            "line": 34,
            "character": 8
          },
          "end": {
            "line": 34,
            "character": 8
          }
        },
        "message": "expected declaration",
        "source": "sourcekitd",
        "severity": 1,
        "relatedInformation": [
          {
            "message": "in extension of 'Todo'",
            "location": {
              "line": 27,
              "character": 0
            }
          }
        ]
      },
      {
        "range": {
          "start": {
            "line": 36,
            "character": 0
          },
          "end": {
            "line": 36,
            "character": 0
          }
        },
        "message": "extraneous '}' at top level",
        "source": "sourcekitd",
        "severity": 1,
        "relatedInformation": []
      }
    ]
  }
}
```

After:
```json
{
  "jsonrpc": "2.0",
  "method": "textDocument/publishDiagnostics",
  "params": {
    "uri": "file:///Users/firehed/dev/reader-backend/Sources/App/Models/Todo.swift",
    "diagnostics": [
      {
        "range": {
          "start": {
            "line": 34,
            "character": 8
          },
          "end": {
            "line": 34,
            "character": 8
          }
        },
        "message": "expected declaration",
        "source": "sourcekitd",
        "severity": 1,
        "relatedInformation": [
          {
            "message": "in extension of 'Todo'",
            "location": {
              "uri": "file:///Users/firehed/dev/reader-backend/Sources/App/Models/Todo.swift",
              "range": {
                "start": {
                  "line": 27,
                  "character": 0
                },
                "end": {
                  "line": 27,
                  "character": 0
                }
              }
            }
          }
        ]
      },
      {
        "range": {
          "start": {
            "line": 36,
            "character": 0
          },
          "end": {
            "line": 36,
            "character": 0
          }
        },
        "message": "extraneous '}' at top level",
        "source": "sourcekitd",
        "severity": 1,
        "relatedInformation": []
      }
    ]
  }
}
```