### PR TITLE
Disable diagnostics for blacklisted document schemes

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -24,6 +24,11 @@ public struct DocumentURI: Codable, Hashable {
     }
   }
 
+  /// The document's URL scheme, if present.
+  public var scheme: String? {
+    return storage.scheme
+  }
+
   /// Returns a filepath if the URI is a URL. If the URI is not a URL, returns
   /// the full URI as a fallback.
   /// This value is intended to be used when interacting with sourcekitd which

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -109,6 +109,7 @@ extension LocalSwiftTests {
         ("testEditing", testEditing),
         ("testEditingNonURL", testEditingNonURL),
         ("testEditorPlaceholderParsing", testEditorPlaceholderParsing),
+        ("testExcludedDocumentSchemeDiagnostics", testExcludedDocumentSchemeDiagnostics),
         ("testFixitInsert", testFixitInsert),
         ("testFixitsAreIncludedInPublishDiagnostics", testFixitsAreIncludedInPublishDiagnostics),
         ("testFixitsAreIncludedInPublishDiagnosticsNotes", testFixitsAreIncludedInPublishDiagnosticsNotes),


### PR DESCRIPTION
- Otherwise can lead to confusing duplicated diagnostics in VSCode
  due to its usage of virtual documents for source control diffbases

- sourcekitd does not properly handle virtual files when the
  `-working-directory` flag is passed