### PR TITLE
Change configuration build path to be absolute

### DIFF
--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basic
 import Utility
 import SKSupport
 
@@ -18,19 +19,19 @@ public struct BuildSetup {
 
   /// Default configuration
   public static let `default` = BuildSetup(configuration: .debug,
-                                           path: ".build",
+                                           path: nil,
                                            flags: BuildFlags())
 
-  /// Build configuration
+  /// Build configuration (debug|release).
   public let configuration: BuildConfiguration
 
-  /// Build artefacts directory path
-  public let path: String
+  /// Build artefacts directory path. If nil, the build system may choose a default value.
+  public let path: AbsolutePath?
 
   /// Additional build flags
   public let flags: BuildFlags
 
-  public init(configuration: BuildConfiguration, path: String, flags: BuildFlags) {
+  public init(configuration: BuildConfiguration, path: AbsolutePath?, flags: BuildFlags) {
     self.configuration = configuration
     self.path = path
     self.flags = flags

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Utility
 import SKSupport
 

--- a/Sources/SKSupport/BuildConfiguration.swift
+++ b/Sources/SKSupport/BuildConfiguration.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Utility
 
 public enum BuildConfiguration: String {

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -113,13 +113,7 @@ public final class SwiftPMWorkspace {
     swiftPMToolchain.extraSwiftCFlags = extraSwiftFlags
     swiftPMToolchain.extraCPPFlags = extraClangFlags
 
-
-    let buildPath: AbsolutePath
-    if let absoluteBuildPath = try? AbsolutePath(validating: buildSetup.path) {
-      buildPath = absoluteBuildPath
-    } else {
-      buildPath = packageRoot.appending(component: buildSetup.path)
-    }
+    let buildPath: AbsolutePath = buildSetup.path ?? packageRoot.appending(component: ".build")
 
     self.workspace = Workspace(
       dataPath: buildPath,

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -35,7 +35,7 @@ public struct TestSourceKitServer {
   }
 
   public static let buildSetup: BuildSetup = BuildSetup(configuration: .debug,
-                                                        path: ".build",
+                                                        path: nil,
                                                         flags: BuildFlags())
 
   public let client: TestClient

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -17,6 +17,7 @@ import SKSupport
 import SKCore
 import SPMLibc
 import Dispatch
+import Basic
 import Utility
 import Foundation
 import sourcekitd // Not needed here, but fixes debugging...
@@ -26,7 +27,7 @@ func parseArguments() throws -> BuildSetup {
   let parser = ArgumentParser(usage: "[options]", overview: "Language Server Protocol implementation for Swift and C-based languages")
   let loggingOption = parser.add(option: "--log-level", kind: LogLevel.self, usage: "Set the logging level (debug|info|warning|error) [default: \(LogLevel.default)]")
   let buildConfigurationOption = parser.add(option: "--configuration", shortName: "-c", kind: BuildConfiguration.self, usage: "Build with configuration (debug|release) [default: debug]")
-  let buildPathOption = parser.add(option: "--build-path", kind: String.self, usage: "Specify build/cache directory [default: ./.build]")
+  let buildPathOption = parser.add(option: "--build-path", kind: PathArgument.self, usage: "Specify build/cache directory")
   let buildFlagsCc = parser.add(option: "-Xcc", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all C compiler invocations")
   let buildFlagsCxx = parser.add(option: "-Xcxx", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all C++ compiler invocations")
   let buildFlagsLinker = parser.add(option: "-Xlinker", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all linker invocations")
@@ -46,9 +47,10 @@ func parseArguments() throws -> BuildSetup {
     Logger.shared.setLogLevel(environmentVariable: "SOURCEKIT_LOGGING")
   }
 
-  return BuildSetup(configuration: parsedArguments.get(buildConfigurationOption) ?? BuildSetup.default.configuration,
-                    path: parsedArguments.get(buildPathOption) ?? BuildSetup.default.path,
-                    flags: buildFlags)
+  return BuildSetup(
+    configuration: parsedArguments.get(buildConfigurationOption) ?? BuildSetup.default.configuration,
+    path: parsedArguments.get(buildPathOption)?.path,
+    flags: buildFlags)
 }
 
 let clientConnection = JSONRPCConection(inFD: STDIN_FILENO, outFD: STDOUT_FILENO, closeHandler: {

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -385,7 +385,7 @@ private func check(
 }
 
 private func buildPath(root: AbsolutePath) -> AbsolutePath {
-  if let absoluteBuildPath = try? AbsolutePath(validating: TestSourceKitServer.buildSetup.path) {
+  if let absoluteBuildPath = TestSourceKitServer.buildSetup.path {
     #if os(macOS)
       return absoluteBuildPath.appending(components: "x86_64-apple-macosx", "debug")
     #else
@@ -393,9 +393,9 @@ private func buildPath(root: AbsolutePath) -> AbsolutePath {
     #endif
   } else {
     #if os(macOS)
-      return root.appending(components: TestSourceKitServer.buildSetup.path, "x86_64-apple-macosx", "debug")
+      return root.appending(components: ".build", "x86_64-apple-macosx", "debug")
     #else
-      return root.appending(components: TestSourceKitServer.buildSetup.path, "x86_64-unknown-linux", "debug")
+      return root.appending(components: ".build", "x86_64-unknown-linux", "debug")
     #endif
   }
 }

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -123,6 +123,44 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     check(aswift.asString, arguments: arguments)
   }
 
+  func testBuildSetup() {
+    // FIXME: should be possible to use InMemoryFileSystem.
+    let fs = localFileSystem
+    let tempDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
+    try! fs.createFiles(root: tempDir.path, files: [
+      "pkg/Sources/lib/a.swift": "",
+      "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(name: "a", products: [], dependencies: [],
+            targets: [.target(name: "lib", dependencies: [])])
+          """
+    ])
+    let packageRoot = tempDir.path.appending(component: "pkg")
+    let tr = ToolchainRegistry.shared
+
+    let config = BuildSetup(
+        configuration: .release,
+        path: packageRoot.appending(component: "non_default_build_path"),
+        flags: BuildFlags(xcc: ["-m32"], xcxx: [], xswiftc: ["-typecheck"], xlinker: []))
+
+    let ws = try! SwiftPMWorkspace(
+      workspacePath: packageRoot,
+      toolchainRegistry: tr,
+      fileSystem: fs,
+      buildSetup: config)
+
+    let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
+    let build = buildPath(root: packageRoot, config: config)
+
+    XCTAssertEqual(ws.buildPath, build)
+    let arguments = ws.settings(for: aswift.asURL, .swift)!.compilerArguments
+
+    check("-typecheck", arguments: arguments)
+    check("-Xcc", "-m32", arguments: arguments)
+    check("-O", arguments: arguments)
+  }
+
   func testManifestArgs() {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
@@ -384,18 +422,22 @@ private func check(
   }
 }
 
-private func buildPath(root: AbsolutePath) -> AbsolutePath {
-  if let absoluteBuildPath = TestSourceKitServer.buildSetup.path {
+private func buildPath(
+  root: AbsolutePath,
+  config: BuildSetup = TestSourceKitServer.buildSetup) -> AbsolutePath
+{
+  let buildConfig = "\(config.configuration)"
+  if let absoluteBuildPath = config.path {
     #if os(macOS)
-      return absoluteBuildPath.appending(components: "x86_64-apple-macosx", "debug")
+      return absoluteBuildPath.appending(components: "x86_64-apple-macosx", buildConfig)
     #else
-      return absoluteBuildPath.appending(components: "x86_64-unknown-linux", "debug")
+      return absoluteBuildPath.appending(components: "x86_64-unknown-linux", buildConfig)
     #endif
   } else {
     #if os(macOS)
-      return root.appending(components: ".build", "x86_64-apple-macosx", "debug")
+      return root.appending(components: ".build", "x86_64-apple-macosx", buildConfig)
     #else
-      return root.appending(components: ".build", "x86_64-unknown-linux", "debug")
+      return root.appending(components: ".build", "x86_64-unknown-linux", buildConfig)
     #endif
   }
 }

--- a/Tests/SKSwiftPMWorkspaceTests/XCTestManifests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/XCTestManifests.swift
@@ -8,6 +8,7 @@ extension SwiftPMWorkspaceTests {
     static let __allTests__SwiftPMWorkspaceTests = [
         ("testBasicCXXArgs", testBasicCXXArgs),
         ("testBasicSwiftArgs", testBasicSwiftArgs),
+        ("testBuildSetup", testBuildSetup),
         ("testDeploymentTargetSwift", testDeploymentTargetSwift),
         ("testManifestArgs", testManifestArgs),
         ("testMultiFileSwift", testMultiFileSwift),


### PR DESCRIPTION
While specifying the build path relative to something might be a useful idea in principle, we would need a clearer story for how it is specified and resolved. When passing a path to a command-line argument, it should be resolved relative to the CWD, not to the package root by default. Incidentally, it doesn't really make sense to have a global default, since different build systems are likely to want different defaults. For now, simplify this configuration to an optional absolute path (passing a relative path on the command line will resolve relative to the CWD). Each build system can interpret `nil` as its preferred default.