### PR TITLE
Attempt to save index on shutdown

### DIFF
--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -38,6 +38,7 @@ public final class SKTibsTestWorkspace {
     immutableProjectDir: URL,
     persistentBuildDir: URL,
     tmpDir: URL,
+    removeTmpDir: Bool,
     toolchain: Toolchain,
     clientCapabilities: ClientCapabilities) throws
   {
@@ -45,6 +46,7 @@ public final class SKTibsTestWorkspace {
       immutableProjectDir: immutableProjectDir,
       persistentBuildDir: persistentBuildDir,
       tmpDir: tmpDir,
+      removeTmpDir: removeTmpDir,
       toolchain: TibsToolchain(toolchain))
 
     initWorkspace(clientCapabilities: clientCapabilities)
@@ -91,15 +93,22 @@ extension SKTibsTestWorkspace {
 
 extension XCTestCase {
 
-  public func staticSourceKitTibsWorkspace(name: String, clientCapabilities: ClientCapabilities = .init(), testFile: String = #file) throws -> SKTibsTestWorkspace? {
+  public func staticSourceKitTibsWorkspace(
+    name: String,
+    clientCapabilities: ClientCapabilities = .init(),
+    tmpDir: URL? = nil,
+    removeTmpDir: Bool = true,
+    testFile: String = #file
+  ) throws -> SKTibsTestWorkspace? {
     let testDirName = testDirectoryName
     let workspace = try SKTibsTestWorkspace(
       immutableProjectDir: inputsDirectory(testFile: testFile)
         .appendingPathComponent(name, isDirectory: true),
       persistentBuildDir: XCTestCase.productsDirectory
         .appendingPathComponent("sk-tests/\(testDirName)", isDirectory: true),
-      tmpDir: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      tmpDir: tmpDir ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         .appendingPathComponent("sk-test-data/\(testDirName)", isDirectory: true),
+      removeTmpDir: removeTmpDir,
       toolchain: ToolchainRegistry.shared.default!,
       clientCapabilities: clientCapabilities)
 

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -352,7 +352,8 @@ extension SourceKitServer {
   }
 
   func shutdown(_ request: Request<Shutdown>) {
-    // Nothing to do yet.
+    // Close the index, which will flush to disk.
+    self.workspace?.index = nil
     request.reply(VoidResponse())
   }
 

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -111,6 +111,7 @@ let server = SourceKitServer(client: clientConnection, options: options.serverOp
   clientConnection.close()
 })
 clientConnection.start(receiveHandler: server, closeHandler: {
+  server.prepareForExit()
   exit(0)
 })
 

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -102,10 +102,7 @@ let clientConnection = JSONRPCConection(
   protocol: MessageRegistry.lspProtocol,
   inFD: STDIN_FILENO,
   outFD: STDOUT_FILENO,
-  syncRequests: options.syncRequests,
-  closeHandler: {
-  exit(0)
-})
+  syncRequests: options.syncRequests)
 
 let installPath = AbsolutePath(Bundle.main.bundlePath)
 ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFileSystem)
@@ -113,7 +110,9 @@ ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFile
 let server = SourceKitServer(client: clientConnection, options: options.serverOptions, onExit: {
   clientConnection.close()
 })
-clientConnection.start(receiveHandler: server)
+clientConnection.start(receiveHandler: server, closeHandler: {
+  exit(0)
+})
 
 Logger.shared.addLogHandler { message, _ in
   clientConnection.send(LogMessage(type: .log, message: message))

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -213,18 +213,17 @@ class ConnectionTests: XCTestCase {
       let conn = JSONRPCConection(
         protocol: MessageRegistry(requests: [], notifications: []),
         inFD: to.fileHandleForReading.fileDescriptor,
-        outFD: from.fileHandleForWriting.fileDescriptor,
-        closeHandler: {
-        // We get an error from XCTest if this is fulfilled more than once.
-        expectation.fulfill()
-      })
+        outFD: from.fileHandleForWriting.fileDescriptor)
 
       final class DummyHandler: MessageHandler {
         func handle<N: NotificationType>(_: N, from: ObjectIdentifier) {}
         func handle<R: RequestType>(_: R, id: RequestID, from: ObjectIdentifier, reply: @escaping (LSPResult<R.Response>) -> Void) {}
       }
 
-      conn.start(receiveHandler: DummyHandler())
+      conn.start(receiveHandler: DummyHandler(), closeHandler: {
+        // We get an error from XCTest if this is fulfilled more than once.
+        expectation.fulfill()
+      })
 
 
       close(to.fileHandleForWriting.fileDescriptor)

--- a/Tests/SourceKitTests/SourceKitTests.swift
+++ b/Tests/SourceKitTests/SourceKitTests.swift
@@ -87,6 +87,61 @@ final class SKTests: XCTestCase {
     ])
   }
 
+  func testIndexShutdown() throws {
+
+    let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("sk-test-data/\(testDirectoryName)", isDirectory: true)
+
+    func listdir(_ url: URL) throws -> [URL] {
+      try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+    }
+
+    func checkRunningIndex(build: Bool) throws -> URL? {
+      guard let ws = try staticSourceKitTibsWorkspace(
+        name: "SwiftModules", tmpDir: tmpDir, removeTmpDir: false)
+      else {
+        return nil
+      }
+
+      if build {
+        try ws.buildAndIndex()
+      }
+
+      let locDef = ws.testLoc("aaa:def")
+      let locRef = ws.testLoc("aaa:call:c")
+      try ws.openDocument(locRef.url, language: .swift)
+      let jump = try ws.sk.sendSync(DefinitionRequest(
+        textDocument: locRef.docIdentifier,
+        position: locRef.position))
+      XCTAssertEqual(jump.count, 1)
+      XCTAssertEqual(jump.first?.url, locDef.url)
+      XCTAssertEqual(jump.first?.range.lowerBound, locDef.position)
+
+      let tmpContents = try listdir(tmpDir)
+      guard let versionedPath = tmpContents.filter({ $0.lastPathComponent.starts(with: "v") }).spm_only else {
+        XCTFail("expected one version path 'v[0-9]*', found \(tmpContents)")
+        return nil
+      }
+
+      let versionContentsBefore = try listdir(versionedPath)
+      XCTAssertEqual(versionContentsBefore.count, 1)
+      XCTAssert(versionContentsBefore.first?.lastPathComponent.starts(with: "p") ?? false)
+
+      _ = try ws.sk.sendSync(Shutdown())
+      return versionedPath
+    }
+
+    guard let versionedPath = try checkRunningIndex(build: true) else { return }
+    
+    let versionContentsAfter = try listdir(versionedPath)
+    XCTAssertEqual(versionContentsAfter.count, 1)
+    XCTAssertEqual(versionContentsAfter.first?.lastPathComponent, "saved")
+
+    _ = try checkRunningIndex(build: true)
+
+    try FileManager.default.removeItem(atPath: tmpDir.path)
+  }
+
   func testCodeCompleteSwiftTibs() throws {
     guard let ws = try staticSourceKitTibsWorkspace(name: "CodeCompleteSingleModule") else { return }
     let loc = ws.testLoc("cc:A")

--- a/Tests/SourceKitTests/SourceKitTests.swift
+++ b/Tests/SourceKitTests/SourceKitTests.swift
@@ -114,7 +114,7 @@ final class SKTests: XCTestCase {
         textDocument: locRef.docIdentifier,
         position: locRef.position))
       XCTAssertEqual(jump.count, 1)
-      XCTAssertEqual(jump.first?.url, locDef.url)
+      XCTAssertEqual(jump.first?.uri, DocumentURI(locDef.url))
       XCTAssertEqual(jump.first?.range.lowerBound, locDef.position)
 
       let tmpContents = try listdir(tmpDir)

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -122,6 +122,7 @@ extension SKTests {
     // to regenerate.
     static let __allTests__SKTests = [
         ("testCodeCompleteSwiftTibs", testCodeCompleteSwiftTibs),
+        ("testIndexShutdown", testIndexShutdown),
         ("testIndexSwiftModules", testIndexSwiftModules),
         ("testInitJSON", testInitJSON),
         ("testInitLocal", testInitLocal),


### PR DESCRIPTION
When the server is about to exit, attempt to save any changes to the index to disk. This should speed up reopening the same project when it is already indexed.  The happy path is when we handle this in the `shutdown` request, since that lets the editor wait for us if they need to.  However, not all editors send shutdown/exit messages, particularly when you quit the application entirely (as opposed to a single editor window), so we sprinkle `prepareForShutdown()` into the connection closed handler as well. I verified manually in such an editor that this lets us save the index on quit.