### PR TITLE
Use AbsolutePath.pathString instead of description

### DIFF
--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -53,10 +53,10 @@ public final class FallbackBuildSystem: BuildSystem {
     if let sdkpath = sdkpath {
       args += [
         "-sdk",
-        sdkpath.description,
+        sdkpath.pathString,
       ]
     }
-    args.append(path.description)
+    args.append(path.pathString)
     return FileBuildSettings(preferredToolchain: nil, compilerArguments: args)
   }
 
@@ -65,10 +65,10 @@ public final class FallbackBuildSystem: BuildSystem {
     if let sdkpath = sdkpath {
       args += [
         "-isysroot",
-        sdkpath.description,
+        sdkpath.pathString,
       ]
     }
-    args.append(path.description)
+    args.append(path.pathString)
     return FileBuildSettings(preferredToolchain: nil, compilerArguments: args)
   }
 }

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -107,7 +107,7 @@ extension Toolchain {
         path: path)
     } else {
       self.init(
-        identifier: path.description,
+        identifier: path.pathString,
         displayName: path.basename,
         path: path)
     }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -95,14 +95,14 @@ public final class SwiftPMWorkspace {
     var extraSwiftFlags: [String] = []
     var extraClangFlags: [String] = []
     if let sdk = sdk {
-      extraSwiftFlags += ["-sdk", sdk.description]
-      extraClangFlags += ["-isysroot", sdk.description]
+      extraSwiftFlags += ["-sdk", sdk.pathString]
+      extraClangFlags += ["-isysroot", sdk.pathString]
     }
 
     if let platformPath = platformPath {
       let flags = [
         "-F",
-        platformPath.appending(components: "Developer", "Library", "Frameworks").description
+        platformPath.appending(components: "Developer", "Library", "Frameworks").pathString
       ]
       extraSwiftFlags += flags
       extraClangFlags += flags
@@ -277,7 +277,7 @@ extension SwiftPMWorkspace {
   /// Retrieve settings for a package manifest (Package.swift).
   func settings(forPackageManifest path: AbsolutePath) -> FileBuildSettings? {
     for package in packageGraph.packages where path == package.manifest.path {
-        let compilerArgs = workspace.interpreterFlags(for: package.path) + [path.description]
+        let compilerArgs = workspace.interpreterFlags(for: package.path) + [path.pathString]
         return FileBuildSettings(
           preferredToolchain: nil,
           compilerArguments: compilerArgs
@@ -311,21 +311,21 @@ extension SwiftPMWorkspace {
       "-emit-dependencies",
       "-emit-module",
       "-emit-module-path",
-      buildPath.appending(component: "\(td.target.c99name).swiftmodule").description
+      buildPath.appending(component: "\(td.target.c99name).swiftmodule").pathString
       // -output-file-map <path>
     ]
     if td.target.type == .library || td.target.type == .test {
       args += ["-parse-as-library"]
     }
     args += ["-c"]
-    args += td.target.sources.paths.map { $0.description }
-    args += ["-I", buildPath.description]
+    args += td.target.sources.paths.map { $0.pathString }
+    args += ["-I", buildPath.pathString]
     args += td.compileArguments()
 
     return FileBuildSettings(
       preferredToolchain: nil,
       compilerArguments: args,
-      workingDirectory: workspacePath.description)
+      workingDirectory: workspacePath.pathString)
   }
 
   /// Retrieve settings for the given C-family language file, which is part of a known target build
@@ -348,7 +348,7 @@ extension SwiftPMWorkspace {
         "-MT",
         "dependencies",
         "-MF",
-        compilePath.deps.description,
+        compilePath.deps.pathString,
       ]
     }
 
@@ -368,27 +368,27 @@ extension SwiftPMWorkspace {
     if let compilePath = compilePath {
       args += [
         "-c",
-        compilePath.source.description,
+        compilePath.source.pathString,
         "-o",
-        compilePath.object.description
+        compilePath.object.pathString
       ]
     } else if path.extension == "h" {
       args += ["-c"]
       if let xflag = language.xflagHeader {
         args += ["-x", xflag]
       }
-      args += [path.description]
+      args += [path.pathString]
     } else {
       args += [
         "-c",
-        path.description,
+        path.pathString,
       ]
     }
 
     return FileBuildSettings(
       preferredToolchain: nil,
       compilerArguments: args,
-      workingDirectory: workspacePath.description)
+      workingDirectory: workspacePath.pathString)
   }
 }
 

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -172,7 +172,7 @@ public final class SourceKitServer: LanguageServer {
       let resp = try service.sendSync(InitializeRequest(
         processId: Int(getpid()),
         rootPath: nil,
-        rootURL: (workspace?.rootPath).map { URL(fileURLWithPath: $0.description) },
+        rootURL: (workspace?.rootPath).map { URL(fileURLWithPath: $0.pathString) },
         initializationOptions: InitializationOptions(),
         capabilities: workspace?.clientCapabilities ?? ClientCapabilities(workspace: nil, textDocument: nil),
         trace: .off,

--- a/Sources/SourceKit/Workspace.swift
+++ b/Sources/SourceKit/Workspace.swift
@@ -95,10 +95,10 @@ public final class Workspace {
        let libPath = toolchainRegistry.default?.libIndexStore
     {
       do {
-        let lib = try IndexStoreLibrary(dylibPath: libPath.description)
+        let lib = try IndexStoreLibrary(dylibPath: libPath.pathString)
         self.index = try IndexStoreDB(
-          storePath: storePath.description,
-          databasePath: dbPath.description,
+          storePath: storePath.pathString,
+          databasePath: dbPath.pathString,
           library: lib)
         log("opened IndexStoreDB at \(dbPath) with store path \(storePath)")
       } catch {

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -149,7 +149,7 @@ func makeJSONRPCClangServer(client: MessageHandler, clangd: AbsolutePath, buildS
   if #available(OSX 10.13, *) {
     process.executableURL = clangd.asURL
   } else {
-    process.launchPath = clangd.description
+    process.launchPath = clangd.pathString
   }
 
   process.arguments = [

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -42,7 +42,7 @@ final class SwiftSourceKitFramework {
 
   init(dylib path: AbsolutePath) throws {
     self.path = path
-    self.dylib = try dlopen(path.description, mode: [.lazy, .local, .first, .deepBind])
+    self.dylib = try dlopen(path.pathString, mode: [.lazy, .local, .first, .deepBind])
 
     func dlsym_required<T>(_ handle: DLHandle, symbol: String) throws -> T {
       guard let sym: T = dlsym(handle, symbol: symbol) else {

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -34,14 +34,14 @@ final class FallbackBuildSystemTests: XCTestCase {
     let args = settings.compilerArguments
     XCTAssertEqual(args, [
       "-sdk",
-      sdk.description,
-      source.description,
+      sdk.pathString,
+      source.pathString,
     ])
 
     bs.sdkpath = nil
 
     XCTAssertEqual(bs.settings(for: source.asURL, .swift)?.compilerArguments, [
-      source.description,
+      source.pathString,
     ])
   }
 
@@ -59,14 +59,14 @@ final class FallbackBuildSystemTests: XCTestCase {
     let args = settings.compilerArguments
     XCTAssertEqual(args, [
       "-isysroot",
-      sdk.description,
-      source.description,
+      sdk.pathString,
+      source.pathString,
     ])
 
     bs.sdkpath = nil
 
     XCTAssertEqual(bs.settings(for: source.asURL, .cpp)?.compilerArguments, [
-      source.description,
+      source.pathString,
     ])
   }
 
@@ -75,7 +75,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem()
     bs.sdkpath = nil
     XCTAssertEqual(bs.settings(for: source.asURL, .c)?.compilerArguments, [
-      source.description,
+      source.pathString,
     ])
   }
 
@@ -84,7 +84,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem()
     bs.sdkpath = nil
     XCTAssertEqual(bs.settings(for: source.asURL, .objective_c)?.compilerArguments, [
-      source.description,
+      source.pathString,
     ])
   }
 
@@ -93,7 +93,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem()
     bs.sdkpath = nil
     XCTAssertEqual(bs.settings(for: source.asURL, .objective_cpp)?.compilerArguments, [
-      source.description,
+      source.pathString,
     ])
   }
 

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -197,7 +197,7 @@ final class ToolchainRegistryTests: XCTestCase {
     }
 
     XCTAssertEqual(tr.default?.identifier, tc.identifier)
-    XCTAssertEqual(tc.identifier, binPath.description)
+    XCTAssertEqual(tc.identifier, binPath.pathString)
     XCTAssertNil(tc.clang)
     XCTAssertNil(tc.clangd)
     XCTAssertNil(tc.swiftc)
@@ -215,7 +215,7 @@ final class ToolchainRegistryTests: XCTestCase {
     }
 
     XCTAssertEqual(tr.default?.identifier, tc.identifier)
-    XCTAssertEqual(tc2.identifier, binPath2.description)
+    XCTAssertEqual(tc2.identifier, binPath2.pathString)
     XCTAssertNotNil(tc2.sourcekitd)
   }
 
@@ -228,7 +228,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
 
-    try! setenv("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.parentDirectory.description)
+    try! setenv("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.parentDirectory.pathString)
 
     tr.scanForToolchains(environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"], fs)
 
@@ -238,7 +238,7 @@ final class ToolchainRegistryTests: XCTestCase {
     }
 
     XCTAssertEqual(tr.default?.identifier, tc.identifier)
-    XCTAssertEqual(tc.identifier, binPath.parentDirectory.description)
+    XCTAssertEqual(tc.identifier, binPath.parentDirectory.pathString)
     XCTAssertNil(tc.clang)
     XCTAssertNil(tc.clangd)
     XCTAssertNil(tc.swiftc)
@@ -255,7 +255,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
 
-    try! setenv("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.parentDirectory.description)
+    try! setenv("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.parentDirectory.pathString)
 
     tr.scanForToolchains(
       environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],
@@ -267,7 +267,7 @@ final class ToolchainRegistryTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(tc.identifier, binPath.parentDirectory.description)
+    XCTAssertEqual(tc.identifier, binPath.parentDirectory.pathString)
     XCTAssertNil(tc.clang)
     XCTAssertNil(tc.clangd)
     XCTAssertNil(tc.swiftc)
@@ -298,7 +298,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(t1.swiftc)
 
     func chmodRX(_ path: AbsolutePath) {
-      XCTAssertEqual(chmod(path.description, S_IRUSR | S_IXUSR), 0)
+      XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
     }
 
     chmodRX(path.appending(components: "bin", "clang"))
@@ -471,7 +471,7 @@ private func makeToolchain(
   let makeExec = { (path: AbsolutePath) in
     try! fs.writeFileContents(path , bytes: "")
     if shouldChmod {
-      XCTAssertEqual(chmod(path.description, S_IRUSR | S_IXUSR), 0)
+      XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
     }
   }
 

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -118,9 +118,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     check("-target", "x86_64-unknown-linux", arguments: arguments)
 #endif
 
-    check("-I", build.description, arguments: arguments)
+    check("-I", build.pathString, arguments: arguments)
 
-    check(aswift.description, arguments: arguments)
+    check(aswift.pathString, arguments: arguments)
   }
 
   func testBuildSetup() {
@@ -186,7 +186,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     let arguments = ws.settings(for: source.asURL, .swift)!.compilerArguments
 
     check("-swift-version", "4.2", arguments: arguments)
-    check(source.description, arguments: arguments)
+    check(source.pathString, arguments: arguments)
   }
 
   func testMultiFileSwift() {
@@ -215,11 +215,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
 
     let argumentsA = ws.settings(for: aswift.asURL, .swift)!.compilerArguments
-    check(aswift.description, arguments: argumentsA)
-    check(bswift.description, arguments: argumentsA)
+    check(aswift.pathString, arguments: argumentsA)
+    check(bswift.pathString, arguments: argumentsA)
     let argumentsB = ws.settings(for: aswift.asURL, .swift)!.compilerArguments
-    check(aswift.description, arguments: argumentsB)
-    check(bswift.description, arguments: argumentsB)
+    check(aswift.pathString, arguments: argumentsB)
+    check(bswift.pathString, arguments: argumentsB)
   }
 
   func testMultiTargetSwift() {
@@ -253,16 +253,16 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
     let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
     let arguments = ws.settings(for: aswift.asURL, .swift)!.compilerArguments
-    check(aswift.description, arguments: arguments)
-    checkNot(bswift.description, arguments: arguments)
+    check(aswift.pathString, arguments: arguments)
+    checkNot(bswift.pathString, arguments: arguments)
     check(
-      "-I", packageRoot.appending(components: "Sources", "libC", "include").description,
+      "-I", packageRoot.appending(components: "Sources", "libC", "include").pathString,
       arguments: arguments)
 
     let argumentsB = ws.settings(for: bswift.asURL, .swift)!.compilerArguments
-    check(bswift.description, arguments: argumentsB)
-    checkNot(aswift.description, arguments: argumentsB)
-    checkNot("-I", packageRoot.appending(components: "Sources", "libC", "include").description,
+    check(bswift.pathString, arguments: argumentsB)
+    checkNot(aswift.pathString, arguments: argumentsB)
+    checkNot("-I", packageRoot.appending(components: "Sources", "libC", "include").pathString,
       arguments: argumentsB)
   }
 
@@ -341,24 +341,24 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       check("-target", "x86_64-unknown-linux", arguments: arguments)
   #endif
 
-      check("-I", packageRoot.appending(components: "Sources", "lib", "include").description,
+      check("-I", packageRoot.appending(components: "Sources", "lib", "include").pathString,
         arguments: arguments)
-      checkNot("-I", build.description, arguments: arguments)
-      checkNot(bcxx.description, arguments: arguments)
+      checkNot("-I", build.pathString, arguments: arguments)
+      checkNot(bcxx.pathString, arguments: arguments)
     }
 
     let args = ws.settings(for: acxx.asURL, .cpp)!.compilerArguments
     checkArgsCommon(args)
     check("-MD", "-MT", "dependencies",
-        "-MF", build.appending(components: "lib.build", "a.cpp.d").description,
+        "-MF", build.appending(components: "lib.build", "a.cpp.d").pathString,
         arguments: args)
-    check("-c", acxx.description, arguments: args)
-    check("-o", build.appending(components: "lib.build", "a.cpp.o").description, arguments: args)
+    check("-c", acxx.pathString, arguments: args)
+    check("-o", build.appending(components: "lib.build", "a.cpp.o").pathString, arguments: args)
 
     let header = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
     let headerArgs = ws.settings(for: header.asURL, .cpp)!.compilerArguments
     checkArgsCommon(headerArgs)
-    check("-c", "-x", "c++-header", header.description, arguments: headerArgs)
+    check("-c", "-x", "c++-header", header.pathString, arguments: headerArgs)
   }
 
   func testDeploymentTargetSwift() {


### PR DESCRIPTION
Per review feedback; pathString is semantically the string we want,
while description is for creating a human-readable string.