### PR TITLE
[5.2] [test] Disable testMuliEditFixitCodeActionNote

### DIFF
--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -698,6 +698,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() {
+#if os(macOS)
     let url = URL(fileURLWithPath: "/a.swift")
     let uri = DocumentURI(url)
 
@@ -743,6 +744,7 @@ final class LocalSwiftTests: XCTestCase {
       TextEdit(range: Position(line: 3, utf16index: 6)..<Position(line: 3, utf16index: 11), newText: ""),
       TextEdit(range: Position(line: 3, utf16index: 14)..<Position(line: 3, utf16index: 20), newText: "hotness"),
     ])
+#endif
   }
 
   func testXMLToMarkdownDeclaration() {


### PR DESCRIPTION
Cherry-pick https://github.com/apple/sourcekit-lsp/pull/245 to swift-5.2-branch

---

SourceKit-LSP appears to be behaving correctly, but the toolchain
sourcekitd is sometimes returning 0 warnings instead of 1 in this test
when run on Linux. Disabling while we investigate, since this does not
appear to be a new issue, nor an issue without sourcekit-lsp itself.

rdar://problem/59487935

---

* **Explanation**: This test has been observed sometimes failing on Linux in PR tests for 5.2. I have also reproduced the issue locally, and it appears to be an existing issue in sourcekitd (not sourcekit-lsp itself). While we dig in, unblock CI by disabling the test.  I have not been able to reproduce on macOS or in any other tests.
* **Scope**: Test-only change.
* **Origination**: The failure started showing up after we added a new test. We are still investigating what the underlying problem in sourcekitd is, but I suspect it's not a new issue.
* **Risk**: No change in behaviour, only slightly reduced test coverage.
* **Testing**: Ran this test suite hundreds of times in docker and no other tests are failing.