### PR TITLE
[test] Flip the default value of allowUnexpectedNotification

### DIFF
--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -83,8 +83,6 @@ public final class SKSwiftPMTestWorkspace {
       library: libIndexStore,
       listenToUnitEvents: false)
 
-    sk.allowUnexpectedNotification = true
-
     testServer.server!.workspace = Workspace(
       rootPath: sourcePath,
       clientCapabilities: ClientCapabilities(),

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -45,7 +45,6 @@ public final class SKTibsTestWorkspace {
       tmpDir: tmpDir,
       toolchain: TibsToolchain(toolchain))
 
-    sk.allowUnexpectedNotification = true
     initWorkspace()
   }
 
@@ -55,7 +54,6 @@ public final class SKTibsTestWorkspace {
       tmpDir: tmpDir,
       toolchain: TibsToolchain(toolchain))
 
-    sk.allowUnexpectedNotification = true
     initWorkspace()
   }
 

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -91,7 +91,7 @@ public final class TestClient: LanguageServerEndpoint {
   public var replyQueue: DispatchQueue = DispatchQueue(label: "testclient-reply-queue")
   var oneShotNotificationHandlers: [((Any) -> Void)] = []
 
-  public var allowUnexpectedNotification: Bool = false
+  public var allowUnexpectedNotification: Bool = true
 
   public func appendOneShotNotificationHandler<N>(_ handler: @escaping (Notification<N>) -> Void) {
     oneShotNotificationHandlers.append({ anyNote in

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -24,6 +24,7 @@ class ConnectionTests: XCTestCase {
 
   override func setUp() {
     connection = TestJSONRPCConnection()
+    connection.client.allowUnexpectedNotification = false
   }
 
   override func tearDown() {

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -23,6 +23,7 @@ class ConnectionTests: XCTestCase {
 
   override func setUp() {
     connection = TestLocalConnection()
+    connection.client.allowUnexpectedNotification = false
   }
 
   override func tearDown() {

--- a/Tests/SourceKitTests/BuildSystemTests.swift
+++ b/Tests/SourceKitTests/BuildSystemTests.swift
@@ -121,6 +121,8 @@ final class BuildSystemTests: XCTestCase {
 
     buildSystem.buildSettingsByFile[url] = FileBuildSettings(compilerArguments: args)
 
+    sk.allowUnexpectedNotification = false
+
     sk.sendNoteSync(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
       language: .objective_c,
@@ -162,6 +164,9 @@ final class BuildSystemTests: XCTestCase {
 
     foo()
     """
+
+    sk.allowUnexpectedNotification = false
+
     sk.sendNoteSync(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
       language: .swift,
@@ -202,6 +207,8 @@ final class BuildSystemTests: XCTestCase {
 
   func testSwiftDocumentBuildSettingsChangedFalseAlarm() {
     let url = URL(fileURLWithPath: "/a.swift")
+
+    sk.allowUnexpectedNotification = false
 
     sk.sendNoteSync(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,

--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -50,7 +50,6 @@ final class DocumentColorTests: XCTestCase {
 
   func performDocumentColorRequest(text: String) -> [ColorInformation] {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
@@ -64,7 +63,6 @@ final class DocumentColorTests: XCTestCase {
 
   func performColorPresentationRequest(text: String, color: Color, range: Range<Position>) -> [ColorPresentation] {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,

--- a/Tests/SourceKitTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitTests/DocumentSymbolTests.swift
@@ -53,7 +53,6 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
 
   func performDocumentSymbolRequest(text: String) -> [DocumentSymbol] {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,

--- a/Tests/SourceKitTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitTests/FoldingRangeTests.swift
@@ -97,7 +97,6 @@ final class FoldingRangeTests: XCTestCase {
 
   func performFoldingRangeRequest(text: String? = nil) -> [FoldingRange] {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -58,7 +58,6 @@ final class LocalClangTests: XCTestCase {
   func testSymbolInfo() {
     guard haveClangd else { return }
     let url = URL(fileURLWithPath: "/a.cpp")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
@@ -123,7 +122,6 @@ final class LocalClangTests: XCTestCase {
   func testFoldingRange() {
     guard haveClangd else { return }
     let url = URL(fileURLWithPath: "/a.cpp")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -54,6 +54,8 @@ final class LocalSwiftTests: XCTestCase {
   func testEditing() {
     let url = URL(fileURLWithPath: "/a.swift")
 
+    sk.allowUnexpectedNotification = false
+
     sk.sendNoteSync(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
       language: .swift,
@@ -417,7 +419,6 @@ final class LocalSwiftTests: XCTestCase {
 
   func testSymbolInfo() {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
@@ -490,7 +491,6 @@ final class LocalSwiftTests: XCTestCase {
 
   func testHover() {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
@@ -538,7 +538,6 @@ final class LocalSwiftTests: XCTestCase {
 
   func testHoverNameEscaping() {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
@@ -594,7 +593,6 @@ final class LocalSwiftTests: XCTestCase {
 
   func testDocumentSymbolHighlight() {
     let url = URL(fileURLWithPath: "/a.swift")
-    sk.allowUnexpectedNotification = true
 
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,

--- a/Tests/SourceKitTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitTests/SwiftCompletionTests.swift
@@ -77,7 +77,6 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func openDocument(text: String? = nil, url: URL) {
-    sk.allowUnexpectedNotification = true
     sk.send(DidOpenTextDocument(textDocument: TextDocumentItem(
       url: url,
       language: .swift,


### PR DESCRIPTION
This is/was mostly useful for testing specific notification
interactions. Most new tests shouldn't need it, so remove the
boilerplate.