### PR TITLE
Undo optimisim around requiring clangd during testing

### DIFF
--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -20,7 +20,7 @@ import XCTest
 final class LocalClangTests: XCTestCase {
 
   /// Whether to fail tests if clangd cannot be found.
-  static let requireClangd: Bool = true
+  static let requireClangd: Bool = false // Note: Swift CI doesn't build clangd on all jobs
 
   /// Whether clangd exists in the toolchain.
   var haveClangd: Bool = false


### PR DESCRIPTION
While the toolchains build clangd now, not all the bots are building it,
so we cannot require it yet.