### PR TITLE
Android: add native support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -190,7 +190,7 @@ let package = Package(
 // by the external environment. This allows sourcekit-lsp to take advantage of the automation used
 // for building the swift toolchain, such as `update-checkout`, or cross-repo PR tests.
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 #else
 import Darwin.C

--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -17,9 +17,8 @@ extension Platform {
   /// The file extension used for a dynamic library on this platform.
   public var dynamicLibraryExtension: String {
     switch self {
-    case .android: return "so"
     case .darwin: return "dylib"
-    case .linux: return "so"
+    case .linux, .android: return "so"
     }
   }
 }

--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -62,7 +62,9 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #else
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
+  #if !os(Android)
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
+  #endif
   #endif
   #endif
 

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -46,6 +46,8 @@ final class SwiftSourceKitFramework {
     self.path = path
     #if os(Windows)
     self.dylib = try dlopen(path.pathString, mode: [])
+    #elseif os(Android)
+    self.dylib = try dlopen(path.pathString, mode: [.lazy, .local, .first])
     #else
     self.dylib = try dlopen(path.pathString, mode: [.lazy, .local, .first, .deepBind])
     #endif

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -44,9 +44,20 @@ def get_swiftpm_options(args):
       # For <Block.h>
       '-Xcxx', '-I', '-Xcxx',
       os.path.join(args.toolchain, 'usr', 'lib', 'swift', 'Block'),
-      # Library rpath for swift, dispatch, Foundation, etc. when installing
-      '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/linux',
     ]
+
+    if 'ANDROID_DATA' in os.environ:
+      swiftpm_args += [
+        '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/android',
+        # SwiftPM will otherwise try to compile against GNU strerror_r on
+        # Android and fail.
+        '-Xswiftc', '-Xcc', '-Xswiftc', '-U_GNU_SOURCE',
+      ]
+    else:
+      # Library rpath for swift, dispatch, Foundation, etc. when installing
+      swiftpm_args += [
+        '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/linux',
+      ]
 
   return swiftpm_args
 


### PR DESCRIPTION
With this pull, I got this repo built and tested natively on Android in [the Termux app](https://termux.com/). It shows no failures in the tests, even though the test output dumps a bunch of non-XCTest warnings and errors, just like on the linux CI.