### PR TITLE
[clang] Workaround module format issue with -gmodules

### DIFF
--- a/Sources/SourceKit/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKit/Clang/ClangLanguageServer.swift
@@ -127,6 +127,14 @@ extension ClangLanguageServerShim {
           "-Xclang", "-fmodule-format=raw"
         ])
       }
+      if let workingDirectory = settings.workingDirectory {
+        // FIXME: this is a workaround for clangd not respecting the compilation
+        // database's "directory" field for relative -fmodules-cache-path.
+        // rdar://63984913
+        settings.compilerArguments.append(contentsOf: [
+          "-working-directory", workingDirectory
+        ])
+      }
 
       clangd.send(DidChangeConfigurationNotification(settings: .clangd(
         ClangWorkspaceSettings(

--- a/Sources/SourceKit/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKit/Clang/ClangLanguageServer.swift
@@ -120,7 +120,14 @@ extension ClangLanguageServerShim {
       return "settings for \(uri): \(settingsStr)"
     }
 
-    if let settings = settings {
+    if var settings = settings {
+      if settings.compilerArguments.contains("-fmodules") == true {
+        // Clangd is not built with support for the 'obj' format.
+        settings.compilerArguments.append(contentsOf: [
+          "-Xclang", "-fmodule-format=raw"
+        ])
+      }
+
       clangd.send(DidChangeConfigurationNotification(settings: .clangd(
         ClangWorkspaceSettings(
           compilationDatabaseChanges: [url.path: ClangCompileCommand(settings, clang: clang)]))))

--- a/Tests/INPUTS/ClangModules/ClangModuleA.h
+++ b/Tests/INPUTS/ClangModules/ClangModuleA.h
@@ -1,0 +1,6 @@
+#ifndef ClangModuleA_h
+#define ClangModuleA_h
+
+void func_ClangModuleA(void);
+
+#endif /* ClangModuleA_h */

--- a/Tests/INPUTS/ClangModules/ClangModules_main.m
+++ b/Tests/INPUTS/ClangModules/ClangModules_main.m
@@ -1,0 +1,6 @@
+/*main_file*/
+@import ClangModuleA;
+
+void test(void) {
+  func_ClangModuleA();
+}

--- a/Tests/INPUTS/ClangModules/module.modulemap
+++ b/Tests/INPUTS/ClangModules/module.modulemap
@@ -1,0 +1,3 @@
+module ClangModuleA {
+  header "ClangModuleA.h"
+}

--- a/Tests/INPUTS/ClangModules/project.json
+++ b/Tests/INPUTS/ClangModules/project.json
@@ -1,0 +1,4 @@
+{
+  "clang_flags": ["-gmodules"],
+  "sources": ["ClangModules_main.m"]
+}

--- a/Tests/SourceKitTests/LocalClangTests.swift
+++ b/Tests/SourceKitTests/LocalClangTests.swift
@@ -164,4 +164,22 @@ final class LocalClangTests: XCTestCase {
       fatalError("error \(result) waiting for diagnostics notification")
     }
   }
+
+  func testClangModules() {
+    guard let ws = try! staticSourceKitTibsWorkspace(name: "ClangModules") else { return }
+    if ToolchainRegistry.shared.default?.clangd == nil { return }
+
+    let loc = ws.testLoc("main_file")
+
+    let expectation = self.expectation(description: "diagnostics")
+
+    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(note.params.diagnostics.count, 0)
+      expectation.fulfill()
+    }
+
+    try! ws.openDocument(loc.url, language: .objective_c)
+
+    waitForExpectations(timeout: 15)
+  }
 }

--- a/Tests/SourceKitTests/XCTestManifests.swift
+++ b/Tests/SourceKitTests/XCTestManifests.swift
@@ -92,6 +92,7 @@ extension LocalClangTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__LocalClangTests = [
+        ("testClangModules", testClangModules),
         ("testClangStdHeaderCanary", testClangStdHeaderCanary),
         ("testFoldingRange", testFoldingRange),
         ("testSymbolInfo", testSymbolInfo),


### PR DESCRIPTION
Clangd is not built with support for the "obj" format of modules, used by e.g. `-gmodules`. Workaround by forcing the module format to "raw".

Incidentally, also workaround an issue with working directory for `-fmodules-cache-path` that was causing running the new test added here to create its module cache in the project sources instead of in the test's build directory.