### PR TITLE
Add SourceKitOptions build server request

### DIFF
--- a/Sources/BuildServerProtocol/FileOptions.swift
+++ b/Sources/BuildServerProtocol/FileOptions.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import LanguageServerProtocol
+
+/// The SourceKitOptions request is sent from the client to the server
+/// to query for the list of compiler options necessary to compile this file.
+public struct SourceKitOptions: RequestType, Hashable {
+  public static let method: String = "textDocument/sourceKitOptions"
+  public typealias Response = SourceKitOptionsResult
+
+  /// The URL of the document to get options for
+  public var uri: URL
+
+  public init(uri: URL) {
+    self.uri = uri
+  }
+}
+
+public struct SourceKitOptionsResult: ResponseType, Hashable {
+  /// The compiler options required for the requested file.
+  public var options: [String]
+
+  /// The working directory for the compile command.
+  public var workingDirectory: String?
+}

--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -14,11 +14,12 @@ import LanguageServerProtocol
 fileprivate let requestTypes: [_RequestType.Type] = [
   InitializeBuild.self,
   ShutdownBuild.self,
+  SourceKitOptions.self,
 ]
 
 fileprivate let notificationTypes: [NotificationType.Type] = [
-  InitializedBuildNotification.self,
   ExitBuildNotification.self,
+  InitializedBuildNotification.self,
 ]
 
 public let bspRegistry = MessageRegistry(requests: requestTypes, notifications: notificationTypes)

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -137,7 +137,9 @@ extension BuildServerBuildSystem: BuildSystem {
   }
 
   public func settings(for url: URL, _ language: Language) -> FileBuildSettings? {
-    // TODO: add `textDocument/sourceKitOptions` request and response
+    if let response = try? self.buildServer?.sendSync(SourceKitOptions(uri: url)) {
+      return FileBuildSettings(compilerArguments: response.options, workingDirectory: response.workingDirectory)
+    }
     return nil
   }
 

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/buildServer.json
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/buildServer.json
@@ -1,0 +1,7 @@
+{
+    "name": "client name",
+    "version": "10",
+    "bspVersion": "2.0",
+    "languages": ["a", "b"],
+    "argv": ["server.py"]
+}

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+
+while True:
+    line = sys.stdin.readline()
+    if len(line) == 0:
+        break
+
+    assert line.startswith('Content-Length:')
+    length = int(line[len('Content-Length:'):])
+    sys.stdin.readline()
+    message = json.loads(sys.stdin.read(length))
+
+    response = None
+    if message["method"] == "build/initialize":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {
+                "displayName": "test server",
+                "version": "0.1",
+                "bspVersion": "2.0",
+                "rootUri": "blah",
+                "capabilities": {"languageIds": ["a", "b"]},
+                "data": {
+                    "indexStorePath": "some/index/store/path"
+                }
+            }
+        }
+    elif message["method"] == "build/initialized":
+        continue
+    elif message["method"] == "build/shutdown":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": None
+        }
+    elif message["method"] == "build/exit":
+        break
+    elif message["method"] == "textDocument/sourceKitOptions":
+        file_path = message["params"]["uri"][len("file://"):]
+        if file_path.endswith(".missing"):
+            # simulate error response for unhandled file
+            response = {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "error": {
+                    "code": -32600,
+                    "message": "unknown file {}".format(file_path),
+                }
+            }
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {
+                    "options": ["-a", "-b"],
+                    "workingDirectory": os.path.dirname(file_path),
+                }
+            }
+    # ignore other notifications
+    elif "id" in message:
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "error": {
+                "code": -32600,
+                "message": "unhandled method {}".format(message["method"]),
+            }
+        }
+
+    if response:
+        responseStr = json.dumps(response)
+        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+        sys.stdout.flush()

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import SKCore
 import TSCBasic
 import LanguageServerProtocol
+import Foundation
 
 final class BuildServerBuildSystemTests: XCTestCase {
 
@@ -25,6 +26,24 @@ final class BuildServerBuildSystemTests: XCTestCase {
 
     XCTAssertNotNil(buildSystem)
     XCTAssertEqual(buildSystem!.indexStorePath, AbsolutePath("some/index/store/path", relativeTo: root))
+  }
+
+  func testSettings() {
+    let root = AbsolutePath(
+      inputsDirectory().appendingPathComponent(testDirectoryName, isDirectory: true).path)
+    let buildFolder = AbsolutePath(NSTemporaryDirectory())
+    let buildSystem = try? BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
+    XCTAssertNotNil(buildSystem)
+
+    // test settings with a response
+    let fileURL = URL(fileURLWithPath: "/path/to/some/file.swift")
+    let settings = buildSystem?.settings(for: fileURL, Language.swift)
+    XCTAssertEqual(settings?.compilerArguments, ["-a", "-b"])
+    XCTAssertEqual(settings?.workingDirectory, fileURL.deletingLastPathComponent().path)
+
+    // test error
+    let missingFileURL = URL(fileURLWithPath: "/path/to/some/missingfile.missing")
+    XCTAssertNil(buildSystem?.settings(for: missingFileURL, Language.swift))
   }
 
 }

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -7,6 +7,7 @@ extension BuildServerBuildSystemTests {
     // to regenerate.
     static let __allTests__BuildServerBuildSystemTests = [
         ("testServerInitialize", testServerInitialize),
+        ("testSettings", testSettings),
     ]
 }
 


### PR DESCRIPTION
Add a request and response for SourceKitOptions, and fetch synchronously as part of the `settings` API. 