### PR TITLE
[swiftpm] Statically link to libSwiftPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "master",
-          "revision": "4e25396f00759d3d781d888ac6b9a0118b5dbe44",
+          "revision": "06a25536b8d7f6b43f93139dea15dd8f7873b8d9",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
           "branch": "master",
-          "revision": "9b6be668d93829f9ef0727ad2d2490e56487fedc",
+          "revision": "d8821ba5eff37b77839c1f74769a798d775a1e8a",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/apple/indexstore-db.git",
         "state": {
           "branch": "master",
-          "revision": "b1258a6827e988a4d9988e5fddf4d4e95cbd59bb",
+          "revision": "bbe9a1ccc6d575260075fba247bf4b25729d7953",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
 
       .target(
         name: "SKSwiftPMWorkspace",
-        dependencies: ["SwiftPM", "SKCore"]),
+        dependencies: ["SwiftPM-auto", "SKCore"]),
       .testTarget(
         name: "SKSwiftPMWorkspaceTests",
         dependencies: ["SKSwiftPMWorkspace", "SKTestSupport"]),
@@ -76,10 +76,7 @@ let package = Package(
       // useful to any Swift package. Similar in spirit to SwiftPM's Basic module.
       .target(
         name: "SKSupport",
-        // FIXME: this should be "Utility", not the full SwiftPM library. Right now that creates
-        // multiple definition warnings at run time because SwiftPM is dynamically linked and
-        // Utility is static.
-        dependencies: ["SwiftPM"]),
+        dependencies: ["SPMUtility"]),
       .testTarget(
         name: "SKSupportTests",
         dependencies: ["SKSupport", "SKTestSupport"]),

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -140,7 +140,7 @@ public final class SwiftPMWorkspace {
       toolchain: swiftPMToolchain,
       flags: buildSetup.flags)
 
-    self.packageGraph = PackageGraph(rootPackages: [])
+    self.packageGraph = PackageGraph(rootPackages: [], requiredDependencies: [])
 
     try reloadPackage()
   }


### PR DESCRIPTION
Switch to using the swiftpm library with automatic linkage, which in practice means we will statically link to libSwiftPM using the standard build. This change allows us to install the sourcekit-lsp binary without also installing a copy of libSwiftPM.dylib (and since swiftpm isn't using a stable ABI we couldn't share that with anything). Previously this was blocked by conflicts between the llvm code in llbuild and in indexstore-db, but this has been resolved.