### PR TITLE
don't add log handler until connection has started

### DIFF
--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -100,10 +100,6 @@ let clientConnection = JSONRPCConection(
   exit(0)
 })
 
-Logger.shared.addLogHandler { message, _ in
-  clientConnection.send(LogMessage(type: .log, message: message))
-}
-
 let installPath = AbsolutePath(Bundle.main.bundlePath)
 ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFileSystem)
 
@@ -111,5 +107,9 @@ let server = SourceKitServer(client: clientConnection, options: options.serverOp
   clientConnection.close()
 })
 clientConnection.start(receiveHandler: server)
+
+Logger.shared.addLogHandler { message, _ in
+  clientConnection.send(LogMessage(type: .log, message: message))
+}
 
 dispatchMain()


### PR DESCRIPTION
This fixes a launch crash if the log level is set above the default and there are any log messages during toolchain scanning. This would cause an assert as the `clientConnection` would try to send a message before it had started.