### PR TITLE
Add a product that contains the modules needed to build a generic LSP client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,18 @@ import PackageDescription
 let package = Package(
     name: "SourceKitLSP",
     products: [
+      .executable(
+        name: "sourcekit-lsp",
+        targets: ["sourcekit-lsp"]
+      ),
+      .library(
+        name: "LSPBindings",
+        type: .static,
+        targets: [
+          "LanguageServerProtocol",
+          "LanguageServerProtocolJSONRPC",
+        ]
+      )
     ],
     dependencies: [
       // See 'Dependencies' below.


### PR DESCRIPTION
After #192 is merged, the `LanguageServerProtocol` and `LanguageServerProtocolJSONRPC` modules contain code that can be used to implement an LSP client or server. Add a library target that contains these modules so they can actually be used as a library dependency.