### PR TITLE
[clangd] Set correct argv[0] for clangd to fix c++ header search

### DIFF
--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -556,8 +556,8 @@ public func languageService(
   switch language {
 
   case .c, .cpp, .objective_c, .objective_cpp:
-    guard let clangd = toolchain.clangd else { return nil }
-    return try makeJSONRPCClangServer(client: client, clangd: clangd, buildSettings: (client as? SourceKitServer)?.workspace?.buildSettings)
+    guard toolchain.clangd != nil else { return nil }
+    return try makeJSONRPCClangServer(client: client, toolchain: toolchain, buildSettings: (client as? SourceKitServer)?.workspace?.buildSettings)
 
   case .swift:
     guard let sourcekitd = toolchain.sourcekitd else { return nil }

--- a/Tests/INPUTS/ClangStdHeaderCanary/project.json
+++ b/Tests/INPUTS/ClangStdHeaderCanary/project.json
@@ -1,0 +1,4 @@
+{
+  "clang_flags": ["-fno-modules", "-Wunused-variable"],
+  "sources": ["std_header_canary.cpp"]
+}

--- a/Tests/INPUTS/ClangStdHeaderCanary/std_header_canary.cpp
+++ b/Tests/INPUTS/ClangStdHeaderCanary/std_header_canary.cpp
@@ -1,0 +1,9 @@
+// Note: tests generally should avoid including system headers
+// to keep them fast and portable. This test is specifically
+// ensuring clangd can find libc++ and builtin headers.
+
+#include <cstdint>
+
+void test() {
+  uint64_t /*unused_b*/b;
+}


### PR DESCRIPTION
Clang looks for the C++ standard headers relative to the clang binary
that we provide in the compilation database. So pass through a real path
so that we get the correct headers.