### PR TITLE
Add `ToolchainLanguageServerCrashHandler` to handle crashes

### DIFF
--- a/Sources/Csourcekitd/include/sourcekitd_functions.h
+++ b/Sources/Csourcekitd/include/sourcekitd_functions.h
@@ -69,6 +69,8 @@ typedef const char *(^sourcekitd_str_from_uid_handler_t)(sourcekitd_uid_t uid);
 typedef struct {
   void (*initialize)(void);
   void (*shutdown)(void);
+  void (*set_interrupted_connection_handler)(
+      sourcekitd_interrupted_connection_handler_t handler);
 
   sourcekitd_uid_t (*uid_get_from_cstr)(const char *string);
   sourcekitd_uid_t (*uid_get_from_buf)(const char *buf, size_t length);

--- a/Sources/SourceKit/ToolchainLanguageServer.swift
+++ b/Sources/SourceKit/ToolchainLanguageServer.swift
@@ -18,6 +18,8 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   // MARK: Lifetime
 
+  var crashHandler: ToolchainLanguageServerCrashHandler? {get set}
+
   func initializeSync(_ initialize: InitializeRequest) throws -> InitializeResult
   func clientInitialized(_ initialized: InitializedNotification)
 

--- a/Sources/SourceKit/ToolchainLanguageServerCrashHandler.swift
+++ b/Sources/SourceKit/ToolchainLanguageServerCrashHandler.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public protocol ToolchainLanguageServerCrashHandler: AnyObject {
+  /// Called when the given `ToolchainLanguageServer` has crashed and needs to be reinitialized with information
+  /// such as the list of open documents.
+  ///
+  /// The handler may or may not chose to re-open previously open documents and/or
+  /// stop sending any further requests to the given `ToolchainLanguageServer`.
+  func handleCrash(_ languageService: ToolchainLanguageServer, _ debugInfo: String)
+}

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -19,9 +19,10 @@ import Foundation
 
 /// A thin wrapper over a connection to a clangd server providing build setting handling.
 final class ClangLanguageServerShim: ToolchainLanguageServer {
-
   /// The server's request queue, used to serialize requests and responses to `clangd`.
   public let queue: DispatchQueue = DispatchQueue(label: "clangd-language-server-queue", qos: .userInitiated)
+
+  public weak var crashHandler: ToolchainLanguageServerCrashHandler? = nil
 
   let clangd: Connection
 
@@ -215,6 +216,7 @@ func makeJSONRPCClangServer(
   process.standardOutput = serverToClient
   process.standardInput = clientToServer
   process.terminationHandler = { process in
+    // TODO: Inform the crash handler and provide a way to restart clangd.
     log("clangd exited: \(process.terminationReason) \(process.terminationStatus)")
     connection.close()
   }

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -69,6 +69,7 @@ final class SwiftSourceKitFramework {
 
     api.initialize = try dlsym_required(dylib, symbol: "sourcekitd_initialize")
     api.shutdown = try dlsym_required(dylib, symbol: "sourcekitd_shutdown")
+    api.set_interrupted_connection_handler = try dlsym_required(dylib, symbol: "sourcekitd_set_interrupted_connection_handler")
     api.uid_get_from_cstr = try dlsym_required(dylib, symbol: "sourcekitd_uid_get_from_cstr")
     api.uid_get_from_buf = try dlsym_required(dylib, symbol: "sourcekitd_uid_get_from_buf")
     api.uid_get_length = try dlsym_required(dylib, symbol: "sourcekitd_uid_get_length")


### PR DESCRIPTION
The handler will be responsible for handling the crash:
- Inform the user of the crash
- Log the crash
- Choosing to restart the `ToolchainLanguageServer` or
  disabling it