### PR TITLE
Make BuildSystemManager passthrough notifications fully `async

### DIFF
--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -210,17 +210,21 @@ extension BuildSystemManager: BuildSystemDelegate {
   }
 
   public func filesDependenciesUpdated(_ changedFiles: Set<DocumentURI>) {
-    if let delegate = self.delegate {
-      notifyQueue.async {
-        delegate.filesDependenciesUpdated(changedFiles)
+    queue.async {
+      if let delegate = self._delegate {
+        self.notifyQueue.async {
+          delegate.filesDependenciesUpdated(changedFiles)
+        }
       }
     }
   }
 
   public func buildTargetsChanged(_ changes: [BuildTargetEvent]) {
-    if let delegate = self.delegate {
-      notifyQueue.async {
-        delegate.buildTargetsChanged(changes)
+    queue.async {
+      if let delegate = self._delegate {
+        self.notifyQueue.async {
+          delegate.buildTargetsChanged(changes)
+        }
       }
     }
   }

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -21,6 +21,7 @@ extension BuildSystemManagerTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__BuildSystemManagerTests = [
+        ("testDependenciesUpdated", testDependenciesUpdated),
         ("testMainFiles", testMainFiles),
         ("testSettingsChangedAfterUnregister", testSettingsChangedAfterUnregister),
         ("testSettingsHeaderChangeMainFile", testSettingsHeaderChangeMainFile),


### PR DESCRIPTION
This avoids having a gotcha in the API where if a build system calls
these methods while it is being called back for settings or to register
for notifications it deadlocks (or crashes in libdispatch to prevent the
deadlock).