### PR TITLE
Add markdown escaping for names in hover request

### DIFF
--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -444,22 +444,13 @@ extension SwiftLanguageServer {
         return
       }
 
-      /// Prepend backslash to all ASCII punctuation, to prevent it
+      /// Prepend backslash to `*` and `_`, to prevent them
       /// from being interpreted as markdown.
-      ///
-      /// Any ASCII punctuation character may be backslash-escaped.
-      /// https://spec.commonmark.org/0.29/#backslash-escapes
-      func escapeMarkdown(_ str: String) -> String {
-        func isAsciiPunctuation(_ char: Character) -> Bool {
-          let asciiPunctuation = Set<Character>(##"""
-          !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
-          """##)
-          return asciiPunctuation.contains(char)
-        }
-        return String(str.flatMap({ isAsciiPunctuation($0) ? ["\\", $0] : [$0] }))
+      func escapeNameMarkdown(_ str: String) -> String {
+        return String(str.flatMap({ ($0 == "*" || $0 == "_") ? ["\\", $0] : [$0] }))
       }
 
-      var result = "# \(escapeMarkdown(name))"
+      var result = "# \(escapeNameMarkdown(name))"
       if let doc = cursorInfo.documentationXML {
         result += """
 

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -444,7 +444,22 @@ extension SwiftLanguageServer {
         return
       }
 
-      var result = "# \(name)"
+      /// Prepend backslash to all ASCII punctuation, to prevent it
+      /// from being interpreted as markdown.
+      ///
+      /// Any ASCII punctuation character may be backslash-escaped.
+      /// https://spec.commonmark.org/0.29/#backslash-escapes
+      func escapeMarkdown(_ str: String) -> String {
+        func isAsciiPunctuation(_ char: Character) -> Bool {
+          let asciiPunctuation = Set<Character>(##"""
+          !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+          """##)
+          return asciiPunctuation.contains(char)
+        }
+        return String(str.flatMap({ isAsciiPunctuation($0) ? ["\\", $0] : [$0] }))
+      }
+
+      var result = "# \(escapeMarkdown(name))"
       if let doc = cursorInfo.documentationXML {
         result += """
 

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -648,7 +648,7 @@ final class LocalSwiftTests: XCTestCase {
         XCTAssertNil(hover.range)
         XCTAssertEqual(hover.contents.kind, .markdown)
         XCTAssertEqual(hover.contents.value, ##"""
-          # test\(\_\:\_\:\)
+          # test(\_:\_:)
           ```
           func test(_ a: Int, _ b: Int)
           ```
@@ -668,7 +668,7 @@ final class LocalSwiftTests: XCTestCase {
         XCTAssertNil(hover.range)
         XCTAssertEqual(hover.contents.kind, .markdown)
         XCTAssertEqual(hover.contents.value, ##"""
-          # \*\%\*\(\_\:\_\:\)
+          # \*%\*(\_:\_:)
           ```
           func *%* (lhs: String, rhs: String)
           ```

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -58,6 +58,7 @@ extension LocalSwiftTests {
         ("testDocumentSymbolHighlight", testDocumentSymbolHighlight),
         ("testEditing", testEditing),
         ("testHover", testHover),
+        ("testHoverNameEscaping", testHoverNameEscaping),
         ("testSymbolInfo", testSymbolInfo),
         ("testXMLToMarkdownComment", testXMLToMarkdownComment),
         ("testXMLToMarkdownDeclaration", testXMLToMarkdownDeclaration),


### PR DESCRIPTION
Very often when hovering over methods with unnamed arguments, italicized colons start showing up. That's because underscores are being interpreted as markdown. This commit fixes that.

I'm not sure if escaping *everything* is a good idea, or maybe I should only escape `*` and `_`? 