### PR TITLE
Send `didSave` notifications to clangd if it supports it

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/ColorPresentationRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ColorPresentationRequest.swift
@@ -23,7 +23,7 @@
 /// - Returns: A list of color presentations for the given document.
 public struct ColorPresentationRequest: TextDocumentRequest, Hashable {
   public static let method: String = "textDocument/colorPresentation"
-  public typealias Response = [ColorPresentation]?
+  public typealias Response = [ColorPresentation]
 
   /// The document to request presentations for.
   public var textDocument: TextDocumentIdentifier

--- a/Sources/LanguageServerProtocol/Requests/DocumentColorRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentColorRequest.swift
@@ -21,7 +21,7 @@
 /// - Returns: A list of color references for the given document.
 public struct DocumentColorRequest: TextDocumentRequest, Hashable {
   public static let method: String = "textDocument/documentColor"
-  public typealias Response = [ColorInformation]?
+  public typealias Response = [ColorInformation]
 
   /// The document in which to search for color references.
   public var textDocument: TextDocumentIdentifier

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -194,16 +194,21 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
     public init(includeText: Bool = false) {
       self.includeText = includeText
     }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.includeText = try container.decodeIfPresent(Bool.self, forKey: .includeText) ?? false
+    }
   }
 
   /// Whether save notifications should be sent to the server.
-  public var save: SaveOptions?
+  public var save: ValueOrBool<SaveOptions>?
 
   public init(openClose: Bool? = true,
               change: TextDocumentSyncKind? = .incremental,
               willSave: Bool? = true,
               willSaveWaitUntil: Bool? = false,
-              save: SaveOptions? = SaveOptions()) {
+              save: ValueOrBool<SaveOptions>? = .value(SaveOptions(includeText: false))) {
     self.openClose = openClose
     self.change = change
     self.willSave = willSave
@@ -218,7 +223,7 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
       self.change = try container.decodeIfPresent(TextDocumentSyncKind.self, forKey: .change)
       self.willSave = try container.decodeIfPresent(Bool.self, forKey: .willSave)
       self.willSaveWaitUntil = try container.decodeIfPresent(Bool.self, forKey: .willSaveWaitUntil)
-      self.save = try container.decodeIfPresent(SaveOptions.self, forKey: .save)
+      self.save = try container.decodeIfPresent(ValueOrBool<SaveOptions>.self, forKey: .save)
       return
     } catch {}
     do {

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -189,15 +189,10 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
   public struct SaveOptions: Codable, Hashable {
 
     /// Whether the client should include the file content in save notifications.
-    public var includeText: Bool
+    public var includeText: Bool?
 
-    public init(includeText: Bool = false) {
+    public init(includeText: Bool? = nil) {
       self.includeText = includeText
-    }
-
-    public init(from decoder: Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      self.includeText = try container.decodeIfPresent(Bool.self, forKey: .includeText) ?? false
     }
   }
 

--- a/Sources/SourceKit/SourceKitServer.swift
+++ b/Sources/SourceKit/SourceKitServer.swift
@@ -93,8 +93,8 @@ public final class SourceKitServer: LanguageServer {
     registerToolchainTextDocumentRequest(SourceKitServer.documentSymbolHighlight, nil)
     registerToolchainTextDocumentRequest(SourceKitServer.foldingRange, nil)
     registerToolchainTextDocumentRequest(SourceKitServer.documentSymbol, nil)
-    registerToolchainTextDocumentRequest(SourceKitServer.documentColor, nil)
-    registerToolchainTextDocumentRequest(SourceKitServer.colorPresentation, nil)
+    registerToolchainTextDocumentRequest(SourceKitServer.documentColor, [])
+    registerToolchainTextDocumentRequest(SourceKitServer.colorPresentation, [])
     registerToolchainTextDocumentRequest(SourceKitServer.codeAction, nil)
   }
 
@@ -455,7 +455,7 @@ extension SourceKitServer {
         change: .incremental,
         willSave: true,
         willSaveWaitUntil: false,
-        save: TextDocumentSyncOptions.SaveOptions(includeText: false)
+        save: .value(TextDocumentSyncOptions.SaveOptions(includeText: false))
       ),
       hoverProvider: true,
       completionProvider: CompletionOptions(

--- a/Sources/SourceKit/clangd/ClangLanguageServer.swift
+++ b/Sources/SourceKit/clangd/ClangLanguageServer.swift
@@ -101,7 +101,9 @@ extension ClangLanguageServerShim {
   }
 
   public func didSaveDocument(_ note: DidSaveTextDocumentNotification) {
-
+    if capabilities?.textDocumentSync?.save?.isSupported == true {
+      clangd.send(note)
+    }
   }
 
   // MARK: - Build System Integration
@@ -167,11 +169,19 @@ extension ClangLanguageServerShim {
   }
 
   func documentColor(_ req: Request<DocumentColorRequest>) {
-    forwardRequest(req, to: clangd)
+    if capabilities?.colorProvider?.isSupported == true {
+      forwardRequest(req, to: clangd)
+    } else {
+      req.reply(.success([]))
+    }
   }
 
   func colorPresentation(_ req: Request<ColorPresentationRequest>) {
-    forwardRequest(req, to: clangd)
+    if capabilities?.colorProvider?.isSupported == true {
+      forwardRequest(req, to: clangd)
+    } else {
+      req.reply(.success([]))
+    }
   }
 
   func codeAction(_ req: Request<CodeActionRequest>) {

--- a/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
+++ b/Sources/SourceKit/sourcekitd/SwiftLanguageServer.swift
@@ -206,7 +206,7 @@ extension SwiftLanguageServer {
         change: .incremental,
         willSave: true,
         willSaveWaitUntil: false,
-        save: TextDocumentSyncOptions.SaveOptions(includeText: false)),
+        save: .value(TextDocumentSyncOptions.SaveOptions(includeText: false))),
       hoverProvider: true,
       completionProvider: CompletionOptions(
         resolveProvider: false,
@@ -758,7 +758,7 @@ extension SwiftLanguageServer {
     queue.async {
       guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
         log("failed to find snapshot for url \(req.params.textDocument.uri)")
-        req.reply(nil)
+        req.reply([])
         return
       }
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -76,7 +76,7 @@ final class CodingTests: XCTestCase {
         change: .incremental,
         willSave: true,
         willSaveWaitUntil: false,
-        save: TextDocumentSyncOptions.SaveOptions(includeText: false)),
+        save: .value(TextDocumentSyncOptions.SaveOptions(includeText: false))),
       completionProvider: CompletionOptions(
         resolveProvider: false,
         triggerCharacters: ["."]))), id: .number(2), json: """

--- a/Tests/SourceKitTests/DocumentColorTests.swift
+++ b/Tests/SourceKitTests/DocumentColorTests.swift
@@ -52,7 +52,7 @@ final class DocumentColorTests: XCTestCase {
       text: text)))
 
     let request = DocumentColorRequest(textDocument: TextDocumentIdentifier(url))
-    return try! sk.sendSync(request)!
+    return try! sk.sendSync(request)
   }
 
   func performColorPresentationRequest(text: String, color: Color, range: Range<Position>) -> [ColorPresentation] {
@@ -68,7 +68,7 @@ final class DocumentColorTests: XCTestCase {
       textDocument: TextDocumentIdentifier(url), 
       color: color, 
       range: range)
-    return try! sk.sendSync(request)!
+    return try! sk.sendSync(request)
   }
 
   func testEmptyText() {


### PR DESCRIPTION
- Minor update to the LSP protocol for `didSave` and `colorProvider` to be more in line with the spec
- Only send color requests over to clangd if it supports it

Rationale for this change: clangd recently implemented didSave support, it is used to rebuild preambles when the user edits a header file referenced by an open file.