### PR TITLE
[editors] Add alternative swift syntax spec to sublime config

### DIFF
--- a/Editors/README.md
+++ b/Editors/README.md
@@ -39,6 +39,7 @@ You will need the path to the `sourcekit-lsp` executable and the Swift toolchain
           "scopes": ["source.swift"],
           "syntaxes": [
             "Packages/Swift/Syntaxes/Swift.tmLanguage",
+            "Packages/Decent Swift Syntax/Swift.sublime-syntax",
           ],
           "languageId": "swift"
         },


### PR DESCRIPTION
This seems to be a commonly used syntax package for swift, so add it to
the config so it will work without troubleshooting.