### PR TITLE
Add new platform for TSCUtility

### DIFF
--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -17,6 +17,7 @@ extension Platform {
   /// The file extension used for a dynamic library on this platform.
   public var dynamicLibraryExtension: String {
     switch self {
+    case .android: return "so"
     case .darwin: return "dylib"
     case .linux: return "so"
     }


### PR DESCRIPTION
The macOS smoke test for apple/swift-package-manager#2396 fails without this addition.

Feel free to ignore until that pull is approved.