### PR TITLE
Separate toolchain discovery from build settings

### DIFF
--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -32,5 +32,8 @@ public protocol BuildSystem {
   /// Returns the settings for the given url and language mode, if known.
   func settings(for: URL, _ language: Language) -> FileBuildSettings?
 
+  /// Returns the toolchain to use to compile this file
+  func toolchain(for: URL, _ language: Language) -> Toolchain?
+
   // TODO: notifications when settings change.
 }

--- a/Sources/SKCore/BuildSystemList.swift
+++ b/Sources/SKCore/BuildSystemList.swift
@@ -38,4 +38,8 @@ extension BuildSystemList: BuildSystem {
     }
     return nil
   }
+
+  public func toolchain(for url: URL, _ language: Language) -> Toolchain? {
+    return providers.first?.toolchain(for: url, language)
+  }
 }

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -43,7 +43,6 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     guard let db = database(for: url),
           let cmd = db[url].first else { return nil }
     return FileBuildSettings(
-      preferredToolchain: nil, // FIXME: infer from path
       compilerArguments: Array(cmd.commandLine.dropFirst()),
       workingDirectory: cmd.directory
     )

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -48,6 +48,8 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     )
   }
 
+  public func toolchain(for: URL, _ language: Language) -> Toolchain? { return nil }
+
   func database(for url: URL) -> CompilationDatabase? {
     if let path = try? AbsolutePath(validating: url.path) {
       return database(for: path)

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -50,6 +50,8 @@ public final class FallbackBuildSystem: BuildSystem {
     }
   }
 
+  public func toolchain(for: URL, _ language: Language) -> Toolchain? { return nil }
+
   func settingsSwift(_ path: AbsolutePath) -> FileBuildSettings {
     var args: [String] = []
     if let sdkpath = sdkpath {

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -59,7 +59,7 @@ public final class FallbackBuildSystem: BuildSystem {
       ]
     }
     args.append(path.pathString)
-    return FileBuildSettings(preferredToolchain: nil, compilerArguments: args)
+    return FileBuildSettings(compilerArguments: args)
   }
 
   func settingsClang(_ path: AbsolutePath, _ language: Language) -> FileBuildSettings {
@@ -71,6 +71,6 @@ public final class FallbackBuildSystem: BuildSystem {
       ]
     }
     args.append(path.pathString)
-    return FileBuildSettings(preferredToolchain: nil, compilerArguments: args)
+    return FileBuildSettings(compilerArguments: args)
   }
 }

--- a/Sources/SKCore/FileBuildSettings.swift
+++ b/Sources/SKCore/FileBuildSettings.swift
@@ -12,13 +12,9 @@
 
 /// Build settings for a single file.
 ///
-/// Encapsulates all the settings needed to compile a single file, including the compiler arguments,
-/// working directory, and preferred toolchain if any. FileBuildSettings are typically the result
-/// of a BuildSystem query.
+/// Encapsulates all the settings needed to compile a single file, including the compiler arguments
+/// and working directory. FileBuildSettings are typically the result of a BuildSystem query.
 public struct FileBuildSettings {
-
-  /// The Toolchain that is preferred for compiling this file, if any.
-  public var preferredToolchain: Toolchain? = nil
 
   /// The compiler arguments to use for this file.
   public var compilerArguments: [String]
@@ -27,11 +23,9 @@ public struct FileBuildSettings {
   public var workingDirectory: String? = nil
 
   public init(
-    preferredToolchain: Toolchain? = nil,
     compilerArguments: [String],
     workingDirectory: String? = nil)
   {
-    self.preferredToolchain = preferredToolchain
     self.compilerArguments = compilerArguments
     self.workingDirectory = workingDirectory
   }

--- a/Sources/SKSupport/Logging.swift
+++ b/Sources/SKSupport/Logging.swift
@@ -107,7 +107,7 @@ public final class Logger {
   }
 
   public func setLogLevel(environmentVariable: String) {
-    if let string = Process.env[environmentVariable],
+    if let string = ProcessEnv.vars[environmentVariable],
        let level = try? LogLevel(argument: string)
     {
       currentLevel = level

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -257,10 +257,7 @@ extension SwiftPMWorkspace {
     func impl(_ path: AbsolutePath) -> FileBuildSettings? {
       for package in packageGraph.packages where path == package.manifest.path {
         let compilerArgs = workspace.interpreterFlags(for: package.path) + [path.pathString]
-        return FileBuildSettings(
-          preferredToolchain: nil,
-          compilerArguments: compilerArgs
-        )
+        return FileBuildSettings(compilerArguments: compilerArgs)
       }
       return nil
     }
@@ -319,7 +316,6 @@ extension SwiftPMWorkspace {
     args += td.compileArguments()
 
     return FileBuildSettings(
-      preferredToolchain: nil,
       compilerArguments: args,
       workingDirectory: workspacePath.pathString)
   }
@@ -382,7 +378,6 @@ extension SwiftPMWorkspace {
     }
 
     return FileBuildSettings(
-      preferredToolchain: nil,
       compilerArguments: args,
       workingDirectory: workspacePath.pathString)
   }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -214,6 +214,11 @@ extension SwiftPMWorkspace: BuildSystem {
     return nil
   }
 
+  public func toolchain(for: LanguageServerProtocol.URL, _ language: Language) -> SKCore.Toolchain? {
+    return nil
+    
+  }
+
   /// Returns the resolved target description for the given file, if one is known.
   func targetDescription(for file: AbsolutePath) -> TargetBuildDescription? {
     if let td = fileToTarget[file] {

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -216,7 +216,6 @@ extension SwiftPMWorkspace: BuildSystem {
 
   public func toolchain(for: LanguageServerProtocol.URL, _ language: Language) -> SKCore.Toolchain? {
     return nil
-    
   }
 
   /// Returns the resolved target description for the given file, if one is known.

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -134,7 +134,7 @@ public final class SourceKitServer: LanguageServer {
   }
 
   func toolchain(for url: URL, _ language: Language) -> Toolchain? {
-    if let toolchain = workspace?.buildSettings.settings(for: url, language)?.preferredToolchain {
+    if let toolchain = workspace?.buildSettings.toolchain(for: url, language) {
       return toolchain
     }
 

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -28,7 +28,6 @@ final class FallbackBuildSystemTests: XCTestCase {
     XCTAssertNil(bs.indexDatabasePath)
 
     let settings = bs.settings(for: source.asURL, .swift)!
-    XCTAssertNil(settings.preferredToolchain)
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
@@ -53,7 +52,6 @@ final class FallbackBuildSystemTests: XCTestCase {
     bs.sdkpath = sdk
 
     let settings = bs.settings(for: source.asURL, .cpp)!
-    XCTAssertNil(settings.preferredToolchain)
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments


### PR DESCRIPTION
Conflating the toolchain discovery into file specific build settings causes multiple settings calls per file. Add a separate interface to fetch the toolchain for a workspace, and default to asking only the first build server. This fixes the duplicate settings calls and allows for faster toolchain lookup for build systems that can determine this quickly.