### PR TITLE
Add Local Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ SourceKit-LSP is still in early development, so you may run into rough edges wit
 | Find References | ✅ | |
 | Background Indexing | ❌ | Build project to update the index using [Indexing While Building](#indexing-while-building) |
 | Workspace Symbols | ✅ | |
-| Refactoring | ❌ | |
+| Global Rename | ❌ | |
+| Local Refactoring | ✅ | |
 | Formatting | ❌ | |
 | Folding | ✅ | |
 | Syntax Highlighting | ❌ | Not currently part of LSP. |

--- a/Sources/LanguageServerProtocol/ApplyEdit.swift
+++ b/Sources/LanguageServerProtocol/ApplyEdit.swift
@@ -17,7 +17,7 @@
 ///   - edit: The edits to apply.
 public struct ApplyEditRequest: RequestType {
   public static let method: String = "workspace/applyEdit"
-  public typealias Response = ApplyEditResponse?
+  public typealias Response = ApplyEditResponse
 
   /// An optional label of the workspace edit.
   /// Used by the client's user interface for things such as

--- a/Sources/LanguageServerProtocol/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/CodeAction.swift
@@ -13,8 +13,8 @@
 import Foundation
 import SKSupport
 
-public typealias CodeActionProviderCompletion = ((Result<[CodeAction], ResponseError>) -> Void)
-public typealias CodeActionProvider = ((CodeActionRequest, @escaping CodeActionProviderCompletion) -> Void)
+public typealias CodeActionProviderCompletion = (LSPResult<[CodeAction]>) -> Void
+public typealias CodeActionProvider = (CodeActionRequest, @escaping CodeActionProviderCompletion) -> Void
 
 /// Request for returning all possible code actions for a given text document and range.
 ///

--- a/Sources/LanguageServerProtocol/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/CodeAction.swift
@@ -13,7 +13,7 @@
 import Foundation
 import SKSupport
 
-public typealias CodeActionProviderCompletion = (([CodeAction]) -> Void)
+public typealias CodeActionProviderCompletion = ((Result<[CodeAction], ResponseError>) -> Void)
 public typealias CodeActionProvider = ((CodeActionRequest, @escaping CodeActionProviderCompletion) -> Void)
 
 /// Request for returning all possible code actions for a given text document and range.

--- a/Sources/LanguageServerProtocol/ExecuteCommand.swift
+++ b/Sources/LanguageServerProtocol/ExecuteCommand.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-/// Request sent from the client to to trigger command execution on the server.
+/// Request sent from the client to trigger command execution on the server.
 ///
 /// The execution of this request can be the result of a request that returns a command,
 /// such as CodeActionsRequest and CodeLensRequest. In most cases, the server creates a WorkspaceEdit
@@ -26,8 +26,8 @@ import Foundation
 public struct ExecuteCommandRequest: RequestType {
   public static let method: String = "workspace/executeCommand"
 
-  // Note: The LSP type for this response is `Any?`.
-  public typealias Response = LSPAny?
+  // Note: The LSP type for this response is `Any?`, but we return the final edit for testing purposes.
+  public typealias Response = WorkspaceEdit?
 
   /// The command to be executed.
   public var command: String

--- a/Sources/LanguageServerProtocol/ExecuteCommand.swift
+++ b/Sources/LanguageServerProtocol/ExecuteCommand.swift
@@ -25,9 +25,7 @@ import Foundation
 ///   - arguments: The arguments to use when executing the command.
 public struct ExecuteCommandRequest: RequestType {
   public static let method: String = "workspace/executeCommand"
-
-  // Note: The LSP type for this response is `Any?`, but we return the final edit for testing purposes.
-  public typealias Response = WorkspaceEdit?
+  public typealias Response = LSPAny?
 
   /// The command to be executed.
   public var command: String

--- a/Sources/LanguageServerProtocol/LSPAny.swift
+++ b/Sources/LanguageServerProtocol/LSPAny.swift
@@ -116,3 +116,8 @@ extension LSPAny: ExpressibleByDictionaryLiteral {
     self = .dictionary(dict)
   }
 }
+
+public protocol LSPAnyCodable {
+  init?(fromLSPDictionary dictionary: [String: LSPAny])
+  func encodeToLSPAny() -> LSPAny
+}

--- a/Sources/LanguageServerProtocol/Position.swift
+++ b/Sources/LanguageServerProtocol/Position.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Position within a text document, expressed as a zero-based line and column (utf-16 code unit offset).
-public struct Position: Hashable, LSPAnyCodable {
+public struct Position: Hashable {
 
   /// Line number within a document (zero-based).
   public var line: Int
@@ -23,7 +23,22 @@ public struct Position: Hashable, LSPAnyCodable {
     self.line = line
     self.utf16index = utf16index
   }
+}
 
+extension Position: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case line
+    case utf16index = "character"
+  }
+}
+
+extension Position: Comparable {
+  public static func < (lhs: Position, rhs: Position) -> Bool {
+    return (lhs.line, lhs.utf16index) < (rhs.line, rhs.utf16index)
+  }
+}
+
+extension Position: LSPAnyCodable {
   public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
     guard case .int(let line) = dictionary[CodingKeys.line.stringValue],
           case .int(let utf16index) = dictionary[CodingKeys.utf16index.stringValue] else
@@ -35,20 +50,9 @@ public struct Position: Hashable, LSPAnyCodable {
   }
 
   public func encodeToLSPAny() -> LSPAny {
-    return .dictionary([CodingKeys.line.stringValue: .int(line),
-                        CodingKeys.utf16index.stringValue: .int(utf16index)])
-  }
-}
-
-extension Position: Codable {
-  public enum CodingKeys: String, CodingKey {
-    case line
-    case utf16index = "character"
-  }
-}
-
-extension Position: Comparable {
-  public static func < (lhs: Position, rhs: Position) -> Bool {
-    return (lhs.line, lhs.utf16index) < (rhs.line, rhs.utf16index)
+    return .dictionary([
+      CodingKeys.line.stringValue: .int(line),
+      CodingKeys.utf16index.stringValue: .int(utf16index)
+    ])
   }
 }

--- a/Sources/LanguageServerProtocol/Position.swift
+++ b/Sources/LanguageServerProtocol/Position.swift
@@ -26,7 +26,7 @@ public struct Position: Hashable {
 }
 
 extension Position: Codable {
-  private enum CodingKeys: String, CodingKey {
+  public enum CodingKeys: String, CodingKey {
     case line
     case utf16index = "character"
   }

--- a/Sources/LanguageServerProtocol/Position.swift
+++ b/Sources/LanguageServerProtocol/Position.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Position within a text document, expressed as a zero-based line and column (utf-16 code unit offset).
-public struct Position: Hashable {
+public struct Position: Hashable, LSPAnyCodable {
 
   /// Line number within a document (zero-based).
   public var line: Int
@@ -22,6 +22,21 @@ public struct Position: Hashable {
   public init(line: Int, utf16index: Int) {
     self.line = line
     self.utf16index = utf16index
+  }
+
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .int(let line) = dictionary[CodingKeys.line.stringValue],
+          case .int(let utf16index) = dictionary[CodingKeys.utf16index.stringValue] else
+    {
+      return nil
+    }
+    self.line = line
+    self.utf16index = utf16index
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .dictionary([CodingKeys.line.stringValue: .int(line),
+                        CodingKeys.utf16index.stringValue: .int(utf16index)])
   }
 }
 

--- a/Sources/LanguageServerProtocol/PositionRange.swift
+++ b/Sources/LanguageServerProtocol/PositionRange.swift
@@ -20,6 +20,30 @@ extension Range where Bound == Position {
   }
 }
 
+extension Range: LSPAnyCodable where Bound == Position {
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .dictionary(let start)? = dictionary[PositionRange.CodingKeys.lowerBound.stringValue],
+          case .int(let startLine) = start[Position.CodingKeys.line.stringValue],
+          case .int(let startutf16index) = start[Position.CodingKeys.utf16index.stringValue],
+          case .dictionary(let end)? = dictionary[PositionRange.CodingKeys.upperBound.stringValue],
+          case .int(let endLine) = end[Position.CodingKeys.line.stringValue],
+          case .int(let endutf16index) = end[Position.CodingKeys.utf16index.stringValue] else
+    {
+      return nil
+    }
+    let startPosition = Position(line: startLine, utf16index: startutf16index)
+    let endPosition = Position(line: endLine, utf16index: endutf16index)
+    self = startPosition..<endPosition
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .dictionary([
+      PositionRange.CodingKeys.lowerBound.stringValue: lowerBound.encodeToLSPAny(),
+      PositionRange.CodingKeys.upperBound.stringValue: upperBound.encodeToLSPAny()
+    ])
+  }
+}
+
 /// An LSP-compatible encoding for `Range<Position>`, for use with `CustomCodable`.
 public struct PositionRange: CustomCodableWrapper {
   public var wrappedValue: Range<Position>

--- a/Sources/LanguageServerProtocol/PositionRange.swift
+++ b/Sources/LanguageServerProtocol/PositionRange.swift
@@ -28,7 +28,7 @@ public struct PositionRange: CustomCodableWrapper {
     self.wrappedValue = wrappedValue
   }
 
-  private enum CodingKeys: String, CodingKey {
+  public enum CodingKeys: String, CodingKey {
     case lowerBound = "start"
     case upperBound = "end"
   }

--- a/Sources/LanguageServerProtocol/PositionRange.swift
+++ b/Sources/LanguageServerProtocol/PositionRange.swift
@@ -20,30 +20,6 @@ extension Range where Bound == Position {
   }
 }
 
-extension Range: LSPAnyCodable where Bound == Position {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
-    guard case .dictionary(let start)? = dictionary[PositionRange.CodingKeys.lowerBound.stringValue],
-          case .int(let startLine) = start[Position.CodingKeys.line.stringValue],
-          case .int(let startutf16index) = start[Position.CodingKeys.utf16index.stringValue],
-          case .dictionary(let end)? = dictionary[PositionRange.CodingKeys.upperBound.stringValue],
-          case .int(let endLine) = end[Position.CodingKeys.line.stringValue],
-          case .int(let endutf16index) = end[Position.CodingKeys.utf16index.stringValue] else
-    {
-      return nil
-    }
-    let startPosition = Position(line: startLine, utf16index: startutf16index)
-    let endPosition = Position(line: endLine, utf16index: endutf16index)
-    self = startPosition..<endPosition
-  }
-
-  public func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      PositionRange.CodingKeys.lowerBound.stringValue: lowerBound.encodeToLSPAny(),
-      PositionRange.CodingKeys.upperBound.stringValue: upperBound.encodeToLSPAny()
-    ])
-  }
-}
-
 /// An LSP-compatible encoding for `Range<Position>`, for use with `CustomCodable`.
 public struct PositionRange: CustomCodableWrapper {
   public var wrappedValue: Range<Position>
@@ -52,7 +28,7 @@ public struct PositionRange: CustomCodableWrapper {
     self.wrappedValue = wrappedValue
   }
 
-  public enum CodingKeys: String, CodingKey {
+  fileprivate enum CodingKeys: String, CodingKey {
     case lowerBound = "start"
     case upperBound = "end"
   }
@@ -68,5 +44,25 @@ public struct PositionRange: CustomCodableWrapper {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(wrappedValue.lowerBound, forKey: .lowerBound)
     try container.encode(wrappedValue.upperBound, forKey: .upperBound)
+  }
+}
+
+extension Range: LSPAnyCodable where Bound == Position {
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .dictionary(let start)? = dictionary[PositionRange.CodingKeys.lowerBound.stringValue],
+          let startPosition = Position(fromLSPDictionary: start),
+          case .dictionary(let end)? = dictionary[PositionRange.CodingKeys.upperBound.stringValue],
+          let endPosition = Position(fromLSPDictionary: end) else
+    {
+      return nil
+    }
+    self = startPosition..<endPosition
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .dictionary([
+      PositionRange.CodingKeys.lowerBound.stringValue: lowerBound.encodeToLSPAny(),
+      PositionRange.CodingKeys.upperBound.stringValue: upperBound.encodeToLSPAny()
+    ])
   }
 }

--- a/Sources/LanguageServerProtocol/TextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/TextDocumentIdentifier.swift
@@ -16,13 +16,29 @@ import struct Foundation.URL
 public typealias URL = Foundation.URL
 
 /// Unique identifier for a document.
-public struct TextDocumentIdentifier: Hashable {
+public struct TextDocumentIdentifier: Hashable, LSPAnyCodable {
 
   /// A URL that uniquely identifies the document.
   public var url: URL
 
   public init(_ url: URL) {
     self.url = url
+  }
+
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .string(let urlString)? = dictionary[TextDocumentIdentifier.CodingKeys.url.stringValue] else {
+      return nil
+    }
+    guard let url = URL(string: urlString) else {
+      return nil
+    }
+    self.url = url
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .dictionary(
+      [CodingKeys.url.stringValue: .string(url.absoluteString)]
+    )
   }
 }
 

--- a/Sources/LanguageServerProtocol/TextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/TextDocumentIdentifier.swift
@@ -16,7 +16,7 @@ import struct Foundation.URL
 public typealias URL = Foundation.URL
 
 /// Unique identifier for a document.
-public struct TextDocumentIdentifier: Hashable, LSPAnyCodable {
+public struct TextDocumentIdentifier: Hashable {
 
   /// A URL that uniquely identifies the document.
   public var url: URL
@@ -24,9 +24,18 @@ public struct TextDocumentIdentifier: Hashable, LSPAnyCodable {
   public init(_ url: URL) {
     self.url = url
   }
+}
 
+// Encode using the key "uri" to match LSP.
+extension TextDocumentIdentifier: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case url = "uri"
+  }
+}
+
+extension TextDocumentIdentifier: LSPAnyCodable {
   public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
-    guard case .string(let urlString)? = dictionary[TextDocumentIdentifier.CodingKeys.url.stringValue] else {
+    guard case .string(let urlString)? = dictionary[CodingKeys.url.stringValue] else {
       return nil
     }
     guard let url = URL(string: urlString) else {
@@ -36,15 +45,8 @@ public struct TextDocumentIdentifier: Hashable, LSPAnyCodable {
   }
 
   public func encodeToLSPAny() -> LSPAny {
-    return .dictionary(
-      [CodingKeys.url.stringValue: .string(url.absoluteString)]
-    )
-  }
-}
-
-// Encode using the key "uri" to match LSP.
-extension TextDocumentIdentifier: Codable {
-  public enum CodingKeys: String, CodingKey {
-    case url = "uri"
+    return .dictionary([
+      CodingKeys.url.stringValue: .string(url.absoluteString)
+    ])
   }
 }

--- a/Sources/LanguageServerProtocol/TextEdit.swift
+++ b/Sources/LanguageServerProtocol/TextEdit.swift
@@ -13,7 +13,7 @@
 import SKSupport
 
 /// Edit to a text document, replacing the contents of `range` with `text`.
-public struct TextEdit: ResponseType, Hashable {
+public struct TextEdit: ResponseType, Hashable, LSPAnyCodable {
 
   /// The range of text to be replaced.
   @CustomCodable<PositionRange>
@@ -25,5 +25,25 @@ public struct TextEdit: ResponseType, Hashable {
   public init(range: Range<Position>, newText: String) {
     self.range = range
     self.newText = newText
+  }
+
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .dictionary(let rangeDict) = dictionary[CodingKeys.range.stringValue],
+          case .string(let newText) = dictionary[CodingKeys.newText.stringValue] else
+    {
+      return nil
+    }
+    guard let range = Range<Position>(fromLSPDictionary: rangeDict) else {
+      return nil
+    }
+    self.range = range
+    self.newText = newText
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .dictionary([
+      CodingKeys.range.stringValue: range.encodeToLSPAny(),
+      CodingKeys.newText.stringValue: .string(newText)
+    ])
   }
 }

--- a/Sources/LanguageServerProtocol/TextEdit.swift
+++ b/Sources/LanguageServerProtocol/TextEdit.swift
@@ -13,7 +13,7 @@
 import SKSupport
 
 /// Edit to a text document, replacing the contents of `range` with `text`.
-public struct TextEdit: ResponseType, Hashable, LSPAnyCodable {
+public struct TextEdit: ResponseType, Hashable {
 
   /// The range of text to be replaced.
   @CustomCodable<PositionRange>
@@ -26,7 +26,9 @@ public struct TextEdit: ResponseType, Hashable, LSPAnyCodable {
     self.range = range
     self.newText = newText
   }
+}
 
+extension TextEdit: LSPAnyCodable {
   public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
     guard case .dictionary(let rangeDict) = dictionary[CodingKeys.range.stringValue],
           case .string(let newText) = dictionary[CodingKeys.newText.stringValue] else

--- a/Sources/LanguageServerProtocol/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/WorkspaceEdit.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A workspace edit represents changes to many resources managed in the workspace.
-public struct WorkspaceEdit: Hashable, ResponseType, LSPAnyCodable {
+public struct WorkspaceEdit: Hashable, ResponseType {
 
   /// The edits to be applied to existing resources.
   public var changes: [URL: [TextEdit]]?
@@ -19,54 +19,26 @@ public struct WorkspaceEdit: Hashable, ResponseType, LSPAnyCodable {
   public init(changes: [URL: [TextEdit]]?) {
     self.changes = changes
   }
-
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
-    guard case .dictionary(let lspDict) = dictionary[CodingKeys.changes.stringValue] else {
-      return nil
-    }
-    var dictionary = [URL: [TextEdit]]()
-    for (key, value) in lspDict {
-      guard let url = URL(string: key) else {
-        return nil
-      }
-      guard case .array(let array) = value else {
-        return nil
-      }
-      var edits = [TextEdit]()
-      for case .dictionary(let editDict) in array {
-        guard let edit = TextEdit(fromLSPDictionary: editDict) else {
-          return nil
-        }
-        edits.append(edit)
-      }
-      dictionary[url] = edits
-    }
-    self.changes = dictionary
-  }
-
-  public func encodeToLSPAny() -> LSPAny {
-    guard let changes = changes else {
-      return nil
-    }
-    let values = changes.map {
-      ($0.key.absoluteString, LSPAny.array($0.value.map { $0.encodeToLSPAny() }))
-    }
-    let dictionary = Dictionary(uniqueKeysWithValues: values)
-    return .dictionary([
-      CodingKeys.changes.stringValue: .dictionary(dictionary)
-    ])
-  }
 }
 
 // Workaround for Codable not correctly encoding dictionaries whose keys aren't strings.
 extension WorkspaceEdit: Codable {
-  enum CodingKeys: String, CodingKey {
+  private enum CodingKeys: String, CodingKey {
     case changes
   }
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.changes = try container.decode([URL: [TextEdit]].self, forKey: .changes)
+    let changesDict = try container.decode([String: [TextEdit]].self, forKey: .changes)
+    var changes = [URL: [TextEdit]]()
+    for change in changesDict {
+      guard let url = URL(string: change.key) else {
+        let error = "Changes key is not an URL."
+        throw DecodingError.dataCorruptedError(forKey: .changes, in: container, debugDescription: error)
+      }
+      changes[url] = change.value
+    }
+    self.changes = changes
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -79,5 +51,61 @@ extension WorkspaceEdit: Codable {
     }
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(stringDictionary, forKey: .changes)
+  }
+}
+
+extension WorkspaceEdit: LSPAnyCodable {
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .dictionary(let lspDict) = dictionary[CodingKeys.changes.stringValue] else {
+      return nil
+    }
+    var dictionary = [URL: [TextEdit]]()
+    for (key, value) in lspDict {
+      guard let url = URL(string: key) else {
+        return nil
+      }
+      guard let edits = [TextEdit](fromLSPArray: value) else {
+        return nil
+      }
+      dictionary[url] = edits
+    }
+    self.changes = dictionary
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    guard let changes = changes else {
+      return nil
+    }
+    let values = changes.map {
+      ($0.key.absoluteString, $0.value.encodeToLSPAny())
+    }
+    let dictionary = Dictionary(uniqueKeysWithValues: values)
+    return .dictionary([
+      CodingKeys.changes.stringValue: .dictionary(dictionary)
+    ])
+  }
+}
+
+extension Array: LSPAnyCodable where Element: LSPAnyCodable {
+  public init?(fromLSPArray array: LSPAny) {
+    guard case .array(let array) = array else {
+      return nil
+    }
+    var result = [Element]()
+    for case .dictionary(let editDict) in array {
+      guard let element = Element.init(fromLSPDictionary: editDict) else {
+        return nil
+      }
+      result.append(element)
+    }
+    self = result
+  }
+
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    return nil
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .array(map { $0.encodeToLSPAny() })
   }
 }

--- a/Sources/LanguageServerProtocol/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/WorkspaceEdit.swift
@@ -11,16 +11,73 @@
 //===----------------------------------------------------------------------===//
 
 /// A workspace edit represents changes to many resources managed in the workspace.
-public struct WorkspaceEdit: Codable, Hashable, ResponseType {
+public struct WorkspaceEdit: Hashable, ResponseType, LSPAnyCodable {
 
   /// The edits to be applied to existing resources.
-  public var changes: [String: [TextEdit]]?
+  public var changes: [URL: [TextEdit]]?
 
   public init(changes: [URL: [TextEdit]]?) {
+    self.changes = changes
+  }
+
+  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+    guard case .dictionary(let lspDict) = dictionary[CodingKeys.changes.stringValue] else {
+      return nil
+    }
+    var dictionary = [URL: [TextEdit]]()
+    for (key, value) in lspDict {
+      guard let url = URL(string: key) else {
+        return nil
+      }
+      guard case .array(let array) = value else {
+        return nil
+      }
+      var edits = [TextEdit]()
+      for case .dictionary(let editDict) in array {
+        guard let edit = TextEdit(fromLSPDictionary: editDict) else {
+          return nil
+        }
+        edits.append(edit)
+      }
+      dictionary[url] = edits
+    }
+    self.changes = dictionary
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    guard let changes = changes else {
+      return nil
+    }
+    let values = changes.map {
+      ($0.key.absoluteString, LSPAny.array($0.value.map { $0.encodeToLSPAny() }))
+    }
+    let dictionary = Dictionary(uniqueKeysWithValues: values)
+    return .dictionary([
+      CodingKeys.changes.stringValue: .dictionary(dictionary)
+    ])
+  }
+}
+
+// Workaround for Codable not correctly encoding dictionaries whose keys aren't strings.
+extension WorkspaceEdit: Codable {
+  enum CodingKeys: String, CodingKey {
+    case changes
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.changes = try container.decode([URL: [TextEdit]].self, forKey: .changes)
+  }
+
+  public func encode(to encoder: Encoder) throws {
     guard let changes = changes else {
       return
     }
-    let changesArray = changes.map { ($0.key.absoluteString, $0.value) }
-    self.changes = Dictionary(uniqueKeysWithValues: changesArray)
+    var stringDictionary = [String: [TextEdit]]()
+    for (key, value) in changes {
+      stringDictionary[key.absoluteString] = value
+    }
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(stringDictionary, forKey: .changes)
   }
 }

--- a/Sources/LanguageServerProtocol/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/WorkspaceEdit.swift
@@ -14,9 +14,13 @@
 public struct WorkspaceEdit: Codable, Hashable, ResponseType {
 
   /// The edits to be applied to existing resources.
-  public var changes: [URL: [TextEdit]]?
+  public var changes: [String: [TextEdit]]?
 
   public init(changes: [URL: [TextEdit]]?) {
-    self.changes = changes
+    guard let changes = changes else {
+      return
+    }
+    let changesArray = changes.map { ($0.key.absoluteString, $0.value) }
+    self.changes = Dictionary(uniqueKeysWithValues: changesArray)
   }
 }

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -175,8 +175,8 @@ extension LineTable {
     return convertColumn(
       line: line,
       column: utf8Column,
-      indexFunction: content.utf8.index,
-      distanceFunction: content.utf16.distance)
+      indexFunction: content.utf8.index(_:offsetBy:limitedBy:),
+      distanceFunction: content.utf16.distance(from:to:))
   }
 
   /// Returns UTF8 column offset at UTF16 version of logical position.
@@ -188,8 +188,8 @@ extension LineTable {
     return convertColumn(
       line: line,
       column: utf16Column,
-      indexFunction: content.utf16.index,
-      distanceFunction: content.utf8.distance)
+      indexFunction: content.utf16.index(_:offsetBy:limitedBy:),
+      distanceFunction: content.utf8.distance(from:to:))
   }
 
   @inlinable

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -172,15 +172,37 @@ extension LineTable {
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
   @inlinable
   public func utf16ColumnAt(line: Int, utf8Column: Int) -> Int? {
+    return convertColumn(
+      line: line,
+      column: utf8Column,
+      indexFunction: content.utf8.index,
+      distanceFunction: content.utf16.distance)
+  }
+
+  /// Returns UTF8 column offset at UTF16 version of logical position.
+  ///
+  /// - parameter line: Line number (zero-based).
+  /// - parameter utf16Column: UTF-16 column offset (zero-based).
+  @inlinable
+  public func utf8ColumnAt(line: Int, utf16Column: Int) -> Int? {
+    return convertColumn(
+      line: line,
+      column: utf16Column,
+      indexFunction: content.utf16.index,
+      distanceFunction: content.utf8.distance)
+  }
+
+  @inlinable
+  func convertColumn(line: Int, column: Int, indexFunction: (Substring.Index, Int, Substring.Index) -> Substring.Index?, distanceFunction: (Substring.Index, Substring.Index) -> Int) -> Int? {
     guard line < count else {
       // Line out of range.
       return nil
     }
     let lineSlice = self[line]
-    guard let targetIndex = content.utf8.index(lineSlice.startIndex, offsetBy: utf8Column, limitedBy: lineSlice.endIndex) else {
+    guard let targetIndex = indexFunction(lineSlice.startIndex, column, lineSlice.endIndex) else {
       // Column out of range
       return nil
     }
-    return content.utf16.distance(from: lineSlice.startIndex, to: targetIndex)
+    return distanceFunction(lineSlice.startIndex, targetIndex)
   }
 }

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -37,7 +37,8 @@ public final class SKTibsTestWorkspace {
     immutableProjectDir: URL,
     persistentBuildDir: URL,
     tmpDir: URL,
-    toolchain: Toolchain) throws
+    toolchain: Toolchain,
+    clientCapabilities: ClientCapabilities) throws
   {
     self.tibsWorkspace = try TibsTestWorkspace(
       immutableProjectDir: immutableProjectDir,
@@ -45,23 +46,23 @@ public final class SKTibsTestWorkspace {
       tmpDir: tmpDir,
       toolchain: TibsToolchain(toolchain))
 
-    initWorkspace()
+    initWorkspace(clientCapabilities: clientCapabilities)
   }
 
-  public init(projectDir: URL, tmpDir: URL, toolchain: Toolchain) throws {
+  public init(projectDir: URL, tmpDir: URL, toolchain: Toolchain, clientCapabilities: ClientCapabilities) throws {
     self.tibsWorkspace = try TibsTestWorkspace(
       projectDir: projectDir,
       tmpDir: tmpDir,
       toolchain: TibsToolchain(toolchain))
 
-    initWorkspace()
+    initWorkspace(clientCapabilities: clientCapabilities)
   }
 
-  func initWorkspace() {
+  func initWorkspace(clientCapabilities: ClientCapabilities) {
     let buildPath = AbsolutePath(builder.buildRoot.path)
     testServer.server!.workspace = Workspace(
       rootPath: AbsolutePath(sources.rootDirectory.path),
-      clientCapabilities: ClientCapabilities(),
+      clientCapabilities: clientCapabilities,
       buildSettings: CompilationDatabaseBuildSystem(projectRoot: buildPath),
       index: index,
       buildSetup: BuildSetup(configuration: .debug, path: buildPath, flags: BuildFlags()))
@@ -89,7 +90,7 @@ extension SKTibsTestWorkspace {
 
 extension XCTestCase {
 
-  public func staticSourceKitTibsWorkspace(name: String, testFile: String = #file) throws -> SKTibsTestWorkspace? {
+  public func staticSourceKitTibsWorkspace(name: String, clientCapabilities: ClientCapabilities = .init(), testFile: String = #file) throws -> SKTibsTestWorkspace? {
     let testDirName = testDirectoryName
     let workspace = try SKTibsTestWorkspace(
       immutableProjectDir: inputsDirectory(testFile: testFile)
@@ -98,7 +99,8 @@ extension XCTestCase {
         .appendingPathComponent("sk-tests/\(testDirName)", isDirectory: true),
       tmpDir: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         .appendingPathComponent("sk-test-data/\(testDirName)", isDirectory: true),
-      toolchain: ToolchainRegistry.shared.default!)
+      toolchain: ToolchainRegistry.shared.default!,
+      clientCapabilities: clientCapabilities)
 
     if workspace.builder.targets.contains(where: { target in !target.clangTUs.isEmpty })
       && !workspace.builder.toolchain.clangHasIndexSupport {

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -93,7 +93,6 @@ public final class TestClient: LanguageServerEndpoint {
   var oneShotRequestHandlers: [((Any) -> Void)] = []
 
   public var allowUnexpectedNotification: Bool = true
-  public var allowUnexpectedRequest: Bool = false
 
   public func appendOneShotNotificationHandler<N>(_ handler: @escaping (Notification<N>) -> Void) {
     oneShotNotificationHandlers.append({ anyNote in
@@ -138,7 +137,6 @@ public final class TestClient: LanguageServerEndpoint {
 
   override public func _handleUnknown<R>(_ request: Request<R>) where R : RequestType {
     guard !oneShotRequestHandlers.isEmpty else {
-      if allowUnexpectedRequest { return }
       fatalError("unexpected request \(request)")
     }
     let handler = oneShotRequestHandlers.removeFirst()

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -92,6 +92,7 @@ public final class TestClient: LanguageServerEndpoint {
   var oneShotNotificationHandlers: [((Any) -> Void)] = []
 
   public var allowUnexpectedNotification: Bool = true
+  public var allowUnexpectedRequest: Bool = false
 
   public func appendOneShotNotificationHandler<N>(_ handler: @escaping (Notification<N>) -> Void) {
     oneShotNotificationHandlers.append({ anyNote in
@@ -121,7 +122,10 @@ public final class TestClient: LanguageServerEndpoint {
   }
 
   override public func _handleUnknown<R>(_ request: Request<R>) where R : RequestType {
-    fatalError()
+    guard allowUnexpectedRequest else {
+      fatalError("unexpected request \(request)")
+    }
+    request.reply(.failure(.cancelled))
   }
 }
 

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -90,6 +90,7 @@ public final class TestClient: LanguageServerEndpoint {
 
   public var replyQueue: DispatchQueue = DispatchQueue(label: "testclient-reply-queue")
   var oneShotNotificationHandlers: [((Any) -> Void)] = []
+  var oneShotRequestHandlers: [((Any) -> Void)] = []
 
   public var allowUnexpectedNotification: Bool = true
   public var allowUnexpectedRequest: Bool = false
@@ -103,9 +104,23 @@ public final class TestClient: LanguageServerEndpoint {
     })
   }
 
+  public func appendOneShotRequestHandler<R>(_ handler: @escaping (Request<R>) -> Void) {
+    oneShotRequestHandlers.append({ anyRequest in
+      guard let request = anyRequest as? Request<R> else {
+        fatalError("received request of the wrong type \(anyRequest); expected \(R.self)")
+      }
+      handler(request)
+    })
+  }
+
   public func handleNextNotification<N>(_ handler: @escaping (Notification<N>) -> Void) {
     precondition(oneShotNotificationHandlers.isEmpty)
     appendOneShotNotificationHandler(handler)
+  }
+
+  public func handleNextRequest<R>(_ handler: @escaping (Request<R>) -> Void) {
+    precondition(oneShotRequestHandlers.isEmpty)
+    appendOneShotRequestHandler(handler)
   }
 
   override public func _registerBuiltinHandlers() {
@@ -122,10 +137,12 @@ public final class TestClient: LanguageServerEndpoint {
   }
 
   override public func _handleUnknown<R>(_ request: Request<R>) where R : RequestType {
-    guard allowUnexpectedRequest else {
+    guard !oneShotRequestHandlers.isEmpty else {
+      if allowUnexpectedRequest { return }
       fatalError("unexpected request \(request)")
     }
-    request.reply(.failure(.cancelled))
+    let handler = oneShotRequestHandlers.removeFirst()
+    handler(request)
   }
 }
 

--- a/Sources/SourceKit/SourceKitLSPCommandMetadata.swift
+++ b/Sources/SourceKit/SourceKitLSPCommandMetadata.swift
@@ -23,14 +23,11 @@ public struct SourceKitLSPCommandMetadata: Codable, Hashable {
 
   public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     let textDocumentKey = CodingKeys.sourcekitlsp_textDocument.stringValue
-    let urlKey = TextDocumentIdentifier.CodingKeys.url.stringValue
     guard case .dictionary(let textDocumentDict)? = dictionary[textDocumentKey],
-          case .string(let urlString)? = textDocumentDict[urlKey],
-          let url = URL(string: urlString) else
+          let textDocument = TextDocumentIdentifier(fromLSPDictionary: textDocumentDict) else
     {
       return nil
     }
-    let textDocument = TextDocumentIdentifier(url)
     self.init(textDocument: textDocument)
   }
 
@@ -39,10 +36,9 @@ public struct SourceKitLSPCommandMetadata: Codable, Hashable {
   }
 
   public func encodeToLSPAny() -> LSPAny {
-    let textDocumentArgument = LSPAny.dictionary(
-      [TextDocumentIdentifier.CodingKeys.url.stringValue: .string(sourcekitlsp_textDocument.url.absoluteString)]
-    )
-    return .dictionary([CodingKeys.sourcekitlsp_textDocument.stringValue: textDocumentArgument])
+    return .dictionary([
+      CodingKeys.sourcekitlsp_textDocument.stringValue: sourcekitlsp_textDocument.encodeToLSPAny()
+    ])
   }
 }
 

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -312,11 +312,11 @@ extension SourceKitServer {
       codeActionProvider: CodeActionServerCapabilities(
         clientCapabilities: req.params.capabilities.textDocument?.codeAction,
         codeActionOptions: CodeActionOptions(codeActionKinds: nil),
-        supportsCodeActions: false // TODO: Turn it on after a provider is implemented.
+        supportsCodeActions: true
       ),
       workspaceSymbolProvider: true,
       executeCommandProvider: ExecuteCommandOptions(
-        commands: [] // FIXME: Clangd commands?
+        commands: builtinSwiftCommands // FIXME: Clangd commands?
       )
     )))
   }

--- a/Sources/SourceKit/sourcekitd/SemanticRefactorCommand.swift
+++ b/Sources/SourceKit/sourcekitd/SemanticRefactorCommand.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import LanguageServerProtocol
+import sourcekitd
+
+public struct SemanticRefactorCommand: SwiftCommand {
+
+  public static let identifier: String = "semantic.refactor.command"
+
+  /// The name of this refactoring action.
+  public var title: String
+
+  /// The sourcekitd identifier of the refactoring action.
+  public var actionString: String
+
+  /// The range to refactor.
+  public var positionRange: Range<Position>
+
+  /// The text document related to the refactoring action.
+  public var textDocument: TextDocumentIdentifier
+
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
+    guard case .dictionary(let documentDict)? = dictionary[CodingKeys.textDocument.stringValue],
+          case .string(let title)? = dictionary[CodingKeys.title.stringValue],
+          case .string(let actionString)? = dictionary[CodingKeys.actionString.stringValue],
+          case .dictionary(let rangeDict)? = dictionary[CodingKeys.positionRange.stringValue] else
+    {
+      return nil
+    }
+    guard let positionRange = Range<Position>(fromLSPDictionary: rangeDict),
+          let textDocument = TextDocumentIdentifier(fromLSPDictionary: documentDict) else {
+      return nil
+    }
+    self.init(title: title,
+              actionString: actionString,
+              positionRange: positionRange,
+              textDocument: textDocument)
+  }
+
+  public init(title: String, actionString: String, positionRange: Range<Position>, textDocument: TextDocumentIdentifier) {
+    self.title = title
+    self.actionString = actionString
+    self.positionRange = positionRange
+    self.textDocument = textDocument
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    return .dictionary([
+      CodingKeys.title.stringValue: .string(title),
+      CodingKeys.actionString.stringValue: .string(actionString),
+      CodingKeys.positionRange.stringValue: positionRange.encodeToLSPAny(),
+      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny()
+    ])
+  }
+}
+
+extension Array where Element == SemanticRefactorCommand {
+  init?(array: SKResponseArray?, range: Range<Position>, textDocument: TextDocumentIdentifier, _ keys: sourcekitd_keys, _ api: sourcekitd_functions_t) {
+    guard let results = array else {
+      return nil
+    }
+    var commands = [SemanticRefactorCommand]()
+    results.forEach { _, value in
+      if let name: String = value[keys.actionname],
+         let actionuid: sourcekitd_uid_t = value[keys.actionuid],
+         let ptr = api.uid_get_string_ptr(actionuid)
+      {
+        let actionName = String(cString: ptr)
+        guard actionName != "source.refactoring.kind.rename.global" else {
+          // TODO: Global refactoring
+          return true
+        }
+        commands.append(SemanticRefactorCommand(
+          title: name,
+          actionString: actionName,
+          positionRange: range,
+          textDocument: textDocument)
+        )
+      }
+      return true
+    }
+    self = commands
+  }
+}

--- a/Sources/SourceKit/sourcekitd/SemanticRefactoring.swift
+++ b/Sources/SourceKit/sourcekitd/SemanticRefactoring.swift
@@ -1,0 +1,157 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import LanguageServerProtocol
+import TSCBasic
+import sourcekitd
+
+/// Detailed information about the result of a specific refactoring operation.
+///
+/// Wraps the information returned by sourcekitd's `semantic_refactoring` request, such as the necessary edits and placeholder locations.
+struct SemanticRefactoring {
+
+  /// The title of the refactoring action.
+  var title: String
+
+  /// The resulting `WorkspaceEdit` of a `semantic_refactoring` request.
+  var edit: WorkspaceEdit
+
+  init(_ title: String, _ edit: WorkspaceEdit) {
+    self.title = title
+    self.edit = edit
+  }
+
+  /// Create a `SemanticRefactoring` from a sourcekitd response dictionary, if possible.
+  ///
+  /// - Parameters:
+  ///   - title: The title of the refactoring action.
+  ///   - dict: Response dictionary to extract information from.
+  ///   - url: The client URL that triggered the `semantic_refactoring` request.
+  ///   - keys: The sourcekitd key set to use for looking up into `dict`.
+  init?(_ title: String, _ dict: SKResponseDictionary, _ url: URL, _ keys: sourcekitd_keys) {
+    guard let categorizedEdits: SKResponseArray = dict[keys.categorizededits] else {
+      return nil
+    }
+
+    var textEdits = [TextEdit]()
+
+    categorizedEdits.forEach { _, value in
+      guard let edits: SKResponseArray = value[keys.edits] else {
+        return false
+      }
+      edits.forEach { _, value in
+        if let startLine: Int = value[keys.line],
+           let startColumn: Int = value[keys.column],
+           let endLine: Int = value[keys.endline],
+           let endColumn: Int = value[keys.endcolumn],
+           let text: String = value[keys.text]
+        {
+          // The LSP is zero based, but semantic_refactoring is one based.
+          let startPosition = Position(line: startLine - 1, utf16index: startColumn - 1)
+          let endPosition = Position(line: endLine - 1, utf16index: endColumn - 1)
+          let edit = TextEdit(range: startPosition..<endPosition, newText: text)
+          textEdits.append(edit)
+        }
+        return true
+      }
+      return true
+    }
+
+    guard textEdits.isEmpty == false else {
+      return nil
+    }
+
+    self.title = title
+    self.edit = WorkspaceEdit(changes: [url: textEdits])
+  }
+}
+
+/// An error from a cursor info request.
+enum SemanticRefactoringError: Error {
+
+  /// The given URL is not a known document.
+  case unknownDocument(URL)
+
+  /// The given position range is invalid.
+  case invalidRange(Range<Position>)
+
+  /// The underlying sourcekitd request failed with the given error.
+  case responseError(ResponseError)
+
+  /// The underlying sourcekitd reported no edits for this action.
+  case noEditsNeeded(URL)
+}
+
+extension SemanticRefactoringError: CustomStringConvertible {
+  var description: String {
+    switch self {
+    case .unknownDocument(let url):
+      return "failed to find snapshot for url \(url)"
+    case .invalidRange(let range):
+      return "failed to refactor due to invalid range: \(range)"
+    case .responseError(let error):
+      return "\(error)"
+    case .noEditsNeeded(let url):
+      return "no edits reported for semantic refactoring action for url \(url)"
+    }
+  }
+}
+
+extension SwiftLanguageServer {
+
+  /// Provides detailed information about the result of a specific refactoring operation.
+  ///
+  /// Wraps the information returned by sourcekitd's `semantic_refactoring` request, such as the necessary edits and placeholder locations.
+  ///
+  /// - Parameters:
+  ///   - url: Document URL in which to perform the request. Must be an open document.
+  ///   - command: The semantic refactor `Command` that triggered this request.
+  ///   - completion: Completion block to asynchronously receive the SemanticRefactoring data, or error.
+  func semanticRefactoring(
+    _ refactorCommand: SemanticRefactorCommand,
+    _ completion: @escaping (Result<SemanticRefactoring, SemanticRefactoringError>) -> Void)
+  {
+    let url = refactorCommand.textDocument.url
+    guard let snapshot = documentManager.latestSnapshot(url) else {
+      return completion(.failure(.unknownDocument(url)))
+    }
+    guard let startOffset = snapshot.utf8Offset(of: refactorCommand.positionRange.lowerBound),
+          let endOffset = snapshot.utf8Offset(of: refactorCommand.positionRange.upperBound) else
+    {
+      return completion(.failure(.invalidRange(refactorCommand.positionRange)))
+    }
+    let skreq = SKRequestDictionary(sourcekitd: sourcekitd)
+    skreq[keys.request] = requests.semantic_refactoring
+    skreq[keys.name] = ""
+    skreq[keys.sourcefile] = url.path
+    skreq[keys.line] = refactorCommand.positionRange.lowerBound.line + 1
+    skreq[keys.column] = refactorCommand.positionRange.lowerBound.utf16index + 1 // LSP is zero based, but this request is 1 based.
+    skreq[keys.length] = endOffset - startOffset
+    skreq[keys.actionuid] = sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!
+    if let settings = buildSystem.settings(for: url, snapshot.document.language) {
+      skreq[keys.compilerargs] = settings.compilerArguments
+    }
+
+    let handle = sourcekitd.send(skreq) { [weak self] result in
+      guard let self = self else { return }
+      guard let dict = result.success else {
+        return completion(.failure(.responseError(result.failure!)))
+      }
+      guard let refactor = SemanticRefactoring(refactorCommand.title, dict, url, self.keys) else {
+        return completion(.failure(.noEditsNeeded(url)))
+      }
+      completion(.success(refactor))
+    }
+
+    // FIXME: cancellation
+    _ = handle
+  }
+}

--- a/Sources/SourceKit/sourcekitd/SwiftCommand.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftCommand.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import SKSupport
+import LanguageServerProtocol
+import Foundation
+
+/// The set of known Swift commands.
+///
+/// All commands from the Swift LSP should be listed here.
+public let builtinSwiftCommands: [String] = [
+  SemanticRefactorCommand.self
+].map { $0.identifier }
+
+/// A `Command` that should be executed by Swift's language server.
+public protocol SwiftCommand: Codable, Hashable {
+  init?(fromLSPDictionary: [String: LSPAny])
+
+  static var identifier: String { get }
+  var title: String { get set }
+
+  func encodeToLSPAny() -> LSPAny
+}
+
+extension SwiftCommand {
+  /// Converts this `SwiftCommand` to a generic LSP `Command` object.
+  public func asCommand() throws -> Command {
+    let argument = encodeToLSPAny()
+    return Command(title: title, command: Self.identifier, arguments: [argument])
+  }
+}
+
+extension ExecuteCommandRequest {
+  /// Attempts to convert the underlying `Command` metadata from this request
+  /// to a specific Swift language server `SwiftCommand`.
+  ///
+  /// - Parameters:
+  ///   - type: The `SwiftCommand` metatype to convert to.
+  public func swiftCommand<T: SwiftCommand>(ofType type: T.Type) -> T? {
+    guard type.identifier == command else {
+      return nil
+    }
+    guard let argument = arguments?.first else {
+      return nil
+    }
+    guard case let .dictionary(dictionary) = argument else {
+      return nil
+    }
+    return type.init(fromLSPDictionary: dictionary)
+  }
+}
+
+public struct SemanticRefactorCommand: SwiftCommand {
+
+  public static var identifier: String {
+    return "semantic.refactor.command"
+  }
+
+  /// The name of this refactoring action.
+  public var title: String
+
+  /// The sourcekitd identifier of the refactoring action.
+  public var actionString: String
+
+  /// The range to refactor.
+  public var positionRange: Range<Position>
+
+  /// The text document related to the refactoring action.
+  public var textDocument: TextDocumentIdentifier
+
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
+    guard case .dictionary(let dict)? = dictionary[CodingKeys.textDocument.stringValue],
+          case .string(let title)? = dictionary[CodingKeys.title.stringValue],
+          case .string(let actionString)? = dictionary[CodingKeys.actionString.stringValue],
+          case .string(let urlString)? = dict[TextDocumentIdentifier.CodingKeys.url.stringValue],
+          case .dictionary(let rangeDict)? = dictionary[CodingKeys.positionRange.stringValue],
+          case .dictionary(let start)? = rangeDict[PositionRange.CodingKeys.lowerBound.stringValue],
+          case .int(let startLine) = start[Position.CodingKeys.line.stringValue],
+          case .int(let startutf16index) = start[Position.CodingKeys.utf16index.stringValue],
+          case .dictionary(let end)? = rangeDict[PositionRange.CodingKeys.upperBound.stringValue],
+          case .int(let endLine) = end[Position.CodingKeys.line.stringValue],
+          case .int(let endutf16index) = end[Position.CodingKeys.utf16index.stringValue],
+          let url = URL(string: urlString) else
+    {
+      return nil
+    }
+    let startPosition = Position(line: startLine, utf16index: startutf16index)
+    let endPosition = Position(line: endLine, utf16index: endutf16index)
+    let positionRange = startPosition..<endPosition
+    self.init(title: title,
+              actionString: actionString,
+              positionRange: positionRange,
+              textDocument: TextDocumentIdentifier(url))
+  }
+
+  public init(title: String, actionString: String, positionRange: Range<Position>, textDocument: TextDocumentIdentifier) {
+    self.title = title
+    self.actionString = actionString
+    self.positionRange = positionRange
+    self.textDocument = textDocument
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    let textDocumentArgument = LSPAny.dictionary(
+      [TextDocumentIdentifier.CodingKeys.url.stringValue: .string(textDocument.url.absoluteString)]
+    )
+    let startRange = LSPAny.dictionary(
+      [Position.CodingKeys.line.stringValue: .int(positionRange.lowerBound.line),
+       Position.CodingKeys.utf16index.stringValue: .int(positionRange.lowerBound.utf16index)]
+    )
+    let endRange = LSPAny.dictionary(
+      [Position.CodingKeys.line.stringValue: .int(positionRange.upperBound.line),
+       Position.CodingKeys.utf16index.stringValue: .int(positionRange.upperBound.utf16index)]
+    )
+    return .dictionary([CodingKeys.title.stringValue: .string(title),
+                        CodingKeys.actionString.stringValue: .string(actionString),
+                        CodingKeys.positionRange.stringValue: .dictionary([
+                          PositionRange.CodingKeys.lowerBound.stringValue: startRange,
+                          PositionRange.CodingKeys.upperBound.stringValue: endRange
+                        ]),
+                        CodingKeys.textDocument.stringValue: textDocumentArgument])
+  }
+}

--- a/Sources/SourceKit/sourcekitd/SwiftCommand.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftCommand.swift
@@ -9,9 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import SKSupport
 import LanguageServerProtocol
-import Foundation
 
 /// The set of known Swift commands.
 ///
@@ -51,54 +49,5 @@ extension ExecuteCommandRequest {
       return nil
     }
     return type.init(fromLSPDictionary: dictionary)
-  }
-}
-
-public struct SemanticRefactorCommand: SwiftCommand {
-
-  public static let identifier: String = "semantic.refactor.command"
-
-  /// The name of this refactoring action.
-  public var title: String
-
-  /// The sourcekitd identifier of the refactoring action.
-  public var actionString: String
-
-  /// The range to refactor.
-  public var positionRange: Range<Position>
-
-  /// The text document related to the refactoring action.
-  public var textDocument: TextDocumentIdentifier
-
-  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard case .dictionary(let documentDict)? = dictionary[CodingKeys.textDocument.stringValue],
-          case .string(let title)? = dictionary[CodingKeys.title.stringValue],
-          case .string(let actionString)? = dictionary[CodingKeys.actionString.stringValue],
-          case .dictionary(let rangeDict)? = dictionary[CodingKeys.positionRange.stringValue] else
-    {
-      return nil
-    }
-    guard let positionRange = Range<Position>(fromLSPDictionary: rangeDict),
-          let textDocument = TextDocumentIdentifier(fromLSPDictionary: documentDict) else {
-      return nil
-    }
-    self.init(title: title,
-              actionString: actionString,
-              positionRange: positionRange,
-              textDocument: textDocument)
-  }
-
-  public init(title: String, actionString: String, positionRange: Range<Position>, textDocument: TextDocumentIdentifier) {
-    self.title = title
-    self.actionString = actionString
-    self.positionRange = positionRange
-    self.textDocument = textDocument
-  }
-
-  public func encodeToLSPAny() -> LSPAny {
-    return .dictionary([CodingKeys.title.stringValue: .string(title),
-                        CodingKeys.actionString.stringValue: .string(actionString),
-                        CodingKeys.positionRange.stringValue: positionRange.encodeToLSPAny(),
-                        CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny()])
   }
 }

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -208,6 +208,8 @@ struct sourcekitd_keys {
   let severity: sourcekitd_uid_t
   let line: sourcekitd_uid_t
   let column: sourcekitd_uid_t
+  let endline: sourcekitd_uid_t
+  let endcolumn: sourcekitd_uid_t
   let filepath: sourcekitd_uid_t
   let ranges: sourcekitd_uid_t
   let usr: sourcekitd_uid_t
@@ -221,6 +223,13 @@ struct sourcekitd_keys {
   let syntaxmap: sourcekitd_uid_t
   let namelength: sourcekitd_uid_t
   let nameoffset: sourcekitd_uid_t
+  let retrieve_refactor_actions: sourcekitd_uid_t
+  let refactor_actions: sourcekitd_uid_t
+  let actionname: sourcekitd_uid_t
+  let actionuid: sourcekitd_uid_t
+  let categorizededits: sourcekitd_uid_t
+  let edits: sourcekitd_uid_t
+  let text: sourcekitd_uid_t
 
   init(api: sourcekitd_functions_t) {
     request = api.uid_get_from_cstr("key.request")!
@@ -239,6 +248,8 @@ struct sourcekitd_keys {
     severity = api.uid_get_from_cstr("key.severity")!
     line = api.uid_get_from_cstr("key.line")!
     column = api.uid_get_from_cstr("key.column")!
+    endline = api.uid_get_from_cstr("key.endline")!
+    endcolumn = api.uid_get_from_cstr("key.endcolumn")!
     filepath = api.uid_get_from_cstr("key.filepath")!
     ranges = api.uid_get_from_cstr("key.ranges")!
     usr = api.uid_get_from_cstr("key.usr")!
@@ -252,6 +263,13 @@ struct sourcekitd_keys {
     syntaxmap = api.uid_get_from_cstr("key.syntaxmap")!
     namelength = api.uid_get_from_cstr("key.namelength")!
     nameoffset = api.uid_get_from_cstr("key.nameoffset")!
+    retrieve_refactor_actions = api.uid_get_from_cstr("key.retrieve_refactor_actions")!
+    refactor_actions = api.uid_get_from_cstr("key.refactor_actions")!
+    actionname = api.uid_get_from_cstr("key.actionname")!
+    actionuid = api.uid_get_from_cstr("key.actionuid")!
+    categorizededits = api.uid_get_from_cstr("key.categorizededits")!
+    edits = api.uid_get_from_cstr("key.edits")!
+    text = api.uid_get_from_cstr("key.text")!
   }
 }
 
@@ -263,6 +281,7 @@ struct sourcekitd_requests {
   let codecomplete: sourcekitd_uid_t
   let cursorinfo: sourcekitd_uid_t
   let relatedidents: sourcekitd_uid_t
+  let semantic_refactoring: sourcekitd_uid_t
 
   init(api: sourcekitd_functions_t) {
     editor_open = api.uid_get_from_cstr("source.request.editor.open")!
@@ -271,6 +290,7 @@ struct sourcekitd_requests {
     codecomplete = api.uid_get_from_cstr("source.request.codecomplete")!
     cursorinfo = api.uid_get_from_cstr("source.request.cursorinfo")!
     relatedidents = api.uid_get_from_cstr("source.request.relatedidents")!
+    semantic_refactoring = api.uid_get_from_cstr("source.request.semantic.refactoring")!
   }
 }
 

--- a/Tests/INPUTS/SemanticRefactor/SemanticRefactorBase.swift
+++ b/Tests/INPUTS/SemanticRefactor/SemanticRefactorBase.swift
@@ -1,5 +1,5 @@
 func foo() -> String {
-  var a = "abc"
-  return a
+  /*sr:extractStart*/var a = "/*sr:string*/"
+  return a/*sr:extractEnd*/
 }
 /*sr:foo*/

--- a/Tests/INPUTS/SemanticRefactor/SemanticRefactorBase.swift
+++ b/Tests/INPUTS/SemanticRefactor/SemanticRefactorBase.swift
@@ -1,0 +1,5 @@
+func foo() -> String {
+  var a = "abc"
+  return a
+}
+/*sr:foo*/

--- a/Tests/INPUTS/SemanticRefactor/project.json
+++ b/Tests/INPUTS/SemanticRefactor/project.json
@@ -1,0 +1,1 @@
+{ "sources": ["SemanticRefactorBase.swift"] }

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -238,6 +238,15 @@ final class CodingTests: XCTestCase {
         "text" : "a"
       }
       """)
+    checkCoding(WorkspaceEdit(changes: [url: []]), json: """
+      {
+        "changes" : {
+          "\(urljson)" : [
+
+          ]
+        }
+      }
+      """)
   }
 
   func testPositionRange() {

--- a/Tests/SourceKitTests/CodeActionTests.swift
+++ b/Tests/SourceKitTests/CodeActionTests.swift
@@ -17,6 +17,47 @@ import XCTest
 import SourceKit
 
 final class CodeActionTests: XCTestCase {
+
+  typealias CodeActionCapabilities = TextDocumentClientCapabilities.CodeAction
+  typealias CodeActionLiteralSupport = CodeActionCapabilities.CodeActionLiteralSupport
+  typealias CodeActionKindCapabilities = CodeActionLiteralSupport.CodeActionKind
+
+  /// Connection and lifetime management for the service.
+  var connection: TestSourceKitServer! = nil
+
+  /// The primary interface to make requests to the SourceKitServer.
+  var sk: TestClient! = nil
+
+  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
+  var workspace: Workspace! = nil
+
+  override func tearDown() {
+    workspace = nil
+    sk = nil
+    connection = nil
+  }
+
+  override func setUp() {
+    connection = TestSourceKitServer()
+    sk = connection.client
+    var documentCapabilities = TextDocumentClientCapabilities()
+    var codeActionCapabilities = CodeActionCapabilities()
+    let codeActionKinds = CodeActionKindCapabilities(valueSet: [.refactor, .quickFix])
+    let codeActionLiteralSupport = CodeActionLiteralSupport(codeActionKind: codeActionKinds)
+    codeActionCapabilities.codeActionLiteralSupport = codeActionLiteralSupport
+    documentCapabilities.codeAction = codeActionCapabilities
+    _ = try! sk.sendSync(InitializeRequest(
+      processId: nil,
+      rootPath: nil,
+      rootURL: nil,
+      initializationOptions: nil,
+      capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
+      trace: .off,
+      workspaceFolders: nil))
+
+    workspace = connection.server!.workspace!
+  }
+
   func testCodeActionResponseLegacySupport() {
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
     let codeAction = CodeAction(title: "1")
@@ -148,5 +189,59 @@ final class CodeActionTests: XCTestCase {
     let command = Command(title: "Command", command: "command.id", arguments: [arguments, arguments])
     let decoded = try! JSONDecoder().decode(Command.self, from: JSONEncoder().encode(command))
     XCTAssertEqual(decoded, command)
+  }
+
+  func testEmptyCodeActionResult() {
+    let url = URL(fileURLWithPath: "/a.swift")
+    sk.allowUnexpectedNotification = true
+
+    sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
+      url: url,
+      language: .swift,
+      version: 12,
+      text: """
+    func foo() -> String {
+      var a = "abc"
+      return a
+    }
+    """)))
+
+    let textDocument = TextDocumentIdentifier(url)
+    let start = Position(line: 2, utf16index: 0)
+    let request = CodeActionRequest(range: start..<start, context: .init(), textDocument: textDocument)
+    let result = try! sk.sendSync(request)
+    XCTAssertEqual(result, .codeActions([]))
+  }
+
+  func testSemanticRefactorCodeActionResult() {
+    let url = URL(fileURLWithPath: "/a.swift")
+    sk.allowUnexpectedNotification = true
+
+    sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
+      url: url,
+      language: .swift,
+      version: 12,
+      text: """
+    func foo() -> String {
+      var a = "abc"
+      return a
+    }
+    """)))
+
+    let textDocument = TextDocumentIdentifier(url)
+    let start = Position(line: 1, utf16index: 11)
+    let request = CodeActionRequest(range: start..<start, context: .init(), textDocument: textDocument)
+    let result = try! sk.sendSync(request)
+
+    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.localize.string", "positionRange": ["start": ["character": 11, "line": 1], "end": ["character": 11, "line": 1]], "title": "Localize String", "textDocument": ["uri": "file:///a.swift"]]
+    let metadataArguments: LSPAny = ["sourcekitlsp_textDocument": ["uri": "file:///a.swift"]]
+    let expectedCommand = Command(title: "Localize String",
+                                  command: "semantic.refactor.command",
+                                  arguments: [expectedCommandArgs] + [metadataArguments])
+    let expectedCodeAction = CodeAction(title: "Localize String",
+                                        kind: .refactor,
+                                        command: expectedCommand)
+
+    XCTAssertEqual(result, .codeActions([expectedCodeAction]))
   }
 }

--- a/Tests/SourceKitTests/CodeActionTests.swift
+++ b/Tests/SourceKitTests/CodeActionTests.swift
@@ -185,15 +185,14 @@ final class CodeActionTests: XCTestCase {
 
   func testSemanticRefactorLocationCodeActionResult() throws {
     guard let ws = try refactorTibsWorkspace() else { return }
-    let loc = ws.testLoc("sr:foo")
+    let loc = ws.testLoc("sr:string")
     try ws.openDocument(loc.url, language: .swift)
 
     let textDocument = TextDocumentIdentifier(loc.url)
-    let start = Position(line: 1, utf16index: 11)
-    let request = CodeActionRequest(range: start..<start, context: .init(), textDocument: textDocument)
+    let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
     let result = try ws.sk.sendSync(request)
 
-    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.localize.string", "positionRange": ["start": ["character": 11, "line": 1], "end": ["character": 11, "line": 1]], "title": "Localize String", "textDocument": ["uri": .string(loc.url.absoluteString)]]
+    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.localize.string", "positionRange": ["start": ["character": 43, "line": 1], "end": ["character": 43, "line": 1]], "title": "Localize String", "textDocument": ["uri": .string(loc.url.absoluteString)]]
 
     let metadataArguments: LSPAny = ["sourcekitlsp_textDocument": ["uri": .string(loc.url.absoluteString)]]
     let expectedCommand = Command(title: "Localize String",
@@ -208,17 +207,18 @@ final class CodeActionTests: XCTestCase {
 
   func testSemanticRefactorRangeCodeActionResult() throws {
     guard let ws = try refactorTibsWorkspace() else { return }
-    let loc = ws.testLoc("sr:foo")
-    try ws.openDocument(loc.url, language: .swift)
+    let rangeStartLoc = ws.testLoc("sr:extractStart")
+    let rangeEndLoc = ws.testLoc("sr:extractEnd")
+    try ws.openDocument(rangeStartLoc.url, language: .swift)
 
-    let textDocument = TextDocumentIdentifier(loc.url)
-    let start = Position(line: 1, utf16index: 2)
-    let end = Position(line: 2, utf16index: 10)
-    let request = CodeActionRequest(range: start..<end, context: .init(), textDocument: textDocument)
+    XCTAssertEqual(rangeStartLoc.url, rangeEndLoc.url)
+
+    let textDocument = TextDocumentIdentifier(rangeStartLoc.url)
+    let request = CodeActionRequest(range: rangeStartLoc.position..<rangeEndLoc.position, context: .init(), textDocument: textDocument)
     let result = try ws.sk.sendSync(request)
 
-    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.extract.function", "positionRange": ["start": ["character": 2, "line": 1], "end": ["character": 10, "line": 2]], "title": "Extract Method", "textDocument": ["uri": .string(loc.url.absoluteString)]]
-    let metadataArguments: LSPAny = ["sourcekitlsp_textDocument": ["uri": .string(loc.url.absoluteString)]]
+    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.extract.function", "positionRange": ["start": ["character": 21, "line": 1], "end": ["character": 27, "line": 2]], "title": "Extract Method", "textDocument": ["uri": .string(rangeStartLoc.url.absoluteString)]]
+    let metadataArguments: LSPAny = ["sourcekitlsp_textDocument": ["uri": .string(rangeStartLoc.url.absoluteString)]]
     let expectedCommand = Command(title: "Extract Method",
                                   command: "semantic.refactor.command",
                                   arguments: [expectedCommandArgs] + [metadataArguments])

--- a/Tests/SourceKitTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitTests/ExecuteCommandTests.swift
@@ -48,23 +48,12 @@ final class ExecuteCommandTests: XCTestCase {
     workspace = connection.server!.workspace!
   }
 
-  func testSemanticRefactoring() {
-    let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
-    sk.allowUnexpectedRequest = true
+  func testLocationSemanticRefactoring() throws {
+    guard let ws = try staticSourceKitTibsWorkspace(name: "SemanticRefactor") else { return }
+    let loc = ws.testLoc("sr:foo")
+    try ws.openDocument(loc.url, language: .swift)
 
-    sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
-      url: url,
-      language: .swift,
-      version: 12,
-      text: """
-    func foo() -> String {
-      var a = "abc"
-      return a
-    }
-    """)))
-
-    let textDocument = TextDocumentIdentifier(url)
+    let textDocument = TextDocumentIdentifier(loc.url)
 
     let startPosition = Position(line: 1, utf16index: 10)
     let endPosition = Position(line: 1, utf16index: 15)
@@ -76,18 +65,68 @@ final class ExecuteCommandTests: XCTestCase {
 
     let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
 
-    var command = try! args.asCommand()
+    var command = try args.asCommand()
     command.arguments?.append(metadata.encodeToLSPAny())
 
     let request = ExecuteCommandRequest(command: command.command, arguments: command.arguments)
 
-    let result = try! sk.sendSync(request)
+    ws.testServer.client.handleNextRequest { (req: Request<ApplyEditRequest>) in
+      req.reply(ApplyEditResponse(applied: true, failureReason: nil))
+    }
 
-    XCTAssertEqual(result, WorkspaceEdit(changes: [
-      url: [TextEdit(range: Position(line: 1, utf16index: 10)..<Position(line: 1, utf16index: 10),
+    let result = try ws.sk.sendSync(request)
+
+    guard case .dictionary(let resultDict) = result else {
+      XCTFail("Result is not a dictionary.")
+      return
+    }
+
+    XCTAssertEqual(WorkspaceEdit(fromLSPDictionary: resultDict), WorkspaceEdit(changes: [
+      loc.url: [TextEdit(range: Position(line: 1, utf16index: 10)..<Position(line: 1, utf16index: 10),
                      newText: "NSLocalizedString("),
             TextEdit(range: Position(line: 1, utf16index: 15)..<Position(line: 1, utf16index: 15),
                      newText: ", comment: \"\")")]
+    ]))
+  }
+
+  func testRangeSemanticRefactoring() throws {
+    guard let ws = try staticSourceKitTibsWorkspace(name: "SemanticRefactor") else { return }
+    let loc = ws.testLoc("sr:foo")
+    try ws.openDocument(loc.url, language: .swift)
+
+    let textDocument = TextDocumentIdentifier(loc.url)
+
+    let startPosition = Position(line: 1, utf16index: 2)
+    let endPosition = Position(line: 2, utf16index: 10)
+
+    let args = SemanticRefactorCommand(title: "Extract Method",
+                                       actionString: "source.refactoring.kind.extract.function",
+                                       positionRange: startPosition..<endPosition,
+                                       textDocument: textDocument)
+
+    let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
+
+    var command = try args.asCommand()
+    command.arguments?.append(metadata.encodeToLSPAny())
+
+    let request = ExecuteCommandRequest(command: command.command, arguments: command.arguments)
+
+    ws.testServer.client.handleNextRequest { (req: Request<ApplyEditRequest>) in
+      req.reply(ApplyEditResponse(applied: true, failureReason: nil))
+    }
+
+    let result = try ws.sk.sendSync(request)
+
+    guard case .dictionary(let resultDict) = result else {
+      XCTFail("Result is not a dictionary.")
+      return
+    }
+
+    XCTAssertEqual(WorkspaceEdit(fromLSPDictionary: resultDict), WorkspaceEdit(changes: [
+      loc.url: [TextEdit(range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
+                     newText: "fileprivate func extractedFunc() -> String {\nvar a = \"abc\"\n  return a\n}\n\n"),
+            TextEdit(range: Position(line: 1, utf16index: 2)..<Position(line: 2, utf16index: 10),
+                     newText: "return extractedFunc()")]
     ]))
   }
 

--- a/Tests/SourceKitTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitTests/ExecuteCommandTests.swift
@@ -50,17 +50,14 @@ final class ExecuteCommandTests: XCTestCase {
 
   func testLocationSemanticRefactoring() throws {
     guard let ws = try staticSourceKitTibsWorkspace(name: "SemanticRefactor") else { return }
-    let loc = ws.testLoc("sr:foo")
+    let loc = ws.testLoc("sr:string")
     try ws.openDocument(loc.url, language: .swift)
 
     let textDocument = TextDocumentIdentifier(loc.url)
 
-    let startPosition = Position(line: 1, utf16index: 10)
-    let endPosition = Position(line: 1, utf16index: 15)
-
     let args = SemanticRefactorCommand(title: "Localize String",
                                        actionString: "source.refactoring.kind.localize.string",
-                                       positionRange: startPosition..<endPosition,
+                                       positionRange: loc.position..<loc.position,
                                        textDocument: textDocument)
 
     let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
@@ -82,9 +79,9 @@ final class ExecuteCommandTests: XCTestCase {
     }
 
     XCTAssertEqual(WorkspaceEdit(fromLSPDictionary: resultDict), WorkspaceEdit(changes: [
-      loc.url: [TextEdit(range: Position(line: 1, utf16index: 10)..<Position(line: 1, utf16index: 10),
+      loc.url: [TextEdit(range: Position(line: 1, utf16index: 29)..<Position(line: 1, utf16index: 29),
                      newText: "NSLocalizedString("),
-            TextEdit(range: Position(line: 1, utf16index: 15)..<Position(line: 1, utf16index: 15),
+            TextEdit(range: Position(line: 1, utf16index: 44)..<Position(line: 1, utf16index: 44),
                      newText: ", comment: \"\")")]
     ]))
   }
@@ -124,7 +121,7 @@ final class ExecuteCommandTests: XCTestCase {
 
     XCTAssertEqual(WorkspaceEdit(fromLSPDictionary: resultDict), WorkspaceEdit(changes: [
       loc.url: [TextEdit(range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
-                     newText: "fileprivate func extractedFunc() -> String {\nvar a = \"abc\"\n  return a\n}\n\n"),
+                     newText: "fileprivate func extractedFunc() -> String {\n/*sr:extractStart*/var a = \"/*sr:string*/\"\n  return a\n}\n\n"),
             TextEdit(range: Position(line: 1, utf16index: 2)..<Position(line: 2, utf16index: 10),
                      newText: "return extractedFunc()")]
     ]))

--- a/Tests/SourceKitTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitTests/ExecuteCommandTests.swift
@@ -17,6 +17,80 @@ import XCTest
 import SourceKit
 
 final class ExecuteCommandTests: XCTestCase {
+
+  /// Connection and lifetime management for the service.
+  var connection: TestSourceKitServer! = nil
+
+  /// The primary interface to make requests to the SourceKitServer.
+  var sk: TestClient! = nil
+
+  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
+  var workspace: Workspace! = nil
+
+  override func tearDown() {
+    workspace = nil
+    sk = nil
+    connection = nil
+  }
+
+  override func setUp() {
+    connection = TestSourceKitServer()
+    sk = connection.client
+    _ = try! sk.sendSync(InitializeRequest(
+      processId: nil,
+      rootPath: nil,
+      rootURL: nil,
+      initializationOptions: nil,
+      capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+      trace: .off,
+      workspaceFolders: nil))
+
+    workspace = connection.server!.workspace!
+  }
+
+  func testSemanticRefactoring() {
+    let url = URL(fileURLWithPath: "/a.swift")
+    sk.allowUnexpectedNotification = true
+    sk.allowUnexpectedRequest = true
+
+    sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
+      url: url,
+      language: .swift,
+      version: 12,
+      text: """
+    func foo() -> String {
+      var a = "abc"
+      return a
+    }
+    """)))
+
+    let textDocument = TextDocumentIdentifier(url)
+
+    let startPosition = Position(line: 1, utf16index: 10)
+    let endPosition = Position(line: 1, utf16index: 15)
+
+    let args = SemanticRefactorCommand(title: "Localize String",
+                                       actionString: "source.refactoring.kind.localize.string",
+                                       positionRange: startPosition..<endPosition,
+                                       textDocument: textDocument)
+
+    let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
+
+    var command = try! args.asCommand()
+    command.arguments?.append(metadata.encodeToLSPAny())
+
+    let request = ExecuteCommandRequest(command: command.command, arguments: command.arguments)
+
+    let result = try! sk.sendSync(request)
+
+    XCTAssertEqual(result, WorkspaceEdit(changes: [
+      url: [TextEdit(range: Position(line: 1, utf16index: 10)..<Position(line: 1, utf16index: 10),
+                     newText: "NSLocalizedString("),
+            TextEdit(range: Position(line: 1, utf16index: 15)..<Position(line: 1, utf16index: 15),
+                     newText: ", comment: \"\")")]
+    ]))
+  }
+
   func testLSPCommandMetadataRetrieval() {
     var req = ExecuteCommandRequest(command: "", arguments: nil)
     XCTAssertNil(req.metadata)

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -22,7 +22,8 @@ extension CodeActionTests {
         ("testCodeActionResponseRespectsSupportedKinds", testCodeActionResponseRespectsSupportedKinds),
         ("testCommandEncoding", testCommandEncoding),
         ("testEmptyCodeActionResult", testEmptyCodeActionResult),
-        ("testSemanticRefactorCodeActionResult", testSemanticRefactorCodeActionResult),
+        ("testSemanticRefactorLocationCodeActionResult", testSemanticRefactorLocationCodeActionResult),
+        ("testSemanticRefactorRangeCodeActionResult", testSemanticRefactorRangeCodeActionResult),
     ]
 }
 
@@ -56,9 +57,10 @@ extension ExecuteCommandTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ExecuteCommandTests = [
+        ("testLocationSemanticRefactoring", testLocationSemanticRefactoring),
         ("testLSPCommandMetadataRemoval", testLSPCommandMetadataRemoval),
         ("testLSPCommandMetadataRetrieval", testLSPCommandMetadataRetrieval),
-        ("testSemanticRefactoring", testSemanticRefactoring),
+        ("testRangeSemanticRefactoring", testRangeSemanticRefactoring),
     ]
 }
 

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -21,6 +21,8 @@ extension CodeActionTests {
         ("testCodeActionResponseLegacySupport", testCodeActionResponseLegacySupport),
         ("testCodeActionResponseRespectsSupportedKinds", testCodeActionResponseRespectsSupportedKinds),
         ("testCommandEncoding", testCommandEncoding),
+        ("testEmptyCodeActionResult", testEmptyCodeActionResult),
+        ("testSemanticRefactorCodeActionResult", testSemanticRefactorCodeActionResult),
     ]
 }
 
@@ -56,6 +58,7 @@ extension ExecuteCommandTests {
     static let __allTests__ExecuteCommandTests = [
         ("testLSPCommandMetadataRemoval", testLSPCommandMetadataRemoval),
         ("testLSPCommandMetadataRetrieval", testLSPCommandMetadataRetrieval),
+        ("testSemanticRefactoring", testSemanticRefactoring),
     ]
 }
 


### PR DESCRIPTION
Adds a refactoring provider to `textDocument/codeActions`. CodeActions can now return SemanticRefactorCommands that are processed and sent back to the client as a `textDocument/applyEdit` request.

<img width="358" alt="Screen Shot 2019-09-26 at 10 25 55 AM" src="https://user-images.githubusercontent.com/11647449/65692229-8e3adc00-e048-11e9-9db3-9fa529bdeba5.png">

Things to note:
- The LSP doesn't support snippets for CodeActions, so unfortunately refactors with placeholders don't work as well as they could... But there are threads that indicate that this might be added to the protocol soon.
- The indentation of the refactors are funky because the formatting request isn't implemented yet.
