### PR TITLE
Remove `@testable import` and `-enable-testing`

### DIFF
--- a/Sources/LanguageServerProtocol/TextEdit.swift
+++ b/Sources/LanguageServerProtocol/TextEdit.swift
@@ -14,10 +14,10 @@
 public struct TextEdit: ResponseType, Hashable {
 
   /// The range of text to be replaced.
-  var range: PositionRange
+  public var range: PositionRange
 
   /// The new text.
-  var newText: String
+  public var newText: String
 
   public init(range: Range<Position>, newText: String) {
     self.range = PositionRange(range)

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -144,7 +144,7 @@ public final class JSONRPCConection {
         return nil
       }
       return outstanding.responseType
-    } as Message.ResponseTypeCallback
+    } as JSONRPCMessage.ResponseTypeCallback
 
     var bytes = bytes[...]
 
@@ -156,7 +156,7 @@ public final class JSONRPCConection {
         bytes = rest
 
         let pointer = UnsafeMutableRawPointer(mutating: UnsafeBufferPointer(rebasing: messageBytes).baseAddress!)
-        let message = try decoder.decode(Message.self, from: Data(bytesNoCopy: pointer, count: messageBytes.count, deallocator: .none))
+        let message = try decoder.decode(JSONRPCMessage.self, from: Data(bytesNoCopy: pointer, count: messageBytes.count, deallocator: .none))
 
         handle(message)
 
@@ -166,7 +166,7 @@ public final class JSONRPCConection {
           case .request:
             if let id = error.id {
               send { encoder in
-                try encoder.encode(Message.errorResponse(ResponseError(error), id: id))
+                try encoder.encode(JSONRPCMessage.errorResponse(ResponseError(error), id: id))
               }
               continue MESSAGE_LOOP
             }
@@ -198,7 +198,7 @@ public final class JSONRPCConection {
   }
 
   /// Handle a single message by dispatching it to `receiveHandler` or an appropriate reply handler.
-  func handle(_ message: Message) {
+  func handle(_ message: JSONRPCMessage) {
     switch message {
     case .notification(let notification):
       notification._handle(receiveHandler!, connection: self)
@@ -289,7 +289,7 @@ extension JSONRPCConection: _IndirectConnection {
   public func send<Notification>(_ notification: Notification) where Notification: NotificationType {
     guard readyToSend() else { return }
     send { encoder in
-      return try encoder.encode(Message.notification(notification))
+      return try encoder.encode(JSONRPCMessage.notification(notification))
     }
   }
 
@@ -316,7 +316,7 @@ extension JSONRPCConection: _IndirectConnection {
     }
 
     send { encoder in
-      return try encoder.encode(Message.request(request, id: id))
+      return try encoder.encode(JSONRPCMessage.request(request, id: id))
     }
 
     return id
@@ -328,9 +328,9 @@ extension JSONRPCConection: _IndirectConnection {
     send { encoder in
       switch response {
       case .success(let result):
-        return try encoder.encode(Message.response(result, id: id))
+        return try encoder.encode(JSONRPCMessage.response(result, id: id))
       case .failure(let error):
-        return try encoder.encode(Message.errorResponse(error, id: id))
+        return try encoder.encode(JSONRPCMessage.errorResponse(error, id: id))
       }
     }
   }

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -150,7 +150,7 @@ public final class JSONRPCConection {
 
     MESSAGE_LOOP: while true {
       do {
-        guard let ((messageBytes, _), rest) = try bytes.splitMessage() else {
+        guard let ((messageBytes, _), rest) = try bytes.jsonrpcSplitMessage() else {
           return bytes
         }
         bytes = rest

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -12,8 +12,8 @@
 
 import LanguageServerProtocol
 
-/// A single JSONRPC message suitable for encoding/decoding.
-enum JSONRPCMessage {
+/// *Public For Testing*. A single JSONRPC message suitable for encoding/decoding.
+public enum JSONRPCMessage {
   case notification(NotificationType)
   case request(_RequestType, id: RequestID)
   case response(ResponseType, id: RequestID)
@@ -26,9 +26,9 @@ extension CodingUserInfoKey {
 
 extension JSONRPCMessage: Codable {
 
-  typealias ResponseTypeCallback = (RequestID) -> ResponseType.Type?
+  public typealias ResponseTypeCallback = (RequestID) -> ResponseType.Type?
 
-  public enum CodingKeys: String, CodingKey {
+  private enum CodingKeys: String, CodingKey {
     case jsonrpc
     case method
     case id
@@ -121,7 +121,7 @@ extension JSONRPCMessage: Codable {
     }
   }
 
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode("2.0", forKey: .jsonrpc)
 

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -12,7 +12,8 @@
 
 import LanguageServerProtocol
 
-enum Message {
+/// A single JSONRPC message suitable for encoding/decoding.
+enum JSONRPCMessage {
   case notification(NotificationType)
   case request(_RequestType, id: RequestID)
   case response(ResponseType, id: RequestID)
@@ -23,7 +24,7 @@ extension CodingUserInfoKey {
   public static let responseTypeCallbackKey: CodingUserInfoKey = CodingUserInfoKey(rawValue: "lsp.jsonrpc.responseTypeCallback")!
 }
 
-extension Message: Codable {
+extension JSONRPCMessage: Codable {
 
   typealias ResponseTypeCallback = (RequestID) -> ResponseType.Type?
 

--- a/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
@@ -13,7 +13,7 @@
 import LanguageServerProtocol
 import SKSupport
 
-struct MessageHeader: Hashable {
+struct JSONRPCMessageHeader: Hashable {
   static let contentLengthKey: [UInt8] = [UInt8]("Content-Length".utf8)
   static let separator: [UInt8] = [UInt8]("\r\n".utf8)
   static let colon: UInt8 = ":".utf8.spm_only!
@@ -25,8 +25,8 @@ struct MessageHeader: Hashable {
 extension RandomAccessCollection where Element == UInt8 {
 
   /// Returns the first message range and header in `self`, or nil.
-  func splitMessage() throws -> ((SubSequence, header: MessageHeader), SubSequence)? {
-    guard let (header, rest) = try parseHeader() else { return nil }
+  func jsonrpcSplitMessage() throws -> ((SubSequence, header: JSONRPCMessageHeader), SubSequence)? {
+    guard let (header, rest) = try jsonrcpParseHeader() else { return nil }
     guard let contentLength = header.contentLength else {
       throw MessageDecodingError.parseError("missing Content-Length header")
     }
@@ -34,16 +34,16 @@ extension RandomAccessCollection where Element == UInt8 {
     return ((rest.prefix(contentLength), header: header), rest.dropFirst(contentLength))
   }
 
-  func parseHeader() throws -> (MessageHeader, SubSequence)? {
-    var header = MessageHeader()
+  func jsonrcpParseHeader() throws -> (JSONRPCMessageHeader, SubSequence)? {
+    var header = JSONRPCMessageHeader()
     var slice = self[...]
-    while let (kv, rest) = try slice.parseHeaderField() {
+    while let (kv, rest) = try slice.jsonrpcParseHeaderField() {
       guard let (key, value) = kv else {
         return (header, rest)
       }
       slice = rest
 
-      if key.elementsEqual(MessageHeader.contentLengthKey) {
+      if key.elementsEqual(JSONRPCMessageHeader.contentLengthKey) {
         guard let count = Int(ascii: value) else {
           throw MessageDecodingError.parseError("expected integer value in \(String(bytes: value, encoding: .utf8) ?? "<invalid>")")
         }
@@ -55,21 +55,21 @@ extension RandomAccessCollection where Element == UInt8 {
     return nil
   }
 
-  func parseHeaderField() throws -> ((key: SubSequence, value: SubSequence)?, SubSequence)? {
-    if starts(with: MessageHeader.separator) {
-      return (nil, dropFirst(MessageHeader.separator.count))
-    } else if first == MessageHeader.separator.first {
+  func jsonrpcParseHeaderField() throws -> ((key: SubSequence, value: SubSequence)?, SubSequence)? {
+    if starts(with: JSONRPCMessageHeader.separator) {
+      return (nil, dropFirst(JSONRPCMessageHeader.separator.count))
+    } else if first == JSONRPCMessageHeader.separator.first {
       return nil
     }
 
-    guard let keyEnd = firstIndex(where: { MessageHeader.invalidKeyBytes.contains($0) }) else {
+    guard let keyEnd = firstIndex(where: { JSONRPCMessageHeader.invalidKeyBytes.contains($0) }) else {
       return nil
     }
-    if self[keyEnd] != MessageHeader.colon {
+    if self[keyEnd] != JSONRPCMessageHeader.colon {
       throw MessageDecodingError.parseError("expected ':' in message header")
     }
     let valueStart = index(after:keyEnd)
-    guard let valueEnd = self[valueStart...].firstIndex(of: MessageHeader.separator) else {
+    guard let valueEnd = self[valueStart...].firstIndex(of: JSONRPCMessageHeader.separator) else {
       return nil
     }
 

--- a/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
@@ -13,19 +13,25 @@
 import LanguageServerProtocol
 import SKSupport
 
-struct JSONRPCMessageHeader: Hashable {
+public struct JSONRPCMessageHeader: Hashable {
   static let contentLengthKey: [UInt8] = [UInt8]("Content-Length".utf8)
   static let separator: [UInt8] = [UInt8]("\r\n".utf8)
   static let colon: UInt8 = ":".utf8.spm_only!
   static let invalidKeyBytes: [UInt8] = [colon] + separator
 
-  var contentLength: Int? = nil
+  public var contentLength: Int? = nil
+
+  public init(contentLength: Int? = nil) {
+    self.contentLength = contentLength
+  }
 }
 
 extension RandomAccessCollection where Element == UInt8 {
 
   /// Returns the first message range and header in `self`, or nil.
-  func jsonrpcSplitMessage() throws -> ((SubSequence, header: JSONRPCMessageHeader), SubSequence)? {
+  public func jsonrpcSplitMessage()
+    throws -> ((SubSequence, header: JSONRPCMessageHeader), SubSequence)?
+  {
     guard let (header, rest) = try jsonrcpParseHeader() else { return nil }
     guard let contentLength = header.contentLength else {
       throw MessageDecodingError.parseError("missing Content-Length header")
@@ -34,7 +40,7 @@ extension RandomAccessCollection where Element == UInt8 {
     return ((rest.prefix(contentLength), header: header), rest.dropFirst(contentLength))
   }
 
-  func jsonrcpParseHeader() throws -> (JSONRPCMessageHeader, SubSequence)? {
+  public func jsonrcpParseHeader() throws -> (JSONRPCMessageHeader, SubSequence)? {
     var header = JSONRPCMessageHeader()
     var slice = self[...]
     while let (kv, rest) = try slice.jsonrpcParseHeaderField() {
@@ -55,7 +61,7 @@ extension RandomAccessCollection where Element == UInt8 {
     return nil
   }
 
-  func jsonrpcParseHeaderField() throws -> ((key: SubSequence, value: SubSequence)?, SubSequence)? {
+  public func jsonrpcParseHeaderField() throws -> ((key: SubSequence, value: SubSequence)?, SubSequence)? {
     if starts(with: JSONRPCMessageHeader.separator) {
       return (nil, dropFirst(JSONRPCMessageHeader.separator.count))
     } else if first == JSONRPCMessageHeader.separator.first {

--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -30,6 +30,13 @@ public struct CompilationDatabaseCompileCommand: Equatable {
 
   /// The name of the build output, or nil.
   public var output: String? = nil
+
+  public init(directory: String, filename: String, commandLine: [String], output: String? = nil) {
+    self.directory = directory
+    self.filename = filename
+    self.commandLine = commandLine
+    self.output = output
+  }
 }
 
 extension CompilationDatabase.Command {

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -17,8 +17,10 @@ import enum SPMUtility.Platform
 /// A simple BuildSystem suitable as a fallback when accurate settings are unknown.
 public final class FallbackBuildSystem: BuildSystem {
 
+  public init() {}
+
   /// The path to the SDK.
-  lazy var sdkpath: AbsolutePath? = {
+  public lazy var sdkpath: AbsolutePath? = {
     if case .darwin? = Platform.currentPlatform,
        let str = try? Process.checkNonZeroExit(
          args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx"),

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -41,7 +41,7 @@ public final class ToolchainRegistry {
   var queue: DispatchQueue = DispatchQueue(label: "toolchain-registry-queue")
 
   /// The currently selected toolchain identifier on Darwin.
-  public internal(set) lazy var darwinToolchainOverride: String? = {
+  public lazy var darwinToolchainOverride: String? = {
     if let id = ProcessEnv.vars["TOOLCHAINS"], !id.isEmpty, id != "default" {
       return id
     }
@@ -151,7 +151,7 @@ extension ToolchainRegistry {
 
 extension ToolchainRegistry {
 
-  enum Error: Swift.Error {
+  public enum Error: Swift.Error {
 
     /// There is already a toolchain with the given identifier.
     case duplicateToolchainIdentifier

--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -14,13 +14,18 @@ import Basic
 import Foundation
 
 /// A helper type for decoding the Info.plist or ToolchainInfo.plist file from an .xctoolchain.
-struct XCToolchainPlist {
+public struct XCToolchainPlist {
 
   /// The toolchain identifer e.g. "com.apple.dt.toolchain.XcodeDefault".
-  var identifier: String
+  public var identifier: String
 
   /// The toolchain's human-readable name.
-  var displayName: String?
+  public var displayName: String?
+
+  public init(identifier: String, displayName: String? = nil) {
+    self.identifier = identifier
+    self.displayName = displayName
+  }
 }
 
 extension XCToolchainPlist {
@@ -79,7 +84,7 @@ extension XCToolchainPlist: Codable {
     case DisplayName
   }
 
-  init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     if let identifier = try container.decodeIfPresent(String.self, forKey: .Identifier) {
       self.identifier = identifier
@@ -90,7 +95,7 @@ extension XCToolchainPlist: Codable {
   }
 
   /// Encode the info plist. **For testing**.
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     if identifier.starts(with: "com.apple") {
       try container.encode(identifier, forKey: .Identifier)

--- a/Sources/SKSupport/Logging.swift
+++ b/Sources/SKSupport/Logging.swift
@@ -35,21 +35,20 @@ public func log(_ message: String, level: LogLevel = .default) {
 /// - parameter messageProducer: The async callback to produce the message.
 /// - parameter currentLevel: The current log level is provided to the callback, which can be used to avoid expensive processing, for example by reducing the verbosity.
 public func logAsync(level: LogLevel = .default, messageProducer: @escaping (_ currentLevel: LogLevel) -> String?) {
-  let logger = Logger.shared
-  logger.logQueue.async {
-    if let message = messageProducer(Logger.shared.currentLevel) {
-      // Use `async: false` since we're already async'd on `logQueue` and we want to preserve ordering.
-      logger.log(message, level: level, async: false)
-    }
-  }
+  Logger.shared.logAsync(level: level, messageProducer: messageProducer)
 }
 
 /// Like `try?`, but logs the error on failure.
-public func orLog<R>(_ prefix: String = "", level: LogLevel = .default, _ block: () throws -> R?) -> R? {
+public func orLog<R>(
+  _ prefix: String = "",
+  level: LogLevel = .default,
+  logger: Logger = Logger.shared,
+  _ block: () throws -> R?) -> R?
+{
   do {
     return try block()
   } catch {
-    log("\(prefix)\(prefix.isEmpty ? "" : " ")\(error)", level: level)
+    logger.log("\(prefix)\(prefix.isEmpty ? "" : " ")\(error)", level: level)
     return nil
   }
 }
@@ -62,7 +61,7 @@ public protocol LogHandler: AnyObject {
 public final class Logger {
 
   /// The shared logger instance.
-  public static var shared: Logger = .init()
+  public internal(set) static var shared: Logger = .init()
 
   let logQueue: DispatchQueue = DispatchQueue(label: "log-queue", qos: .utility)
 
@@ -115,7 +114,33 @@ public final class Logger {
     }
   }
 
-  public func log(_ message: String, level: LogLevel, async: Bool = true) {
+  /// Log the given message.
+  ///
+  /// If `level >= currentLevel`, it will be emitted. However, the converse is not necessarily true: on platforms that provide `os_log`, the message may be emitted by `os_log` according to its own rules about log level.
+  ///
+  /// Additional message handlers will only be called if `level >= currentLevel`.
+  ///
+  /// - parameter message: The message to print.
+  /// - parameter level: The `LogLevel` of the message, used to determine whether it is emitted.
+  public func log(_ message: String, level: LogLevel = .default) {
+    self.log(message, level: level, async: true)
+  }
+
+  /// Log a message that is produced asynchronously by a callback, which is useful for logging messages that are expensive to compute and can be safely produced asynchronously. The callback is guaranteed to be called exactly once.
+  ///
+  /// - parameter level: The `LogLevel` of the message, used to determine whether it is emitted.
+  /// - parameter messageProducer: The async callback to produce the message.
+  /// - parameter currentLevel: The current log level is provided to the callback, which can be used to avoid expensive processing, for example by reducing the verbosity.
+  public func logAsync(level: LogLevel = .default, messageProducer: @escaping (_ currentLevel: LogLevel) -> String?) {
+    self.logQueue.async {
+      if let message = messageProducer(self.currentLevel) {
+        // Use `async: false` since we're already async'd on `logQueue` and we want to preserve ordering.
+        self.log(message, level: level, async: false)
+      }
+    }
+  }
+
+  func log(_ message: String, level: LogLevel = .default, async: Bool) {
 
     let currentLevel = self.currentLevel
 

--- a/Sources/SKSupport/Logging.swift
+++ b/Sources/SKSupport/Logging.swift
@@ -62,8 +62,7 @@ public protocol LogHandler: AnyObject {
 public final class Logger {
 
   /// The shared logger instance.
-  public internal(set)
-  static var shared: Logger = .init()
+  public static var shared: Logger = .init()
 
   let logQueue: DispatchQueue = DispatchQueue(label: "log-queue", qos: .utility)
 
@@ -83,6 +82,11 @@ public final class Logger {
   }
 
   var handlers: [LogHandler] = []
+
+  public init(disableOSLog: Bool = false, disableNSLog: Bool = false) {
+    self.disableOSLog = disableOSLog
+    self.disableNSLog = disableNSLog
+  }
 
   public func addLogHandler(_ handler: LogHandler) {
     logQueue.async {
@@ -150,6 +154,9 @@ public final class Logger {
       handler.handle(message, level: level)
     }
   }
+
+  /// *For Testing*. Flush the logging queue before returning.
+  public func flush() { logQueue.sync {} }
 }
 
 public class AnyLogHandler: LogHandler {

--- a/Sources/SourceKit/DocumentManager.swift
+++ b/Sources/SourceKit/DocumentManager.swift
@@ -15,10 +15,10 @@ import LanguageServerProtocol
 import Dispatch
 
 public struct DocumentSnapshot {
-  var document: Document
-  var version: Int
-  var lineTable: LineTable
-  var text: String { return lineTable.content }
+  public var document: Document
+  public var version: Int
+  public var lineTable: LineTable
+  public var text: String { return lineTable.content }
 
   public init(document: Document, version: Int, lineTable: LineTable) {
     self.document = document

--- a/Sources/SourceKit/Workspace.swift
+++ b/Sources/SourceKit/Workspace.swift
@@ -42,7 +42,7 @@ public final class Workspace {
   public var index: IndexStoreDB? = nil
 
   /// Open documents.
-  let documentManager: DocumentManager = DocumentManager()
+  public let documentManager: DocumentManager = DocumentManager()
 
   /// Language service for an open document, if available.
   var documentService: [URL: Connection] = [:]

--- a/Sources/SourceKit/sourcekitd/CommentXML.swift
+++ b/Sources/SourceKit/sourcekitd/CommentXML.swift
@@ -24,7 +24,7 @@ enum CommentXMLError: Error {
 /// Converts from sourcekit's XML documentation format to Markdown.
 ///
 /// This code should go away and sourcekitd should return the Markdown directly.
-func xmlDocumentationToMarkdown(_ xmlString: String) throws -> String {
+public func xmlDocumentationToMarkdown(_ xmlString: String) throws -> String {
   let xml = try XMLDocument(xmlString: xmlString)
   guard let root = xml.rootElement() else {
     throw CommentXMLError.noRootElement

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolJSONRPC
 import LanguageServerProtocol
 import XCTest
 import SKTestSupport

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -187,7 +187,7 @@ final class CodingTests: XCTestCase {
     {"jsonrpc":"2.0","method":"$/cancelRequest","params":{}}
     """)
 
-    let responseTypeCallback: Message.ResponseTypeCallback = {
+    let responseTypeCallback: JSONRPCMessage.ResponseTypeCallback = {
       return $0 == .string("unknown") ? nil : InitializeResult.self
     }
 
@@ -216,9 +216,9 @@ final class CodingTests: XCTestCase {
 }
 
 private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Request: RequestType & Equatable {
-  checkCoding(Message.request(value, id: id), json: json, file: file, line: line) {
+  checkCoding(JSONRPCMessage.request(value, id: id), json: json, file: file, line: line) {
 
-    guard case Message.request(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Request else {
+    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Request else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -229,9 +229,9 @@ private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: 
 }
 
 private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = #file, line: UInt = #line) where Notification: NotificationType & Equatable {
-  checkCoding(Message.notification(value), json: json, file: file, line: line) {
+  checkCoding(JSONRPCMessage.notification(value), json: json, file: file, line: line) {
 
-    guard case Message.notification(let decodedValueOpaque) = $0, let decodedValue = decodedValueOpaque as? Notification else {
+    guard case JSONRPCMessage.notification(let decodedValueOpaque) = $0, let decodedValue = decodedValueOpaque as? Notification else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -242,13 +242,13 @@ private func checkMessageCoding<Notification>(_ value: Notification, json: Strin
 
 private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Response: ResponseType & Equatable {
 
-  let callback: Message.ResponseTypeCallback = {
+  let callback: JSONRPCMessage.ResponseTypeCallback = {
     return $0 == .string("unknown") ? nil : Response.self
   }
 
-  checkCoding(Message.response(value, id: id), json: json, userInfo: [.responseTypeCallbackKey: callback], file: file, line: line) {
+  checkCoding(JSONRPCMessage.response(value, id: id), json: json, userInfo: [.responseTypeCallbackKey: callback], file: file, line: line) {
 
-    guard case Message.response(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Response else {
+    guard case JSONRPCMessage.response(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Response else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -259,9 +259,9 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
 }
 
 private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) {
-  checkCoding(Message.errorResponse(value, id: id), json: json, file: file, line: line) {
+  checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, file: file, line: line) {
 
-    guard case Message.errorResponse(let decodedValue, let decodedID) = $0 else {
+    guard case JSONRPCMessage.errorResponse(let decodedValue, let decodedID) = $0 else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -277,7 +277,7 @@ private func checkMessageDecodingError(_ expected: MessageDecodingError, json: S
   decoder.userInfo = userInfo
 
   do {
-    _ = try decoder.decode(Message.self, from: data)
+    _ = try decoder.decode(JSONRPCMessage.self, from: data)
     XCTFail("expected error not seen", file: file, line: line)
   } catch let error as MessageDecodingError {
     XCTAssertEqual(expected, error, file: file, line: line)

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -60,8 +60,8 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    let note1 = try! JSONEncoder().encode(Message.notification(EchoNotification(string: "hello!")))
-    let note2 = try! JSONEncoder().encode(Message.notification(EchoNotification(string: "no way!")))
+    let note1 = try! JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
+    let note2 = try! JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
 
     let note1Str: String = "Content-Length: \(note1.count)\r\n\r\n\(String(data: note1, encoding: .utf8)!)"
     let note2Str: String = "Content-Length: \(note2.count)\r\n\r\n\(String(data: note2, encoding: .utf8)!)"

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import LanguageServerProtocolJSONRPC
+import LanguageServerProtocolJSONRPC
 import LanguageServerProtocol
 import XCTest
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -19,7 +19,7 @@ final class MessageParsingTests: XCTestCase {
   func testSplitMessage() {
     func check(_ string: String, contentLen: Int? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
-      guard let ((content, header), rest) = try! bytes.splitMessage() else {
+      guard let ((content, header), rest) = try! bytes.jsonrpcSplitMessage() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
         return
       }
@@ -30,7 +30,7 @@ final class MessageParsingTests: XCTestCase {
 
     func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
       do {
-        _ = try [UInt8](string.utf8).splitMessage()
+        _ = try [UInt8](string.utf8).jsonrpcSplitMessage()
         XCTFail("missing expected error", file: file, line: line)
       } catch let error as MessageDecodingError {
         XCTAssertEqual(error, expected, file: file, line: line)
@@ -53,9 +53,9 @@ final class MessageParsingTests: XCTestCase {
   }
 
   func testParseHeader() {
-    func check(_ string: String, header expected: MessageHeader? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, header expected: JSONRPCMessageHeader? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
-      guard let (header, rest) = try! bytes.parseHeader() else {
+      guard let (header, rest) = try! bytes.jsonrcpParseHeader() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
         return
       }
@@ -65,7 +65,7 @@ final class MessageParsingTests: XCTestCase {
 
     func checkErrorBytes(_ bytes: [UInt8], _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
       do {
-        _ = try bytes.parseHeader()
+        _ = try bytes.jsonrcpParseHeader()
         XCTFail("missing expected error", file: file, line: line)
       } catch let error as MessageDecodingError {
         XCTAssertEqual(error, expected, file: file, line: line)
@@ -83,10 +83,10 @@ final class MessageParsingTests: XCTestCase {
     check("Content-Length: 1", restLen: nil)
     check("Content-Length: 1\r", restLen: nil)
     check("Content-Length: 1\r\n", restLen: nil)
-    check("Content-Length: 1\r\n\r\n", header: MessageHeader(contentLength: 1), restLen: 0)
-    check("Content-Length: 1\r\n\r\n{}", header: MessageHeader(contentLength: 1), restLen: 2)
-    check("A:B\r\nContent-Length: 1\r\nC:D\r\n\r\n", header: MessageHeader(contentLength: 1), restLen: 0)
-    check("Content-Length:123   \r\n\r\n", header: MessageHeader(contentLength: 123), restLen: 0)
+    check("Content-Length: 1\r\n\r\n", header: JSONRPCMessageHeader(contentLength: 1), restLen: 0)
+    check("Content-Length: 1\r\n\r\n{}", header: JSONRPCMessageHeader(contentLength: 1), restLen: 2)
+    check("A:B\r\nContent-Length: 1\r\nC:D\r\n\r\n", header: JSONRPCMessageHeader(contentLength: 1), restLen: 0)
+    check("Content-Length:123   \r\n\r\n", header: JSONRPCMessageHeader(contentLength: 123), restLen: 0)
 
     checkError("Content-Length:0x1\r\n\r\n", MessageDecodingError.parseError("expected integer value in 0x1"))
     checkError("Content-Length:a123\r\n\r\n", MessageDecodingError.parseError("expected integer value in a123"))
@@ -97,7 +97,7 @@ final class MessageParsingTests: XCTestCase {
   func testParseHeaderField() {
     func check(_ string: String, keyLen: Int? = nil, valueLen: Int? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
-      guard let (kv, rest) = try! bytes.parseHeaderField() else {
+      guard let (kv, rest) = try! bytes.jsonrpcParseHeaderField() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
         return
       }
@@ -114,7 +114,7 @@ final class MessageParsingTests: XCTestCase {
 
     func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
       do {
-        _ = try [UInt8](string.utf8).parseHeaderField()
+        _ = try [UInt8](string.utf8).jsonrpcParseHeaderField()
         XCTFail("missing expected error", file: file, line: line)
       } catch let error as MessageDecodingError {
         XCTAssertEqual(error, expected, file: file, line: line)

--- a/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
+++ b/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import LanguageServerProtocol
+import LanguageServerProtocol
 
 import XCTest
 

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SKCore
+import SKCore
 import Basic
 import SKTestSupport
 import XCTest

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SKCore
+import SKCore
 import LanguageServerProtocol
 import Basic
 import XCTest

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SKCore
+import SKCore
 import Basic
 import SPMUtility
 import XCTest

--- a/Tests/SKSupportTests/SupportPerfTests.swift
+++ b/Tests/SKSupportTests/SupportPerfTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SKSupport
+import SKSupport
 import SKTestSupport
 import Basic
 import XCTest

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -104,11 +104,7 @@ final class SupportTests: XCTestCase {
   }
 
   func testLogging() {
-    let orig = Logger.shared
-    defer { Logger.shared = orig }
-
     let testLogger = Logger(disableOSLog: true, disableNSLog: true)
-    Logger.shared = testLogger
 
     var messages: [(String, LogLevel)] = []
     let obj = testLogger.addLogHandler { message, level in
@@ -123,11 +119,11 @@ final class SupportTests: XCTestCase {
 
     testLogger.currentLevel = .default
 
-    log("a")
+    testLogger.log("a")
     check(&messages, expected: [("a", .default)])
     check(&messages, expected: [])
 
-    log("b\n\nc")
+    testLogger.log("b\n\nc")
     check(&messages, expected: [("b\n\nc", .default)])
 
     enum MyError: Error { case one }
@@ -136,22 +132,22 @@ final class SupportTests: XCTestCase {
       return x
     }
 
-    XCTAssertEqual(orLog { try throw1(0) }, 0)
+    XCTAssertEqual(orLog(logger: testLogger) { try throw1(0) }, 0)
     check(&messages, expected: [])
-    XCTAssertNil(orLog { try throw1(1) })
+    XCTAssertNil(orLog(logger: testLogger) { try throw1(1) })
     check(&messages, expected: [("one", .default)])
-    XCTAssertNil(orLog("hi") { try throw1(1) })
+    XCTAssertNil(orLog("hi", logger: testLogger) { try throw1(1) })
     check(&messages, expected: [("hi one", .default)])
 
-    logAsync { (currentLevel) -> String? in
+    testLogger.logAsync { (currentLevel) -> String? in
       return "\(currentLevel)"
     }
     check(&messages, expected: [("info", .default)])
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ("e", .warning),
@@ -160,10 +156,10 @@ final class SupportTests: XCTestCase {
 
     testLogger.currentLevel = .warning
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ("e", .warning),
@@ -171,10 +167,10 @@ final class SupportTests: XCTestCase {
 
     testLogger.currentLevel = .error
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ])
@@ -186,10 +182,10 @@ final class SupportTests: XCTestCase {
     // .warning
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_1")
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ("e", .warning),
@@ -198,10 +194,10 @@ final class SupportTests: XCTestCase {
     // .error
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_0")
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ])
@@ -209,10 +205,10 @@ final class SupportTests: XCTestCase {
     // missing - no change
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ])
@@ -221,10 +217,10 @@ final class SupportTests: XCTestCase {
     try! ProcessEnv.setVar("TEST_ENV_LOGGGING_err", value: "")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ])
@@ -233,10 +229,10 @@ final class SupportTests: XCTestCase {
     try! ProcessEnv.setVar("TEST_ENV_LOGGGING_err", value: "a3")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ])
@@ -245,10 +241,10 @@ final class SupportTests: XCTestCase {
     try! ProcessEnv.setVar("TEST_ENV_LOGGGING_err", value: "1000")
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
 
-    log("d", level: .error)
-    log("e", level: .warning)
-    log("f", level: .info)
-    log("g", level: .debug)
+    testLogger.log("d", level: .error)
+    testLogger.log("e", level: .warning)
+    testLogger.log("f", level: .info)
+    testLogger.log("g", level: .debug)
     check(&messages, expected: [
       ("d", .error),
       ("e", .warning),
@@ -273,7 +269,7 @@ final class SupportTests: XCTestCase {
     testLogger.currentLevel = .default
     testLogger.addLogHandler(obj)
 
-    log("a")
+    testLogger.log("a")
     check(&messages, expected: [
       ("a", .default),
       ("a", .default),
@@ -281,7 +277,7 @@ final class SupportTests: XCTestCase {
 
     testLogger.removeLogHandler(obj)
 
-    log("a")
+    testLogger.log("a")
     check(&messages, expected: [])
   }
 

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import SKSupport
+import SKSupport
 import Basic
 
 final class SupportTests: XCTestCase {
@@ -107,10 +107,8 @@ final class SupportTests: XCTestCase {
     let orig = Logger.shared
     defer { Logger.shared = orig }
 
-    let testLogger = Logger()
+    let testLogger = Logger(disableOSLog: true, disableNSLog: true)
     Logger.shared = testLogger
-    testLogger.disableNSLog = true
-    testLogger.disableOSLog = true
 
     var messages: [(String, LogLevel)] = []
     let obj = testLogger.addLogHandler { message, level in
@@ -118,7 +116,7 @@ final class SupportTests: XCTestCase {
     }
 
     func check(_ messages: inout [(String, LogLevel)], expected: [(String, LogLevel)], file: StaticString = #file, line: UInt = #line) {
-      testLogger.logQueue.sync {}
+      testLogger.flush()
       XCTAssert(messages == expected, "\(messages) does not match expected \(expected)", file: file, line: line)
       messages.removeAll()
     }

--- a/Tests/SourceKitTests/CodeActionTests.swift
+++ b/Tests/SourceKitTests/CodeActionTests.swift
@@ -14,8 +14,7 @@ import LanguageServerProtocol
 import SKSupport
 import SKTestSupport
 import XCTest
-
-@testable import SourceKit
+import SourceKit
 
 final class CodeActionTests: XCTestCase {
   func testCodeActionResponseLegacySupport() {

--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -13,9 +13,8 @@
 import SKSupport
 import SKTestSupport
 import XCTest
-
 import LanguageServerProtocol
-@testable import SourceKit
+import SourceKit
 
 final class DocumentColorTests: XCTestCase {
   /// Connection and lifetime management for the service.

--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -14,7 +14,7 @@ import SKSupport
 import SKTestSupport
 import XCTest
 
-@testable import LanguageServerProtocol
+import LanguageServerProtocol
 @testable import SourceKit
 
 final class DocumentColorTests: XCTestCase {

--- a/Tests/SourceKitTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitTests/DocumentSymbolTests.swift
@@ -14,8 +14,7 @@ import LanguageServerProtocol
 import SKSupport
 import SKTestSupport
 import XCTest
-
-@testable import SourceKit
+import SourceKit
 
 final class DocumentSymbolTest: XCTestCase {
   typealias DocumentSymbolCapabilities = TextDocumentClientCapabilities.DocumentSymbol

--- a/Tests/SourceKitTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitTests/FoldingRangeTests.swift
@@ -14,8 +14,7 @@ import LanguageServerProtocol
 import SKSupport
 import SKTestSupport
 import XCTest
-
-@testable import SourceKit
+import SourceKit
 
 final class FoldingRangeTests: XCTestCase {
 

--- a/Tests/SourceKitTests/ImplementationTests.swift
+++ b/Tests/SourceKitTests/ImplementationTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SourceKit
+import SourceKit
 import LanguageServerProtocol
 import XCTest
 import SKTestSupport

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -14,8 +14,7 @@ import LanguageServerProtocol
 import SKCore
 import SKTestSupport
 import XCTest
-
-@testable import SourceKit
+import SourceKit
 
 final class LocalClangTests: XCTestCase {
 

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SourceKit
 import LanguageServerProtocol
 import SKSupport
 import SKTestSupport
@@ -17,8 +18,6 @@ import XCTest
 
 // Workaround ambiguity with Foundation.
 typealias Notification = LanguageServerProtocol.Notification
-
-@testable import SourceKit
 
 final class LocalSwiftTests: XCTestCase {
 

--- a/Tests/SourceKitTests/SourceKitTests.swift
+++ b/Tests/SourceKitTests/SourceKitTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SourceKit
+import SourceKit
 import LanguageServerProtocol
 import Basic
 import SPMUtility

--- a/Tests/SourceKitTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitTests/SwiftCompletionTests.swift
@@ -14,8 +14,7 @@ import LanguageServerProtocol
 import SKSupport
 import SKTestSupport
 import XCTest
-
-@testable import SourceKit
+import SourceKit
 
 final class SwiftCompletionTests: XCTestCase {
 

--- a/Tests/SourceKitTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitTests/SwiftPMIntegration.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SourceKit
+import SourceKit
 import LanguageServerProtocol
 import SKTestSupport
 import XCTest

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -29,10 +29,6 @@ def get_swiftpm_options(args):
   if args.verbose:
     swiftpm_args += ['--verbose']
 
-  if args.configuration == 'release':
-    # Enable running tests that use @testable in release builds.
-    swiftpm_args += ['-Xswiftc', '-enable-testing']
-
   if platform.system() != 'Darwin':
     swiftpm_args += [
       # Dispatch headers


### PR DESCRIPTION
Using `-enable-testing` means we unnecessarily exposed internal symbols in our release builds and also has been hiding some cases where we were missing public API, particularly memberwise initializers.  It also meant you couldn't test a release build without passing the extra option.

Most of the changes are good general improvements, including exposing API that should be public anyway. In a few cases we marked an API public only for testing and underscored it.