### PR TITLE
port to SwiftNIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,11 @@ let package = Package(
       )
     ],
     dependencies: [
-      // See 'Dependencies' below.
+
+      .package(url: "https://github.com/apple/swift-nio.git", from: "2.10.0"),
+      .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.1"),
+
+      // See 'Toolchain Dependencies' below for additional dependencies.
     ],
     targets: [
       .target(
@@ -134,6 +138,9 @@ let package = Package(
         dependencies: [
           "LanguageServerProtocol",
           "LSPLogging",
+          "NIO",
+          "NIOFoundationCompat",
+          "NIOExtras",
         ]
       ),
       .testTarget(

--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -27,21 +27,18 @@ public struct TestJSONRPCConnection {
   public let serverConnection: JSONRPCConnection
 
   public init() {
-    // FIXME: DispatchIO doesn't like when the Pipes close behind its back even after the tests
-    // finish. Until we fix the lifetime, leak.
-    _ = Unmanaged.passRetained(clientToServer)
-    _ = Unmanaged.passRetained(serverToClient)
-
     clientConnection = JSONRPCConnection(
       protocol: testMessageRegistry,
-      inFD: serverToClient.fileHandleForReading.fileDescriptor,
-      outFD: clientToServer.fileHandleForWriting.fileDescriptor
+      inputFileHandle: serverToClient.fileHandleForReading,
+      outputFileHandle: clientToServer.fileHandleForWriting,
+      takeFileDescriptorOwnership: true
     )
 
     serverConnection = JSONRPCConnection(
       protocol: testMessageRegistry,
-      inFD: clientToServer.fileHandleForReading.fileDescriptor,
-      outFD: serverToClient.fileHandleForWriting.fileDescriptor
+      inputFileHandle: clientToServer.fileHandleForReading,
+      outputFileHandle: serverToClient.fileHandleForWriting,
+      takeFileDescriptorOwnership: true
     )
 
     client = TestClient(server: clientConnection)

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -245,8 +245,9 @@ private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: Absolute
 
   let connection = JSONRPCConnection(
     protocol: BuildServerProtocol.bspRegistry,
-    inFD: serverToClient.fileHandleForReading.fileDescriptor,
-    outFD: clientToServer.fileHandleForWriting.fileDescriptor
+    inputFileHandle: serverToClient.fileHandleForReading,
+    outputFileHandle: clientToServer.fileHandleForWriting,
+    takeFileDescriptorOwnership: true
   )
 
   connection.start(receiveHandler: client)

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -63,20 +63,17 @@ public struct TestSourceKitServer {
         let clientToServer: Pipe = Pipe()
         let serverToClient: Pipe = Pipe()
 
-        // FIXME: DispatchIO doesn't like when the Pipes close behind its back even after the tests
-        // finish. Until we fix the lifetime, leak.
-        _ = Unmanaged.passRetained(clientToServer)
-        _ = Unmanaged.passRetained(serverToClient)
-
         let clientConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
-          inFD: serverToClient.fileHandleForReading.fileDescriptor,
-          outFD: clientToServer.fileHandleForWriting.fileDescriptor
+          inputFileHandle: serverToClient.fileHandleForReading,
+          outputFileHandle: clientToServer.fileHandleForWriting,
+          takeFileDescriptorOwnership: true
         )
         let serverConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
-          inFD: clientToServer.fileHandleForReading.fileDescriptor,
-          outFD: serverToClient.fileHandleForWriting.fileDescriptor
+          inputFileHandle: clientToServer.fileHandleForReading,
+          outputFileHandle: serverToClient.fileHandleForWriting,
+          takeFileDescriptorOwnership: true
         )
 
         client = TestClient(server: clientConnection)

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -191,8 +191,9 @@ func makeJSONRPCClangServer(
 
   let connection = JSONRPCConnection(
     protocol: MessageRegistry.lspProtocol,
-    inFD: serverToClient.fileHandleForReading.fileDescriptor,
-    outFD: clientToServer.fileHandleForWriting.fileDescriptor
+    inputFileHandle: serverToClient.fileHandleForReading,
+    outputFileHandle: clientToServer.fileHandleForWriting,
+    takeFileDescriptorOwnership: true
   )
 
   let connectionToClient = LocalConnection()

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -100,8 +100,9 @@ do {
 
 let clientConnection = JSONRPCConnection(
   protocol: MessageRegistry.lspProtocol,
-  inFD: STDIN_FILENO,
-  outFD: STDOUT_FILENO,
+  inputFileHandle: FileHandle(fileDescriptor: STDIN_FILENO, closeOnDealloc: false),
+  outputFileHandle: FileHandle(fileDescriptor: STDOUT_FILENO, closeOnDealloc: false),
+  takeFileDescriptorOwnership: false, // in this case we want to preserve `STDIN_FILENO` and `STDOUT_FILENO`.
   syncRequests: options.syncRequests)
 
 let installPath = AbsolutePath(Bundle.main.bundlePath)


### PR DESCRIPTION
Co-Authored-By: Ben Langmuir <blangmuir@apple.com>

Motivation:

SwiftNIO offers a lot of functionality that can be used to make the
sourcekit-lsp code more straightforward and more testable.

Modifications:

Replace DispatchIO with SwiftNIO, specifically NIO's PipeChannel which
allows two UNIX pipes / terminals / ... to be used as the input/output
file descriptors for a Channel.

Result:

More straightforward code.