### PR TITLE
Add lodash to devDependencies at version ^4.14.132

### DIFF
--- a/Editors/vscode/package-lock.json
+++ b/Editors/vscode/package-lock.json
@@ -4,6 +4,12 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@types/lodash": {
+            "version": "4.14.132",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
+            "integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw==",
+            "dev": true
+        },
         "@types/node": {
             "version": "8.10.36",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
@@ -58,7 +64,7 @@
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
@@ -417,7 +423,7 @@
         "domhandler": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-            "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
                 "domelementtype": "1"
@@ -473,7 +479,7 @@
         "entities": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-            "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
             "dev": true
         },
         "escape-string-regexp": {
@@ -1505,7 +1511,7 @@
         "lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
         "lodash.isequal": {
@@ -1523,7 +1529,7 @@
         "markdown-it": {
             "version": "8.4.2",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-            "integrity": "sha1-OG+YmY3BWjdyKqdyIIT0Agvdm1Q=",
+            "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -1613,7 +1619,7 @@
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true
         },
         "mime-db": {
@@ -1750,7 +1756,7 @@
         "nth-check": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-            "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
             "dev": true,
             "requires": {
                 "boolbase": "~1.0.0"
@@ -1830,7 +1836,7 @@
         "osenv": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-            "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
                 "os-homedir": "^1.0.0",
@@ -1878,7 +1884,7 @@
         "parse5": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-            "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
                 "@types/node": "*"

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -31,6 +31,7 @@
         "vscode-languageclient": "^4.0.0"
     },
     "devDependencies": {
+        "@types/lodash": "^4.14.132",
         "@types/node": "^8.10.25",
         "typescript": "^2.6.1",
         "vsce": "^1.53.2",


### PR DESCRIPTION
**Problem**

Right now, running `npm run createDevPackage` fails because `npm run compile` throws an error:

```
../../../../node_modules/@types/lodash/index.d.ts:12651:53 - error TS2344: Type 'T' does not satisfy the constraint 'object'.

12651         isWeakSet<T>(value?: any): value is WeakSet<T>;
```

While the changes below help everything build, I also still get an error when trying to run it on a Swift project:

```
[Error - 2:54:32 AM] Starting client failed
Error: Unsupported server configuration {
    "command": "",
    "args": [],
    "options": {
        "env": {
            /* ... */,
            "SOURCEKIT_TOOLCHAIN_PATH": "/Library/Developer/Toolchains/swift-latest.xctoolchain"
        }
    }
}
	at createMessageTransports._getServerWorkingDir.then.serverWorkingDir (/Users/brian/.vscode/extensions/unpublished.sourcekit-lsp-0.0.1/node_modules/vscode-languageclient/lib/main.js:356:35)
```

**Solution**

There are two fixes I tested locally for resolving the part where it won't install properly:

1) Manually pinning `@types/lodash` to `"^4.14.132"` in the `package.json`. 
2) Downgrading TypeScript target to es5. (didn't like this idea)

I picked the first option for this PR. It's odd that this fixes the failure and it seemed like the least intrusive way to address the issue, but I'm by no means an expert.

Hoping this helps.

**Console Output**

```shell
$ npm run compile --verbose
```
```
npm info it worked if it ends with ok
npm verb cli [ '/Users/brian/.nvm/versions/node/v6.9.2/bin/node',
npm verb cli   '/Users/brian/.nvm/versions/node/v6.9.2/bin/npm',
npm verb cli   'run',
npm verb cli   'compile',
npm verb cli   '--verbose' ]
npm info using npm@6.9.0
npm info using node@v6.9.2
npm verb run-script [ 'precompile', 'compile', 'postcompile' ]
npm info lifecycle sourcekit-lsp@0.0.1~precompile: sourcekit-lsp@0.0.1
npm info lifecycle sourcekit-lsp@0.0.1~compile: sourcekit-lsp@0.0.1

> sourcekit-lsp@0.0.1 compile /Users/brian/Projects/sourcekit-lsp/Editors/vscode
> tsc -p ./

../../../../node_modules/@types/lodash/index.d.ts:12651:53 - error TS2344: Type 'T' does not satisfy the constraint 'object'.

12651         isWeakSet<T>(value?: any): value is WeakSet<T>;
                                                          ~


npm verb lifecycle sourcekit-lsp@0.0.1~compile: unsafe-perm in lifecycle true
npm verb lifecycle sourcekit-lsp@0.0.1~compile: PATH: /Users/brian/.nvm/versions/node/v6.9.2/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/Users/brian/Projects/sourcekit-lsp/Editors/vscode/node_modules/.bin:/Users/brian/.rbenv/shims:/Users/brian/.rvm/gems/ruby-2.5.1/bin:/Users/brian/.rvm/gems/ruby-2.5.1@global/bin:/Users/brian/.rvm/rubies/ruby-2.5.1/bin:/Applications/Postgres.app/Contents/Versions/latest/bin:/Users/brian/.nvm/versions/node/v6.9.2/bin:/Users/brian/bin:/usr/local/bin:/Users/brian/go/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/share/dotnet:~/.dotnet/tools:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/brian/.rvm/bin:/Users/brian/.rvm/bin
npm verb lifecycle sourcekit-lsp@0.0.1~compile: CWD: /Users/brian/Projects/sourcekit-lsp/Editors/vscode
npm info lifecycle sourcekit-lsp@0.0.1~compile: Failed to exec compile script
npm verb stack Error: sourcekit-lsp@0.0.1 compile: `tsc -p ./`
npm verb stack Exit status 2
npm verb stack     at EventEmitter.<anonymous> (/Users/brian/.nvm/versions/node/v6.9.2/lib/node_modules/npm/node_modules/npm-lifecycle/index.js:301:16)
npm verb stack     at emitTwo (events.js:106:13)
npm verb stack     at EventEmitter.emit (events.js:191:7)
npm verb stack     at ChildProcess.<anonymous> (/Users/brian/.nvm/versions/node/v6.9.2/lib/node_modules/npm/node_modules/npm-lifecycle/lib/spawn.js:55:14)
npm verb stack     at emitTwo (events.js:106:13)
npm verb stack     at ChildProcess.emit (events.js:191:7)
npm verb stack     at maybeClose (internal/child_process.js:877:16)
npm verb stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
npm verb pkgid sourcekit-lsp@0.0.1
npm verb cwd /Users/brian/Projects/sourcekit-lsp/Editors/vscode
npm verb Darwin 18.5.0
npm verb argv "/Users/brian/.nvm/versions/node/v6.9.2/bin/node" "/Users/brian/.nvm/versions/node/v6.9.2/bin/npm" "run" "compile" "--verbose"
npm verb node v6.9.2
npm verb npm  v6.9.0
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! sourcekit-lsp@0.0.1 compile: `tsc -p ./`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the sourcekit-lsp@0.0.1 compile script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm verb exit [ 2, true ]
npm timing npm Completed in 2730ms

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/brian/.npm/_logs/2019-05-26T03_55_35_742Z-debug.log
```