### PR TITLE
Disable clangd indexing

### DIFF
--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -209,7 +209,9 @@ func makeJSONRPCClangServer(
   }
 
   process.arguments = [
-    "-compile_args_from=lsp", // Provide compiler args programmatically.
+    "-compile_args_from=lsp",   // Provide compiler args programmatically.
+    "-background-index=false",  // Disable clangd indexing, we use the build
+    "-index=false",             // system index store instead.
   ] + clangdOptions
 
   process.standardOutput = serverToClient


### PR DESCRIPTION
This PR disables clangd indexing features. This functionality is currently provided by the build system's index store instead.