### PR TITLE
Add EditorPlaceholder parsing for completion snippets

### DIFF
--- a/Sources/SourceKit/sourcekitd/EditorPlaceholder.swift
+++ b/Sources/SourceKit/sourcekitd/EditorPlaceholder.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum EditorPlaceholder: Hashable {
+  case basic(String)
+  case typed(displayName: String, type: String, typeForExpansion: String)
+
+  static let placeholderPrefix: String = "<#"
+  static let placeholderSuffix: String = "#>"
+
+  public init?(_ skPlaceholder: String) {
+    guard skPlaceholder.hasPrefix(EditorPlaceholder.placeholderPrefix) &&
+          skPlaceholder.hasSuffix(EditorPlaceholder.placeholderSuffix) else {
+      return nil
+    }
+    var skPlaceholder = skPlaceholder.dropFirst(2).dropLast(2)
+    guard skPlaceholder.hasPrefix("T##") else {
+      self = .basic(String(skPlaceholder))
+      return
+    }
+    skPlaceholder = skPlaceholder.dropFirst(3)
+    guard let end = skPlaceholder.range(of: "##") else {
+      let type = String(skPlaceholder)
+      self = .typed(displayName: type, type: type, typeForExpansion: type)
+      return
+    }
+    let displayName = String(skPlaceholder[skPlaceholder.startIndex..<end.lowerBound])
+    skPlaceholder = skPlaceholder[end.upperBound...]
+    if let end = skPlaceholder.range(of: "##") {
+      let type = String(skPlaceholder[skPlaceholder.startIndex..<end.lowerBound])
+      let typeForExpansion = String(skPlaceholder[end.upperBound...])
+      self = .typed(displayName: displayName, type: type, typeForExpansion: typeForExpansion)
+    } else {
+      let type = String(skPlaceholder)
+      self = .typed(displayName: displayName, type: type, typeForExpansion: type)
+    }
+  }
+
+  public var displayName: String {
+    switch self {
+    case .basic(let displayName), .typed(let displayName, _, _):
+      return displayName
+    }
+  }
+}

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -670,4 +670,58 @@ final class LocalSwiftTests: XCTestCase {
       }
     }
   }
+
+  func testEditorPlaceholderParsing() {
+    var text = "<#basic placeholder" +
+    "#>" // Need to end this in another line so Xcode doesn't treat it as a real placeholder
+    var data = EditorPlaceholder(text)
+    XCTAssertNotNil(data)
+    if let data = data {
+      XCTAssertEqual(data, .basic("basic placeholder"))
+      XCTAssertEqual(data.displayName, "basic placeholder")
+    }
+    text = "<#T##x: Int##Int" +
+    "#>"
+    data = EditorPlaceholder(text)
+    XCTAssertNotNil(data)
+    if let data = data {
+      XCTAssertEqual(data, .typed(displayName: "x: Int", type: "Int", typeForExpansion: "Int"))
+      XCTAssertEqual(data.displayName, "x: Int")
+    }
+    text = "<#T##x: Int##Blah##()->Int" +
+    "#>"
+    data = EditorPlaceholder(text)
+    XCTAssertNotNil(data)
+    if let data = data {
+      XCTAssertEqual(data, .typed(displayName: "x: Int", type: "Blah", typeForExpansion: "()->Int"))
+      XCTAssertEqual(data.displayName, "x: Int")
+    }
+    text = "<#T##Int" +
+    "#>"
+    data = EditorPlaceholder(text)
+    XCTAssertNotNil(data)
+    if let data = data {
+      XCTAssertEqual(data, .typed(displayName: "Int", type: "Int", typeForExpansion: "Int"))
+      XCTAssertEqual(data.displayName, "Int")
+    }
+    text = "<#foo"
+    data = EditorPlaceholder(text)
+    XCTAssertNil(data)
+    text = " <#foo"
+    data = EditorPlaceholder(text)
+    XCTAssertNil(data)
+    text = "foo"
+    data = EditorPlaceholder(text)
+    XCTAssertNil(data)
+    text = "foo#>"
+    data = EditorPlaceholder(text)
+    XCTAssertNil(data)
+    text = "<#foo#"
+    data = EditorPlaceholder(text)
+    XCTAssertNil(data)
+    text = " <#foo" +
+    "#>"
+    data = EditorPlaceholder(text)
+    XCTAssertNil(data)
+  }
 }

--- a/Tests/SourceKitTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitTests/SwiftCompletionTests.swift
@@ -142,8 +142,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.filterText, "test(a:)")
       // FIXME:
       XCTAssertNil(test.textEdit)
-      // FIXME: should be "a" in the placeholder.
-      XCTAssertEqual(test.insertText, "test(a: ${1:value})")
+      XCTAssertEqual(test.insertText, "test(a: ${1:Int})")
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
 
@@ -160,7 +159,6 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.filterText, "test(a:)")
       // FIXME:
       XCTAssertNil(test.textEdit)
-      // FIXME: should be "a" in the placeholder.
       XCTAssertEqual(test.insertText, "test(a: )")
       XCTAssertEqual(test.insertTextFormat, .plain)
     }

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -66,6 +66,7 @@ extension LocalSwiftTests {
     static let __allTests__LocalSwiftTests = [
         ("testDocumentSymbolHighlight", testDocumentSymbolHighlight),
         ("testEditing", testEditing),
+        ("testEditorPlaceholderParsing", testEditorPlaceholderParsing),
         ("testHover", testHover),
         ("testHoverNameEscaping", testHoverNameEscaping),
         ("testSymbolInfo", testSymbolInfo),


### PR DESCRIPTION
Porting the editor placeholder component from the compiler so we can show a completion snippet's true contents.