### PR TITLE
[index]  Avoid querying main files for a non-file URL

### DIFF
--- a/Sources/SourceKit/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKit/IndexStoreDB+MainFilesProvider.swift
@@ -17,9 +17,13 @@ import SKCore
 
 extension IndexStoreDB: MainFilesProvider {
   public func mainFilesContainingFile(_ uri: DocumentURI) -> Set<DocumentURI> {
-    let mainFiles = Set(
-    self.mainFilesContainingFile(path: uri.pseudoPath)
-      .lazy.map({ DocumentURI(URL(fileURLWithPath: $0)) }))
+    let mainFiles: Set<DocumentURI>
+    if let url = uri.fileURL {
+      mainFiles = Set(self.mainFilesContainingFile(path: url.path)
+        .lazy.map({ DocumentURI(URL(fileURLWithPath: $0, isDirectory: false)) }))
+    } else {
+      mainFiles = []
+    }
     log("mainFilesContainingFile(\(uri.pseudoPath)) -> \(mainFiles)")
     return mainFiles
   }

--- a/Tests/SourceKitTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitTests/MainFilesProviderTests.swift
@@ -13,6 +13,7 @@
 import SourceKit
 import SKCore
 import SKTestSupport
+import LanguageServerProtocol
 import IndexStoreDB
 import XCTest
 
@@ -82,5 +83,7 @@ final class MainFilesProviderTests: XCTestCase {
     XCTAssertEqual(ws.index.mainFilesContainingFile(bridging), [d])
 
     wait(for: [mainFilesDelegate.expectation], timeout: 15)
+
+    XCTAssertEqual(ws.index.mainFilesContainingFile(DocumentURI(string: "not:file")), [])
   }
 }


### PR DESCRIPTION
IndexStoreDB expects a file path, so exit early if we have something else.