### PR TITLE
[test] Disable --parallel testing temporarily

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -114,7 +114,7 @@ def handle_invocation(swift_exec, args):
     tests = os.path.join(bin_path, 'sk-tests')
     print('Cleaning ' + tests)
     shutil.rmtree(tests, ignore_errors=True)
-    swiftpm('test', swift_exec, swiftpm_args + ['--parallel'], env)
+    swiftpm('test', swift_exec, swiftpm_args, env)
   elif args.action == 'install':
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, env)
     swiftpm('build', swift_exec, swiftpm_args, env)


### PR DESCRIPTION
We have a couple of non-deterministic CI failures right now, and they
may be triggered by, or made more frequent by doing parallel testing.
Disbaling while I continue to investigate.

rdar://61837752
rdar://61965529