### PR TITLE
Add -Xclangd to allow forwarding options to clangd command-line

### DIFF
--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -23,13 +23,13 @@ public struct BuildSetup {
                                            flags: BuildFlags())
 
   /// Build configuration (debug|release).
-  public let configuration: BuildConfiguration
+  public var configuration: BuildConfiguration
 
   /// Build artefacts directory path. If nil, the build system may choose a default value.
-  public let path: AbsolutePath?
+  public var path: AbsolutePath?
 
   /// Additional build flags
-  public let flags: BuildFlags
+  public var flags: BuildFlags
 
   public init(configuration: BuildConfiguration, path: AbsolutePath?, flags: BuildFlags) {
     self.configuration = configuration

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -34,9 +34,7 @@ public struct TestSourceKitServer {
       serverConnection: JSONRPCConection)
   }
 
-  public static let buildSetup: BuildSetup = BuildSetup(configuration: .debug,
-                                                        path: nil,
-                                                        flags: BuildFlags())
+  public static let serverOptions: SourceKitServer.Options = SourceKitServer.Options()
 
   public let client: TestClient
   let connImpl: ConnectionImpl
@@ -51,7 +49,7 @@ public struct TestSourceKitServer {
         let clientConnection = LocalConnection()
         let serverConnection = LocalConnection()
         client = TestClient(server: serverConnection)
-        server = SourceKitServer(client: clientConnection, buildSetup: TestSourceKitServer.buildSetup, onExit: {
+        server = SourceKitServer(client: clientConnection, options: Self.serverOptions, onExit: {
           clientConnection.close()
         })
 
@@ -81,7 +79,7 @@ public struct TestSourceKitServer {
         )
 
         client = TestClient(server: clientConnection)
-        server = SourceKitServer(client: serverConnection, buildSetup: TestSourceKitServer.buildSetup, onExit: {
+        server = SourceKitServer(client: serverConnection, options: Self.serverOptions, onExit: {
           serverConnection.close()
         })
 

--- a/Sources/SourceKit/SourceKitServer+Options.swift
+++ b/Sources/SourceKit/SourceKitServer+Options.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SKCore
+
+extension SourceKitServer {
+
+  /// Configuration options for the SourceKitServer.
+  public struct Options {
+
+    /// Additional compiler flags (e.g. `-Xswiftc` for SwiftPM projects) and other build-related
+    /// configuration.
+    public var buildSetup: BuildSetup
+
+    /// Additional arguments to pass to `clangd` on the command-line.
+    public var clangdOptions: [String]
+
+    public init(buildSetup: BuildSetup = .default, clangdOptions: [String] = []) {
+      self.buildSetup = buildSetup
+      self.clangdOptions = clangdOptions
+    }
+  }
+}

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -143,7 +143,7 @@ extension ClangLanguageServerShim {
   }
 }
 
-func makeJSONRPCClangServer(client: MessageHandler, toolchain: Toolchain, buildSettings: BuildSystem?) throws -> Connection {
+func makeJSONRPCClangServer(client: MessageHandler, toolchain: Toolchain, buildSettings: BuildSystem?, clangdOptions: [String]) throws -> Connection {
 
   guard let clangd = toolchain.clangd else {
     preconditionFailure("missing clang from toolchain \(toolchain.identifier)")
@@ -182,6 +182,8 @@ func makeJSONRPCClangServer(client: MessageHandler, toolchain: Toolchain, buildS
   process.arguments = [
     "-compile_args_from=lsp", // Provide compiler args programmatically.
   ]
+  process.arguments!.append(contentsOf: clangdOptions)
+
   process.standardOutput = serverToClient
   process.standardInput = clientToServer
   process.terminationHandler = { process in

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -33,7 +33,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup))
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup))
     }
   }
 
@@ -54,7 +54,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup))
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup))
     }
   }
 
@@ -75,7 +75,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry(),
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup))
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup))
     }
   }
 
@@ -98,7 +98,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let build = buildPath(root: packageRoot)
@@ -185,7 +185,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let source = resolveSymlinks(packageRoot.appending(component: "Package.swift"))
       let arguments = ws.settings(for: source.asURL, .swift)!.compilerArguments
@@ -215,7 +215,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
@@ -255,7 +255,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
@@ -296,7 +296,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
@@ -328,7 +328,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let bcxx = packageRoot.appending(components: "Sources", "lib", "b.cpp")
@@ -392,7 +392,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.shared,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let arguments = ws.settings(for: aswift.asURL, .swift)!.compilerArguments
@@ -430,7 +430,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift1 = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let aswift2 = tempDir
@@ -483,7 +483,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.buildSetup)
+        buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let ah = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
@@ -535,7 +535,7 @@ private func check(
 
 private func buildPath(
   root: AbsolutePath,
-  config: BuildSetup = TestSourceKitServer.buildSetup) -> AbsolutePath
+  config: BuildSetup = TestSourceKitServer.serverOptions.buildSetup) -> AbsolutePath
 {
   let buildPath = config.path ?? root.appending(component: ".build")
   return buildPath.appending(components: Triple.hostTriple.tripleString, "\(config.configuration)")

--- a/Tests/SourceKitTests/BuildSystemTests.swift
+++ b/Tests/SourceKitTests/BuildSystemTests.swift
@@ -82,7 +82,7 @@ final class BuildSystemTests: XCTestCase {
       clientCapabilities: ClientCapabilities(),
       buildSettings: buildSystem,
       index: nil,
-      buildSetup: TestSourceKitServer.buildSetup)
+      buildSetup: TestSourceKitServer.serverOptions.buildSetup)
     testServer.server!.workspace = workspace
 
     sk = testServer.client


### PR DESCRIPTION
And factor the configuration that we thread through to the sourcekit server.