### PR TITLE
Try to build SPM workspace at open, if index store is not available.

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -135,6 +135,14 @@ public final class SwiftPMWorkspace {
     self.packageGraph = PackageGraph(rootPackages: [])
 
     try reloadPackage()
+
+    if !fileSystem.exists(self.buildParameters.indexStore) {
+        let swiftBuildPath = swiftPMToolchain.swiftCompiler.parentDirectory.appending(component: "swift-build")
+        try Basic.Process.popen(arguments: [swiftBuildPath.asString,
+                                            "--package-path", packageRoot.asString,
+                                            "--configuration", buildParameters.configuration.rawValue,
+                                            "--build-path", buildPath.asString])
+    }
   }
 
   /// Creates a build system using the Swift Package Manager, if this workspace is a package.


### PR DESCRIPTION
Try to build SPM workspace if an index location is not available. This most likely will create an index (or not, but that's ok). Useful for newly opened workspaces - otherwise this command has to be run manually.

Spawn swift-build because SwiftPM doesn't expose `Command` module where build logic is implemented.

PS. also I tried to generate llbuild manifest file and use llbuild directly. In theory this would work, however, there is something missing/wrong and llbuild wasn't able to properly build the project out of that.