### PR TITLE
Add support for file watching in the build server protocol

### DIFF
--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -13,12 +13,14 @@ import LanguageServerProtocol
 
 fileprivate let requestTypes: [_RequestType.Type] = [
   InitializeBuild.self,
+  RegisterForChanges.self,
   ShutdownBuild.self,
   SourceKitOptions.self,
 ]
 
 fileprivate let notificationTypes: [NotificationType.Type] = [
   ExitBuildNotification.self,
+  FileOptionsChangedNotification.self,
   InitializedBuildNotification.self,
 ]
 

--- a/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
+++ b/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
@@ -47,8 +47,5 @@ public struct FileOptionsChangedNotification: NotificationType {
   public var uri: URL
 
   /// The updated options for the registered file.
-  public var options: [String]
-
-  /// The working directory for the compile command.
-  public var workingDirectory: String?
+  public var updatedOptions: SourceKitOptionsResult
 }

--- a/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
+++ b/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import LanguageServerProtocol
+
+
+/// The register for changes request is sent from the language
+/// server to the build server to register or unregister for
+/// changes in file options or dependencies. On changes a
+/// FileOptionsChangedNotification is sent.
+public struct RegisterForChanges: RequestType {
+  public static let method: String = "textDocument/registerForChanges"
+  public typealias Response = VoidResponse
+
+  /// The URL of the document to get options for.
+  public var uri: URL
+
+  /// Whether to register or unregister for the file.
+  public var action: RegisterAction
+
+  public init(uri: URL, action: RegisterAction) {
+    self.uri = uri
+    self.action = action
+  }
+}
+
+public enum RegisterAction: String, Hashable, Codable {
+  case register = "register"
+  case unregister = "unregister"
+}
+
+/// The FileOptionsChangedNotification is sent from the
+/// build server to the language server when it detects
+/// changes to a registered files build settings.
+public struct FileOptionsChangedNotification: NotificationType {
+  public static let method: String = "build/sourceKitOptionsChanged"
+
+  /// The URL of the document that has changed settings.
+  public var uri: URL
+
+  /// The updated options for the registered file.
+  public var options: [String]
+
+  /// The working directory for the compile command.
+  public var workingDirectory: String?
+}

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/buildServer.json
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/buildServer.json
@@ -1,0 +1,7 @@
+{
+    "name": "client name",
+    "version": "10",
+    "bspVersion": "2.0",
+    "languages": ["a", "b"],
+    "argv": ["server.py"]
+}

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+
+def send(data):
+    dataStr = json.dumps(data)
+    sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+    sys.stdout.flush()
+
+
+while True:
+    line = sys.stdin.readline()
+    if len(line) == 0:
+        break
+
+    assert line.startswith('Content-Length:')
+    length = int(line[len('Content-Length:'):])
+    sys.stdin.readline()
+    message = json.loads(sys.stdin.read(length))
+
+    response = None
+    notification = None
+
+    if message["method"] == "build/initialize":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {
+                "displayName": "test server",
+                "version": "0.1",
+                "bspVersion": "2.0",
+                "rootUri": "blah",
+                "capabilities": {"languageIds": ["a", "b"]},
+                "data": {
+                    "indexStorePath": "some/index/store/path"
+                }
+            }
+        }
+    elif message["method"] == "build/initialized":
+        continue
+    elif message["method"] == "build/shutdown":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": None
+        }
+    elif message["method"] == "build/exit":
+        break
+    elif message["method"] == "textDocument/registerForChanges":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": None
+        }
+        if message["params"]["action"] == "register":
+            notification = {
+                "jsonrpc": "2.0",
+                "method": "build/sourceKitOptionsChanged",
+                "params": {
+                    "uri": message["params"]["uri"],
+                    "options": [ "-a", "-b" ],
+                    "workingDirectory": "/some/dir",
+                }
+            }
+
+    # ignore other notifications
+    elif "id" in message:
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "error": {
+                "code": -32600,
+                "message": "unhandled method {}".format(message["method"]),
+            }
+        }
+
+    if response: send(response)
+    if notification: send(notification)

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
@@ -61,8 +61,10 @@ while True:
                 "method": "build/sourceKitOptionsChanged",
                 "params": {
                     "uri": message["params"]["uri"],
-                    "options": [ "-a", "-b" ],
-                    "workingDirectory": "/some/dir",
+                    "updatedOptions": {
+                        "options": ["a", "b"],
+                        "workingDirectory": "/some/dir"
+                    }
                 }
             }
 

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ extension BuildServerBuildSystemTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__BuildServerBuildSystemTests = [
+        ("testFileRegistration", testFileRegistration),
         ("testServerInitialize", testServerInitialize),
         ("testSettings", testSettings),
     ]


### PR DESCRIPTION
This PR adds requests for registering and unregistering file watching via the build server protocol. This will trigger a notification on changes that includes the updated build settings for a registered file. The same mechanism will be used for dependency changes via a separate notification.