### PR TITLE
[test] Disable another `measure` method missed previously on Linux

### DIFF
--- a/Sources/SKTestSupport/PerfTestCase.swift
+++ b/Sources/SKTestSupport/PerfTestCase.swift
@@ -45,6 +45,9 @@ open class PerfTestCase: XCTestCase {
     {
       block()
     }
+    public func measure(block: () -> Void) {
+      block()
+    }
   #endif
 #endif
 


### PR DESCRIPTION
On macOS since there is an override, both `measure` methods funnel
through one entry point, but on other platforms they are not `open`, so
we need to shadow all of them.