### PR TITLE
Add serverOptions extension configuration to allow setting flags for sourcekit-lsp

### DIFF
--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -46,10 +46,10 @@
                     "default": "sourcekit-lsp",
                     "description": "The path of the sourcekit-lsp executable"
                 },
-                "sourcekit-lsp.serverOptions": {
+                "sourcekit-lsp.serverArguments": {
                     "type": "array",
                     "default": [],
-                    "description": "Options to pass to sourcekit-lsp. Option keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']"
+                    "description": "Arguments to pass to sourcekit-lsp. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']"
                 },
                 "sourcekit-lsp.toolchainPath": {
                     "type": "string",

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -49,6 +49,9 @@
                 "sourcekit-lsp.serverArguments": {
                     "type": "array",
                     "default": [],
+                    "items": {
+                        "type": "string"
+                    },
                     "description": "Arguments to pass to sourcekit-lsp. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']"
                 },
                 "sourcekit-lsp.toolchainPath": {

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -46,6 +46,11 @@
                     "default": "sourcekit-lsp",
                     "description": "The path of the sourcekit-lsp executable"
                 },
+                "sourcekit-lsp.serverOptions": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Options to pass to sourcekit-lsp. Option keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']"
+                },
                 "sourcekit-lsp.toolchainPath": {
                     "type": "string",
                     "default": "",

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -8,7 +8,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const sourcekit: langclient.Executable = {
         command: config.get<string>('serverPath', 'sourcekit-lsp'),
-        args: []
+        args: config.get<string[]>('serverArguments', [])
     };
 
     const toolchain = config.get<string>('toolchainPath', '');

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -8,7 +8,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const sourcekit: langclient.Executable = {
         command: config.get<string>('serverPath', 'sourcekit-lsp'),
-        args: config.get<string[]>('serverOptions', [])
+        args: config.get<string[]>('serverArguments', [])
     };
 
     const toolchain = config.get<string>('toolchainPath', '');

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -8,7 +8,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const sourcekit: langclient.Executable = {
         command: config.get<string>('serverPath', 'sourcekit-lsp'),
-        args: config.get<string[]>('serverArguments', [])
+        args: config.get<string[]>('serverOptions', [])
     };
 
     const toolchain = config.get<string>('toolchainPath', '');


### PR DESCRIPTION
I had the need to be able to pass the `-Xlinker` flag to `sourcekit-lsp` from my VSCode extension and noticed that this didn't seem to be a configuration option currently. This should support passing any of the flags for `sourcekit-lsp` via the extension. 