### PR TITLE
Bump swift-tools-version to 5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 import PackageDescription
 

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -239,8 +239,8 @@ public final class JSONRPCConection {
     header.utf8.map{$0}.withUnsafeBytes { buffer in
       dispatchData.append(buffer)
     }
-    messageData.withUnsafeBytes { pointer in
-      dispatchData.append(UnsafeRawBufferPointer(start: pointer, count: messageData.count))
+    messageData.withUnsafeBytes { rawBufferPointer in
+      dispatchData.append(rawBufferPointer)
     }
 
     send(rawData: dispatchData)


### PR DESCRIPTION
Changes in swiftpm require swift-5.1, so bump our swift-tools-version to make it explicit. And fix a new deprecation warning.