### PR TITLE
Provide Fix-Its through codeActions and PublishDiagnostics

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -111,7 +111,7 @@ public struct CodeActionContext: Codable, Hashable {
   }
 }
 
-public struct CodeAction: Codable, Equatable {
+public struct CodeAction: Codable, Hashable {
 
   /// A short, human-readable, title for this code action.
   public var title: String

--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -356,8 +356,14 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     /// Whether the client accepts diagnostics with related information.
     public var relatedInformation: Bool? = nil
 
-    public init(relatedInformation: Bool? = nil) {
+    /// Requests that SourceKit-LSP send `Diagnostic.codeActions`.
+    /// **LSP Extension from clangd**.
+    public var codeActionsInline: Bool? = nil
+
+    public init(relatedInformation: Bool? = nil,
+                codeActionsInline: Bool? = nil) {
       self.relatedInformation = relatedInformation
+      self.codeActionsInline = codeActionsInline
     }
   }
 

--- a/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
@@ -47,13 +47,18 @@ public struct Diagnostic: Codable, Hashable {
   /// Related diagnostic notes.
   public var relatedInformation: [DiagnosticRelatedInformation]?
 
+  /// All the code actions that address this diagnostic.
+  /// **LSP Extension from clangd**.
+  public var codeActions: [CodeAction]?
+
   public init(
     range: Range<Position>,
     severity: DiagnosticSeverity?,
     code: DiagnosticCode? = nil,
     source: String?,
     message: String,
-    relatedInformation: [DiagnosticRelatedInformation]? = nil)
+    relatedInformation: [DiagnosticRelatedInformation]? = nil,
+    codeActions: [CodeAction]? = nil)
   {
     self._range = CustomCodable<PositionRange>(wrappedValue: range)
     self.severity = severity
@@ -61,6 +66,7 @@ public struct Diagnostic: Codable, Hashable {
     self.source = source
     self.message = message
     self.relatedInformation = relatedInformation
+    self.codeActions = codeActions
   }
 }
 

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -215,6 +215,7 @@ struct sourcekitd_keys {
   let name: sourcekitd_uid_t
   let kind: sourcekitd_uid_t
   let notification: sourcekitd_uid_t
+  let fixits: sourcekitd_uid_t
   let diagnostics: sourcekitd_uid_t
   let diagnostic_stage: sourcekitd_uid_t
   let severity: sourcekitd_uid_t
@@ -263,6 +264,7 @@ struct sourcekitd_keys {
     name = api.uid_get_from_cstr("key.name")!
     kind = api.uid_get_from_cstr("key.kind")!
     notification = api.uid_get_from_cstr("key.notification")!
+    fixits = api.uid_get_from_cstr("key.fixits")!
     diagnostics = api.uid_get_from_cstr("key.diagnostics")!
     diagnostic_stage = api.uid_get_from_cstr("key.diagnostic_stage")!
     severity = api.uid_get_from_cstr("key.severity")!

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -108,6 +108,8 @@ extension LocalSwiftTests {
         ("testEditing", testEditing),
         ("testEditingNonURL", testEditingNonURL),
         ("testEditorPlaceholderParsing", testEditorPlaceholderParsing),
+        ("testFixitsAreIncludedInPublishDiagnostics", testFixitsAreIncludedInPublishDiagnostics),
+        ("testFixitsAreReturnedFromCodeActions", testFixitsAreReturnedFromCodeActions),
         ("testHover", testHover),
         ("testHoverNameEscaping", testHoverNameEscaping),
         ("testSymbolInfo", testSymbolInfo),


### PR DESCRIPTION
Return the Fix-Its from the `codeActions` request. 

Also, `clangd` specifies an LSP extension through which Fix-Its can directly be attached to diagnostics. Implement that extension to also attach Swift Fix-Its in the same way.

rdar://56624104