### PR TITLE
[build-script] Add --parallel to supress output on success

### DIFF
--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -239,8 +239,7 @@ class ConnectionTests: XCTestCase {
         expectation.fulfill()
       })
 
-
-      close(to.fileHandleForWriting.fileDescriptor)
+      to.fileHandleForWriting.closeFile()
       // 100 us was chosen empirically to encourage races.
       usleep(100)
       conn.close()

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -133,7 +133,7 @@ def main():
     tests = os.path.join(bin_path, 'sk-tests')
     print('Cleaning ' + tests)
     shutil.rmtree(tests, ignore_errors=True)
-    swiftpm('test', swift_exec, swiftpm_args, env)
+    swiftpm('test', swift_exec, swiftpm_args + ['--parallel'], env)
   elif args.action == 'install':
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, env)
     swiftpm('build', swift_exec, swiftpm_args, env)


### PR DESCRIPTION
It's slightly faster and it helps supress the test output when tests
succeed (which avoids false positives in Jenkins' error regexes, for
example the error from "let pack" in a test).