### PR TITLE
Support MarkedStrings in Hover responses

### DIFF
--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -497,7 +497,7 @@ extension SwiftLanguageServer {
         """
       }
 
-      req.reply(HoverResponse(contents: MarkupContent(kind: .markdown, value: result), range: nil))
+      req.reply(HoverResponse(contents: .markupContent(MarkupContent(kind: .markdown, value: result)), range: nil))
     }
   }
 

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -207,7 +207,7 @@ final class CodingTests: XCTestCase {
     checkCoding(DiagnosticCode.string("hi"), json: "\"hi\"")
 
     let markup = MarkupContent(kind: .plaintext, value: "a")
-    checkCoding(HoverResponse(contents: markup, range: nil), json: """
+    checkCoding(HoverResponse(contents: .markupContent(markup), range: nil), json: """
       {
         "contents" : {
           "kind" : "plaintext",
@@ -216,7 +216,25 @@ final class CodingTests: XCTestCase {
       }
       """)
 
-    checkCoding(HoverResponse(contents: markup, range: range), json: """
+    checkCoding(HoverResponse(contents: .markedString(.markdown(value: "test")), range: nil), json: """
+      {
+        "contents" : "test"
+      }
+      """)
+
+    checkCoding(HoverResponse(contents: .markedStrings([.markdown(value: "test"), .codeBlock(language: "swift", value: "let foo = 2")]), range: nil), json: """
+      {
+        "contents" : [
+          "test",
+          {
+            "language" : "swift",
+            "value" : "let foo = 2"
+          }
+        ]
+      }
+      """)
+
+    checkCoding(HoverResponse(contents: .markupContent(markup), range: range), json: """
       {
         "contents" : {
           "kind" : "plaintext",

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -729,8 +729,12 @@ final class LocalSwiftTests: XCTestCase {
       XCTAssertNotNil(resp)
       if let hover = resp {
         XCTAssertNil(hover.range)
-        XCTAssertEqual(hover.contents.kind, .markdown)
-        XCTAssertEqual(hover.contents.value, """
+        guard case .markupContent(let content) = hover.contents else {
+          XCTFail("hover.contents is not .markupContents")
+          return
+        }
+        XCTAssertEqual(content.kind, .markdown)
+        XCTAssertEqual(content.value, """
           # S
           ```
           struct S
@@ -776,8 +780,12 @@ final class LocalSwiftTests: XCTestCase {
       XCTAssertNotNil(resp)
       if let hover = resp {
         XCTAssertNil(hover.range)
-        XCTAssertEqual(hover.contents.kind, .markdown)
-        XCTAssertEqual(hover.contents.value, ##"""
+        guard case .markupContent(let content) = hover.contents else {
+          XCTFail("hover.contents is not .markupContents")
+          return
+        }
+        XCTAssertEqual(content.kind, .markdown)
+        XCTAssertEqual(content.value, ##"""
           # test(\_:\_:)
           ```
           func test(_ a: Int, _ b: Int)
@@ -796,8 +804,12 @@ final class LocalSwiftTests: XCTestCase {
       XCTAssertNotNil(resp)
       if let hover = resp {
         XCTAssertNil(hover.range)
-        XCTAssertEqual(hover.contents.kind, .markdown)
-        XCTAssertEqual(hover.contents.value, ##"""
+        guard case .markupContent(let content) = hover.contents else {
+          XCTFail("hover.contents is not .markupContents")
+          return
+        }
+        XCTAssertEqual(content.kind, .markdown)
+        XCTAssertEqual(content.value, ##"""
           # \*%\*(\_:\_:)
           ```
           func *%* (lhs: String, rhs: String)


### PR DESCRIPTION
The LSP spec also allows `MarkedString`s as response contents to the Hover request.