### PR TITLE
Upgrade CustomCodable to handle optional values using encodeIfPresent

### DIFF
--- a/Sources/LanguageServerProtocol/TextDocumentContentChangeEvent.swift
+++ b/Sources/LanguageServerProtocol/TextDocumentContentChangeEvent.swift
@@ -15,8 +15,9 @@
 /// If `range` and `rangeLength` are unspecified, the whole document content is replaced.
 ///
 /// The `range.end` and `rangeLength` are potentially redundant. Based on https://github.com/Microsoft/language-server-protocol/issues/9, servers should be lenient and accept either.
-public struct TextDocumentContentChangeEvent: Hashable {
+public struct TextDocumentContentChangeEvent: Codable, Hashable {
 
+  @CustomCodable<PositionRange?>
   public var range: Range<Position>?
 
   public var rangeLength: Int?
@@ -24,35 +25,8 @@ public struct TextDocumentContentChangeEvent: Hashable {
   public var text: String
 
   public init(range: Range<Position>? = nil, rangeLength: Int? = nil, text: String) {
-    self.range = range
+    self._range = CustomCodable(wrappedValue: range)
     self.rangeLength = rangeLength
     self.text = text
-  }
-}
-
-// Needs a custom implementation for range, because `Optional` is the only type that uses
-// `encodeIfPresent` in the synthesized conformance, and the
-// [LSP specification does not allow `null` in most places](https://github.com/microsoft/language-server-protocol/issues/355).
-extension TextDocumentContentChangeEvent: Codable {
-  private enum CodingKeys: String, CodingKey {
-    case range
-    case rangeLength
-    case text
-  }
-
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.range = try container
-      .decodeIfPresent(PositionRange.self, forKey: .range)?
-      .wrappedValue
-    self.rangeLength = try container.decodeIfPresent(Int.self, forKey: .rangeLength)
-    self.text = try container.decode(String.self, forKey: .text)
-  }
-
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encodeIfPresent(range.map { PositionRange(wrappedValue: $0) }, forKey: .range)
-    try container.encodeIfPresent(rangeLength, forKey: .rangeLength)
-    try container.encode(text, forKey: .text)
   }
 }

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -289,6 +289,35 @@ final class CodingTests: XCTestCase {
       }
       """)
   }
+
+  func testCustomCodableOptional() {
+    struct WithPosRange: Codable, Equatable {
+      @CustomCodable<PositionRange?>
+      var range: Range<Position>?
+    }
+
+    let range = Position(line: 5, utf16index: 23) ..< Position(line: 6, utf16index: 0)
+    checkCoding(WithPosRange(range: range), json: """
+      {
+        "range" : {
+          "end" : {
+            "character" : 0,
+            "line" : 6
+          },
+          "start" : {
+            "character" : 23,
+            "line" : 5
+          }
+        }
+      }
+      """)
+
+    checkCoding(WithPosRange(range: nil), json: """
+      {
+
+      }
+      """)
+  }
 }
 
 func with<T>(_ value: T, mutate: (inout T) -> Void) -> T {

--- a/Tests/LanguageServerProtocolTests/XCTestManifests.swift
+++ b/Tests/LanguageServerProtocolTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ extension CodingTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__CodingTests = [
+        ("testCustomCodableOptional", testCustomCodableOptional),
         ("testPositionRange", testPositionRange),
         ("testValueCoding", testValueCoding),
     ]


### PR DESCRIPTION
The LSP spec requires us to omit keys for nil values rather than using
the JSON `null` constant in most places. This change to CustomCodable
allows us to do it automatically using CustomCodable, removing one of
the limitations of the property wrapper.

The idea for the adding overloads of `encode` and `decode` came from
https://forums.swift.org/t/pre-pitch-codable-customization-using-propertywrappers/30244/