### PR TITLE
[test] Speed up negative expectation test by 4 seconds

### DIFF
--- a/Tests/SourceKitTests/BuildSystemTests.swift
+++ b/Tests/SourceKitTests/BuildSystemTests.swift
@@ -227,9 +227,9 @@ final class BuildSystemTests: XCTestCase {
       expectation.fulfill()
     }
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 5)
+    let result = XCTWaiter.wait(for: [expectation], timeout: 1)
     if result != .completed {
-      fatalError("error \(result) waiting for diagnostics notification")
+      fatalError("error \(result) unexpected diagnostics notification")
     }
   }
 }


### PR DESCRIPTION
Saves 4 seconds from test time, which is ~33% of the total warm test
time on my machine when testing in serial.

I verified a timeout of 1 second is still long enough to reliably check
the desired behaviour. Since this test is designed to timeout on
success, we want the shortest timeout possible that will check the
behaviour.