### PR TITLE
Use SourceKit's not_recommended field to populate deprecated in Code Completion responses

### DIFF
--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -448,6 +448,9 @@ extension SwiftLanguageServer {
             textEdit = nil
           }
 
+          // Map SourceKit's not_recommended field to LSP's deprecated
+          let notRecommended = (value[self.keys.not_recommended] as Int?).map({ $0 != 0 })
+
           let kind: sourcekitd_uid_t? = value[self.keys.kind]
           result.items.append(CompletionItem(
             label: name,
@@ -458,7 +461,7 @@ extension SwiftLanguageServer {
             textEdit: textEdit,
             insertText: text,
             insertTextFormat: isInsertTextSnippet ? .snippet : .plain,
-            deprecated: nil
+            deprecated: notRecommended ?? false
           ))
 
           return true

--- a/Tests/SourceKitTests/SourceKitTests.swift
+++ b/Tests/SourceKitTests/SourceKitTests.swift
@@ -169,7 +169,7 @@ final class SKTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "method(a: )"),
         insertText: "method(a: )",
         insertTextFormat: .plain,
-        deprecated: nil),
+        deprecated: false),
       CompletionItem(
         label: "self",
         kind: .keyword,
@@ -179,7 +179,7 @@ final class SKTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "self"),
         insertText: "self",
         insertTextFormat: .plain,
-        deprecated: nil),
+        deprecated: false),
     ]))
   }
 }

--- a/Tests/SourceKitTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitTests/SwiftPMIntegration.swift
@@ -41,7 +41,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "foo()"),
         insertText: "foo()",
         insertTextFormat: .plain,
-        deprecated: nil),
+        deprecated: false),
       CompletionItem(
         label: "self",
         kind: .keyword,
@@ -51,7 +51,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "self"),
         insertText: "self",
         insertTextFormat: .plain,
-        deprecated: nil),
+        deprecated: false),
     ]))
   }
 }


### PR DESCRIPTION
The `not_recommended` flag in SourceKit to some degree matches the `deprecated` field in LSP. Instead of not providing any deprecation information, it might be a good idea to map the fields, even if they don't match exactly.