### PR TITLE
Move sourcekit-lsp off of SwiftPM's POSIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Package.resolved
 /*.xcodeproj
 /*.sublime-project
 /*.sublime-workspace
+/.swiftpm

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -14,7 +14,6 @@ import SKSupport
 import Basic
 import SPMUtility
 import Dispatch
-import POSIX
 import Foundation
 
 /// Set of known toolchains.
@@ -43,7 +42,7 @@ public final class ToolchainRegistry {
 
   /// The currently selected toolchain identifier on Darwin.
   public internal(set) lazy var darwinToolchainOverride: String? = {
-    if let id = getenv("TOOLCHAINS"), !id.isEmpty, id != "default" {
+    if let id = ProcessEnv.vars["TOOLCHAINS"], !id.isEmpty, id != "default" {
       return id
     }
     return nil
@@ -278,7 +277,7 @@ extension ToolchainRegistry {
   {
     var shouldSetDefault = setDefault
     for envVar in environmentVariables {
-      if let pathStr = getenv(envVar),
+      if let pathStr = ProcessEnv.vars[envVar],
          let path = try? AbsolutePath(validating: pathStr),
          let toolchain = try? _registerToolchain(path, fileSystem),
          shouldSetDefault
@@ -301,7 +300,7 @@ extension ToolchainRegistry {
 
   func _scanForToolchains(pathVariables: [String], _ fileSystem: FileSystem) {
     pathVariables.lazy.flatMap { envVar in
-      getEnvSearchPaths(pathString: getenv(envVar), currentWorkingDirectory: nil)
+      getEnvSearchPaths(pathString: ProcessEnv.vars[envVar], currentWorkingDirectory: nil)
     }
     .forEach { path in
       _ = try? _registerToolchain(path, fileSystem)

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -14,7 +14,6 @@
 import Basic
 import SPMUtility
 import XCTest
-import POSIX
 
 final class ToolchainRegistryTests: XCTestCase {
   func testDefaultBasic() {
@@ -186,8 +185,8 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
 
-    try! setenv("SOURCEKIT_PATH", value: "/bogus:\(binPath):/bogus2")
-    defer { try! setenv("SOURCEKIT_PATH", value: "") }
+    try! ProcessEnv.setVar("SOURCEKIT_PATH", value: "/bogus:\(binPath):/bogus2")
+    defer { try! ProcessEnv.setVar("SOURCEKIT_PATH", value: "") }
 
     tr.scanForToolchains(fs)
 
@@ -205,7 +204,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tc.libIndexStore)
 
     let binPath2 = AbsolutePath("/other/my_toolchain/bin")
-    try! setenv("SOME_TEST_ENV_PATH", value: "/bogus:\(binPath2):/bogus2")
+    try! ProcessEnv.setVar("SOME_TEST_ENV_PATH", value: "/bogus:\(binPath2):/bogus2")
     makeToolchain(binPath: binPath2, fs, sourcekitd: true)
     tr.scanForToolchains(pathVariables: ["NOPE", "SOME_TEST_ENV_PATH", "MORE_NOPE"], fs)
 
@@ -228,7 +227,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
 
-    try! setenv("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.parentDirectory.pathString)
+    try! ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.parentDirectory.pathString)
 
     tr.scanForToolchains(environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"], fs)
 
@@ -255,7 +254,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
 
-    try! setenv("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.parentDirectory.pathString)
+    try! ProcessEnv.setVar("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.parentDirectory.pathString)
 
     tr.scanForToolchains(
       environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],

--- a/Tests/SKSupportTests/SupportPerfTests.swift
+++ b/Tests/SKSupportTests/SupportPerfTests.swift
@@ -13,7 +13,6 @@
 @testable import SKSupport
 import SKTestSupport
 import Basic
-import POSIX
 import XCTest
 
 final class SupportPerfTests: PerfTestCase {

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -13,7 +13,6 @@
 import XCTest
 @testable import SKSupport
 import Basic
-import POSIX
 
 final class SupportTests: XCTestCase {
 
@@ -184,8 +183,8 @@ final class SupportTests: XCTestCase {
 
     testLogger.currentLevel = .default
 
-    try! setenv("TEST_ENV_LOGGGING_1", value: "1")
-    try! setenv("TEST_ENV_LOGGGING_0", value: "0")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_1", value: "1")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_0", value: "0")
     // .warning
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_1")
 
@@ -221,7 +220,7 @@ final class SupportTests: XCTestCase {
       ])
 
     // invalid - no change
-    try! setenv("TEST_ENV_LOGGGING_err", value: "")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_err", value: "")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
     log("d", level: .error)
@@ -233,7 +232,7 @@ final class SupportTests: XCTestCase {
       ])
 
     // invalid - no change
-    try! setenv("TEST_ENV_LOGGGING_err", value: "a3")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_err", value: "a3")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
     log("d", level: .error)
@@ -245,7 +244,7 @@ final class SupportTests: XCTestCase {
       ])
 
     // too high - max out at .debug
-    try! setenv("TEST_ENV_LOGGGING_err", value: "1000")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_err", value: "1000")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
     log("d", level: .error)
@@ -260,16 +259,16 @@ final class SupportTests: XCTestCase {
       ])
 
     // By string.
-    try! setenv("TEST_ENV_LOGGGING_string", value: "error")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_string", value: "error")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
     XCTAssertEqual(testLogger.currentLevel, .error)
-    try! setenv("TEST_ENV_LOGGGING_string", value: "warning")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_string", value: "warning")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
     XCTAssertEqual(testLogger.currentLevel, .warning)
-    try! setenv("TEST_ENV_LOGGGING_string", value: "info")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_string", value: "info")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
     XCTAssertEqual(testLogger.currentLevel, .info)
-    try! setenv("TEST_ENV_LOGGGING_string", value: "debug")
+    try! ProcessEnv.setVar("TEST_ENV_LOGGGING_string", value: "debug")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_string")
     XCTAssertEqual(testLogger.currentLevel, .debug)
 


### PR DESCRIPTION
SwiftPM's POSIX is going removed soon in order to make it more cross-platform. This removes all usage of POSIX from sourcekit-lsp.

<rdar://problem/49198341> Move sourcekit-lsp off of SwiftPM's POSIX