### PR TITLE
make project.json spec-compliant by removing a trailing comma

### DIFF
--- a/Tests/INPUTS/SwiftModules/project.json
+++ b/Tests/INPUTS/SwiftModules/project.json
@@ -2,6 +2,6 @@
   "targets": [
     { "name": "A", "sources": ["a.swift"] },
     { "name": "B", "sources": ["b.swift"], "dependencies": ["A"] },
-    { "name": "C", "sources": ["c.swift"], "dependencies": ["B"] },
+    { "name": "C", "sources": ["c.swift"], "dependencies": ["B"] }
   ]
 }


### PR DESCRIPTION
JSON spec doesn't allow trailing commas, so my editor was complaining