### PR TITLE
Increase some low test timeouts

### DIFF
--- a/Tests/SourceKitTests/SourceKitTests.swift
+++ b/Tests/SourceKitTests/SourceKitTests.swift
@@ -210,7 +210,7 @@ final class SKTests: XCTestCase {
     }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 3)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: 15)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }
@@ -231,7 +231,7 @@ final class SKTests: XCTestCase {
     }
     server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
-    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: 3)
+    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: 15)
     if finished != .completed {
       fatalError("error \(finished) waiting for post-build diagnostics notification")
     }
@@ -260,7 +260,7 @@ final class SKTests: XCTestCase {
     // files without a recently upstreamed extension.
     try "".write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
     try ws.openDocument(moduleRef.url, language: .c)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 3)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: 15)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }
@@ -279,7 +279,7 @@ final class SKTests: XCTestCase {
     }
     server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
-    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: 3)
+    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: 15)
     if finished != .completed {
       fatalError("error \(finished) waiting for post-build diagnostics notification")
     }


### PR DESCRIPTION
While these should be fast the majority of the time, we don't want to
fail in a loaded high variance CI environment.

This is a speculative fix for https://bugs.swift.org/browse/SR-12378
rdar://60552818