### PR TITLE
Support for clangd's go-to-definition for #include/#import

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -53,7 +53,10 @@ public struct DocumentURI: Codable, Hashable {
     guard let url = URL(string: string) else {
       fatalError("Failed to construct DocumentURI from '\(string)'")
     }
-    self.init(url)
+    // We need to call `standardizedFileURL` which will handle escaping file URLs of special
+    // sequences like `%40` (`@`). For non-file URLs, this explicitly is documented to
+    // return itself.
+    self.init(url.standardizedFileURL)
   }
 
   public init(_ url: URL) {

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -599,6 +599,8 @@ extension SourceKitServer {
     let index = self.workspace?.index
     let callback = callbackOnQueue(self.queue) { (result: Result<SymbolInfoRequest.Response, ResponseError>) in
       guard let symbols: [SymbolDetails] = result.success ?? nil, let symbol = symbols.first else {
+        let handled = languageService.definition(req)
+        guard !handled else { return }
         if let error = result.failure {
           req.reply(.failure(error))
         } else {

--- a/Sources/SourceKit/ToolchainLanguageServer.swift
+++ b/Sources/SourceKit/ToolchainLanguageServer.swift
@@ -40,6 +40,9 @@ public protocol ToolchainLanguageServer: AnyObject {
   func hover(_ req: Request<HoverRequest>)
   func symbolInfo(_ request: Request<SymbolInfoRequest>)
 
+  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
+  func definition(_ request: Request<DefinitionRequest>) -> Bool
+
   func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>)
   func foldingRange(_ req: Request<FoldingRangeRequest>)
   func documentSymbol(_ req: Request<DocumentSymbolRequest>)

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -144,7 +144,7 @@ extension ClangLanguageServerShim {
 
   /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
   public func definition(_ req: Request<DefinitionRequest>) -> Bool {
-    // We handle it to provide jump-to-header support for import/includes.
+    // We handle it to provide jump-to-header support for #import/#include.
     forwardRequest(req, to: clangd)
     return true
   }

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -141,6 +141,14 @@ extension ClangLanguageServerShim {
 
   // MARK: - Text Document
 
+
+  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
+  public func definition(_ req: Request<DefinitionRequest>) -> Bool {
+    // We handle it to provide jump-to-header support for import/includes.
+    forwardRequest(req, to: clangd)
+    return true
+  }
+
   func completion(_ req: Request<CompletionRequest>) {
     forwardRequest(req, to: clangd)
   }

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -426,6 +426,12 @@ extension SwiftLanguageServer {
     return TextEdit(range: textEditRangeStart..<requestPosition, newText: newText)
   }
 
+  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
+  public func definition(_ request: Request<DefinitionRequest>) -> Bool {
+    // We don't handle it.
+    return false
+  }
+
   public func completion(_ req: Request<CompletionRequest>) {
     let keys = self.keys
 

--- a/Tests/INPUTS/BasicCXX/Object.h
+++ b/Tests/INPUTS/BasicCXX/Object.h
@@ -1,0 +1,5 @@
+struct /*Object*/Object {
+  int field;
+};
+
+struct Object * newObject();

--- a/Tests/INPUTS/BasicCXX/main.c
+++ b/Tests/INPUTS/BasicCXX/main.c
@@ -1,0 +1,6 @@
+#include /*Object:include:main*/"Object.h"
+
+int main(int argc, const char *argv[]) {
+  struct Object *obj = newObject();
+  return obj->field;
+}

--- a/Tests/INPUTS/BasicCXX/project.json
+++ b/Tests/INPUTS/BasicCXX/project.json
@@ -1,0 +1,1 @@
+{ "sources": ["main.c"] }

--- a/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
+++ b/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
@@ -26,4 +26,10 @@ final class LanguageServerProtocolTests: XCTestCase {
     XCTAssertEqual(Language.objective_cpp.xflag, "objective-c++")
     XCTAssertEqual(Language.objective_cpp.xflagHeader, "objective-c++-header")
   }
+
+  func testURLEscaping() {
+    let expectedURL = URL(string: "file:///folder/image@3x.png")
+    let doc = DocumentURI(string: "file:///folder/image%403x.png")
+    XCTAssertEqual(doc.fileURL, expectedURL)
+  }
 }

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -118,11 +118,11 @@ final class BuildServerBuildSystemTests: XCTestCase {
         XCTAssertEqual(items[1].target.uri, targets[1].uri)
         XCTAssertEqual(items[0].sources[0].uri, DocumentURI(URL(fileURLWithPath: "/path/to/a/file")))
         XCTAssertEqual(items[0].sources[0].kind, SourceItemKind.file)
-        XCTAssertEqual(items[0].sources[1].uri, DocumentURI(URL(fileURLWithPath: "/path/to/a/folder/")))
+        XCTAssertEqual(items[0].sources[1].uri, DocumentURI(URL(fileURLWithPath: "/path/to/a/folder", isDirectory: true)))
         XCTAssertEqual(items[0].sources[1].kind, SourceItemKind.directory)
         XCTAssertEqual(items[1].sources[0].uri, DocumentURI(URL(fileURLWithPath: "/path/to/b/file")))
         XCTAssertEqual(items[1].sources[0].kind, SourceItemKind.file)
-        XCTAssertEqual(items[1].sources[1].uri, DocumentURI(URL(fileURLWithPath: "/path/to/b/folder/")))
+        XCTAssertEqual(items[1].sources[1].uri, DocumentURI(URL(fileURLWithPath: "/path/to/b/folder", isDirectory: true)))
         XCTAssertEqual(items[1].sources[1].kind, SourceItemKind.directory)
         expectation.fulfill()
       case .failure(let error):

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -164,34 +164,4 @@ final class LocalClangTests: XCTestCase {
       fatalError("error \(result) waiting for diagnostics notification")
     }
   }
-
-  func testClangGoToInclude() throws {
-    guard let ws = try staticSourceKitTibsWorkspace(name: "BasicCXX") else { return }
-    guard haveClangd else { return }
-
-    let mainLoc = ws.testLoc("Object:include:main")
-    let expectedDoc = ws.testLoc("Object").docIdentifier.uri
-    let includePosition =
-        Position(line: mainLoc.position.line, utf16index: mainLoc.utf16Column + 2)
-
-    try ws.openDocument(mainLoc.url, language: .c)
-
-    let goToInclude = DefinitionRequest(
-      textDocument: mainLoc.docIdentifier, position: includePosition)
-    let resp = try! ws.sk.sendSync(goToInclude)
-
-    let locationsOrLinks = try XCTUnwrap(resp, "Response is nil")
-    switch locationsOrLinks {
-    case .locations(let locations):
-      XCTAssert(!locations.isEmpty, "Found no locations for go-to-#include")
-      if let loc = locations.first {
-        XCTAssertEqual(loc.uri, expectedDoc)
-      }
-    case .locationLinks(let locationLinks):
-      XCTAssert(!locationLinks.isEmpty, "Found no location links for go-to-#include")
-      if let link = locationLinks.first {
-        XCTAssertEqual(link.targetUri, expectedDoc)
-      }
-    }
-  }
 }

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -164,4 +164,34 @@ final class LocalClangTests: XCTestCase {
       fatalError("error \(result) waiting for diagnostics notification")
     }
   }
+
+  func testClangGoToInclude() throws {
+    guard let ws = try staticSourceKitTibsWorkspace(name: "BasicCXX") else { return }
+    guard haveClangd else { return }
+
+    let mainLoc = ws.testLoc("Object:include:main")
+    let expectedDoc = ws.testLoc("Object").docIdentifier.uri
+    let includePosition =
+        Position(line: mainLoc.position.line, utf16index: mainLoc.utf16Column + 2)
+
+    try ws.openDocument(mainLoc.url, language: .c)
+
+    let goToInclude = DefinitionRequest(
+      textDocument: mainLoc.docIdentifier, position: includePosition)
+    let resp = try! ws.sk.sendSync(goToInclude)
+
+    let locationsOrLinks = try XCTUnwrap(resp, "Response is nil")
+    switch locationsOrLinks {
+    case .locations(let locations):
+      XCTAssert(!locations.isEmpty, "Found no locations for go-to-#include")
+      if let loc = locations.first {
+        XCTAssertEqual(loc.uri, expectedDoc)
+      }
+    case .locationLinks(let locationLinks):
+      XCTAssert(!locationLinks.isEmpty, "Found no location links for go-to-#include")
+      if let link = locationLinks.first {
+        XCTAssertEqual(link.targetUri, expectedDoc)
+      }
+    }
+  }
 }

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -140,6 +140,7 @@ extension SKTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__SKTests = [
+        ("testClangdGoToInclude", testClangdGoToInclude),
         ("testCodeCompleteSwiftTibs", testCodeCompleteSwiftTibs),
         ("testDependenciesUpdatedCXXTibs", testDependenciesUpdatedCXXTibs),
         ("testDependenciesUpdatedSwiftTibs", testDependenciesUpdatedSwiftTibs),


### PR DESCRIPTION
- By forwarding the request to clangd when it fails to give
  symbol information, we are able to use its built in
  go-to-definition support for headers (jump to header file)