### PR TITLE
Support WSL by adding additional #os(macOS) check in ClangLanguageServer

### DIFF
--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -146,11 +146,15 @@ func makeJSONRPCClangServer(client: MessageHandler, clangd: AbsolutePath, buildS
 
   let process = Foundation.Process()
 
-  if #available(OSX 10.13, *) {
-    process.executableURL = clangd.asURL
-  } else {
+  #if os(macOS)
+    if #available(OSX 10.13, *) {
+      process.executableURL = clangd.asURL
+    } else {
+      process.launchPath = clangd.pathString
+    }
+  #else
     process.launchPath = clangd.pathString
-  }
+  #endif
 
   process.arguments = [
     "-compile_args_from=lsp", // Provide compiler args programmatically.
@@ -162,11 +166,15 @@ func makeJSONRPCClangServer(client: MessageHandler, clangd: AbsolutePath, buildS
     connection.close()
   }
 
-  if #available(OSX 10.13, *) {
-    try process.run()
-  } else {
+  #if os(macOS)
+    if #available(OSX 10.13, *) {
+      try process.run()
+    } else {
+      process.launch()
+    }
+  #else
     process.launch()
-  }
+  #endif
 
   return connectionToShim
 }


### PR DESCRIPTION
This branch fixes the build on Windows Subsystem for Linux that would previously throw the following error:

```swift
.../sourcekit-lsp/Sources/SourceKit/clangd/ClangLanguageServer.swift:166:9: error: value of type 'Process' has no member 'run'
    try process.run()
        ^~~~~~~ ~~~
```