### PR TITLE
Improve handling/testing of `filesDependenciesUpdated` for clangd

### DIFF
--- a/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
+++ b/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
@@ -74,12 +74,19 @@ public struct DidChangeTextDocumentNotification: NotificationType, Hashable {
   /// Edits to the document.
   public var contentChanges: [TextDocumentContentChangeEvent]
 
+  /// Force the LSP to rebuild its AST for the given file. This is useful for clangd to workaround clangd's assumption that
+  /// missing header files will stay missing.
+  /// **LSP Extension from clangd**.
+  public var forceRebuild: Bool? = nil
+
   public init(
     textDocument: VersionedTextDocumentIdentifier,
-    contentChanges: [TextDocumentContentChangeEvent])
+    contentChanges: [TextDocumentContentChangeEvent],
+    forceRebuild: Bool? = nil)
   {
     self.textDocument = textDocument
     self.contentChanges = contentChanges
+    self.forceRebuild = forceRebuild
   }
 }
 

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -129,11 +129,13 @@ extension ClangLanguageServerShim {
   }
 
   public func documentDependenciesUpdated(_ uri: DocumentURI, language: Language) {
-    // In order to tell clangd to reload an AST, we send it an empty `didChangeTextDocument`. This
-    // works well for us as the moment since clangd ignores the document version.
+    // In order to tell clangd to reload an AST, we send it an empty `didChangeTextDocument`
+    // with `forceRebuild` set in case any missing header files have been added.
+    // This works well for us as the moment since clangd ignores the document version.
     let note = DidChangeTextDocumentNotification(
       textDocument: VersionedTextDocumentIdentifier(uri, version: nil),
-      contentChanges: [])
+      contentChanges: [],
+      forceRebuild: true)
     clangd.send(note)
   }
 

--- a/Tests/INPUTS/GeneratedHeader/lib.c
+++ b/Tests/INPUTS/GeneratedHeader/lib.c
@@ -1,0 +1,3 @@
+int /*libX:def*/libX(int value) {
+  return value ? 22 : 0;
+}

--- a/Tests/INPUTS/GeneratedHeader/main.c
+++ b/Tests/INPUTS/GeneratedHeader/main.c
@@ -1,0 +1,5 @@
+#include "lib-generated.h"
+
+int main(int argc, const char *argv[]) {
+  return /*libX:call:main*/libX(argc);
+}

--- a/Tests/INPUTS/GeneratedHeader/project.json
+++ b/Tests/INPUTS/GeneratedHeader/project.json
@@ -1,0 +1,1 @@
+{ "sources": ["main.c", "lib.c"] }

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -140,6 +140,7 @@ extension SKTests {
     // to regenerate.
     static let __allTests__SKTests = [
         ("testCodeCompleteSwiftTibs", testCodeCompleteSwiftTibs),
+        ("testDependenciesUpdatedCXXTibs", testDependenciesUpdatedCXXTibs),
         ("testDependenciesUpdatedSwiftTibs", testDependenciesUpdatedSwiftTibs),
         ("testIndexShutdown", testIndexShutdown),
         ("testIndexSwiftModules", testIndexSwiftModules),


### PR DESCRIPTION
- Add support for recently upstreamed `forceRebuild` extension (https://github.com/llvm/llvm-project/commit/6ff0228c6df37e052fa6e8e3927e83b289402cf6).
  Note that until it is merged into Apple-clangd we can't add a test for it with missing headers

- Add a test for the clangd functionality by modifying a generated header file