### PR TITLE
Fix for very rare sourcekit-lsp crash.

### DIFF
--- a/Sources/SKCore/LanguageServer.swift
+++ b/Sources/SKCore/LanguageServer.swift
@@ -179,7 +179,9 @@ extension LanguageServerEndpoint: MessageHandler {
       self.requestCancellation[key] = cancellationToken
 
       let request = Request(params, id: id, clientID: clientID, cancellation: cancellationToken, reply: { [weak self] result in
-        self?.requestCancellation[key] = nil
+        self?.queue.async {
+            self?.requestCancellation[key] = nil
+        }
         reply(result)
         self?._logResponse(result, id: id, method: R.method)
       })


### PR DESCRIPTION
Hi Apple,

I'm seeing a very rare crash of the sourcekit-lsp project repeatedly running the project https://github.com/johnno1962/siteify (which uses the https://github.com/ChimeHQ/SwiftLSPClient library) to soak test some threading primitives I'm working on. The crash generally has a stack trace  of the form:
```
Thread 2 Crashed:: Dispatch queue: swift-language-server-queue
0   sourcekit-lsp                 	0x0000000109d6fb68 specialized Dictionary._Variant.removeValue(forKey:) + 40
1   sourcekit-lsp                 	0x0000000109d6f87c closure #1 in closure #1 in LanguageServerEndpoint.handle<A>(_:id:from:reply:) + 172 (LanguageServer.swift:181)
2   sourcekit-lsp                 	0x0000000109d727d0 partial apply for closure #1 in closure #1 in LanguageServerEndpoint.handle<A>(_:id:from:reply:) + 64
3   sourcekit-lsp                 	0x0000000109c04c20 Request.reply(_:) + 208
4   sourcekit-lsp                 	0x0000000109de29e0 closure #1 in closure #1 in SwiftLanguageServer.documentSymbol(_:) + 976
5   sourcekit-lsp                 	0x0000000109df2d15 partial apply for closure #1 in closure #1 in SwiftLanguageServer.documentColor(_:) + 37
6   sourcekit-lsp                 	0x0000000109df526b partial apply for closure #3 in closure #2 in SwiftSourceKitFramework.send(_:_:reply:) + 27
7   sourcekit-lsp                 	0x0000000109a24a09 thunk for @escaping @callee_guaranteed () -> () + 25
8   libdispatch.dylib             	0x00007fff791435f8 _dispatch_call_block_and_release + 12
9   libdispatch.dylib             	0x00007fff7914463d _dispatch_client_callout + 8
10  libdispatch.dylib             	0x00007fff7914a8e0 _dispatch_lane_serial_drain + 602
11  libdispatch.dylib             	0x00007fff7914b396 _dispatch_lane_invoke + 385
12  libdispatch.dylib             	0x00007fff791536ed _dispatch_workloop_worker_thread + 598
13  libsystem_pthread.dylib       	0x00007fff79384611 _pthread_wqthread + 421
14  libsystem_pthread.dylib       	0x00007fff793843fd start_wqthread + 13
```
Seems like the callback on the request is being executed on the queue `swift-language-server-queue` whereas the dictionary `requestCancellation` is normally updated by the queue `language-server-queue` and hence the crash. I've queued the key deletion to this queue and it's not crashed since. The line number in the stack trace is slightly different as I have rebased to sync with master since I caught the crash.