### PR TITLE
Improve BuildServerBuildSystemTests error handling

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -30,7 +30,7 @@ public final class BuildServerBuildSystem {
   let requestQueue: DispatchQueue
 
   var handler: BuildServerHandler?
-  var buildServer: Connection?
+  var buildServer: JSONRPCConection?
   public private(set) var indexStorePath: AbsolutePath?
 
   /// Delegate to handle any build system events.
@@ -74,6 +74,7 @@ public final class BuildServerBuildSystem {
           log("error shutting down build server: \(error)")
         }
         buildServer.send(ExitBuildNotification())
+        buildServer.close()
       })
     }
   }
@@ -232,7 +233,7 @@ struct BuildServerConfig: Codable {
   let argv: [String]
 }
 
-private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: AbsolutePath, serverFlags: [String]?) throws -> Connection {
+private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: AbsolutePath, serverFlags: [String]?) throws -> JSONRPCConection {
   let clientToServer = Pipe()
   let serverToClient = Pipe()
 

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetOutputs/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetOutputs/server.py
@@ -69,5 +69,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetSources/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargetSources/server.py
@@ -92,5 +92,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargets/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testBuildTargets/server.py
@@ -88,5 +88,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
@@ -7,8 +7,12 @@ import sys
 
 def send(data):
     dataStr = json.dumps(data)
-    sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
-    sys.stdout.flush()
+    try:
+        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+        sys.stdout.flush()
+    except IOError:
+        # stdout closed, time to quit
+        raise SystemExit(0)
 
 
 while True:

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
@@ -53,5 +53,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break

--- a/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
+++ b/Tests/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
@@ -75,5 +75,9 @@ while True:
 
     if response:
         responseStr = json.dumps(response)
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
-        sys.stdout.flush()
+        try:
+            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.flush()
+        except IOError:
+            # stdout closed, time to quit
+            break


### PR DESCRIPTION
This changes the python test server to catch write errors and exit 0 in that case. It also adds a missing call to `connection.close()` in `BuildServerBuildSystem.deinit()` to close the open pipes on shutdown.