### PR TITLE
Update recommended toolchain to 2019-02-14-a

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/apple/indexstore-db.git",
         "state": {
           "branch": "master",
-          "revision": "bbe9a1ccc6d575260075fba247bf4b25729d7953",
+          "revision": "0921902a3124305c87913153610567d5a297de2f",
           "version": null
         }
       },
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "master",
-          "revision": "06a25536b8d7f6b43f93139dea15dd8f7873b8d9",
+          "revision": "b350222a15432d19083d0a1ebb05e66cc57759f1",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
           "branch": "master",
-          "revision": "d8821ba5eff37b77839c1f74769a798d775a1e8a",
+          "revision": "70bf4231ee1fe28129d70ddb9c87b58947531ef4",
           "version": null
         }
       }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SourceKit-LSP is an implementation of the [Language Server Protocol](https://mic
 
 SourceKit-LSP is under heavy development! The best way to try it out is to build it from source. You will also need a Swift development toolchain and an editor that supports LSP.
 
-1. Install the `swift-DEVELOPMENT-SNAPSHOT-2019-01-22-a` toolchain snapshot from https://swift.org/download/#snapshots. Set the environment variable `SOURCEKIT_TOOLCHAIN_PATH` to the absolute path to the toolchain or otherwise configure your editor to use this toolchain. See [Toolchains](#toolchains) for more information.
+1. Install the `swift-DEVELOPMENT-SNAPSHOT-2019-02-14-a` toolchain snapshot from https://swift.org/download/#snapshots. Set the environment variable `SOURCEKIT_TOOLCHAIN_PATH` to the absolute path to the toolchain or otherwise configure your editor to use this toolchain. See [Toolchains](#toolchains) for more information.
 
 2. Build the language server executable `sourcekit-lsp` using `swift build`. See [Building](#building-sourcekit-lsp) for more information.
 
@@ -73,7 +73,7 @@ SourceKit-LSP depends on tools such as `sourcekitd` and `clangd`, which it loads
 
 ### Recommended Toolchain
 
-Use the `swift-DEVELOPMENT-SNAPSHOT-2019-01-22-a` toolchain snapshot from https://swift.org/download/#snapshots. SourceKit-LSP is still early in its development and we are actively adding functionality to the toolchain to support it.
+Use the `swift-DEVELOPMENT-SNAPSHOT-2019-02-14-a` toolchain snapshot from https://swift.org/download/#snapshots. SourceKit-LSP is still early in its development and we are actively adding functionality to the toolchain to support it.
 
 ### Selecting the Toolchain
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ SourceKit-LSP is still in early development, so you may run into rough edges wit
 | Feature | Status | Notes |
 |---------|:------:|-------|
 | Swift | ✅ | |
-| C/C++/ObjC | ❌ | [clangd](https://clang.llvm.org/extra/clangd.html) is not available in the recommended toolchain. You can try out C/C++/ObjC support by building clangd from source and putting it in `PATH`.
+| C/C++/ObjC | ❌ | As of `swift-DEVELOPMENT-SNAPSHOT-2019-02-14-a` [clangd](https://clang.llvm.org/extra/clangd.html) is available but hitting frequent assertion failures.
 | Code completion | ✅ | |
 | Quick Help (Hover) | ✅ | |
 | Diagnostics | ✅ | |

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -20,7 +20,7 @@ import XCTest
 final class LocalClangTests: XCTestCase {
 
   /// Whether to fail tests if clangd cannot be found.
-  static let requireClangd: Bool = false
+  static let requireClangd: Bool = true
 
   /// Whether clangd exists in the toolchain.
   var haveClangd: Bool = false


### PR DESCRIPTION
Also update swiftpm pinned version.

We have clangd in the toolchain now, and it's sufficient to pass our minimal tests.  Unfortunately it's hitting frequent assertion failures during editing, so I'm not marking it as supported yet.