### PR TITLE
[test] Make test URLs unique to avoid sourcekitd race

### DIFF
--- a/Tests/SourceKitTests/BuildSystemTests.swift
+++ b/Tests/SourceKitTests/BuildSystemTests.swift
@@ -115,7 +115,7 @@ final class BuildSystemTests: XCTestCase {
   func testClangdDocumentUpdatedBuildSettings() {
     guard haveClangd else { return }
 
-    let url = URL(fileURLWithPath: "/file.m")
+    let url = URL(fileURLWithPath: "/\(#function)/file.m")
     let args = [url.path, "-DDEBUG"]
     let text = """
     #ifdef FOO
@@ -164,7 +164,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentUpdatedBuildSettings() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let args = FallbackBuildSystem().settings(for: DocumentURI(url), .swift)!.compilerArguments
 
     buildSystem.buildSettingsByFile[DocumentURI(url)] =
@@ -220,7 +220,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentBuildSettingsChangedFalseAlarm() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
 
     sk.allowUnexpectedNotification = false
 

--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -43,7 +43,7 @@ final class DocumentColorTests: XCTestCase {
   }
 
   func performDocumentColorRequest(text: String) -> [ColorInformation] {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),
@@ -56,7 +56,7 @@ final class DocumentColorTests: XCTestCase {
   }
 
   func performColorPresentationRequest(text: String, color: Color, range: Range<Position>) -> [ColorPresentation] {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),

--- a/Tests/SourceKitTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitTests/DocumentSymbolTests.swift
@@ -46,7 +46,7 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
   }
 
   func performDocumentSymbolRequest(text: String) -> DocumentSymbolResponse {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -57,7 +57,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEditing() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -343,8 +343,8 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testCrossFileDiagnostics() {
-    let urlA = URL(fileURLWithPath: "/a.swift")
-    let urlB = URL(fileURLWithPath: "/b.swift")
+    let urlA = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let urlB = URL(fileURLWithPath: "/\(#function)/b.swift")
     let uriA = DocumentURI(urlA)
     let uriB = DocumentURI(urlB)
 
@@ -404,7 +404,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDiagnosticsReopen() {
-    let urlA = URL(fileURLWithPath: "/a.swift")
+    let urlA = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uriA = DocumentURI(urlA)
     sk.allowUnexpectedNotification = false
 
@@ -454,7 +454,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnostics() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -488,7 +488,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnosticsNotes() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -541,7 +541,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitInsert() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -581,7 +581,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActions() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -635,7 +635,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActionsNotes() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -690,7 +690,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionPrimary() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -733,7 +733,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -1034,7 +1034,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testSymbolInfo() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
@@ -1107,7 +1107,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHover() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
@@ -1159,7 +1159,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHoverNameEscaping() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),
@@ -1222,7 +1222,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDocumentSymbolHighlight() {
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(

--- a/Tests/SourceKitTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitTests/LocalSwiftTests.swift
@@ -733,7 +733,6 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() {
-#if os(macOS)
     let url = URL(fileURLWithPath: "/a.swift")
     let uri = DocumentURI(url)
 
@@ -779,7 +778,6 @@ final class LocalSwiftTests: XCTestCase {
       TextEdit(range: Position(line: 3, utf16index: 6)..<Position(line: 3, utf16index: 11), newText: ""),
       TextEdit(range: Position(line: 3, utf16index: 14)..<Position(line: 3, utf16index: 20), newText: "hotness"),
     ])
-#endif
   }
 
   func testXMLToMarkdownDeclaration() {

--- a/Tests/SourceKitTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitTests/SwiftCompletionTests.swift
@@ -80,7 +80,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletion() {
     initializeServer()
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(url: url)
 
     let selfDot = try! sk.sendSync(CompletionRequest(
@@ -129,7 +129,7 @@ final class SwiftCompletionTests: XCTestCase {
     capabilities.completionItem = CompletionCapabilities.CompletionItem(snippetSupport: true)
 
     initializeServer(capabilities: capabilities)
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(url: url)
 
     func getTestMethodCompletion(_ position: Position, label: String) -> CompletionItem? {
@@ -200,7 +200,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionPosition() {
     initializeServer()
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(text: "foo", url: url)
 
     for col in 0 ... 3 {
@@ -224,7 +224,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOptional() {
     initializeServer()
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let text = """
     struct Foo {
       let bar: Int
@@ -250,7 +250,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOverride() {
     initializeServer()
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let text = """
     class Base {
       func foo() {}
@@ -275,7 +275,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOverrideInNewLine() {
     initializeServer()
-    let url = URL(fileURLWithPath: "/a.swift")
+    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let text = """
     class Base {
       func foo() {}


### PR DESCRIPTION
If a document is re-opened really quickly after a previous open or
modification, we might get a notification from the previous state of the
document when its AST finishes building. In normal operation, this is
benign, because when we make a request to get the new diagnostics and
semantic highlights, they are guaranteed to be for the new document. But
in testing, we don't generally anticipate these spurious notifications.
The ideal fix for this would be to shutdown and restart sourcekitd
server between tests. Currently there are bugs preventing that from
working in sourcekitd, so as a workaround, make sure all URLs in tests
are uniqued so they will not collide.

rdar://59488048