### PR TITLE
build: repair build on Windows

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -70,8 +70,9 @@ add_library(LanguageServerProtocol
   )
 set_target_properties(LanguageServerProtocol PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(LanguageServerProtocol PUBLIC
+    swiftDispatch
     Foundation)
 endif()
 

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(SourceKitLSP PUBLIC
   SourceKitD
   TSCUtility)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(SourceKit PRIVATE
+  target_link_libraries(SourceKitLSP PRIVATE
     FoundationXML)
 endif()
 

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -39,6 +39,10 @@ target_link_libraries(SourceKitLSP PUBLIC
   SKSwiftPMWorkspace
   SourceKitD
   TSCUtility)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(SourceKit PRIVATE
+    FoundationXML)
+endif()
 
 if(BUILD_SHARED_LIBS)
   get_swift_host_arch(swift_arch)

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -11,6 +11,10 @@ target_link_libraries(sourcekit-lsp PRIVATE
   LanguageServerProtocolJSONRPC
   SourceKitLSP
   TSCUtility)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(sourcekit-lsp PRIVATE
+    FoundationXML)
+endif()
 
 install(TARGETS sourcekit-lsp
   DESTINATION bin)


### PR DESCRIPTION
This enables building SourceKit-LSP on Windows.  This is sufficient to
repair the build, though it is insufficient to run currently.