### PR TITLE
 [build-script] Add installation support for sourcekit-lsp

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -78,6 +78,7 @@ def main():
     parser.add_argument('--ninja-bin', metavar='PATH', help='ninja binary to use for testing')
     parser.add_argument('--build-path', metavar='PATH', default='.build', help='build in the given path')
     parser.add_argument('--configuration', '-c', default='debug', help='build using configuration (release|debug)')
+    parser.add_argument('--no-local-deps', action='store_true', help='use normal remote dependencies when building')
     parser.add_argument('--verbose', '-v', action='store_true', help='enable verbose output')
 
   subparsers = parser.add_subparsers(title='subcommands', dest='action', metavar='action')
@@ -108,7 +109,8 @@ def main():
   # Set the toolchain used in tests at runtime
   env['SOURCEKIT_TOOLCHAIN_PATH'] = args.toolchain
   # Use local dependencies (i.e. checked out next sourcekit-lsp).
-  env['SWIFTCI_USE_LOCAL_DEPS'] = "1"
+  if not args.no_local_deps:
+    env['SWIFTCI_USE_LOCAL_DEPS'] = "1"
 
   if args.ninja_bin:
     env['NINJA_BIN'] = args.ninja_bin

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -15,6 +15,7 @@ def swiftpm(action, swift_exec, swiftpm_args, env=None):
   subprocess.check_call(cmd, env=env)
 
 def swiftpm_bin_path(swift_exec, swiftpm_args, env=None):
+  swiftpm_args = filter(lambda arg: arg != '-v' and arg != '--verbose', swiftpm_args)
   cmd = [swift_exec, 'build', '--show-bin-path'] + swiftpm_args
   print(' '.join(cmd))
   return subprocess.check_output(cmd, env=env).strip()


### PR DESCRIPTION
When invoked with the `install` action, build-script-helper.py will rsync the produced sourcekit-lsp to the toolchain's bin directory. On Linux, we add an extra relative rpath to find the swift corelibs (unfotunately we currently have no way to remove the absolute rpath; the same is true for all other swift-built binaries in the toolchain). On macOS, we replace the rpath.