### PR TITLE
[test] Disable testMuliEditFixitCodeActionNote

### DIFF
--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -698,6 +698,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() {
+#if os(macOS)
     let url = URL(fileURLWithPath: "/a.swift")
     let uri = DocumentURI(url)
 
@@ -743,6 +744,7 @@ final class LocalSwiftTests: XCTestCase {
       TextEdit(range: Position(line: 3, utf16index: 6)..<Position(line: 3, utf16index: 11), newText: ""),
       TextEdit(range: Position(line: 3, utf16index: 14)..<Position(line: 3, utf16index: 20), newText: "hotness"),
     ])
+#endif
   }
 
   func testXMLToMarkdownDeclaration() {


### PR DESCRIPTION
SourceKit-LSP appears to be behaving correctly, but the toolchain
sourcekitd is sometimes returning 0 warnings instead of 1 in this test
when run on Linux. Disabling while we investigate, since this does not
appear to be a new issue, nor an issue without sourcekit-lsp itself.

rdar://problem/59487935