### PR TITLE
FoundationXML: Adoption

### DIFF
--- a/Sources/SourceKit/sourcekitd/CommentXML.swift
+++ b/Sources/SourceKit/sourcekitd/CommentXML.swift
@@ -13,6 +13,10 @@
 import SKSupport
 import Foundation
 
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
 enum CommentXMLError: Error {
   case noRootElement
 }


### PR DESCRIPTION
CommentXML.swift needs to import `FoundationXML` if available. Required to land https://github.com/apple/swift-corelibs-foundation/pull/2432, but can land independently of it.