### PR TITLE
Fix relative path assertion failure

### DIFF
--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -19,7 +19,7 @@ public struct BuildSetup {
 
   /// Default configuration
   public static let `default` = BuildSetup(configuration: .debug,
-                                           path: "./.build",
+                                           path: ".build",
                                            flags: BuildFlags())
 
   /// Build configuration


### PR DESCRIPTION
This isn't a full fix (we should handle this more gracefully in
general), but at least the default value will work now.