### PR TITLE
Make JSONRPCConnection's closeHandler public and pass the connection as a parameter

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -22,9 +22,9 @@ public struct TestJSONRPCConnection {
   public let clientToServer: Pipe = Pipe()
   public let serverToClient: Pipe = Pipe()
   public let client: TestClient
-  public let clientConnection: JSONRPCConection
+  public let clientConnection: JSONRPCConnection
   public let server: TestServer
-  public let serverConnection: JSONRPCConection
+  public let serverConnection: JSONRPCConnection
 
   public init() {
     // FIXME: DispatchIO doesn't like when the Pipes close behind its back even after the tests
@@ -32,13 +32,13 @@ public struct TestJSONRPCConnection {
     _ = Unmanaged.passRetained(clientToServer)
     _ = Unmanaged.passRetained(serverToClient)
 
-    clientConnection = JSONRPCConection(
+    clientConnection = JSONRPCConnection(
       protocol: testMessageRegistry,
       inFD: serverToClient.fileHandleForReading.fileDescriptor,
       outFD: clientToServer.fileHandleForWriting.fileDescriptor
     )
 
-    serverConnection = JSONRPCConection(
+    serverConnection = JSONRPCConnection(
       protocol: testMessageRegistry,
       inFD: clientToServer.fileHandleForReading.fileDescriptor,
       outFD: serverToClient.fileHandleForWriting.fileDescriptor

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -52,7 +52,7 @@ public final class JSONRPCConnection {
   /// The set of currently outstanding outgoing requests along with information about how to decode and handle their responses.
   var outstandingRequests: [RequestID: OutstandingRequest] = [:]
 
-  var closeHandler: (() -> Void)! = nil
+  public var closeHandler: ((_ connection: JSONRPCConnection) -> Void)! = nil
 
   public init(
     protocol messageRegistry: MessageRegistry,
@@ -91,7 +91,7 @@ public final class JSONRPCConnection {
   /// Start processing `inFD` and send messages to `receiveHandler`.
   ///
   /// - parameter receiveHandler: The message handler to invoke for requests received on the `inFD`.
-  public func start(receiveHandler: MessageHandler, closeHandler: @escaping () -> Void = {}) {
+  public func start(receiveHandler: MessageHandler, closeHandler: @escaping (_ connection: JSONRPCConnection) -> Void = {_ in }) {
     precondition(state == .created)
     state = .running
     self.receiveHandler = receiveHandler
@@ -301,7 +301,7 @@ public final class JSONRPCConnection {
       receiveIO.close(flags: .stop)
       sendIO.close(flags: .stop)
       receiveHandler = nil // break retain cycle
-      closeHandler()
+      closeHandler(self)
     }
   }
 

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -18,7 +18,7 @@ import LSPLogging
 /// A connection between a message handler (e.g. language server) in the same process as the connection object and a remote message handler (e.g. language client) that may run in another process using JSON RPC messages sent over a pair of in/out file descriptors.
 ///
 /// For example, inside a language server, the `JSONRPCConnection` takes the language service implemenation as its `receiveHandler` and itself provides the client connection for sending notifications and callbacks.
-public final class JSONRPCConection {
+public final class JSONRPCConnection {
 
   var receiveHandler: MessageHandler? = nil
   let queue: DispatchQueue = DispatchQueue(label: "jsonrpc-queue", qos: .userInitiated)
@@ -297,7 +297,7 @@ public final class JSONRPCConection {
       guard state == .running else { return }
       state = .closed
 
-      log("\(JSONRPCConection.self): closing...")
+      log("\(JSONRPCConnection.self): closing...")
       receiveIO.close(flags: .stop)
       sendIO.close(flags: .stop)
       receiveHandler = nil // break retain cycle
@@ -313,7 +313,7 @@ public final class JSONRPCConection {
 
 }
 
-extension JSONRPCConection: Connection {
+extension JSONRPCConnection: Connection {
   // MARK: Connection interface
 
   public func send<Notification>(_ notification: Notification) where Notification: NotificationType {

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -30,7 +30,7 @@ public final class BuildServerBuildSystem {
   let requestQueue: DispatchQueue
 
   var handler: BuildServerHandler?
-  var buildServer: JSONRPCConection?
+  var buildServer: JSONRPCConnection?
 
   public private(set) var indexDatabasePath: AbsolutePath?
   public private(set) var indexStorePath: AbsolutePath?
@@ -239,11 +239,11 @@ struct BuildServerConfig: Codable {
   let argv: [String]
 }
 
-private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: AbsolutePath, serverFlags: [String]?) throws -> JSONRPCConection {
+private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: AbsolutePath, serverFlags: [String]?) throws -> JSONRPCConnection {
   let clientToServer = Pipe()
   let serverToClient = Pipe()
 
-  let connection = JSONRPCConection(
+  let connection = JSONRPCConnection(
     protocol: BuildServerProtocol.bspRegistry,
     inFD: serverToClient.fileHandleForReading.fileDescriptor,
     outFD: clientToServer.fileHandleForWriting.fileDescriptor

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -31,8 +31,8 @@ public struct TestSourceKitServer {
     case jsonrpc(
       clientToServer: Pipe,
       serverToClient: Pipe,
-      clientConnection: JSONRPCConection,
-      serverConnection: JSONRPCConection)
+      clientConnection: JSONRPCConnection,
+      serverConnection: JSONRPCConnection)
   }
 
   public static let serverOptions: SourceKitServer.Options = SourceKitServer.Options()
@@ -68,12 +68,12 @@ public struct TestSourceKitServer {
         _ = Unmanaged.passRetained(clientToServer)
         _ = Unmanaged.passRetained(serverToClient)
 
-        let clientConnection = JSONRPCConection(
+        let clientConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
           inFD: serverToClient.fileHandleForReading.fileDescriptor,
           outFD: clientToServer.fileHandleForWriting.fileDescriptor
         )
-        let serverConnection = JSONRPCConection(
+        let serverConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
           inFD: clientToServer.fileHandleForReading.fileDescriptor,
           outFD: serverToClient.fileHandleForWriting.fileDescriptor

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -189,7 +189,7 @@ func makeJSONRPCClangServer(
   let clientToServer: Pipe = Pipe()
   let serverToClient: Pipe = Pipe()
 
-  let connection = JSONRPCConection(
+  let connection = JSONRPCConnection(
     protocol: MessageRegistry.lspProtocol,
     inFD: serverToClient.fileHandleForReading.fileDescriptor,
     outFD: clientToServer.fileHandleForWriting.fileDescriptor

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -110,7 +110,7 @@ ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFile
 let server = SourceKitServer(client: clientConnection, options: options.serverOptions, onExit: {
   clientConnection.close()
 })
-clientConnection.start(receiveHandler: server, closeHandler: {
+clientConnection.start(receiveHandler: server, closeHandler: { _ in
   server.prepareForExit()
   exit(0)
 })

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -98,7 +98,7 @@ do {
   exit(1)
 }
 
-let clientConnection = JSONRPCConection(
+let clientConnection = JSONRPCConnection(
   protocol: MessageRegistry.lspProtocol,
   inFD: STDIN_FILENO,
   outFD: STDOUT_FILENO,

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -220,7 +220,8 @@ class ConnectionTests: XCTestCase {
         func handle<R: RequestType>(_: R, id: RequestID, from: ObjectIdentifier, reply: @escaping (LSPResult<R.Response>) -> Void) {}
       }
 
-      conn.start(receiveHandler: DummyHandler(), closeHandler: {
+      conn.start(receiveHandler: DummyHandler(), closeHandler: { connection in
+        XCTAssert(connection === conn)
         // We get an error from XCTest if this is fulfilled more than once.
         expectation.fulfill()
       })

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -210,7 +210,7 @@ class ConnectionTests: XCTestCase {
       let expectation = self.expectation(description: "closed")
       expectation.assertForOverFulfill = true
 
-      let conn = JSONRPCConection(
+      let conn = JSONRPCConnection(
         protocol: MessageRegistry(requests: [], notifications: []),
         inFD: to.fileHandleForReading.fileDescriptor,
         outFD: from.fileHandleForWriting.fileDescriptor)


### PR DESCRIPTION
This allows a user to unregister from close notifications. Also, if a single method is listening for the closing of multiple `JSONRPCConnections` it is able to distinguish those.