### PR TITLE
Reject unknown command-line argument values

### DIFF
--- a/Sources/SKSupport/BuildConfiguration.swift
+++ b/Sources/SKSupport/BuildConfiguration.swift
@@ -17,11 +17,7 @@ public enum BuildConfiguration: String {
   case release
 }
 
-extension BuildConfiguration: ArgumentKind {
-  public init(argument: String) throws {
-    self = BuildConfiguration(rawValue: argument) ?? .debug
-  }
-
+extension BuildConfiguration: StringEnumArgument {
   /// Type of shell completion to provide for this argument.
   public static var completion: ShellCompletion {
     return ShellCompletion.none

--- a/Sources/SKSupport/LogLevel.swift
+++ b/Sources/SKSupport/LogLevel.swift
@@ -60,7 +60,11 @@ extension LogLevel: ArgumentKind {
     case "debug":
       self = .debug
     default:
-      self = LogLevel.default
+      // Also accept a numerical log level.
+      guard let value = Int(argument), let level = LogLevel(rawValue: value) else {
+        throw ArgumentConversionError.unknown(value: argument)
+      }
+      self = level
     }
   }
 

--- a/Sources/SKSupport/LogLevel.swift
+++ b/Sources/SKSupport/LogLevel.swift
@@ -60,11 +60,19 @@ extension LogLevel: ArgumentKind {
     case "debug":
       self = .debug
     default:
-      // Also accept a numerical log level.
-      guard let value = Int(argument), let level = LogLevel(rawValue: value) else {
+
+      // Also accept a numerical log level, for parity with SOURCEKIT_LOGGING environment variable.
+      guard let value = Int(argument) else {
         throw ArgumentConversionError.unknown(value: argument)
       }
-      self = level
+
+      if let level = LogLevel(rawValue: value) {
+        self = level
+      } else if value > LogLevel.debug.rawValue  {
+        self = .debug
+      } else {
+        throw ArgumentConversionError.custom("numerical log level \(value) is out of range")
+      }
     }
   }
 

--- a/Sources/SKSupport/LogLevel.swift
+++ b/Sources/SKSupport/LogLevel.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Utility
+
+#if canImport(os)
+import os
+#endif
+
+public enum LogLevel: Int, Equatable {
+  case error = 0
+  case warning = 1
+  case info = 2
+  case debug = 3
+
+  public static let `default`: LogLevel = .info
+}
+
+extension LogLevel: Comparable {
+  public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+}
+
+extension LogLevel: CustomStringConvertible {
+
+  public var description: String {
+    switch self {
+    case .error:
+      return "error"
+    case .warning:
+      return "warning"
+    case .info:
+      return "info"
+    case .debug:
+      return "debug"
+    }
+  }
+}
+
+extension LogLevel: ArgumentKind {
+
+  public init(argument: String) throws {
+    switch argument {
+    case "error":
+      self = .error
+    case "warning":
+      self = .warning
+    case "info":
+      self = .info
+    case "debug":
+      self = .debug
+    default:
+      self = LogLevel.default
+    }
+  }
+
+  /// Type of shell completion to provide for this argument.
+  public static var completion: ShellCompletion {
+    return ShellCompletion.none
+  }
+}
+
+#if canImport(os)
+extension LogLevel {
+  @available(OSX 10.12, *)
+  public var osLogType: OSLogType {
+    switch self {
+    case .debug:
+      return .debug
+    case .info:
+      return .info
+    case .warning:
+      return .default
+    case .error:
+      return .error
+    }
+  }
+}
+#endif

--- a/Sources/SKSupport/Logging.swift
+++ b/Sources/SKSupport/Logging.swift
@@ -12,59 +12,10 @@
 
 import Basic
 import Foundation
-import Utility
 
 #if canImport(os)
 import os // os_log
 #endif
-
-public enum LogLevel: Int, Equatable {
-  case error = 0
-  case warning = 1
-  case info = 2
-  case debug = 3
-
-  public static let `default`: LogLevel = .info
-}
-
-extension LogLevel: CustomStringConvertible {
-
-  public var description: String {
-    switch self {
-    case .error:
-      return "error"
-    case .warning:
-      return "warning"
-    case .info:
-      return "info"
-    case .debug:
-      return "debug"
-    }
-  }
-}
-
-extension LogLevel: ArgumentKind {
-
-  public init(argument: String) throws {
-    switch argument {
-    case "error":
-      self = .error
-    case "warning":
-      self = .warning
-    case "info":
-      self = .info
-    case "debug":
-      self = .debug
-    default:
-      self = LogLevel.default
-    }
-  }
-
-  /// Type of shell completion to provide for this argument.
-  public static var completion: ShellCompletion {
-    return ShellCompletion.none
-  }
-}
 
 /// Log the given message.
 ///
@@ -215,27 +166,3 @@ public class AnyLogHandler: LogHandler {
     handler(message, level)
   }
 }
-
-extension LogLevel: Comparable {
-  public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
-    return lhs.rawValue < rhs.rawValue
-  }
-}
-
-#if canImport(os)
-extension LogLevel {
-  @available(OSX 10.12, *)
-  public var osLogType: OSLogType {
-    switch self {
-    case .debug:
-      return .debug
-    case .info:
-      return .info
-    case .warning:
-      return .default
-    case .error:
-      return .error
-    }
-  }
-}
-#endif

--- a/Sources/SKSupport/Logging.swift
+++ b/Sources/SKSupport/Logging.swift
@@ -104,12 +104,10 @@ public final class Logger {
   }
 
   public func setLogLevel(environmentVariable: String) {
-    if let string = Process.env[environmentVariable], let value = Int(string) {
-      if let level = LogLevel(rawValue: value) {
-        currentLevel = level
-      } else if value > LogLevel.debug.rawValue  {
-        currentLevel = LogLevel.debug
-      }
+    if let string = Process.env[environmentVariable],
+       let level = try? LogLevel(argument: string)
+    {
+      currentLevel = level
     }
   }
 

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -244,7 +244,7 @@ final class SupportTests: XCTestCase {
       ("d", .error),
       ])
 
-    // too high - max out at .debyg
+    // too high - max out at .debug
     try! setenv("TEST_ENV_LOGGGING_err", value: "1000")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
@@ -258,6 +258,20 @@ final class SupportTests: XCTestCase {
       ("f", .info),
       ("g", .debug),
       ])
+
+    // By string.
+    try! setenv("TEST_ENV_LOGGGING_string", value: "error")
+    testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
+    XCTAssertEqual(testLogger.currentLevel, .error)
+    try! setenv("TEST_ENV_LOGGGING_string", value: "warning")
+    testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
+    XCTAssertEqual(testLogger.currentLevel, .warning)
+    try! setenv("TEST_ENV_LOGGGING_string", value: "info")
+    testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
+    XCTAssertEqual(testLogger.currentLevel, .info)
+    try! setenv("TEST_ENV_LOGGGING_string", value: "debug")
+    testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
+    XCTAssertEqual(testLogger.currentLevel, .debug)
 
     testLogger.currentLevel = .default
     testLogger.addLogHandler(obj)


### PR DESCRIPTION
Make arguments to `--configuration` and `--log-level` reject unknown values rather than falling back to a default value silently. Also, unify the parsing of `--log-level` on the command-line and `env SOURCEKIT_LOGGING` so that they take the same values.  Specifically, they accept either a string (debug|info|warning|error), or a numerical value > 0.