### PR TITLE
[JSONRPC] Do not exit until outstanding I/O has finished

### DIFF
--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -197,6 +197,20 @@ class ConnectionTests: XCTestCase {
     waitForExpectations(timeout: 10)
   }
 
+  func testSendBeforeClose() {
+    let client = connection.client
+    let server = connection.server
+
+    let expectation = self.expectation(description: "received notification")
+    client.handleNextNotification { (note: Notification<EchoNotification>) in
+      expectation.fulfill()
+    }
+
+    server.client.send(EchoNotification(string: "about to close!"))
+    connection.serverConnection.close()
+
+    waitForExpectations(timeout: 10)
+  }
 
   /// We can explicitly close a connection, but the connection also
   /// automatically closes itself if the pipe is closed (or has an error).

--- a/Tests/LanguageServerProtocolJSONRPCTests/XCTestManifests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/XCTestManifests.swift
@@ -34,6 +34,7 @@ extension ConnectionTests {
         ("testMessageBuffer", testMessageBuffer),
         ("testRound", testRound),
         ("testSendAfterClose", testSendAfterClose),
+        ("testSendBeforeClose", testSendBeforeClose),
         ("testUnexpectedResponse", testUnexpectedResponse),
         ("testUnknownNotification", testUnknownNotification),
         ("testUnknownRequest", testUnknownRequest),


### PR DESCRIPTION
Specifically, we care that all outstanding **writes** are finished before we call the close handler, because otherwise we may (a) send corrupted output during shutdown, or (b) drop notifications and replies sent during the shutdown process.  The former is an issue for clients that are not robust about parse failures, and the latter is an issue for reproducibility and robustness during testing/debugging - in particular, we have some integration tests that send data without waiting for individual replies and they need to finish outstanding replies before exiting.

rdar://60159448