### PR TITLE
[codeActions] Ignore "supportedKinds", which isn't really an opt-in list

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -56,17 +56,11 @@ public enum CodeActionRequestResponse: ResponseType, Codable, Equatable {
   case commands([Command])
 
   public init(codeActions: [CodeAction], clientCapabilities: TextDocumentClientCapabilities.CodeAction?) {
-    if let literalSupport = clientCapabilities?.codeActionLiteralSupport {
-      let supportedKinds = literalSupport.codeActionKind.valueSet
-      self = .codeActions(codeActions.filter {
-        if let kind = $0.kind {
-          return supportedKinds.contains(kind)
-        } else {
-          // The client guarantees that unsupported kinds will be treated,
-          // so it's probably safe to include unspecified kinds into the result.
-          return true
-        }
-      })
+    if clientCapabilities?.codeActionLiteralSupport != nil {
+      // The client guarantees that unsupported kinds will be handled, and in
+      // practice some clients use `"codeActionKind":{"valueSet":[]}`, since
+      // they support all kinds anyway.
+      self = .codeActions(codeActions)
     } else {
       self = .commands(codeActions.compactMap { $0.command })
     }

--- a/Tests/SourceKitTests/CodeActionTests.swift
+++ b/Tests/SourceKitTests/CodeActionTests.swift
@@ -77,7 +77,12 @@ final class CodeActionTests: XCTestCase {
     XCTAssertEqual(commands, [command])
   }
 
-  func testCodeActionResponseRespectsSupportedKinds() {
+  func testCodeActionResponseIgnoresSupportedKinds() {
+    // The client guarantees that unsupported kinds will be handled, and in
+    // practice some clients use `"codeActionKind":{"valueSet":[]}`, since
+    // they support all kinds anyway. So to avoid filtering all actions, we
+    // ignore the supported kinds.
+
     let unspecifiedAction = CodeAction(title: "Unspecified")
     let refactorAction = CodeAction(title: "Refactor", kind: .refactor)
     let quickfixAction = CodeAction(title: "Quickfix", kind: .quickFix)
@@ -103,7 +108,7 @@ final class CodeActionTests: XCTestCase {
                                              from: data)
 
     response = .init(codeActions: actions, clientCapabilities: capabilities)
-    XCTAssertEqual(response, .codeActions([unspecifiedAction, refactorAction]))
+    XCTAssertEqual(response, .codeActions([unspecifiedAction, refactorAction, quickfixAction]))
 
     capabilityJson =
     """
@@ -121,7 +126,7 @@ final class CodeActionTests: XCTestCase {
                                              from: data)
 
     response = .init(codeActions: actions, clientCapabilities: capabilities)
-    XCTAssertEqual(response, .codeActions([unspecifiedAction]))
+    XCTAssertEqual(response, .codeActions([unspecifiedAction, refactorAction, quickfixAction]))
   }
 
   func testCodeActionResponseCommandMetadataInjection() {

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -19,7 +19,7 @@ extension CodeActionTests {
     static let __allTests__CodeActionTests = [
         ("testCodeActionResponseCommandMetadataInjection", testCodeActionResponseCommandMetadataInjection),
         ("testCodeActionResponseLegacySupport", testCodeActionResponseLegacySupport),
-        ("testCodeActionResponseRespectsSupportedKinds", testCodeActionResponseRespectsSupportedKinds),
+        ("testCodeActionResponseIgnoresSupportedKinds", testCodeActionResponseIgnoresSupportedKinds),
         ("testCommandEncoding", testCommandEncoding),
         ("testEmptyCodeActionResult", testEmptyCodeActionResult),
         ("testSemanticRefactorLocalRenameResult", testSemanticRefactorLocalRenameResult),


### PR DESCRIPTION
The client guarantees that unsupported kinds will be handled, and in practice some clients, such as Sublime's LSP plugin, use `"codeActionKind":{"valueSet":[]}`, since they support all kinds anyway.

This behaviour was also clarified in a [spec issue report](https://github.com/Microsoft/language-server-protocol/issues/620) where it was confirmed the server can send any actions it wants. It seems preferable to ignore it.