### PR TITLE
Add extra -Xcxx to docs, otherwise doesn't run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SourceKit-LSP is designed to build against the latest SwiftPM, so if you run int
 The C++ code in the index requires `libdispatch`, but unlike Swift code, it cannot find it automatically on Linux. You can work around this by adding a search path manually.
 
 ```sh
-$ swift build -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift -I<path_to_swift_toolchain>/usr/lib/swift/Block
+$ swift build -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift/Block
 ```
 
 ### Using the Generated Xcode Project


### PR DESCRIPTION
Tiny change to the docs, tried again getting sourcekit-lsp working on Ubuntu and succeeded.

I can't be 100% sure, but I think this was the problem. For some reason it was compiling *without* the Block addition on my machine. If you ran without the extra `-Xcxx` it would fail with:
```
error: unknown option -I/usr/local/bin/swift-5.1-DEVELOPMENT-SNAPSHOT-2019-05-29-a-ubuntu18.04/usr/lib/swift/Block; use --help to list available options
```
So I removed the Block without thinking of adding another `-Xcxx` flag instead...

Anyway, I think the docs should reflect a working command...!