### PR TITLE
Completion item returns type name in details

### DIFF
--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -345,12 +345,12 @@ extension SwiftLanguageServer {
 
         let filterName: String? = value[self.keys.name]
         let insertText: String? = value[self.keys.sourcetext]
+        let typeName: String? = value[self.keys.typename]
 
         let kind: sourcekitd_uid_t? = value[self.keys.kind]
-
         result.items.append(CompletionItem(
           label: name,
-          detail: nil,
+          detail: typeName,
           sortText: nil,
           filterText: filterName,
           textEdit: nil,

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -206,6 +206,7 @@ struct sourcekitd_keys {
   let filepath: sourcekitd_uid_t
   let ranges: sourcekitd_uid_t
   let usr: sourcekitd_uid_t
+  let typename: sourcekitd_uid_t
   let annotated_decl: sourcekitd_uid_t
   let doc_full_as_xml: sourcekitd_uid_t
   let syntactic_only: sourcekitd_uid_t
@@ -233,6 +234,7 @@ struct sourcekitd_keys {
     filepath = api.uid_get_from_cstr("key.filepath")!
     ranges = api.uid_get_from_cstr("key.ranges")!
     usr = api.uid_get_from_cstr("key.usr")!
+    typename = api.uid_get_from_cstr("key.typename")!
     annotated_decl = api.uid_get_from_cstr("key.annotated_decl")!
     doc_full_as_xml = api.uid_get_from_cstr("key.doc.full_as_xml")!
     syntactic_only = api.uid_get_from_cstr("key.syntactic_only")!

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -186,7 +186,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertNotNil(abc)
     if let abc = abc {
       XCTAssertEqual(abc.kind, .property)
-      XCTAssertNil(abc.detail)
+      XCTAssertEqual(abc.detail, "Int")
       XCTAssertEqual(abc.filterText, "abc")
       // FIXME:
       XCTAssertNil(abc.textEdit)
@@ -197,7 +197,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertNotNil(test)
     if let test = test {
       XCTAssertEqual(test.kind, .method)
-      XCTAssertNil(test.detail)
+      XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(a:)")
       // FIXME:
       XCTAssertNil(test.textEdit)


### PR DESCRIPTION
LSP `CompletionItem.detail?` value
> A human-readable string with additional information about this item, like type or symbol information.

sourcekitd have this information, so it can be used.