### PR TITLE
Move custom PositionRange encoding into a property wrapper

### DIFF
--- a/Sources/LanguageServerProtocol/CodeAction.swift
+++ b/Sources/LanguageServerProtocol/CodeAction.swift
@@ -35,7 +35,8 @@ public struct CodeActionRequest: TextDocumentRequest, Hashable {
   public typealias Response = CodeActionRequestResponse?
 
   /// The range for which the command was invoked.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   /// Context carrying additional information.
   public var context: CodeActionContext
@@ -44,7 +45,7 @@ public struct CodeActionRequest: TextDocumentRequest, Hashable {
   public var textDocument: TextDocumentIdentifier
 
   public init(range: Range<Position>, context: CodeActionContext, textDocument: TextDocumentIdentifier) {
-    self.range = PositionRange(range)
+    self.range = range
     self.context = context
     self.textDocument = textDocument
   }

--- a/Sources/LanguageServerProtocol/ColorPresentationRequest.swift
+++ b/Sources/LanguageServerProtocol/ColorPresentationRequest.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
+
 /// The color presentation request is sent from the client to the server to obtain 
 /// a list of presentations for a color value at a given location. Clients can 
 /// use the result to modify a color reference, or show in a color picker 
@@ -32,16 +34,13 @@ public struct ColorPresentationRequest: TextDocumentRequest, Hashable {
   public var color: Color
 
   /// The range where the color would be inserted. Serves as a context.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
-  public init(
-    textDocument: TextDocumentIdentifier, 
-    color: Color, 
-    range: Range<Position>) 
-  {
+  public init(textDocument: TextDocumentIdentifier, color: Color, range: Range<Position>) {
     self.textDocument = textDocument
     self.color = color
-    self.range = PositionRange(range)
+    self.range = range
   }
 }
 

--- a/Sources/LanguageServerProtocol/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/Diagnostic.swift
@@ -2,13 +2,15 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import SKSupport
 
 /// The serverity level of a Diagnostic, between hint and error.
 public enum DiagnosticSeverity: Int, Codable, Hashable {
@@ -28,7 +30,8 @@ public enum DiagnosticCode: Hashable {
 public struct Diagnostic: Codable, Hashable {
 
   /// The primary position/range of the diagnostic.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   /// Whether this is a warning, error, etc.
   public var severity: DiagnosticSeverity?
@@ -54,7 +57,7 @@ public struct Diagnostic: Codable, Hashable {
     message: String,
     relatedInformation: [DiagnosticRelatedInformation]? = nil)
   {
-    self.range = PositionRange(range)
+    self.range = range
     self.severity = severity
     self.code = code
     self.source = source

--- a/Sources/LanguageServerProtocol/DocumentColor.swift
+++ b/Sources/LanguageServerProtocol/DocumentColor.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
+
 /// The document color request is sent from the client to the server to list
 /// all color references found in a given text document. Along with the range, 
 /// a color value in RGB is returned.
@@ -33,13 +35,14 @@ public struct DocumentColorRequest: TextDocumentRequest, Hashable {
 
 public struct ColorInformation: ResponseType, Hashable {
   /// The range in the document where this color appears.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   /// The actual color value for this color range.
   public var color: Color
 
   public init(range: Range<Position>, color: Color) {
-    self.range = PositionRange(range)
+    self.range = range
     self.color = color
   }
 }

--- a/Sources/LanguageServerProtocol/DocumentHighlight.swift
+++ b/Sources/LanguageServerProtocol/DocumentHighlight.swift
@@ -2,13 +2,15 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import SKSupport
 
 /// Request to find document ranges that should be highlighted to match the given cursor position.
 ///
@@ -57,13 +59,14 @@ public enum DocumentHighlightKind: Int, Codable, Hashable {
 public struct DocumentHighlight: ResponseType, Hashable {
 
   /// The range of the highlight.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   /// What kind of reference this is. Default is `.text`.
   public var kind: DocumentHighlightKind?
 
   public init(range: Range<Position>, kind: DocumentHighlightKind?) {
-    self.range = PositionRange(range)
+    self.range = range
     self.kind = kind
   }
 }

--- a/Sources/LanguageServerProtocol/DocumentSymbol.swift
+++ b/Sources/LanguageServerProtocol/DocumentSymbol.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
+
 /// Request for symbols to display in the document outline.
 ///
 /// This is used to provide list of all symbols in the document and display inside which 
@@ -55,13 +57,15 @@ public struct DocumentSymbol: Hashable, Codable, ResponseType {
   /// The range enclosing this symbol not including leading/trailing whitespace but everything else
   /// like comments. This information is typically used to determine if the clients cursor is
   /// inside the symbol to reveal in the symbol in the UI.
-  var range: PositionRange
+  @CustomCodable<PositionRange>
+  var range: Range<Position>
 
   /// The range that should be selected and revealed when this symbol is being picked, 
   /// e.g the name of a function.
   ///
   /// Must be contained by the `range`.
-  var selectionRange: PositionRange
+  @CustomCodable<PositionRange>
+  var selectionRange: Range<Position>
 
   /// Children of this symbol, e.g. properties of a class.
   var children: [DocumentSymbol]?
@@ -71,8 +75,8 @@ public struct DocumentSymbol: Hashable, Codable, ResponseType {
     detail: String?, 
     kind: SymbolKind,
     deprecated: Bool?,
-    range: PositionRange,
-    selectionRange: PositionRange,
+    range: Range<Position>,
+    selectionRange: Range<Position>,
     children: [DocumentSymbol]?)
   {
     self.name = name

--- a/Sources/LanguageServerProtocol/Formatting.swift
+++ b/Sources/LanguageServerProtocol/Formatting.swift
@@ -2,13 +2,15 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import SKSupport
 
 /// Request to format an entire document.
 ///
@@ -49,7 +51,8 @@ public struct DocumentRangeFormatting: TextDocumentRequest, Hashable {
   public var textDocument: TextDocumentIdentifier
 
   /// The range to format within `textDocument`.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   /// Options to customize the formatting.
   public var options: FormattingOptions

--- a/Sources/LanguageServerProtocol/Location.swift
+++ b/Sources/LanguageServerProtocol/Location.swift
@@ -2,13 +2,15 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import SKSupport
 
 /// Range within a particular document.
 ///
@@ -17,11 +19,12 @@ public struct Location: ResponseType, Hashable {
 
   public var url: URL
 
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   public init(url: URL, range: Range<Position>) {
     self.url = url
-    self.range = PositionRange(range)
+    self.range = range
   }
 }
 

--- a/Sources/LanguageServerProtocol/PositionRange.swift
+++ b/Sources/LanguageServerProtocol/PositionRange.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,38 +10,39 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Half-open range of Positions `[start, end)` within a text document, for use in LSP messages.
-///
-/// It is generally preferred to work with Range<Position> directly, but when passing values in LSP
-/// messages, use PositionRange to provide the correct (de)serialization.
-public struct PositionRange: Hashable {
-
-  /// The `lowerBound` of the range (inclusive).
-  public var lowerBound: Position
-
-  /// The `upperBound` of the range (exclusive).
-  public var upperBound: Position
-
-  /// The equivalent range expressed as a `Swift.Range`.
-  public var asRange: Range<Position> { return lowerBound..<upperBound}
-
-  public init(_ range: Range<Position>) {
-    self.lowerBound = range.lowerBound
-    self.upperBound = range.upperBound
-  }
-}
-
-extension PositionRange: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case lowerBound = "start"
-    case upperBound = "end"
-  }
-}
+import SKSupport
 
 extension Range where Bound == Position {
 
   /// Create a range for a single position.
   public init(_ pos: Position) {
     self = pos ..< pos
+  }
+}
+
+/// An LSP-compatible encoding for `Range<Position>`, for use with `CustomCodable`.
+public struct PositionRange: CustomCodableWrapper {
+  public var wrappedValue: Range<Position>
+
+  public init(wrappedValue: Range<Position>) {
+    self.wrappedValue = wrappedValue
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case lowerBound = "start"
+    case upperBound = "end"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lhs = try container.decode(Position.self, forKey: .lowerBound)
+    let rhs = try container.decode(Position.self, forKey: .upperBound)
+    self.wrappedValue = lhs..<rhs
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(wrappedValue.lowerBound, forKey: .lowerBound)
+    try container.encode(wrappedValue.upperBound, forKey: .upperBound)
   }
 }

--- a/Sources/LanguageServerProtocol/TextDocumentContentChangeEvent.swift
+++ b/Sources/LanguageServerProtocol/TextDocumentContentChangeEvent.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,17 +15,44 @@
 /// If `range` and `rangeLength` are unspecified, the whole document content is replaced.
 ///
 /// The `range.end` and `rangeLength` are potentially redundant. Based on https://github.com/Microsoft/language-server-protocol/issues/9, servers should be lenient and accept either.
-public struct TextDocumentContentChangeEvent: Codable, Hashable {
+public struct TextDocumentContentChangeEvent: Hashable {
 
-  public var range: PositionRange?
+  public var range: Range<Position>?
 
   public var rangeLength: Int?
 
   public var text: String
 
   public init(range: Range<Position>? = nil, rangeLength: Int? = nil, text: String) {
-    self.range = range.map { PositionRange($0) }
+    self.range = range
     self.rangeLength = rangeLength
     self.text = text
+  }
+}
+
+// Needs a custom implementation for range, because `Optional` is the only type that uses
+// `encodeIfPresent` in the synthesized conformance, and the
+// [LSP specification does not allow `null` in most places](https://github.com/microsoft/language-server-protocol/issues/355).
+extension TextDocumentContentChangeEvent: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case range
+    case rangeLength
+    case text
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.range = try container
+      .decodeIfPresent(PositionRange.self, forKey: .range)?
+      .wrappedValue
+    self.rangeLength = try container.decodeIfPresent(Int.self, forKey: .rangeLength)
+    self.text = try container.decode(String.self, forKey: .text)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(range.map { PositionRange(wrappedValue: $0) }, forKey: .range)
+    try container.encodeIfPresent(rangeLength, forKey: .rangeLength)
+    try container.encode(text, forKey: .text)
   }
 }

--- a/Sources/LanguageServerProtocol/TextEdit.swift
+++ b/Sources/LanguageServerProtocol/TextEdit.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,17 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
+
 /// Edit to a text document, replacing the contents of `range` with `text`.
 public struct TextEdit: ResponseType, Hashable {
 
   /// The range of text to be replaced.
-  public var range: PositionRange
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   /// The new text.
   public var newText: String
 
   public init(range: Range<Position>, newText: String) {
-    self.range = PositionRange(range)
+    self.range = range
     self.newText = newText
   }
 }

--- a/Sources/SKSupport/CustomCodable.swift
+++ b/Sources/SKSupport/CustomCodable.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Property wrapper allowing per-property customization of how the value is
+/// encoded/decoded when using Codable.
+///
+/// CustomCodable is generic over a `CustomCoder: CustomCodableWrapper`, which
+/// wraps the underlying value, and provides the specific Codable implementation.
+/// Since each instance of CustomCodable provides its own CustomCoder wrapper,
+/// properties of the same type can provide different Codable implementations
+/// within the same container.
+///
+/// Example: change the encoding of a property `foo` in the following struct to
+/// do its encoding through a String instead of the normal Codable implementation.
+///
+/// ```
+/// struct MyStruct: Codable {
+///   @CustomCodable<SillyIntCoding> var foo: Int
+/// }
+///
+/// struct SillyIntCoding: CustomCodableWrapper {
+///   init(from decoder: Decoder) throws {
+///     wrappedValue = try Int(decoder.singleValueContainer().decoder(String.self))!
+///   }
+///   func encode(to encoder: Encoder) throws {
+///     try encoder.singleValueContainer().encode("\(wrappedValue)")
+///   }
+///   var wrappedValue: Int { get }
+///   init(wrappedValue: WrappedValue) { self.wrappedValue = wrappedValue }
+/// }
+/// ```
+///
+/// * Note: Unfortunately this wrapper does not work perfectly with `Optional`.
+///   While you can add a conformance for it, it will `encodeNil` rather than
+///   using `encodeIfPresent` on the containing type, since the synthesized
+///   implementation only uses `encodeIfPresent` if the property itself is
+///   `Optional`.
+@propertyWrapper
+public struct CustomCodable<CustomCoder: CustomCodableWrapper> {
+
+  /// The underlying value.
+  public var wrappedValue: CustomCoder.WrappedValue
+
+  public init(wrappedValue: CustomCoder.WrappedValue) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+extension CustomCodable: Codable {
+  public init(from decoder: Decoder) throws {
+    self.wrappedValue = try CustomCoder(from: decoder).wrappedValue
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try CustomCoder(wrappedValue: self.wrappedValue).encode(to: encoder)
+  }
+}
+
+extension CustomCodable: Equatable where CustomCoder.WrappedValue: Equatable {}
+extension CustomCodable: Hashable where CustomCoder.WrappedValue: Hashable {}
+
+/// Wrapper type providing a Codable implementation for use with `CustomCodable`.
+public protocol CustomCodableWrapper: Codable {
+
+  /// The type of the underlying value being wrapped.
+  associatedtype WrappedValue
+
+  /// The underlying value.
+  var wrappedValue: WrappedValue { get }
+
+  /// Create a wrapper from an underlying value.
+  init(wrappedValue: WrappedValue)
+}

--- a/Sources/SourceKit/sourcekitd/Diagnostic.swift
+++ b/Sources/SourceKit/sourcekitd/Diagnostic.swift
@@ -57,7 +57,7 @@ extension Diagnostic {
       sknotes.forEach { (_, sknote) -> Bool in
         guard let note = Diagnostic(sknote, in: snapshot) else { return true }
         notes?.append(DiagnosticRelatedInformation(
-          location: Location(url: snapshot.document.url, range: note.range.asRange),
+          location: Location(url: snapshot.document.url, range: note.range),
           message: note.message
         ))
         return true

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -558,13 +558,13 @@ extension SwiftLanguageServer {
           return nil
         }
         
-        let range = PositionRange(start..<end)
-        let selectionRange: PositionRange
+        let range = start..<end
+        let selectionRange: Range<Position>
         if let nameOffset: Int = value[self.keys.nameoffset],
            let nameStart: Position = snapshot.positionOf(utf8Offset: nameOffset),
            let nameLength: Int = value[self.keys.namelength],
            let nameEnd: Position = snapshot.positionOf(utf8Offset: nameOffset + nameLength) {
-          selectionRange = PositionRange(nameStart..<nameEnd)
+          selectionRange = nameStart..<nameEnd
         } else {
           selectionRange = range
         }
@@ -700,7 +700,7 @@ extension SwiftLanguageServer {
     // Empty string as a label breaks VSCode color picker
     let label = "Color Literal"
     let newText = "#colorLiteral(red: \(color.red), green: \(color.green), blue: \(color.blue), alpha: \(color.alpha))"
-    let textEdit = TextEdit(range: req.params.range.asRange, newText: newText)
+    let textEdit = TextEdit(range: req.params.range, newText: newText)
     let presentation = ColorPresentation(label: label, textEdit: textEdit, additionalTextEdits: nil)
     req.reply([presentation])
   }

--- a/Tests/LanguageServerProtocolTests/XCTestManifests.swift
+++ b/Tests/LanguageServerProtocolTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ extension CodingTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__CodingTests = [
+        ("testPositionRange", testPositionRange),
         ("testValueCoding", testValueCoding),
     ]
 }

--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -141,7 +141,7 @@ final class DocumentColorTests: XCTestCase {
     XCTAssertEqual(presentations.count, 1)
     let presentation = presentations[0]
     XCTAssertEqual(presentation.label, "Color Literal")
-    XCTAssertEqual(presentation.textEdit?.range.asRange, range)
+    XCTAssertEqual(presentation.textEdit?.range, range)
     XCTAssertEqual(presentation.textEdit?.newText, newText)
   }
 }

--- a/Tests/SourceKitTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitTests/DocumentSymbolTests.swift
@@ -65,10 +65,10 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
     return try! sk.sendSync(request)!
   }
 
-  func range(from startTuple: (Int, Int), to endTuple: (Int, Int)) -> PositionRange {
+  func range(from startTuple: (Int, Int), to endTuple: (Int, Int)) -> Range<Position> {
     let startPos = Position(line: startTuple.0, utf16index: startTuple.1)
     let endPos = Position(line: endTuple.0, utf16index: endTuple.1)
-    return PositionRange(startPos..<endPos)
+    return startPos..<endPos
   }
 
   func testEmpty() {

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -151,7 +151,7 @@ final class LocalClangTests: XCTestCase {
       // Don't use exact equality because of differences in recent clang.
       XCTAssertEqual(note.params.diagnostics.count, 1)
       XCTAssertEqual(note.params.diagnostics.first?.range,
-        PositionRange(Position(loc) ..< Position(ws.testLoc("unused_b:end"))))
+        Position(loc) ..< Position(ws.testLoc("unused_b:end")))
       XCTAssertEqual(note.params.diagnostics.first?.severity, .warning)
       XCTAssertEqual(note.params.diagnostics.first?.message, "Unused variable 'b'")
       expectation.fulfill()


### PR DESCRIPTION
This lets us use the `Range<Position>` without manually converting back
and forth in the majority of cases. See the note on HoverResponse for
the behaviour with Optional that makes us have to provide a custom
Codable implementation in two places that used to be synthesized.