### PR TITLE
add fileEvents in vscode extension

### DIFF
--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -26,7 +26,11 @@ export function activate(context: vscode.ExtensionContext) {
             'objective-c',
             'objective-cpp'
         ],
-        synchronize: undefined
+        synchronize: {
+          fileEvents: [
+            vscode.workspace.createFileSystemWatcher("**/*.swift"),
+          ],
+        }
     };
 
     const client = new langclient.LanguageClient('sourcekit-lsp', 'SourceKit Language Server', serverOptions, clientOptions);


### PR DESCRIPTION
`fileEvents` will enable us to get `workspace.didChangeWatchedFiles` notification from vscode. also, we can always add this behind one **Flag** to enable/disable file watching form client 

For now, only Swift files are added for  `fileEvents`. in future we can add more file extensions for c/c++/obj-c

```ts
synchronize: {
  fileEvents: [
    vscode.workspace.createFileSystemWatcher("**/*.swift"),
 // vscode.workspace.createFileSystemWatcher("**/*.c"),
  ],
}
```

We can always implement `sourcekit-lsp` side file watchers in the future. 
but for now, we can implement `workspace.didChangeWatchedFiles` for editors like vscode