### PR TITLE
Add initial support for exposing educational notes as diagnostic codes

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -356,13 +356,18 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     /// Whether the client accepts diagnostics with related information.
     public var relatedInformation: Bool? = nil
 
+    // Clients support complex diagnostic codes (e.g. code and target URI).
+    public var complexDiagnosticCodeSupport: Bool? = nil
+
     /// Requests that SourceKit-LSP send `Diagnostic.codeActions`.
     /// **LSP Extension from clangd**.
     public var codeActionsInline: Bool? = nil
 
     public init(relatedInformation: Bool? = nil,
+                complexDiagnosticCodeSupport: Bool? = nil,
                 codeActionsInline: Bool? = nil) {
       self.relatedInformation = relatedInformation
+      self.complexDiagnosticCodeSupport = complexDiagnosticCodeSupport
       self.codeActionsInline = codeActionsInline
     }
   }

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -85,3 +85,7 @@ public struct DocumentURI: Codable, Hashable {
     try storage.absoluteString.encode(to: encoder)
   }
 }
+
+extension DocumentURI: CustomStringConvertible {
+  public var description: String { storage.absoluteString }
+}

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -109,10 +109,15 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
     let stageUID: sourcekitd_uid_t? = response[sourcekitd.keys.diagnostic_stage]
     let stage = stageUID.flatMap { DiagnosticStage($0, sourcekitd: sourcekitd) } ?? .sema
 
+    let useEducationalNotesAsCodes =
+      (clientCapabilities.textDocument?.publishDiagnostics?.complexDiagnosticCodeSupport == true)
+
     // Note: we make the notification even if there are no diagnostics to clear the current state.
     var newDiags: [CachedDiagnostic] = []
     response[keys.diagnostics]?.forEach { _, diag in
-      if let diag = CachedDiagnostic(diag, in: snapshot) {
+      if let diag = CachedDiagnostic(diag,
+                                     in: snapshot,
+                                     useEducationalNoteAsCode: useEducationalNotesAsCodes) {
         newDiags.append(diag)
       }
       return true

--- a/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftSourceKitFramework.swift
@@ -217,6 +217,7 @@ struct sourcekitd_keys {
   let notification: sourcekitd_uid_t
   let fixits: sourcekitd_uid_t
   let diagnostics: sourcekitd_uid_t
+  let educational_note_paths: sourcekitd_uid_t
   let diagnostic_stage: sourcekitd_uid_t
   let severity: sourcekitd_uid_t
   let line: sourcekitd_uid_t
@@ -268,6 +269,7 @@ struct sourcekitd_keys {
     notification = api.uid_get_from_cstr("key.notification")!
     fixits = api.uid_get_from_cstr("key.fixits")!
     diagnostics = api.uid_get_from_cstr("key.diagnostics")!
+    educational_note_paths = api.uid_get_from_cstr("key.educational_note_paths")!
     diagnostic_stage = api.uid_get_from_cstr("key.diagnostic_stage")!
     severity = api.uid_get_from_cstr("key.severity")!
     line = api.uid_get_from_cstr("key.line")!

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -203,8 +203,30 @@ final class CodingTests: XCTestCase {
     checkCoding(Language.swift, json: "\"swift\"")
     checkCoding(Language(rawValue: "unknown"), json: "\"unknown\"")
 
-    checkCoding(DiagnosticCode.number(123), json: "123")
-    checkCoding(DiagnosticCode.string("hi"), json: "\"hi\"")
+    checkCoding(DiagnosticCode(number: 123), json: "123")
+    checkCoding(DiagnosticCode(string: "hi"), json: "\"hi\"")
+    checkCoding(DiagnosticCode(number: 123, target: DocumentURI(string: "http://www.swift.org")), json: """
+      {
+        "target" : "http:\\/\\/www.swift.org",
+        "value" : 123
+      }
+      """)
+    checkCoding(DiagnosticCode(string: "hi", target: DocumentURI(string: "http://www.swift.org")), json: """
+      {
+        "target" : "http:\\/\\/www.swift.org",
+        "value" : "hi"
+      }
+      """)
+    checkDecoding(json: """
+      {
+        "value" : "foo"
+      }
+      """, expected: DiagnosticCode(string: "foo"))
+    checkDecoding(json: """
+    {
+      "value" : 123
+    }
+    """, expected: DiagnosticCode(number: 123))
 
     let markup = MarkupContent(kind: .plaintext, value: "a")
     checkCoding(HoverResponse(contents: .markupContent(markup), range: nil), json: """

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -109,6 +109,7 @@ extension LocalSwiftTests {
         ("testEditing", testEditing),
         ("testEditingNonURL", testEditingNonURL),
         ("testEditorPlaceholderParsing", testEditorPlaceholderParsing),
+        ("testEducationalNotesAreUsedAsDiagnosticCodes", testEducationalNotesAreUsedAsDiagnosticCodes),
         ("testExcludedDocumentSchemeDiagnostics", testExcludedDocumentSchemeDiagnostics),
         ("testFixitInsert", testFixitInsert),
         ("testFixitsAreIncludedInPublishDiagnostics", testFixitsAreIncludedInPublishDiagnostics),


### PR DESCRIPTION
I've attached a gif of what this looks like in VSCode. A couple of notes on the implementation:
- https://github.com/apple/swift/pull/31521 is a prerequisite
- This relies on proposed changes in LSPv3.16, which is not yet released. The proposed new capability can be found here: https://github.com/microsoft/vscode-languageserver-node/blob/d2909f55704da3f30d5cd231125b4b90dbac88cf/protocol/src/protocol.ts#L1398
- This change alone is not enough for the feature to work in VSCode. We'll also need to update the vscode-languageclient dependency in the VSCode extension from 4.0.0 to 7.0.0 when it's released. I've tested with the 7.0.0-next.1 preview and confirmed it's working

![Screen Recording 2020-05-03 at 6 48 05 PM](https://user-images.githubusercontent.com/1946221/81134121-9923ec00-8f08-11ea-82fa-d9fe9e9378c2.gif)
