### PR TITLE
Fix issue preventing DocumentSymbols from working with clangd

### DIFF
--- a/Sources/LanguageServerProtocol/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/ClientCapabilities.swift
@@ -267,9 +267,12 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
 
     public var symbolKind: SymbolKind? = nil
 
-    public init(dynamicRegistration: Bool? = nil, symbolKind: SymbolKind? = nil) {
+    public var hierarchicalDocumentSymbolSupport: Bool? = nil
+
+    public init(dynamicRegistration: Bool? = nil, symbolKind: SymbolKind? = nil, hierarchicalDocumentSymbolSupport: Bool? = nil) {
       self.dynamicRegistration = dynamicRegistration
       self.symbolKind = symbolKind
+      self.hierarchicalDocumentSymbolSupport = hierarchicalDocumentSymbolSupport
     }
   }
 


### PR DESCRIPTION
- Clangd uses the HierarchicalDocumentSymbolSupport field of the
  documentSymbol capabilities, if we don't pass it through clangd
  will change its behavior potentially resulting in a response
  error (e.g. in Visual Studio Code)