### PR TITLE
[linux] Re-enable parallel testing after avoiding static destructors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,8 +46,12 @@ let package = Package(
       ),
 
       .target(
+        name: "CSKTestSupport",
+        dependencies: []),
+      .target(
         name: "SKTestSupport",
         dependencies: [
+          "CSKTestSupport",
           "ISDBTestSupport",
           "LSPTestSupport",
           "SourceKit",

--- a/Sources/CSKTestSupport/CSKTestSupport.c
+++ b/Sources/CSKTestSupport/CSKTestSupport.c
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __linux__
+// For testing, override __cxa_atexit to prevent registration of static
+// destructors due to SR-12668.
+int __cxa_atexit(void (*f) (void *), void *arg, void *dso_handle) {
+  return 0;
+}
+#endif

--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -59,12 +59,8 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
   // Platform-specific flags.
   #if os(macOS)
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: RTLD_FIRST)
-    public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #else
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
-  #if !os(Android)
-    public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
-  #endif
   #endif
   #endif
 

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -46,10 +46,8 @@ final class SwiftSourceKitFramework {
     self.path = path
     #if os(Windows)
     self.dylib = try dlopen(path.pathString, mode: [])
-    #elseif os(Android)
-    self.dylib = try dlopen(path.pathString, mode: [.lazy, .local, .first])
     #else
-    self.dylib = try dlopen(path.pathString, mode: [.lazy, .local, .first, .deepBind])
+    self.dylib = try dlopen(path.pathString, mode: [.lazy, .local, .first])
     #endif
 
     func dlsym_required<T>(_ handle: DLHandle, symbol: String) throws -> T {

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -121,7 +121,8 @@ let server = SourceKitServer(client: clientConnection, options: options.serverOp
 })
 clientConnection.start(receiveHandler: server, closeHandler: {
   server.prepareForExit()
-  exit(0)
+  // Use _Exit to avoid running static destructors due to SR-12668.
+  _Exit(0)
 })
 
 Logger.shared.addLogHandler { message, _ in

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -88,7 +88,7 @@ def delete_rpath(rpath, binary):
 
 def should_test_parallel():
   if platform.system() == 'Linux':
-    distro = platform.distro()
+    distro = platform.linux_distribution()
     if distro[0] != 'Ubuntu':
       # Workaround hang in Process.run() that hasn't been tracked down yet.
       return False


### PR DESCRIPTION
* [linux] Stop using RTLD_DEEPBIND in dlopen of libsourcekitdInProc.so (depends on https://github.com/apple/swift/pull/31287)
* [linux] Avoid running static destructors due to SR-12668
* [test] Re-enable --parallel testing

This should avoid the crash that has been affecting parallel testing on Ubuntu 16.04.