### PR TITLE
 [sourcekit-lsp] Prefer containing toolchain if applicable

### DIFF
--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -68,6 +68,7 @@ extension ToolchainRegistry {
   ///
   /// If called with the default values, creates a toolchain registry that searches:
   /// * env SOURCEKIT_TOOLCHAIN_PATH <-- will override default toolchain
+  /// * installPath <-- will override default toolchain
   /// * (Darwin) The currently selected Xcode
   /// * (Darwin) [~]/Library/Developer/Toolchains
   /// * env SOURCEKIT_PATH, PATH
@@ -77,9 +78,9 @@ extension ToolchainRegistry {
   /// let tr = ToolchainRegistry()
   /// tr.scanForToolchains()
   /// ```
-  public convenience init(_ fileSystem: FileSystem) {
+  public convenience init(installPath: AbsolutePath? = nil, _ fileSystem: FileSystem) {
     self.init()
-    scanForToolchains(fileSystem)
+    scanForToolchains(installPath: installPath, fileSystem)
   }
 }
 
@@ -222,18 +223,12 @@ extension ToolchainRegistry {
   ///
   /// If called with the default values, creates a toolchain registry that searches:
   /// * env SOURCEKIT_TOOLCHAIN_PATH <-- will override default toolchain
+  /// * installPath <-- will override default toolchain
   /// * (Darwin) The currently selected Xcode
   /// * (Darwin) [~]/Library/Developer/Toolchains
   /// * env SOURCEKIT_PATH, PATH
-  ///
-  /// This is equivalent to
-  /// ```
-  /// tr.scanForToolchains(environmentVariables: environmentVariables, setDefault: true)
-  /// xcodes.forEach { tr.scanForToolchains(xcode: $0) }
-  /// xctoolchainSearchPaths.forEach { tr.scanForToolchains(xctoolchainSearchPath: $0) }
-  /// tr.scanForToolchains(pathVariables: pathVariables)
-  /// ```
   public func scanForToolchains(
+    installPath: AbsolutePath? = nil,
     environmentVariables: [String] = ["SOURCEKIT_TOOLCHAIN_PATH"],
     xcodes: [AbsolutePath] = [currentXcodeDeveloperPath].compactMap({$0}),
     xctoolchainSearchPaths: [AbsolutePath] = [
@@ -245,6 +240,12 @@ extension ToolchainRegistry {
   {
     queue.sync {
       _scanForToolchains(environmentVariables: environmentVariables, setDefault: true, fileSystem)
+      if let installPath = installPath,
+        let toolchain = try? _registerToolchain(installPath, fileSystem),
+        _default == nil
+      {
+        _default = toolchain
+      }
       xcodes.forEach { _scanForToolchains(xcode: $0, fileSystem) }
       xctoolchainSearchPaths.forEach { _scanForToolchains(xctoolchainSearchPath: $0, fileSystem) }
       _scanForToolchains(pathVariables: pathVariables, fileSystem)

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -69,7 +69,7 @@ public final class SwiftPMWorkspace {
 
     self.packageRoot = resolveSymlinks(packageRoot)
 
-    guard let destinationToolchainBinDir = toolchainRegistry.default?.path?.appending(components: "usr", "bin") else {
+    guard let destinationToolchainBinDir = toolchainRegistry.default?.swiftc?.parentDirectory else {
         throw Error.cannotDetermineHostToolchain
     }
 

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -69,6 +69,9 @@ do {
   exit(1)
 }
 
+let installPath = AbsolutePath(Bundle.main.bundlePath)
+ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFileSystem)
+
 let server = SourceKitServer(client: clientConnection, buildSetup: buildSetup, onExit: {
   clientConnection.close()
 })

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -165,6 +165,12 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNotNil(tc)
     XCTAssertEqual(tc?.identifier, "org.fake.explicit")
 
+    let tcBin = Toolchain(path.appending(components: "usr", "bin"), fs)
+    XCTAssertNotNil(tcBin)
+    XCTAssertEqual(tc?.identifier, tcBin?.identifier)
+    XCTAssertEqual(tc?.path, tcBin?.path)
+    XCTAssertEqual(tc?.displayName, tcBin?.displayName)
+
     let overrideReg = ToolchainRegistry(fs)
     overrideReg.darwinToolchainOverride = "org.fake.global.B"
     XCTAssertEqual(overrideReg.darwinToolchainIdentifier, "org.fake.global.B")

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -171,6 +171,12 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertEqual(tc?.path, tcBin?.path)
     XCTAssertEqual(tc?.displayName, tcBin?.displayName)
 
+
+    let trInstall = ToolchainRegistry()
+    trInstall.scanForToolchains(installPath: path.appending(components: "usr", "bin"), environmentVariables: [], xcodes: [], xctoolchainSearchPaths: [], pathVariables: [], fs)
+    XCTAssertEqual(trInstall.default?.identifier, "org.fake.explicit")
+    XCTAssertEqual(trInstall.default?.path, path)
+
     let overrideReg = ToolchainRegistry(fs)
     overrideReg.darwinToolchainOverride = "org.fake.global.B"
     XCTAssertEqual(overrideReg.darwinToolchainIdentifier, "org.fake.global.B")
@@ -417,6 +423,36 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssert(toolchains.count == 2)
     XCTAssert(toolchains[0] === xcodeA)
     XCTAssert(toolchains[1] === xcodeB)
+  }
+
+  func testInstallPath() {
+    let fs = InMemoryFileSystem()
+    makeToolchain(binPath: AbsolutePath("/t1/bin"), fs, sourcekitd: true)
+
+    let trEmpty = ToolchainRegistry(installPath: nil, fs)
+    XCTAssertNil(trEmpty.default)
+
+    let tr1 = ToolchainRegistry(installPath: AbsolutePath("/t1/bin"), fs)
+    XCTAssertEqual(tr1.default?.path, AbsolutePath("/t1/bin"))
+    XCTAssertNotNil(tr1.default?.sourcekitd)
+
+    let tr2 = ToolchainRegistry(installPath: AbsolutePath("/t2/bin"), fs)
+    XCTAssertNil(tr2.default)
+  }
+
+  func testInstallPathVsEnv() {
+    let fs = InMemoryFileSystem()
+    makeToolchain(binPath: AbsolutePath("/t1/bin"), fs, sourcekitd: true)
+    makeToolchain(binPath: AbsolutePath("/t2/bin"), fs, sourcekitd: true)
+
+    try! ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: "/t2/bin")
+
+    let tr = ToolchainRegistry()
+    tr.scanForToolchains(installPath: AbsolutePath("/t1/bin"), environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"], fs)
+    XCTAssertEqual(tr.toolchains.count, 2)
+
+    // Env variable wins.
+    XCTAssertEqual(tr.default?.path, AbsolutePath("/t2/bin"))
   }
 }
 


### PR DESCRIPTION
If the sourcekit-lsp binary is embedded inside a toolchain, pass that install path to the toolchain registry and use it by default.