### PR TITLE
[build-script-helper] Add a search path to be able to find `Block.h` from the just built toolchain

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -38,6 +38,9 @@ def get_swiftpm_options(args):
       # Dispatch headers
       '-Xcxx', '-I', '-Xcxx',
       os.path.join(args.toolchain, 'usr', 'lib', 'swift'),
+      # For <Block.h>
+      '-Xcxx', '-I', '-Xcxx',
+      os.path.join(args.toolchain, 'usr', 'lib', 'swift', 'Block'),
     ]
 
   return swiftpm_args


### PR DESCRIPTION
This is similar to https://github.com/apple/indexstore-db/pull/33