### PR TITLE
On Linux, must include full path to `Block.h`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SourceKit-LSP is designed to build against the latest SwiftPM, so if you run int
 The C++ code in the index requires `libdispatch`, but unlike Swift code, it cannot find it automatically on Linux. You can work around this by adding a search path manually.
 
 ```sh
-$ swift build -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift
+$ swift build -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift -I<path_to_swift_toolchain>/usr/lib/swift/Block
 ```
 
 ### Using the Generated Xcode Project


### PR DESCRIPTION
`swift build -Xcxx -I/usr/lib/swift` fails on Linux w/

```
.../sourcekit-lsp/.build/checkouts/indexstore-db/lib/CIndexStoreDB/CIndexStoreDB.cpp:20:10: fatal error: 'Block.h' file not found
#include <Block.h>
         ^~~~~~~~~
1 error generated.
```

I needed to add `-I/usr/lib/swift/Block` to make it work. This change make the documentation here consistent with https://github.com/apple/indexstore-db.