### PR TITLE
Remove the need to use `Connection` to talk to internal LSPs

### DIFF
--- a/Sources/LanguageServerProtocol/WorkspaceSettings.swift
+++ b/Sources/LanguageServerProtocol/WorkspaceSettings.swift
@@ -16,7 +16,6 @@
 public enum WorkspaceSettingsChange: Codable, Hashable {
 
   case clangd(ClangWorkspaceSettings)
-  case documentUpdated(DocumentUpdatedBuildSettings)
   case unknown
 
   public init(from decoder: Decoder) throws {
@@ -25,8 +24,6 @@ public enum WorkspaceSettingsChange: Codable, Hashable {
     // it will rectify this issue.
     if let settings = try? ClangWorkspaceSettings(from: decoder) {
       self = .clangd(settings)
-    } else if let settings = try? DocumentUpdatedBuildSettings(from: decoder) {
-      self = .documentUpdated(settings)
     } else {
       self = .unknown
     }
@@ -35,8 +32,6 @@ public enum WorkspaceSettingsChange: Codable, Hashable {
   public func encode(to encoder: Encoder) throws {
     switch self {
     case .clangd(let settings):
-      try settings.encode(to: encoder)
-    case .documentUpdated(let settings):
       try settings.encode(to: encoder)
     case .unknown:
       break // Nothing to do.
@@ -77,19 +72,5 @@ public struct ClangCompileCommand: Codable, Hashable {
   public init(compilationCommand: [String], workingDirectory: String) {
     self.compilationCommand = compilationCommand
     self.workingDirectory = workingDirectory
-  }
-}
-
-/// Workspace settings for a document that has updated build settings.
-public struct DocumentUpdatedBuildSettings: Codable, Hashable {
-  /// The url of the document that has updated.
-  public var url: URL
-
-   /// The language of the document that has updated.
-  public var language: Language
-
-   public init(url: URL, language: Language) {
-    self.url = url
-    self.language = language
   }
 }

--- a/Sources/SourceKit/DocumentManager.swift
+++ b/Sources/SourceKit/DocumentManager.swift
@@ -150,25 +150,25 @@ extension DocumentManager {
 
   /// Convenience wrapper for `open(_:language:version:text:)` that logs on failure.
   @discardableResult
-  func open(_ note: Notification<DidOpenTextDocument>) -> DocumentSnapshot? {
-    let doc = note.params.textDocument
+  func open(_ note: DidOpenTextDocument) -> DocumentSnapshot? {
+    let doc = note.textDocument
     return orLog("failed to open document", level: .error) {
       try open(doc.url, language: doc.language, version: doc.version, text: doc.text)
     }
   }
 
   /// Convenience wrapper for `close(_:)` that logs on failure.
-  func close(_ note: Notification<DidCloseTextDocument>) {
+  func close(_ note: DidCloseTextDocument) {
     orLog("failed to close document", level: .error) {
-      try close(note.params.textDocument.url)
+      try close(note.textDocument.url)
     }
   }
 
   /// Convenience wrapper for `edit(_:newVersion:edits:editCallback:)` that logs on failure.
   @discardableResult
-  func edit(_ note: Notification<DidChangeTextDocument>, editCallback: ((_ before: DocumentSnapshot, TextDocumentContentChangeEvent) -> Void)? = nil) -> DocumentSnapshot? {
+  func edit(_ note: DidChangeTextDocument, editCallback: ((_ before: DocumentSnapshot, TextDocumentContentChangeEvent) -> Void)? = nil) -> DocumentSnapshot? {
     return orLog("failed to edit document", level: .error) {
-      try edit(note.params.textDocument.url, newVersion: note.params.textDocument.version ?? -1, edits: note.params.contentChanges, editCallback: editCallback)
+      try edit(note.textDocument.url, newVersion: note.textDocument.version ?? -1, edits: note.contentChanges, editCallback: editCallback)
     }
   }
 }

--- a/Sources/SourceKit/ToolchainLanguageServer.swift
+++ b/Sources/SourceKit/ToolchainLanguageServer.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LanguageServerProtocol
+
+/// A `LanguageServer` that exists within the context of the current process.
+public protocol ToolchainLanguageServer: AnyObject {
+
+  // MARK: Lifetime
+
+  func initializeSync(_ initialize: InitializeRequest) throws -> InitializeResult
+  func clientInitialized(_ initialized: InitializedNotification)
+
+  // MARK: - Text synchronization
+
+  func openDocument(_ note: DidOpenTextDocument)
+  func closeDocument(_ note: DidCloseTextDocument)
+  func changeDocument(_ note: DidChangeTextDocument)
+  func willSaveDocument(_ note: WillSaveTextDocument)
+  func didSaveDocument(_ note: DidSaveTextDocument)
+  func documentUpdatedBuildSettings(_ url: URL, language: Language)
+
+  // MARK: - Text Document
+
+  func completion(_ req: Request<CompletionRequest>)
+  func hover(_ req: Request<HoverRequest>)
+  func symbolInfo(_ request: Request<SymbolInfoRequest>)
+
+  func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>)
+  func foldingRange(_ req: Request<FoldingRangeRequest>)
+  func documentSymbol(_ req: Request<DocumentSymbolRequest>)
+  func documentColor(_ req: Request<DocumentColorRequest>)
+  func colorPresentation(_ req: Request<ColorPresentationRequest>)
+  func codeAction(_ req: Request<CodeActionRequest>)
+
+  // MARK: - Other
+
+  func executeCommand(_ req: Request<ExecuteCommandRequest>)
+}

--- a/Sources/SourceKit/Workspace.swift
+++ b/Sources/SourceKit/Workspace.swift
@@ -45,7 +45,7 @@ public final class Workspace {
   public let documentManager: DocumentManager = DocumentManager()
 
   /// Language service for an open document, if available.
-  var documentService: [URL: Connection] = [:]
+  var documentService: [URL: ToolchainLanguageServer] = [:]
 
   public init(
     rootPath: AbsolutePath?,

--- a/Sources/SourceKit/sourcekitd/CursorInfo.swift
+++ b/Sources/SourceKit/sourcekitd/CursorInfo.swift
@@ -72,6 +72,82 @@ extension CursorInfoError: CustomStringConvertible {
 
 extension SwiftLanguageServer {
 
+  /// Must be called on self.queue.
+  func _cursorInfo(
+    _ url: URL,
+    _ range: Range<Position>,
+    additionalParameters appendAdditionalParameters: ((SKRequestDictionary) -> Void)? = nil,
+    _ completion: @escaping (Swift.Result<CursorInfo?, CursorInfoError>) -> Void)
+  {
+    guard let snapshot = documentManager.latestSnapshot(url) else {
+       return completion(.failure(.unknownDocument(url)))
+     }
+
+    guard let offsetRange = snapshot.utf8OffsetRange(of: range) else {
+      return completion(.failure(.invalidRange(range)))
+    }
+
+    let keys = self.keys
+
+    let skreq = SKRequestDictionary(sourcekitd: sourcekitd)
+    skreq[keys.request] = requests.cursorinfo
+    skreq[keys.offset] = offsetRange.lowerBound
+    if offsetRange.upperBound != offsetRange.lowerBound {
+      skreq[keys.length] = offsetRange.count
+    }
+    skreq[keys.sourcefile] = snapshot.document.url.path
+
+    // FIXME: SourceKit should probably cache this for us.
+    if let settings = self.buildSettingsByFile[snapshot.document.url] {
+      skreq[keys.compilerargs] = settings.compilerArguments
+    }
+
+    appendAdditionalParameters?(skreq)
+
+    let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
+      guard let self = self else { return }
+      guard let dict = result.success else {
+        return completion(.failure(.responseError(result.failure!)))
+      }
+
+      guard let _: sourcekitd_uid_t = dict[keys.kind] else {
+        // Nothing to report.
+        return completion(.success(nil))
+      }
+
+      var location: Location? = nil
+      if let filepath: String = dict[keys.filepath],
+         let offset: Int = dict[keys.offset],
+         let pos = snapshot.positionOf(utf8Offset: offset)
+      {
+        location = Location(url: URL(fileURLWithPath: filepath), range: Range(pos))
+      }
+
+      let refactorActionsArray: SKResponseArray? = dict[keys.refactor_actions]
+
+      completion(.success(
+        CursorInfo(
+          SymbolDetails(
+          name: dict[keys.name],
+          containerName: nil,
+          usr: dict[keys.usr],
+          bestLocalDeclaration: location),
+        annotatedDeclaration: dict[keys.annotated_decl],
+        documentationXML: dict[keys.doc_full_as_xml],
+        refactorActions:
+          [SemanticRefactorCommand](
+          array: refactorActionsArray,
+          range: range,
+          textDocument: TextDocumentIdentifier(url),
+          keys,
+          self.api)
+      )))
+    }
+
+    // FIXME: cancellation
+    _ = handle
+  }
+
   /// Provides detailed information about a symbol under the cursor, if any.
   ///
   /// Wraps the information returned by sourcekitd's `cursor_info` request, such as symbol name,
@@ -87,74 +163,9 @@ extension SwiftLanguageServer {
     additionalParameters appendAdditionalParameters: ((SKRequestDictionary) -> Void)? = nil,
     _ completion: @escaping (Swift.Result<CursorInfo?, CursorInfoError>) -> Void)
   {
-    guard let snapshot = documentManager.latestSnapshot(url) else {
-      return completion(.failure(.unknownDocument(url)))
-    }
-
-    guard let offsetRange = snapshot.utf8OffsetRange(of: range) else {
-      return completion(.failure(.invalidRange(range)))
-    }
-
-    let keys = self.keys
- 
-    let skreq = SKRequestDictionary(sourcekitd: sourcekitd)
-    skreq[keys.request] = requests.cursorinfo
-    skreq[keys.offset] = offsetRange.lowerBound
-    if offsetRange.upperBound != offsetRange.lowerBound {
-      skreq[keys.length] = offsetRange.count
-    }
-    skreq[keys.sourcefile] = snapshot.document.url.path
-
-    appendAdditionalParameters?(skreq)
-
-    queue.async {
-      // FIXME: SourceKit should probably cache this for us.
-      if let settings = self.buildSettingsByFile[snapshot.document.url] {
-        skreq[keys.compilerargs] = settings.compilerArguments
-      }
-
-      let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
-        guard let self = self else { return }
-        guard let dict = result.success else {
-          return completion(.failure(.responseError(result.failure!)))
-        }
-
-        guard let _: sourcekitd_uid_t = dict[keys.kind] else {
-          // Nothing to report.
-          return completion(.success(nil))
-        }
-
-        var location: Location? = nil
-        if let filepath: String = dict[keys.filepath],
-           let offset: Int = dict[keys.offset],
-           let pos = snapshot.positionOf(utf8Offset: offset)
-        {
-          location = Location(url: URL(fileURLWithPath: filepath), range: Range(pos))
-        }
-
-        let refactorActionsArray: SKResponseArray? = dict[keys.refactor_actions]
-
-        completion(.success(
-          CursorInfo(
-            SymbolDetails(
-            name: dict[keys.name],
-            containerName: nil,
-            usr: dict[keys.usr],
-            bestLocalDeclaration: location),
-          annotatedDeclaration: dict[keys.annotated_decl],
-          documentationXML: dict[keys.doc_full_as_xml],
-          refactorActions:
-            [SemanticRefactorCommand](
-            array: refactorActionsArray,
-            range: range,
-            textDocument: TextDocumentIdentifier(url),
-            keys,
-            self.api)
-          )))
-      }
-
-      // FIXME: cancellation
-      _ = handle
+    self.queue.async {
+      self._cursorInfo(url, range,
+                       additionalParameters: appendAdditionalParameters, completion)
     }
   }
 }

--- a/Sources/SourceKit/sourcekitd/SemanticRefactoring.swift
+++ b/Sources/SourceKit/sourcekitd/SemanticRefactoring.swift
@@ -126,32 +126,34 @@ extension SwiftLanguageServer {
     _ refactorCommand: SemanticRefactorCommand,
     _ completion: @escaping (Result<SemanticRefactoring, SemanticRefactoringError>) -> Void)
   {
-    let url = refactorCommand.textDocument.url
-    guard let snapshot = documentManager.latestSnapshot(url) else {
-      return completion(.failure(.unknownDocument(url)))
-    }
-    guard let offsetRange = snapshot.utf8OffsetRange(of: refactorCommand.positionRange) else {
-      return completion(.failure(.failedToRetrieveOffset(refactorCommand.positionRange)))
-    }
-    let line = refactorCommand.positionRange.lowerBound.line
-    let utf16Column = refactorCommand.positionRange.lowerBound.utf16index
-    guard let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column) else {
-      return completion(.failure(.invalidRange(refactorCommand.positionRange)))
-    }
     let keys = self.keys
-    let skreq = SKRequestDictionary(sourcekitd: sourcekitd)
-    skreq[keys.request] = requests.semantic_refactoring
-    // Preferred name for e.g. an extracted variable.
-    // Empty string means sourcekitd chooses a name automatically.
-    skreq[keys.name] = ""
-    skreq[keys.sourcefile] = url.path
-    // LSP is zero based, but this request is 1 based.
-    skreq[keys.line] = line + 1
-    skreq[keys.column] = utf8Column + 1
-    skreq[keys.length] = offsetRange.count
-    skreq[keys.actionuid] = sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!
 
     queue.async {
+      let url = refactorCommand.textDocument.url
+      guard let snapshot = self.documentManager.latestSnapshot(url) else {
+        return completion(.failure(.unknownDocument(url)))
+      }
+      guard let offsetRange = snapshot.utf8OffsetRange(of: refactorCommand.positionRange) else {
+        return completion(.failure(.failedToRetrieveOffset(refactorCommand.positionRange)))
+      }
+      let line = refactorCommand.positionRange.lowerBound.line
+      let utf16Column = refactorCommand.positionRange.lowerBound.utf16index
+      guard let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column) else {
+        return completion(.failure(.invalidRange(refactorCommand.positionRange)))
+      }
+
+      let skreq = SKRequestDictionary(sourcekitd: self.sourcekitd)
+      skreq[keys.request] = self.requests.semantic_refactoring
+      // Preferred name for e.g. an extracted variable.
+      // Empty string means sourcekitd chooses a name automatically.
+      skreq[keys.name] = ""
+      skreq[keys.sourcefile] = url.path
+      // LSP is zero based, but this request is 1 based.
+      skreq[keys.line] = line + 1
+      skreq[keys.column] = utf8Column + 1
+      skreq[keys.length] = offsetRange.count
+      skreq[keys.actionuid] = self.sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!
+
       // FIXME: SourceKit should probably cache this for us.
       if let settings = self.buildSettingsByFile[snapshot.document.url] {
         skreq[keys.compilerargs] = settings.compilerArguments


### PR DESCRIPTION
`SourceKitServer` now talks to the `SwiftLanguageServer` and
`ClangLanguageServerShim` directly through the `LanguageService`
protocol.

I have some TODOs left in the code to double check the threading
as I'm not quite sure how it should behave. Should each internal
LSP be responsible for handling the threading?
