### PR TITLE
Move LanguageServer to SKCore

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -16,8 +16,6 @@ import SKSupport
 import Foundation
 import BuildServerProtocol
 
-typealias Notification = LanguageServerProtocol.Notification
-
 /// A `BuildSystem` based on communicating with a build server
 ///
 /// Provides build settings from a build server launched based on a

--- a/Sources/SKCore/LanguageServer.swift
+++ b/Sources/SKCore/LanguageServer.swift
@@ -12,6 +12,9 @@
 
 import SKSupport
 import Dispatch
+import LanguageServerProtocol
+
+public typealias Notification = LanguageServerProtocol.Notification
 
 /// An abstract language server.
 ///

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKCore
 import SKSupport
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC


### PR DESCRIPTION
In an effort to clean up `LanguageServerProtocol`, move the `LanguageServer` type to `SKCore`.