### PR TITLE
Eliminate _IndirectConnection and replace it by closure

### DIFF
--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -38,12 +38,6 @@ extension Connection {
   }
 }
 
-/// Implementation detail of connections where the endpoints cannot directly reply via a function call.
-public protocol _IndirectConnection: Connection {
-  /// *Implementation detail*.
-  func sendReply<Response>(_: LSPResult<Response>, id: RequestID) where Response: ResponseType
-}
-
 /// An abstract message handler, such as a language server or client.
 public protocol MessageHandler: AnyObject {
 


### PR DESCRIPTION
This allows us to move the semaphore logic out of the message to the connection where it belongs.