### PR TITLE
[test] Workaround an issue with createDirectory on Linux

### DIFF
--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -57,11 +57,11 @@ public final class SKSwiftPMTestWorkspace {
     _ = try? fm.removeItem(at: tmpDir)
 
     buildDir = tmpDir.appendingPathComponent("build", isDirectory: true)
-    try fm.createDirectory(at: buildDir, withIntermediateDirectories: true, attributes: nil)
+    try fm.tibs_createDirectoryWithIntermediates(at: buildDir)
     let sourceDir = tmpDir.appendingPathComponent("src", isDirectory: true)
     try fm.copyItem(at: projectDir, to: sourceDir)
     let databaseDir = tmpDir.appendingPathComponent("db", isDirectory: true)
-    try fm.createDirectory(at: databaseDir, withIntermediateDirectories: true, attributes: nil)
+    try fm.tibs_createDirectoryWithIntermediates(at: databaseDir)
 
     self.sources = try TestSources(rootDirectory: sourceDir)
 
@@ -76,7 +76,7 @@ public final class SKSwiftPMTestWorkspace {
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore!.pathString)
 
-    try fm.createDirectory(atPath: swiftpm.indexStorePath!.pathString, withIntermediateDirectories: true)
+    try fm.tibs_createDirectoryWithIntermediates(at: swiftpm.indexStorePath!.asURL)
 
     let indexDelegate = SourceKitIndexDelegate()
 


### PR DESCRIPTION
Apply the same workaround as we did in indexstore-db. We haven't seen
this particular instance fail, but it theoretically has the same issue
here.

rdar://61545973