### PR TITLE
Adds buildTarget/didChange notification to the build server protocol

### DIFF
--- a/Sources/BuildServerProtocol/BuildTargets.swift
+++ b/Sources/BuildServerProtocol/BuildTargets.swift
@@ -226,12 +226,12 @@ public struct BuildTargetEvent: Codable, Hashable {
   public var target: BuildTargetIdentifier
 
   /// The kind of change for this build target.
-  public var kind: BuildTargetEventKind
+  public var kind: BuildTargetEventKind?
 
   /// Any additional metadata about what information changed.
   public var data: LSPAny?
 
-  public init(target: BuildTargetIdentifier, kind: BuildTargetEventKind, data: LSPAny?) {
+  public init(target: BuildTargetIdentifier, kind: BuildTargetEventKind?, data: LSPAny?) {
     self.target = target
     self.kind = kind
     self.data = data

--- a/Sources/BuildServerProtocol/BuildTargets.swift
+++ b/Sources/BuildServerProtocol/BuildTargets.swift
@@ -211,7 +211,7 @@ public struct OutputsItem: Codable, Hashable {
 /// The build target changed notification is sent from the server to the client
 /// to signal a change in a build target. The server communicates during the
 /// initialize handshake whether this method is supported or not.
-public struct BuildTargetChangedNotification: NotificationType {
+public struct BuildTargetsChangedNotification: NotificationType {
   public static let method: String = "buildTarget/didChange"
 
   public var changes: [BuildTargetEvent]

--- a/Sources/BuildServerProtocol/BuildTargets.swift
+++ b/Sources/BuildServerProtocol/BuildTargets.swift
@@ -230,6 +230,12 @@ public struct BuildTargetEvent: Codable, Hashable {
 
   /// Any additional metadata about what information changed.
   public var data: LSPAny?
+
+  public init(target: BuildTargetIdentifier, kind: BuildTargetEventKind, data: LSPAny?) {
+    self.target = target
+    self.kind = kind
+    self.data = data
+  }
 }
 
 public enum BuildTargetEventKind: Int, Codable, Hashable {

--- a/Sources/BuildServerProtocol/BuildTargets.swift
+++ b/Sources/BuildServerProtocol/BuildTargets.swift
@@ -207,3 +207,38 @@ public struct OutputsItem: Codable, Hashable {
   /// The output paths for sources that belong to this build target.
   public var outputPaths: [URL]
 }
+
+/// The build target changed notification is sent from the server to the client
+/// to signal a change in a build target. The server communicates during the
+/// initialize handshake whether this method is supported or not.
+public struct BuildTargetChangedNotification: NotificationType {
+  public static let method: String = "buildTarget/didChange"
+
+  public var changes: [BuildTargetEvent]
+
+  public init(changes: [BuildTargetEvent]) {
+    self.changes = changes
+  }
+}
+
+public struct BuildTargetEvent: Codable, Hashable {
+  /// The identifier for the changed build target.
+  public var target: BuildTargetIdentifier
+
+  /// The kind of change for this build target.
+  public var kind: BuildTargetEventKind
+
+  /// Any additional metadata about what information changed.
+  public var data: LSPAny?
+}
+
+public enum BuildTargetEventKind: Int, Codable, Hashable {
+  /// The build target is new.
+  case created = 1
+
+  /// The build target has changed.
+  case changed = 2
+
+  /// The build target has been deleted.
+  case deleted = 3
+}

--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -22,6 +22,7 @@ fileprivate let requestTypes: [_RequestType.Type] = [
 ]
 
 fileprivate let notificationTypes: [NotificationType.Type] = [
+  BuildTargetChangedNotification.self,
   ExitBuildNotification.self,
   FileOptionsChangedNotification.self,
   InitializedBuildNotification.self,

--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -22,7 +22,7 @@ fileprivate let requestTypes: [_RequestType.Type] = [
 ]
 
 fileprivate let notificationTypes: [NotificationType.Type] = [
-  BuildTargetChangedNotification.self,
+  BuildTargetsChangedNotification.self,
   ExitBuildNotification.self,
   FileOptionsChangedNotification.self,
   InitializedBuildNotification.self,

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -126,7 +126,12 @@ final class BuildServerHandler: LanguageServerEndpoint {
   public weak var delegate: BuildSystemDelegate? = nil
 
   override func _registerBuiltinHandlers() {
+    _register(BuildServerHandler.handleBuildTargetsChanged)
     _register(BuildServerHandler.handleFileOptionsChanged)
+  }
+
+  func handleBuildTargetsChanged(_ notification: Notification<BuildTargetsChangedNotification>) {
+    self.delegate?.buildTargetsChanged(notification.params.changes)
   }
 
   func handleFileOptionsChanged(_ notification: Notification<FileOptionsChangedNotification>) {

--- a/Sources/SKCore/BuildSystemDelegate.swift
+++ b/Sources/SKCore/BuildSystemDelegate.swift
@@ -9,15 +9,21 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
+import BuildServerProtocol
 import LanguageServerProtocol
 import TSCBasic
 
 /// Handles  build system events, such as file build settings changes.
 public protocol BuildSystemDelegate: AnyObject {
+  /// Notify the delegate that the build targets have changed.
+  ///
+  /// The callee should request new sources and outputs for the build targets of
+  /// interest.
+  func buildTargetsChanged(_ changes: [BuildTargetEvent])
 
   /// Notify the delegate that the given files' build settings have changed.
   ///
-  /// The callee should request new build settings for any of the given files that they are interested in.
+  /// The callee should request new build settings for any of the given files
+  /// that they are interested in.
   func fileBuildSettingsChanged(_ changedFiles: Set<URL>)
 }

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerProtocol
 import LanguageServerProtocol
 import SKCore
 import SKSupport
@@ -238,6 +239,10 @@ public final class SourceKitServer: LanguageServer {
 // MARK: - Build System Delegate
 
 extension SourceKitServer: BuildSystemDelegate {
+  public func buildTargetsChanged(_ changes: [BuildTargetEvent]) {
+    // TODO: do something with these changes once build target support is in place
+  }
+
   public func fileBuildSettingsChanged(_ changedFiles: Set<URL>) {
     guard let workspace = self.workspace else {
       return

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/buildServer.json
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/buildServer.json
@@ -1,0 +1,7 @@
+{
+    "name": "client name",
+    "version": "10",
+    "bspVersion": "2.0",
+    "languages": ["a", "b"],
+    "argv": ["server.py"]
+}

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/server.py
@@ -7,8 +7,12 @@ import sys
 
 def send(data):
     dataStr = json.dumps(data)
-    sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
-    sys.stdout.flush()
+    try:
+        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+        sys.stdout.flush()
+    except IOError:
+        # stdout closed, time to quit
+        raise SystemExit(0)
 
 
 while True:

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/server.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+
+def send(data):
+    dataStr = json.dumps(data)
+    sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+    sys.stdout.flush()
+
+
+while True:
+    line = sys.stdin.readline()
+    if len(line) == 0:
+        break
+
+    assert line.startswith('Content-Length:')
+    length = int(line[len('Content-Length:'):])
+    sys.stdin.readline()
+    message = json.loads(sys.stdin.read(length))
+
+    response = None
+    notification = None
+
+    if message["method"] == "build/initialize":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {
+                "displayName": "test server",
+                "version": "0.1",
+                "bspVersion": "2.0",
+                "rootUri": "blah",
+                "capabilities": {"languageIds": ["a", "b"]},
+                "data": {
+                    "indexStorePath": "some/index/store/path"
+                }
+            }
+        }
+    elif message["method"] == "build/initialized":
+        continue
+    elif message["method"] == "build/shutdown":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": None
+        }
+    elif message["method"] == "build/exit":
+        break
+    elif message["method"] == "textDocument/registerForChanges":
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": None
+        }
+        if message["params"]["action"] == "register":
+            notification = {
+                "jsonrpc": "2.0",
+                "method": "buildTarget/didChange",
+                "params": {
+                    "changes": [
+                        {
+                            "target": {"uri": "build://target/a"},
+                            "kind": 1,
+                            "data": {"key": "value"}
+                        }
+                    ]
+                }
+            }
+
+    # ignore other notifications
+    elif "id" in message:
+        response = {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "error": {
+                "code": -32600,
+                "message": "unhandled method {}".format(message["method"]),
+            }
+        }
+
+    if response: send(response)
+    if notification: send(notification)

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -156,12 +156,11 @@ final class BuildServerBuildSystemTests: XCTestCase {
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
   }
 
-  func testBuildTargetsChanged() {
+  func testBuildTargetsChanged() throws {
     let root = AbsolutePath(
       inputsDirectory().appendingPathComponent(testDirectoryName, isDirectory: true).path)
     let buildFolder = AbsolutePath(NSTemporaryDirectory())
-    let buildSystem = try? BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
-    XCTAssertNotNil(buildSystem)
+    let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "target changed")
@@ -171,8 +170,8 @@ final class BuildServerBuildSystemTests: XCTestCase {
         kind: .created,
         data: .dictionary(["key": "value"])): expectation,
     ])
-    buildSystem?.delegate = buildSystemDelegate
-    buildSystem?.registerForChangeNotifications(for: fileUrl)
+    buildSystem.delegate = buildSystemDelegate
+    buildSystem.registerForChangeNotifications(for: fileUrl)
 
     let result = XCTWaiter.wait(for: [expectation], timeout: 15)
     if result != .completed {

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -165,6 +165,10 @@ final class TestDelegate: BuildSystemDelegate {
     self.expectations = expectations
   }
 
+  func buildTargetsChanged(_ changes: [BuildTargetEvent]) {
+    
+  }
+
   func fileBuildSettingsChanged(_ changedFiles: Set<URL>) {
     for url in changedFiles {
       expectations[url]?.fulfill()

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -155,23 +155,52 @@ final class BuildServerBuildSystemTests: XCTestCase {
     })
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
   }
+
+  func testBuildTargetsChanged() {
+    let root = AbsolutePath(
+      inputsDirectory().appendingPathComponent(testDirectoryName, isDirectory: true).path)
+    let buildFolder = AbsolutePath(NSTemporaryDirectory())
+    let buildSystem = try? BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
+    XCTAssertNotNil(buildSystem)
+
+    let fileUrl = URL(fileURLWithPath: "/some/file/path")
+    let expectation = XCTestExpectation(description: "target changed")
+    let targetIdentifier = BuildTargetIdentifier(uri: URL(string: "build://target/a")!)
+    let buildSystemDelegate = TestDelegate(targetExpectations: [
+      BuildTargetEvent(target: targetIdentifier,
+        kind: .created,
+        data: .dictionary(["key": "value"])): expectation,
+    ])
+    buildSystem?.delegate = buildSystemDelegate
+    buildSystem?.registerForChangeNotifications(for: fileUrl)
+
+    let result = XCTWaiter.wait(for: [expectation], timeout: 15)
+    if result != .completed {
+      fatalError("error \(result) waiting for targets changed notification")
+    }
+  }
 }
 
 final class TestDelegate: BuildSystemDelegate {
 
-  let expectations: [URL:XCTestExpectation]
+  let fileExpectations: [URL:XCTestExpectation]
+  let targetExpectations: [BuildTargetEvent:XCTestExpectation]
 
-  public init(expectations: [URL:XCTestExpectation]) {
-    self.expectations = expectations
+  public init(fileExpectations: [URL:XCTestExpectation] = [:],
+              targetExpectations: [BuildTargetEvent:XCTestExpectation] = [:]) {
+    self.fileExpectations = fileExpectations
+    self.targetExpectations = targetExpectations
   }
 
   func buildTargetsChanged(_ changes: [BuildTargetEvent]) {
-    
+    for event in changes {
+      targetExpectations[event]?.fulfill()
+    }
   }
 
   func fileBuildSettingsChanged(_ changedFiles: Set<URL>) {
     for url in changedFiles {
-      expectations[url]?.fulfill()
+      fileExpectations[url]?.fulfill()
     }
   }
 }

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -54,7 +54,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "\(fileUrl) settings updated")
-    let buildSystemDelegate = TestDelegate(expectations: [fileUrl: expectation])
+    let buildSystemDelegate = TestDelegate(fileExpectations: [fileUrl: expectation])
     buildSystem.delegate = buildSystemDelegate
     buildSystem.registerForChangeNotifications(for: fileUrl)
 

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -8,6 +8,7 @@ extension BuildServerBuildSystemTests {
     static let __allTests__BuildServerBuildSystemTests = [
         ("testBuildTargetOutputs", testBuildTargetOutputs),
         ("testBuildTargets", testBuildTargets),
+        ("testBuildTargetsChanged", testBuildTargetsChanged),
         ("testBuildTargetSources", testBuildTargetSources),
         ("testFileRegistration", testFileRegistration),
         ("testServerInitialize", testServerInitialize),


### PR DESCRIPTION
This PR adds the `buildTarget/didChange` notification to the build server protocol, as well as a `BuildSystemDelegate` method that is called when it is received.