### PR TITLE
Infer index store path from compilation database

### DIFF
--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -60,6 +60,7 @@ extension CompilationDatabase.Command {
 public protocol CompilationDatabase {
   typealias Command = CompilationDatabaseCompileCommand
   subscript(_ path: URL) -> [Command] { get }
+  var allCommands: AnySequence<Command> { get }
 }
 
 /// Loads the compilation database located in `directory`, if any.
@@ -103,6 +104,8 @@ public struct JSONCompilationDatabase: CompilationDatabase, Equatable {
     }
     return []
   }
+
+  public var allCommands: AnySequence<Command> { AnySequence(commands) }
 
   public mutating func add(_ command: Command) {
     let url = command.url

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -31,6 +31,20 @@ public final class CompilationDatabaseBuildSystem {
 
   let fileSystem: FileSystem
 
+  public lazy var indexStorePath: AbsolutePath? = {
+    if let allCommands = self.compdb?.allCommands {
+      for command in allCommands {
+        let args = command.commandLine
+        for i in args.indices.reversed() {
+          if args[i] == "-index-store-path" && i != args.endIndex - 1 {
+            return try? AbsolutePath(validating: args[i+1])
+          }
+        }
+      }
+    }
+    return nil
+  }()
+
   public init(projectRoot: AbsolutePath? = nil, fileSystem: FileSystem = localFileSystem) {
     self.fileSystem = fileSystem
     if let path = projectRoot {
@@ -41,9 +55,9 @@ public final class CompilationDatabaseBuildSystem {
 
 extension CompilationDatabaseBuildSystem: BuildSystem {
 
-  // FIXME: derive from the compiler arguments.
-  public var indexStorePath: AbsolutePath? { return nil }
-  public var indexDatabasePath: AbsolutePath? { return nil }
+  public var indexDatabasePath: AbsolutePath? {
+    indexStorePath?.parentDirectory.appending(component: "IndexDatabase")
+  }
 
   public func settings(for uri: DocumentURI, _ language: Language) -> FileBuildSettings? {
     guard let url = uri.fileURL else {

--- a/Sources/SourceKit/SourceKitServer+Options.swift
+++ b/Sources/SourceKit/SourceKitServer+Options.swift
@@ -24,9 +24,13 @@ extension SourceKitServer {
     /// Additional arguments to pass to `clangd` on the command-line.
     public var clangdOptions: [String]
 
-    public init(buildSetup: BuildSetup = .default, clangdOptions: [String] = []) {
+    /// Additional options for the index.
+    public var indexOptions: IndexOptions
+
+    public init(buildSetup: BuildSetup = .default, clangdOptions: [String] = [], indexOptions: IndexOptions = .init()) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
+      self.indexOptions = indexOptions
     }
   }
 }

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -293,7 +293,7 @@ extension SourceKitServer {
 
   func initialize(_ req: Request<InitializeRequest>) {
 
-    var indexOptions = IndexOptions()
+    var indexOptions = self.options.indexOptions
     if case .dictionary(let options) = req.params.initializationOptions {
       if case .bool(let listenToUnitEvents) = options["listenToUnitEvents"] {
         indexOptions.listenToUnitEvents = listenToUnitEvents

--- a/Sources/SourceKit/Workspace.swift
+++ b/Sources/SourceKit/Workspace.swift
@@ -100,8 +100,8 @@ public final class Workspace {
       log("cannot setup build integration for workspace at URI \(rootUri) because the URI it is not a valid file URL")
     }
 
-    if let storePath = buildSettings.indexStorePath,
-       let dbPath = buildSettings.indexDatabasePath,
+    if let storePath = indexOptions.indexStorePath ?? settings.indexStorePath,
+       let dbPath = indexOptions.indexDatabasePath ?? settings.indexDatabasePath,
        let libPath = toolchainRegistry.default?.libIndexStore
     {
       do {
@@ -121,11 +121,17 @@ public final class Workspace {
 
 public struct IndexOptions {
 
+  /// Override the index-store-path provided by the build system.
+  public var indexStorePath: AbsolutePath?
+
+  /// Override the index-database-path provided by the build system.
+  public var indexDatabasePath: AbsolutePath?
+
   /// *For Testing* Whether the index should listen to unit events, or wait for
   /// explicit calls to pollForUnitChangesAndWait().
   public var listenToUnitEvents: Bool
 
-  public init(listenToUnitEvents: Bool = true) {
+  public init(indexStorePath: AbsolutePath? = nil, indexDatabasePath: AbsolutePath? = nil, listenToUnitEvents: Bool = true) {
     self.listenToUnitEvents = listenToUnitEvents
   }
 }

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -49,6 +49,8 @@ func parseArguments() throws -> CommandLineOptions {
   let buildFlagsLinker = parser.add(option: "-Xlinker", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all linker invocations")
   let buildFlagsSwift = parser.add(option: "-Xswiftc", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all Swift compiler invocations")
   let clangdOptions = parser.add(option: "-Xclangd", kind: [String].self, strategy: .oneByOne, usage: "Pass options to clangd command-line")
+  let indexStorePath = parser.add(option: "-index-store-path", kind: PathArgument.self, usage: "Override index-store-path from the build system")
+  let indexDatabasePath = parser.add(option: "-index-db-path", kind: PathArgument.self, usage: "Override index-database-path from the build system")
 
   let parsedArguments = try parser.parse(arguments)
 
@@ -75,6 +77,13 @@ func parseArguments() throws -> CommandLineOptions {
 
   if let options = parsedArguments.get(clangdOptions) {
     result.serverOptions.clangdOptions = options
+  }
+
+  if let path = parsedArguments.get(indexStorePath)?.path {
+    result.serverOptions.indexOptions.indexStorePath = path
+  }
+  if let path = parsedArguments.get(indexDatabasePath)?.path {
+    result.serverOptions.indexOptions.indexDatabasePath = path
   }
 
   if let logLevel = parsedArguments.get(loggingOption) {

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -22,6 +22,12 @@ extension CompilationDatabaseTests {
     // to regenerate.
     static let __allTests__CompilationDatabaseTests = [
         ("testCompilationDatabaseBuildSystem", testCompilationDatabaseBuildSystem),
+        ("testCompilationDatabaseBuildSystemIndexStoreClang", testCompilationDatabaseBuildSystemIndexStoreClang),
+        ("testCompilationDatabaseBuildSystemIndexStoreSwift0", testCompilationDatabaseBuildSystemIndexStoreSwift0),
+        ("testCompilationDatabaseBuildSystemIndexStoreSwift1", testCompilationDatabaseBuildSystemIndexStoreSwift1),
+        ("testCompilationDatabaseBuildSystemIndexStoreSwift2", testCompilationDatabaseBuildSystemIndexStoreSwift2),
+        ("testCompilationDatabaseBuildSystemIndexStoreSwift3", testCompilationDatabaseBuildSystemIndexStoreSwift3),
+        ("testCompilationDatabaseBuildSystemIndexStoreSwift4", testCompilationDatabaseBuildSystemIndexStoreSwift4),
         ("testDecodeCompDBCommand", testDecodeCompDBCommand),
         ("testEncodeCompDBCommand", testEncodeCompDBCommand),
         ("testJSONCompilationDatabaseCoding", testJSONCompilationDatabaseCoding),


### PR DESCRIPTION
Find the index store path by searching through the command-line
arguments, and if found, also provide a default database path next to
the index store. Also add command-line arguments so that either of these
can be overridden. We could also easily add these as initialization
options if an LSP client wanted to provide them in the future.