### PR TITLE
Add BSP lifecycle notifications

### DIFF
--- a/Sources/BuildServerProtocol/InitializeBuild.swift
+++ b/Sources/BuildServerProtocol/InitializeBuild.swift
@@ -143,4 +143,6 @@ public struct TestProvider: Codable, Hashable {
 
 public struct InitializedBuildNotification: NotificationType {
   public static let method: String = "build/initialized"
+
+  public init() {}
 }

--- a/Sources/BuildServerProtocol/ShutdownBuild.swift
+++ b/Sources/BuildServerProtocol/ShutdownBuild.swift
@@ -19,6 +19,8 @@ import LanguageServerProtocol
 public struct ShutdownBuild: RequestType {
   public static let method: String = "build/shutdown"
   public typealias Response = VoidResponse
+
+  public init() {}
 }
 
 /// Like the language server protocol, a notification to ask the
@@ -27,4 +29,6 @@ public struct ShutdownBuild: RequestType {
 /// otherwise with error code 1.
 public struct ExitBuildNotification: NotificationType {
   public static let method: String = "build/exit"
+
+  public init() {}
 }

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -58,7 +58,11 @@ public final class BuildServerBuildSystem {
   }
 
   deinit {
-    _ = try? self.buildServer?.sendSync(ShutdownBuild())
+    do {
+      _ = try self.buildServer?.sendSync(ShutdownBuild())
+    } catch {
+      log("error shutting down build server: \(error)")
+    }
     self.buildServer?.send(ExitBuildNotification())
   }
 

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -57,6 +57,11 @@ public final class BuildServerBuildSystem {
     }
   }
 
+  deinit {
+    _ = try? self.buildServer?.sendSync(ShutdownBuild())
+    self.buildServer?.send(ExitBuildNotification())
+  }
+
   private func initializeBuildServer() throws {
     let serverPath = AbsolutePath(serverConfig.argv[0], relativeTo: projectRoot)
     let flags = Array(serverConfig.argv[1...])
@@ -78,6 +83,7 @@ public final class BuildServerBuildSystem {
     let handler = BuildServerHandler()
     let buildServer = try makeJSONRPCBuildServer(client: handler, serverPath: serverPath, serverFlags: flags)
     let response = try buildServer.sendSync(initializeRequest)
+    buildServer.send(InitializedBuildNotification())
     log("initialized build server \(response.displayName)")
     self.buildServer = buildServer
     self.handler = handler

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -85,9 +85,32 @@ public final class BuildServerBuildSystem {
     let response = try buildServer.sendSync(initializeRequest)
     buildServer.send(InitializedBuildNotification())
     log("initialized build server \(response.displayName)")
+
+    // see if index store was set as part of the server metadata
+    if let indexStorePath = readReponseDataKey(data: response.data, key: "indexStorePath") {
+      self.indexStorePath = AbsolutePath(indexStorePath, relativeTo: self.projectRoot)
+    }
     self.buildServer = buildServer
     self.handler = handler
   }
+}
+
+private func readReponseDataKey(data: LSPAny?, key: String) -> String? {
+  switch data {
+  case .dictionary(let dataDict):
+    if let val = dataDict[key] {
+      switch val {
+      case .string(let stringVal):
+        return stringVal
+      default:
+        break
+      }
+  }
+  default:
+    break
+  }
+
+  return nil
 }
 
 final class BuildServerHandler: LanguageServerEndpoint {

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -102,18 +102,9 @@ public final class BuildServerBuildSystem {
 }
 
 private func readReponseDataKey(data: LSPAny?, key: String) -> String? {
-  switch data {
-  case .dictionary(let dataDict):
-    if let val = dataDict[key] {
-      switch val {
-      case .string(let stringVal):
-        return stringVal
-      default:
-        break
-      }
-  }
-  default:
-    break
+  if case .dictionary(let dataDict)? = data,
+    case .string(let stringVal)? = dataDict[key] {
+    return stringVal
   }
 
   return nil

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
@@ -25,11 +25,12 @@ while True:
                 "rootUri": "blah",
                 "capabilities": {"languageIds": ["a", "b"]},
                 "data": {
-                    "index_store_path": "some/index/store/path"
+                    "indexStorePath": "some/index/store/path"
                 }
             }
         }
-    else:
+    # ignore notifications
+    elif "id" in message:
         response = {
             "jsonrpc": "2.0",
             "id": message["id"],

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
@@ -14,6 +14,7 @@ while True:
     sys.stdin.readline()
     message = json.loads(sys.stdin.read(length))
 
+    response = None
     if message["method"] == "build/initialize":
         response = {
             "jsonrpc": "2.0",
@@ -29,18 +30,28 @@ while True:
                 }
             }
         }
-    # ignore notifications
+    elif message["method"] == "build/initialized":
+        continue
+    elif message["method"] == "build/shutdown":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": None
+        }
+    elif message["method"] == "build/exit":
+        break
+    # ignore other notifications
     elif "id" in message:
         response = {
             "jsonrpc": "2.0",
             "id": message["id"],
             "error": {
                 "code": 123,
-                "message": "unhandled method",
+                "message": "unhandled method {}".format(message["method"]),
             }
         }
 
-    responseStr = json.dumps(response)
-    sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-    sys.stdout.flush()
-
+    if response:
+        responseStr = json.dumps(response)
+        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+        sys.stdout.flush()

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -24,6 +24,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
     let buildSystem = try? BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
     XCTAssertNotNil(buildSystem)
+    XCTAssertEqual(buildSystem!.indexStorePath, AbsolutePath("some/index/store/path", relativeTo: root))
   }
 
 }


### PR DESCRIPTION
Sends the BSP lifecycle notifications according to the spec. This PR also adds support for reading the index store path from the build server initialize response metadata.