### PR TITLE
Fix hang/crash when a write failure occurs

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -242,7 +242,9 @@ public final class JSONRPCConection {
       if errorCode != 0 {
         log("IO error sending message \(errorCode)", level: .error)
         if done {
-          self?.close()
+          self?.queue.async {
+            self?._close()
+          }
         }
       }
     }


### PR DESCRIPTION
This code was doing a sync dispatch to a queue it was already running
on. Instead, go through the same path as other close calls.  This would
hang, or if you're lucky crash when dispatch detects the issue.