### PR TITLE
Pass in MessageRegistry instead of using a singleton

### DIFF
--- a/Sources/LanguageServerProtocol/MessageRegistry.swift
+++ b/Sources/LanguageServerProtocol/MessageRegistry.swift
@@ -10,22 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 
 public final class MessageRegistry {
 
-  private(set)
-  var methodToRequest: [String: _RequestType.Type] = {
-    Dictionary(uniqueKeysWithValues: builtinRequests.map { ($0.method, $0) })
-  }()
+  public static let lspMessageRegistry: MessageRegistry =
+    MessageRegistry(requests: builtinRequests, notifications: builtinNotifications)
 
-  private(set)
-  var methodToNotification: [String: NotificationType.Type] = {
-    Dictionary(uniqueKeysWithValues: builtinNotifications.map { ($0.method, $0) })
-  }()
+  private let methodToRequest: [String: _RequestType.Type]
+  private let methodToNotification: [String: NotificationType.Type]
 
-  /// The global message registry.
-  public static let shared: MessageRegistry = .init()
+  public init(requests: [_RequestType.Type], notifications: [NotificationType.Type]) {
+    self.methodToRequest = Dictionary(uniqueKeysWithValues: requests.map { ($0.method, $0) })
+    self.methodToNotification = Dictionary(uniqueKeysWithValues: notifications.map { ($0.method, $0) })
+  }
 
   /// Returns the type of the message named `method`, or nil if it is unknown.
   public func requestType(for method: String) -> _RequestType.Type? {
@@ -37,15 +34,4 @@ public final class MessageRegistry {
     return methodToNotification[method]
   }
 
-  /// Adds a new message type to the registry. **For test messages only; not thread-safe!**.
-  public func _register(_ type: _RequestType.Type) {
-    precondition(methodToRequest[type.method] == nil)
-    methodToRequest[type.method] = type
-  }
-
-  /// Adds a new message type to the registry. **For test messages only; not thread-safe!**.
-  public func _register(_ type: NotificationType.Type) {
-    precondition(methodToNotification[type.method] == nil)
-    methodToNotification[type.method] = type
-  }
 }

--- a/Sources/LanguageServerProtocol/MessageRegistry.swift
+++ b/Sources/LanguageServerProtocol/MessageRegistry.swift
@@ -13,7 +13,7 @@
 
 public final class MessageRegistry {
 
-  public static let lspMessageRegistry: MessageRegistry =
+  public static let lspProtocol: MessageRegistry =
     MessageRegistry(requests: builtinRequests, notifications: builtinNotifications)
 
   private let methodToRequest: [String: _RequestType.Type]

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -51,7 +51,7 @@ public final class JSONRPCConection {
 
   var closeHandler: () -> Void
 
-  public init(messageRegistry: MessageRegistry, inFD: Int32, outFD: Int32, closeHandler: @escaping () -> Void = {}) {
+  public init(protocol messageRegistry: MessageRegistry, inFD: Int32, outFD: Int32, closeHandler: @escaping () -> Void = {}) {
     state = .created
     self.closeHandler = closeHandler
     self.messageRegistry = messageRegistry

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -25,6 +25,7 @@ public final class JSONRPCConection {
   let sendQueue: DispatchQueue = DispatchQueue(label: "jsonrpc-send-queue", qos: .userInitiated)
   let receiveIO: DispatchIO
   let sendIO: DispatchIO
+  let messageRegistry: MessageRegistry
 
   enum State {
     case created, running, closed
@@ -50,9 +51,10 @@ public final class JSONRPCConection {
 
   var closeHandler: () -> Void
 
-  public init(inFD: Int32, outFD: Int32, closeHandler: @escaping () -> Void = {}) {
+  public init(messageRegistry: MessageRegistry, inFD: Int32, outFD: Int32, closeHandler: @escaping () -> Void = {}) {
     state = .created
     self.closeHandler = closeHandler
+    self.messageRegistry = messageRegistry
 
     receiveIO = DispatchIO(type: .stream, fileDescriptor: inFD, queue: queue) { (error: Int32) in
       if error != 0 {
@@ -136,6 +138,9 @@ public final class JSONRPCConection {
   func parseAndHandleMessages(from bytes: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8>.SubSequence {
 
     let decoder = JSONDecoder()
+
+    // Set message registry to use for model decoding.
+    decoder.userInfo[.messageRegistryKey] = messageRegistry
 
     // Setup callback for response type.
     decoder.userInfo[.responseTypeCallbackKey] = { id in

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -34,13 +34,13 @@ public struct TestJSONRPCConnection {
     _ = Unmanaged.passRetained(serverToClient)
 
     clientConnection = JSONRPCConection(
-      messageRegistry: testMessageRegistry,
+      protocol: testMessageRegistry,
       inFD: serverToClient.fileHandleForReading.fileDescriptor,
       outFD: clientToServer.fileHandleForWriting.fileDescriptor
     )
 
     serverConnection = JSONRPCConection(
-      messageRegistry: testMessageRegistry,
+      protocol: testMessageRegistry,
       inFD: clientToServer.fileHandleForReading.fileDescriptor,
       outFD: serverToClient.fileHandleForWriting.fileDescriptor
     )

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -19,8 +19,6 @@ import XCTest
 // Workaround ambiguity with Foundation.
 public typealias Notification = LanguageServerProtocol.Notification
 
-public let initRequestsOnce: Void = registerTestRequests()
-
 public struct TestJSONRPCConnection {
   public let clientToServer: Pipe = Pipe()
   public let serverToClient: Pipe = Pipe()
@@ -30,19 +28,19 @@ public struct TestJSONRPCConnection {
   public let serverConnection: JSONRPCConection
 
   public init() {
-    _ = initRequestsOnce
-
     // FIXME: DispatchIO doesn't like when the Pipes close behind its back even after the tests
     // finish. Until we fix the lifetime, leak.
     _ = Unmanaged.passRetained(clientToServer)
     _ = Unmanaged.passRetained(serverToClient)
 
     clientConnection = JSONRPCConection(
+      messageRegistry: testMessageRegistry,
       inFD: serverToClient.fileHandleForReading.fileDescriptor,
       outFD: clientToServer.fileHandleForWriting.fileDescriptor
     )
 
     serverConnection = JSONRPCConection(
+      messageRegistry: testMessageRegistry,
       inFD: clientToServer.fileHandleForReading.fileDescriptor,
       outFD: serverToClient.fileHandleForWriting.fileDescriptor
     )
@@ -67,8 +65,6 @@ public struct TestLocalConnection {
   public let serverConnection: LocalConnection = .init()
 
   public init() {
-    _ = initRequestsOnce
-
     client = TestClient(server: serverConnection)
     server = TestServer(client: clientConnection)
 
@@ -230,16 +226,9 @@ public final class TestServer: LanguageServer {
 
 // MARK: Test requests.
 
-public func registerTestRequests() {
-  [
-    EchoRequest.self,
-    EchoError.self,
-  ].forEach { MessageRegistry.shared._register($0) }
-
-  [
-    EchoNotification.self,
-  ].forEach { MessageRegistry.shared._register($0) }
-}
+private let testMessageRegistry = MessageRegistry(
+  requests: [EchoRequest.self, EchoError.self],
+  notifications: [EchoNotification.self])
 
 extension String: ResponseType {}
 

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -70,12 +70,12 @@ public struct TestSourceKitServer {
         _ = Unmanaged.passRetained(serverToClient)
 
         let clientConnection = JSONRPCConection(
-          messageRegistry: MessageRegistry.lspMessageRegistry,
+          protocol: MessageRegistry.lspProtocol,
           inFD: serverToClient.fileHandleForReading.fileDescriptor,
           outFD: clientToServer.fileHandleForWriting.fileDescriptor
         )
         let serverConnection = JSONRPCConection(
-          messageRegistry: MessageRegistry.lspMessageRegistry,
+          protocol: MessageRegistry.lspProtocol,
           inFD: clientToServer.fileHandleForReading.fileDescriptor,
           outFD: serverToClient.fileHandleForWriting.fileDescriptor
         )

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -45,7 +45,6 @@ public struct TestSourceKitServer {
   public let server: SourceKitServer?
 
   public init(connectionKind: ConnectionKind = .local) {
-     _ = initRequestsOnce
 
     switch connectionKind {
       case .local:
@@ -71,10 +70,12 @@ public struct TestSourceKitServer {
         _ = Unmanaged.passRetained(serverToClient)
 
         let clientConnection = JSONRPCConection(
+          messageRegistry: MessageRegistry.lspMessageRegistry,
           inFD: serverToClient.fileHandleForReading.fileDescriptor,
           outFD: clientToServer.fileHandleForWriting.fileDescriptor
         )
         let serverConnection = JSONRPCConection(
+          messageRegistry: MessageRegistry.lspMessageRegistry,
           inFD: clientToServer.fileHandleForReading.fileDescriptor,
           outFD: serverToClient.fileHandleForWriting.fileDescriptor
         )

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -134,6 +134,7 @@ func makeJSONRPCClangServer(client: MessageHandler, toolchain: Toolchain, buildS
   let serverToClient: Pipe = Pipe()
 
   let connection = JSONRPCConection(
+    messageRegistry: MessageRegistry.lspMessageRegistry,
     inFD: serverToClient.fileHandleForReading.fileDescriptor,
     outFD: clientToServer.fileHandleForWriting.fileDescriptor
   )

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -134,7 +134,7 @@ func makeJSONRPCClangServer(client: MessageHandler, toolchain: Toolchain, buildS
   let serverToClient: Pipe = Pipe()
 
   let connection = JSONRPCConection(
-    messageRegistry: MessageRegistry.lspMessageRegistry,
+    protocol: MessageRegistry.lspProtocol,
     inFD: serverToClient.fileHandleForReading.fileDescriptor,
     outFD: clientToServer.fileHandleForWriting.fileDescriptor
   )

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -53,7 +53,11 @@ func parseArguments() throws -> BuildSetup {
     flags: buildFlags)
 }
 
-let clientConnection = JSONRPCConection(inFD: STDIN_FILENO, outFD: STDOUT_FILENO, closeHandler: {
+let clientConnection = JSONRPCConection(
+  messageRegistry: MessageRegistry.lspMessageRegistry,
+  inFD: STDIN_FILENO,
+  outFD: STDOUT_FILENO,
+  closeHandler: {
   exit(0)
 })
 

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -54,7 +54,7 @@ func parseArguments() throws -> BuildSetup {
 }
 
 let clientConnection = JSONRPCConection(
-  messageRegistry: MessageRegistry.lspMessageRegistry,
+  protocol: MessageRegistry.lspProtocol,
   inFD: STDIN_FILENO,
   outFD: STDOUT_FILENO,
   closeHandler: {

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -215,7 +215,7 @@ final class CodingTests: XCTestCase {
   }
 }
 
-let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspMessageRegistry]
+let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspProtocol]
 
 private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Request: RequestType & Equatable {
   checkCoding(JSONRPCMessage.request(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -191,7 +191,7 @@ final class CodingTests: XCTestCase {
       return $0 == .string("unknown") ? nil : InitializeResult.self
     }
 
-    let info = [CodingUserInfoKey.responseTypeCallbackKey: responseTypeCallback]
+    let info = defaultCodingInfo.merging([CodingUserInfoKey.responseTypeCallbackKey: responseTypeCallback]) { (_, new) in new }
 
     checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification", id: .number(2)), json: """
     {"jsonrpc":"2.0","id":2,"params":{}}
@@ -215,8 +215,10 @@ final class CodingTests: XCTestCase {
   }
 }
 
+let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspMessageRegistry]
+
 private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Request: RequestType & Equatable {
-  checkCoding(JSONRPCMessage.request(value, id: id), json: json, file: file, line: line) {
+  checkCoding(JSONRPCMessage.request(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Request else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -229,7 +231,7 @@ private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: 
 }
 
 private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = #file, line: UInt = #line) where Notification: NotificationType & Equatable {
-  checkCoding(JSONRPCMessage.notification(value), json: json, file: file, line: line) {
+  checkCoding(JSONRPCMessage.notification(value), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.notification(let decodedValueOpaque) = $0, let decodedValue = decodedValueOpaque as? Notification else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -246,7 +248,10 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
     return $0 == .string("unknown") ? nil : Response.self
   }
 
-  checkCoding(JSONRPCMessage.response(value, id: id), json: json, userInfo: [.responseTypeCallbackKey: callback], file: file, line: line) {
+  var codingInfo = defaultCodingInfo
+  codingInfo[.responseTypeCallbackKey] = callback
+
+  checkCoding(JSONRPCMessage.response(value, id: id), json: json, userInfo: codingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.response(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Response else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -259,7 +264,7 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
 }
 
 private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) {
-  checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, file: file, line: line) {
+  checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.errorResponse(let decodedValue, let decodedID) = $0 else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -271,7 +276,7 @@ private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: Str
   }
 }
 
-private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = #file, line: UInt = #line) {
+private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo, file: StaticString = #file, line: UInt = #line) {
   let data = json.data(using: .utf8)!
   let decoder = JSONDecoder()
   decoder.userInfo = userInfo


### PR DESCRIPTION
In preparation for adding other JSON RPC protocols, the MessageRegistry shared singleton has to be refactored to be passed in state to the JSON RPC connection instead. This allows for each connection to specify the messages it expects.