### PR TITLE
[NFC] Update for diagnostic changes

### DIFF
--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -255,7 +255,7 @@ final class LocalSwiftTests: XCTestCase {
     }, { (note: Notification<PublishDiagnosticsNotification>) in
       log("Received diagnostics for edit 3 - semantic")
       XCTAssertEqual(note.params.version, 14)
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(note.params.diagnostics.count, 1)
     })
 
     sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 15), contentChanges: [

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -130,7 +130,7 @@ final class LocalSwiftTests: XCTestCase {
     }, { (note: Notification<PublishDiagnosticsNotification>) in
       log("Received diagnostics for edit 3 - semantic")
       XCTAssertEqual(note.params.version, 14)
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(note.params.diagnostics.count, 1)
     })
 
     sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 15), contentChanges: [


### PR DESCRIPTION
A warning diagnostic will be emitted (by https://github.com/apple/swift/pull/29576) when discarding a function's result and the result type is `Void`, since that is redundant. This patch updates a test where we expect no diagnostics to be triggered.