### PR TITLE
[refactoring] Disable "local rename"

### DIFF
--- a/Sources/SourceKit/sourcekitd/SemanticRefactorCommand.swift
+++ b/Sources/SourceKit/sourcekitd/SemanticRefactorCommand.swift
@@ -75,8 +75,8 @@ extension Array where Element == SemanticRefactorCommand {
          let ptr = api.uid_get_string_ptr(actionuid)
       {
         let actionName = String(cString: ptr)
-        guard actionName != "source.refactoring.kind.rename.global" else {
-          // TODO: Global refactoring
+        guard !actionName.hasPrefix("source.refactoring.kind.rename.") else {
+          // TODO: Rename.
           return true
         }
         commands.append(SemanticRefactorCommand(

--- a/Tests/INPUTS/SemanticRefactor/SemanticRefactorBase.swift
+++ b/Tests/INPUTS/SemanticRefactor/SemanticRefactorBase.swift
@@ -3,3 +3,8 @@ func foo() -> String {
   return a/*sr:extractEnd*/
 }
 /*sr:foo*/
+
+func localRename() {
+  var /*sr:local*/local = 1
+  _ = local
+}

--- a/Tests/SourceKitTests/CodeActionTests.swift
+++ b/Tests/SourceKitTests/CodeActionTests.swift
@@ -183,6 +183,17 @@ final class CodeActionTests: XCTestCase {
     XCTAssertEqual(result, .codeActions([]))
   }
 
+  func testSemanticRefactorLocalRenameResult() throws {
+    guard let ws = try refactorTibsWorkspace() else { return }
+    let loc = ws.testLoc("sr:local")
+    try ws.openDocument(loc.url, language: .swift)
+
+    let textDocument = TextDocumentIdentifier(loc.url)
+    let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
+    let result = try ws.sk.sendSync(request)
+    XCTAssertEqual(result, .codeActions([]))
+  }
+
   func testSemanticRefactorLocationCodeActionResult() throws {
     guard let ws = try refactorTibsWorkspace() else { return }
     let loc = ws.testLoc("sr:string")

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -22,6 +22,7 @@ extension CodeActionTests {
         ("testCodeActionResponseRespectsSupportedKinds", testCodeActionResponseRespectsSupportedKinds),
         ("testCommandEncoding", testCommandEncoding),
         ("testEmptyCodeActionResult", testEmptyCodeActionResult),
+        ("testSemanticRefactorLocalRenameResult", testSemanticRefactorLocalRenameResult),
         ("testSemanticRefactorLocationCodeActionResult", testSemanticRefactorLocationCodeActionResult),
         ("testSemanticRefactorRangeCodeActionResult", testSemanticRefactorRangeCodeActionResult),
     ]


### PR DESCRIPTION
This needs similar support to global rename before it actually works.
Disable for now.