### PR TITLE
Make initial workspace load asynchronous

### DIFF
--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -23,11 +23,7 @@ final class DocumentColorTests: XCTestCase {
   /// The primary interface to make requests to the SourceKitServer.
   var sk: TestClient! = nil
 
-  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
-  var workspace: Workspace! = nil
-
   override func tearDown() {
-    workspace = nil
     sk = nil
     connection = nil
   }
@@ -44,8 +40,6 @@ final class DocumentColorTests: XCTestCase {
       capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
       trace: .off,
       workspaceFolders: nil))
-
-    workspace = connection.server!.workspace!
   }
 
   func performDocumentColorRequest(text: String) -> [ColorInformation] {

--- a/Tests/SourceKitTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitTests/DocumentSymbolTests.swift
@@ -25,11 +25,7 @@ final class DocumentSymbolTest: XCTestCase {
   /// The primary interface to make requests to the SourceKitServer.
   var sk: TestClient! = nil
 
-  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
-  var workspace: Workspace! = nil
-
 override func tearDown() {
-  workspace = nil
   sk = nil
   connection = nil
 }
@@ -47,8 +43,6 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
       capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
       trace: .off,
       workspaceFolders: nil))
-
-    workspace = connection.server!.workspace!
   }
 
   func performDocumentSymbolRequest(text: String) -> DocumentSymbolResponse {

--- a/Tests/SourceKitTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitTests/ExecuteCommandTests.swift
@@ -24,11 +24,7 @@ final class ExecuteCommandTests: XCTestCase {
   /// The primary interface to make requests to the SourceKitServer.
   var sk: TestClient! = nil
 
-  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
-  var workspace: Workspace! = nil
-
   override func tearDown() {
-    workspace = nil
     sk = nil
     connection = nil
   }
@@ -44,8 +40,6 @@ final class ExecuteCommandTests: XCTestCase {
       capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
       trace: .off,
       workspaceFolders: nil))
-
-    workspace = connection.server!.workspace!
   }
 
   func testLocationSemanticRefactoring() throws {

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -29,7 +29,9 @@ final class LocalSwiftTests: XCTestCase {
   var sk: TestClient! = nil
 
   /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
-  var workspace: Workspace! = nil
+  var workspace: Workspace! {
+    connection.server!.workspace!
+  }
 
   override func setUp() {
     connection = TestSourceKitServer()
@@ -42,12 +44,9 @@ final class LocalSwiftTests: XCTestCase {
         capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
         trace: .off,
         workspaceFolders: nil))
-
-    workspace = connection.server!.workspace!
   }
 
   override func tearDown() {
-    workspace = nil
     sk = nil
     connection = nil
   }

--- a/Tests/SourceKitTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitTests/SwiftCompletionTests.swift
@@ -41,15 +41,11 @@ final class SwiftCompletionTests: XCTestCase {
   /// The primary interface to make requests to the SourceKitServer.
   var sk: TestClient! = nil
 
-  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
-  var workspace: Workspace! = nil
-
   override func tearDown() {
     shutdownServer()
   }
 
   func shutdownServer() {
-    workspace = nil
     sk = nil
     connection = nil
   }
@@ -72,8 +68,6 @@ final class SwiftCompletionTests: XCTestCase {
       capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
       trace: .off,
       workspaceFolders: nil))
-
-    workspace = connection.server!.workspace!
   }
 
   func openDocument(text: String? = nil, url: URL) {


### PR DESCRIPTION
Some editors treat the initialize request as blocking, or otherwise time
out if it takes too long. We have been scraping that edge for swiftpm
projects (time taken to load the manifest and construct a build graph),
and large compilation databases (time taken to parse the json and then
split commands into separate arguments). In practice, a *debug build* of
sourcekit-lsp was failing to open a large compilation database fast
enough for sublime text's lsp plugin (3 second limit).

This change hides the latency for loading the build system and creating
the index by letting it continue beyond the initialize request, blocking
instead the next request. This is not a complete solution. In addition
to hiding latency in between requests, this also is based on editors
being more forgiving about slow requests beyond the first initialize.`

We should also continue to improve the performance of the initial load
of the build system and index. And we should also consider more
prinicipled ways to use asynchronicity, for example by not doing the
initial load on the server's message queue. The main challenge for that
is that we have some assumptions, particularly in tests, that the index
will be created already, and for the index to load we currently block on
the build system load in order to get the index directory.