### PR TITLE
Swap `BuildSystem` to remove build settings method

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -242,7 +242,9 @@ public final class JSONRPCConection {
       if errorCode != 0 {
         log("IO error sending message \(errorCode)", level: .error)
         if done {
-          self?.close()
+          self?.queue.async {
+            self?._close()
+          }
         }
       }
     }

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -30,7 +30,7 @@ public final class BuildServerBuildSystem {
   let requestQueue: DispatchQueue
 
   var handler: BuildServerHandler?
-  var buildServer: Connection?
+  var buildServer: JSONRPCConection?
   public private(set) var indexStorePath: AbsolutePath?
 
   /// Delegate to handle any build system events.
@@ -74,6 +74,7 @@ public final class BuildServerBuildSystem {
           log("error shutting down build server: \(error)")
         }
         buildServer.send(ExitBuildNotification())
+        buildServer.close()
       })
     }
   }
@@ -232,7 +233,7 @@ struct BuildServerConfig: Codable {
   let argv: [String]
 }
 
-private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: AbsolutePath, serverFlags: [String]?) throws -> Connection {
+private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: AbsolutePath, serverFlags: [String]?) throws -> JSONRPCConection {
   let clientToServer = Pipe()
   let serverToClient = Pipe()
 

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -31,9 +31,6 @@ public protocol BuildSystem: AnyObject {
   /// The path to put the index database, if any.
   var indexDatabasePath: AbsolutePath? { get }
 
-  /// Returns the settings for the given url and language mode, if known.
-  func settings(for: URL, _ language: Language) -> FileBuildSettings?
-
   /// Returns the toolchain to use to compile this file
   func toolchain(for: URL, _ language: Language) -> Toolchain?
 
@@ -43,7 +40,10 @@ public protocol BuildSystem: AnyObject {
 
   /// Register the given file for build-system level change notifications, such
   /// as command line flag changes, dependency changes, etc.
-  func registerForChangeNotifications(for: URL)
+  ///
+  /// If the `BuildSystem` has cached build settings information, it is recommended to
+  /// immediately notify its delegate, as an optimization.
+  func registerForChangeNotifications(for: URL, language: Language)
 
   /// Unregister the given file for build-system level change notifications,
   /// such as command line flag changes, dependency changes, etc.

--- a/Sources/SKCore/BuildSystemList.swift
+++ b/Sources/SKCore/BuildSystemList.swift
@@ -36,20 +36,11 @@ extension BuildSystemList: BuildSystem {
 
   public var indexDatabasePath: AbsolutePath? { return providers.first?.indexDatabasePath }
 
-  public func settings(for url: URL, _ language: Language) -> FileBuildSettings? {
-    for provider in providers {
-      if let settings = provider.settings(for: url, language) {
-        return settings
-      }
-    }
-    return nil
-  }
-
   /// Register the given file for build-system level change notifications, such as command
   /// line flag changes, dependency changes, etc.
-  public func registerForChangeNotifications(for url: URL) {
+  public func registerForChangeNotifications(for url: URL, language: Language) {
     // Only register with the primary build system, since we only use its delegate.
-    providers.first?.registerForChangeNotifications(for: url)
+    providers.first?.registerForChangeNotifications(for: url, language: language)
   }
 
   /// Unregister the given file for build-system level change notifications, such as command

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -54,8 +54,12 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
 
   public func toolchain(for: URL, _ language: Language) -> Toolchain? { return nil }
 
-  /// We don't support change watching.
-  public func registerForChangeNotifications(for: URL) {}
+  /// We don't support change watching, so we only notify our `delegate` of the settings here.
+  public func registerForChangeNotifications(for url: URL, language: Language) {
+    if let settings = self.settings(for: url, language) {
+      self.delegate?.fileBuildSettingsChanged([url: .modified(settings)])
+    }
+  }
 
   /// We don't support change watching.
   public func unregisterForChangeNotifications(for: URL) {}

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -54,8 +54,12 @@ public final class FallbackBuildSystem: BuildSystem {
     }
   }
 
-  /// We don't support change watching.
-  public func registerForChangeNotifications(for: URL) {}
+  /// We don't support change watching, so we only notify our `delegate` of the settings here.
+  public func registerForChangeNotifications(for url: URL, language: Language) {
+    if let settings = self.settings(for: url, language) {
+      self.delegate?.fileBuildSettingsChanged([url: .modified(settings)])
+    }
+  }
 
   /// We don't support change watching.
   public func unregisterForChangeNotifications(for: URL) {}

--- a/Sources/SKCore/FileBuildSettingsChange.swift
+++ b/Sources/SKCore/FileBuildSettingsChange.swift
@@ -10,14 +10,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
-import TSCBasic
+/// Denotes a change in build settings for a single file.
+public enum FileBuildSettingsChange {
 
-/// Handles  build system events, such as file build settings changes.
-public protocol BuildSystemDelegate: AnyObject {
+  /// The `BuildSystem` no longer has `FileBuildSettings` for the file.
+  case removed
 
-  /// Notify the delegate that the given files' build settings have changed.
-  ///
-  /// The callee should request new build settings for any of the given files that they are interested in.
-  func fileBuildSettingsChanged(_ changes: [URL: FileBuildSettingsChange])
+  /// The `FileBuildSettings` have been modified.
+  case modified(FileBuildSettings)
+}
+
+public extension FileBuildSettingsChange {
+  var newFileBuildSettings: FileBuildSettings? {
+    switch self {
+    case .removed:
+      return nil
+    case .modified(let settings):
+      return settings
+    }
+  }
 }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -224,8 +224,14 @@ extension SwiftPMWorkspace: BuildSystem {
 
   /// Register the given file for build-system level change notifications, such as command
   /// line flag changes, dependency changes, etc.
-  public func registerForChangeNotifications(for url: LanguageServerProtocol.URL) {
+  public func registerForChangeNotifications(
+    for url: LanguageServerProtocol.URL,
+    language: Language)
+  {
     // TODO: Support for change detection (via file watching)
+    if let settings = self.settings(for: url, language) {
+      self.delegate?.fileBuildSettingsChanged([url: .modified(settings)])
+    }
   }
 
   /// Unregister the given file for build-system level change notifications, such as command

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -125,6 +125,17 @@ extension SKSwiftPMTestWorkspace {
       version: 1,
       text: try sources.sourceCache.get(url))))
   }
+
+  public func initialize(clientCapabilities: ClientCapabilities) throws {
+    _ = try sk.sendSync(InitializeRequest(
+      processId: nil,
+      rootPath: nil,
+      rootURL: nil,
+      initializationOptions: nil,
+      capabilities: clientCapabilities,
+      trace: .off,
+      workspaceFolders: nil))
+  }
 }
 
 extension XCTestCase {

--- a/Sources/SourceKit/ToolchainLanguageServer.swift
+++ b/Sources/SourceKit/ToolchainLanguageServer.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import LanguageServerProtocol
+import SKCore
 
 /// A `LanguageServer` that exists within the context of the current process.
 public protocol ToolchainLanguageServer: AnyObject {
@@ -28,7 +29,11 @@ public protocol ToolchainLanguageServer: AnyObject {
   func changeDocument(_ note: DidChangeTextDocument)
   func willSaveDocument(_ note: WillSaveTextDocument)
   func didSaveDocument(_ note: DidSaveTextDocument)
-  func documentUpdatedBuildSettings(_ url: URL, language: Language)
+
+  // MARK: - Build System Interactions
+
+  /// Note that this may be called before a respective `openDocument`.
+  func documentChangedBuildSettings(_ url: URL, _ change: FileBuildSettingsChange)
 
   // MARK: - Text Document
 

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -69,6 +69,7 @@ final class SwiftSourceKitFramework {
 
     api.initialize = try dlsym_required(dylib, symbol: "sourcekitd_initialize")
     api.shutdown = try dlsym_required(dylib, symbol: "sourcekitd_shutdown")
+    api.set_interrupted_connection_handler = try dlsym_required(dylib, symbol: "sourcekitd_set_interrupted_connection_handler")
     api.uid_get_from_cstr = try dlsym_required(dylib, symbol: "sourcekitd_uid_get_from_cstr")
     api.uid_get_from_buf = try dlsym_required(dylib, symbol: "sourcekitd_uid_get_from_buf")
     api.uid_get_length = try dlsym_required(dylib, symbol: "sourcekitd_uid_get_length")

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetOutputs/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetOutputs/server.py
@@ -69,5 +69,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetSources/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetSources/server.py
@@ -92,5 +92,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargets/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargets/server.py
@@ -88,5 +88,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
@@ -7,8 +7,12 @@ import sys
 
 def send(data):
     dataStr = json.dumps(data)
-    sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
-    sys.stdout.flush()
+    try:
+        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+        sys.stdout.flush()
+    except IOError:
+        # stdout closed, time to quit
+        raise SystemExit(0)
 
 
 while True:

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
@@ -53,5 +53,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
@@ -75,5 +75,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -56,7 +56,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
     let expectation = XCTestExpectation(description: "\(fileUrl) settings updated")
     let buildSystemDelegate = TestDelegate(expectations: [fileUrl: expectation])
     buildSystem.delegate = buildSystemDelegate
-    buildSystem.registerForChangeNotifications(for: fileUrl)
+    buildSystem.registerForChangeNotifications(for: fileUrl, language: .swift)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
   }
@@ -159,14 +159,14 @@ final class BuildServerBuildSystemTests: XCTestCase {
 
 final class TestDelegate: BuildSystemDelegate {
 
-  let expectations: [URL:XCTestExpectation]
+  let expectations: [URL: XCTestExpectation]
 
-  public init(expectations: [URL:XCTestExpectation]) {
+  public init(expectations: [URL: XCTestExpectation]) {
     self.expectations = expectations
   }
 
-  func fileBuildSettingsChanged(_ changedFiles: Set<URL>) {
-    for url in changedFiles {
+  func fileBuildSettingsChanged(_ changes: [URL: FileBuildSettingsChange]) {
+    for url in changes.keys {
       expectations[url]?.fulfill()
     }
   }

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -197,7 +197,7 @@ final class CompilationDatabaseTests: XCTestCase {
       ]
       """)
 
-    let buildSystem: BuildSystem = CompilationDatabaseBuildSystem(
+    let buildSystem = CompilationDatabaseBuildSystem(
       projectRoot: AbsolutePath("/a"), fileSystem: fs)
 
     let settings = buildSystem.settings(for: URL(fileURLWithPath: "/a/a.swift"), .swift)

--- a/Tests/SourceKitTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitTests/SwiftPMIntegration.swift
@@ -23,6 +23,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
 
     let call = ws.testLoc("Lib.foo:call")
     let def = ws.testLoc("Lib.foo:def")
+    try ws.initialize(clientCapabilities: ClientCapabilities(workspace: nil, textDocument: nil))
     try ws.openDocument(call.url, language: .swift)
     let refs = try ws.sk.sendSync(ReferencesRequest(textDocument: call.docIdentifier, position: call.position))
 


### PR DESCRIPTION
Instead the `BuildSystem` should inform its delegate of changes to build settings via `fileBuildSettingsChanged`