### PR TITLE
Embrace Swift.Result in place SwiftPM.Basic.Result

### DIFF
--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -34,7 +34,7 @@ extension Connection {
       semaphore.signal()
     }
     semaphore.wait()
-    return try result!.dematerialize()
+    return try result!.get()
   }
 }
 

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -10,10 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
-
 /// A convenience wrapper for `Result` where the error is a `ResponseError`.
-public typealias LSPResult<T> = Result<T, ResponseError>
+public typealias LSPResult<T> = Swift.Result<T, ResponseError>
 
 /// Error code suitable for use between language server and client.
 public struct ErrorCode: RawRepresentable, Codable, Hashable {

--- a/Sources/SKSupport/Result.swift
+++ b/Sources/SKSupport/Result.swift
@@ -10,12 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
-
-extension Result {
+extension Swift.Result {
 
   /// Project out the .success value, or nil.
-  public var success: Value? {
+  public var success: Success? {
     switch self {
     case .success(let value):
       return value
@@ -25,7 +23,7 @@ extension Result {
   }
 
   /// Project out the .failure value, or nil.
-  public var failure: ErrorType? {
+  public var failure: Failure? {
     switch self {
     case .failure(let error):
       return error

--- a/Sources/SourceKit/sourcekitd/CursorInfo.swift
+++ b/Sources/SourceKit/sourcekitd/CursorInfo.swift
@@ -113,7 +113,7 @@ extension SwiftLanguageServer {
   func cursorInfo(
     _ url: URL,
     _ position: Position,
-    _ completion: @escaping (Result<CursorInfo?, CursorInfoError>) -> Void)
+    _ completion: @escaping (Swift.Result<CursorInfo?, CursorInfoError>) -> Void)
   {
     guard let snapshot = documentManager.latestSnapshot(url) else {
       return completion(.failure(.unknownDocument(url)))

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -41,7 +41,7 @@ class ConnectionTests: XCTestCase {
     let expectation = self.expectation(description: "response received")
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.dematerialize(), "hello!")
+      XCTAssertEqual(try! resp.get(), "hello!")
       expectation.fulfill()
     }
 
@@ -96,7 +96,7 @@ class ConnectionTests: XCTestCase {
     let expectation2 = self.expectation(description: "response received 2")
 
     _ = client.send(EchoError(code: nil)) { resp in
-      XCTAssertEqual(try! resp.dematerialize(), VoidResponse())
+      XCTAssertEqual(try! resp.get(), VoidResponse())
       expectation.fulfill()
     }
 
@@ -156,7 +156,7 @@ class ConnectionTests: XCTestCase {
     // Nothing bad should happen; check that the next request works.
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.dematerialize(), "hello!")
+      XCTAssertEqual(try! resp.get(), "hello!")
       expectation.fulfill()
     }
 
@@ -173,7 +173,7 @@ class ConnectionTests: XCTestCase {
     // Nothing bad should happen; check that the next request works.
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.dematerialize(), "hello!")
+      XCTAssertEqual(try! resp.get(), "hello!")
       expectation.fulfill()
     }
 

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -34,7 +34,7 @@ class ConnectionTests: XCTestCase {
     let expectation = self.expectation(description: "response received")
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.dematerialize(), "hello!")
+      XCTAssertEqual(try! resp.get(), "hello!")
       expectation.fulfill()
     }
 
@@ -47,7 +47,7 @@ class ConnectionTests: XCTestCase {
     let expectation2 = self.expectation(description: "response received 2")
 
     _ = client.send(EchoError(code: nil)) { resp in
-      XCTAssertEqual(try! resp.dematerialize(), VoidResponse())
+      XCTAssertEqual(try! resp.get(), VoidResponse())
       expectation.fulfill()
     }
 

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -20,24 +20,24 @@ final class SupportTests: XCTestCase {
     enum MyError: Error, Equatable {
       case err1, err2
     }
-    typealias MyResult<T> = Result<T, MyError>
+    typealias MyResult<T> = Swift.Result<T, MyError>
 
-    XCTAssertEqual(MyResult(1), .success(1))
-    XCTAssertNotEqual(MyResult(2), .success(1))
-    XCTAssertNotEqual(MyResult(.err1), .success(1))
-    XCTAssertEqual(MyResult(.err1), MyResult<Int>.failure(.err1))
-    XCTAssertNotEqual(MyResult(.err1), MyResult<Int>.failure(.err2))
+    XCTAssertEqual(MyResult.success(1), .success(1))
+    XCTAssertNotEqual(MyResult.success(2), .success(1))
+    XCTAssertNotEqual(MyResult.failure(.err1), .success(1))
+    XCTAssertEqual(MyResult.failure(.err1), MyResult<Int>.failure(.err1))
+    XCTAssertNotEqual(MyResult.failure(.err1), MyResult<Int>.failure(.err2))
   }
 
   func testResultProjection() {
     enum MyError: Error, Equatable {
       case err1, err2
     }
-    typealias MyResult<T> = Result<T, MyError>
+    typealias MyResult<T> = Swift.Result<T, MyError>
 
-    XCTAssertEqual(MyResult(1).success, 1)
-    XCTAssertNil(MyResult(.err1).success)
-    XCTAssertNil(MyResult(1).failure)
+    XCTAssertEqual(MyResult.success(1).success, 1)
+    XCTAssertNil(MyResult.failure(.err1).success)
+    XCTAssertNil(MyResult.success(1).failure)
     XCTAssertEqual(MyResult<Int>.failure(.err1).failure, .err1)
   }
 


### PR DESCRIPTION
- Replace SwiftPM.Basic.Result with Swift.Result type