### PR TITLE
[test] Fix notification handler test when run in serial

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -126,6 +126,7 @@ let package = Package(
         dependencies: [
           "SourceKitD",
           "SKCore",
+          "SKTestSupport",
         ]
       ),
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -101,6 +101,7 @@ def handle_invocation(swift_exec, args):
   env = os.environ
   # Set the toolchain used in tests at runtime
   env['SOURCEKIT_TOOLCHAIN_PATH'] = args.toolchain
+  env['INDEXSTOREDB_TOOLCHAIN_BIN_PATH'] = args.toolchain
   # Use local dependencies (i.e. checked out next sourcekit-lsp).
   if not args.no_local_deps:
     env['SWIFTCI_USE_LOCAL_DEPS'] = "1"


### PR DESCRIPTION
The test was passing with --parallel since each test was being run in
its own process, but not when run in serial since other documents could
trigger unexpected notifications. Also make the uniqueness of the path
reliable using a mutable workspace.