### PR TITLE
Fix a number of resource leaks when using SourceKit-LSP in tests or as a library

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -254,7 +254,11 @@ private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: Absolute
     outFD: clientToServer.fileHandleForWriting.fileDescriptor
   )
 
-  connection.start(receiveHandler: client)
+  connection.start(receiveHandler: client) {
+    // FIXME: keep the pipes alive until we close the connection. This
+    // should be fixed systemically.
+    withExtendedLifetime((clientToServer, serverToClient)) {}
+  }
   let process = Foundation.Process()
 
   if #available(OSX 10.13, *) {

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -110,7 +110,7 @@ public final class BuildSystemManager {
   weak var mainFilesProvider: MainFilesProvider?
 
   /// Build system delegate that will receive notifications about setting changes, etc.
-  var _delegate: BuildSystemDelegate?
+  weak var _delegate: BuildSystemDelegate?
 
   /// Create a BuildSystemManager that wraps the given build system. The new
   /// manager will modify the delegate of the underlying build system.

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -63,11 +63,6 @@ public struct TestSourceKitServer {
         let clientToServer: Pipe = Pipe()
         let serverToClient: Pipe = Pipe()
 
-        // FIXME: DispatchIO doesn't like when the Pipes close behind its back even after the tests
-        // finish. Until we fix the lifetime, leak.
-        _ = Unmanaged.passRetained(clientToServer)
-        _ = Unmanaged.passRetained(serverToClient)
-
         let clientConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
           inFD: serverToClient.fileHandleForReading.fileDescriptor,
@@ -84,8 +79,16 @@ public struct TestSourceKitServer {
           serverConnection.close()
         })
 
-        clientConnection.start(receiveHandler: client)
-        serverConnection.start(receiveHandler: server!)
+        clientConnection.start(receiveHandler: client) {
+          // FIXME: keep the pipes alive until we close the connection. This
+          // should be fixed systemically.
+          withExtendedLifetime((clientToServer, serverToClient)) {}
+        }
+        serverConnection.start(receiveHandler: server!) {
+          // FIXME: keep the pipes alive until we close the connection. This
+          // should be fixed systemically.
+          withExtendedLifetime((clientToServer, serverToClient)) {}
+        }
 
         connImpl = .jsonrpc(
           clientToServer: clientToServer,

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -19,7 +19,7 @@ import SourceKitLSP
 import class Foundation.Pipe
 import LSPTestSupport
 
-public struct TestSourceKitServer {
+public final class TestSourceKitServer {
   public enum ConnectionKind {
     case local, jsonrpc
   }
@@ -39,6 +39,8 @@ public struct TestSourceKitServer {
 
   public let client: TestClient
   let connImpl: ConnectionImpl
+
+  public var hasShutdown: Bool = false
 
   /// The server, if it is in the same process.
   public let server: SourceKitServer?
@@ -98,15 +100,15 @@ public struct TestSourceKitServer {
     }
   }
 
-  func close() {
-    switch connImpl {
-      case .local(clientConnection: let cc, serverConnection: let sc):
-      cc.close()
-      sc.close()
+  deinit {
+    close()
+  }
 
-    case .jsonrpc(clientToServer: _, serverToClient: _, clientConnection: let cc, serverConnection: let sc):
-      cc.close()
-      sc.close()
+  func close() {
+    if !hasShutdown {
+      hasShutdown = true
+      _ = try! self.client.sendSync(ShutdownRequest())
+      self.client.send(ExitNotification())
     }
   }
 }

--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -69,10 +69,18 @@ public final class SourceKitDRegistry {
     lock.withLock {
       let existing = active.removeValue(forKey: key)
       if let existing = existing {
-        assert(self.cemetary[key] == nil)
+        assert(self.cemetary[key]?.value == nil)
         cemetary[key] = WeakSourceKitD(value: existing)
       }
       return existing
+    }
+  }
+
+  /// Remove all SourceKitD instances, including weak ones.
+  public func clear() {
+    lock.withLock {
+      active.removeAll()
+      cemetary.removeAll()
     }
   }
 }

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -247,7 +247,11 @@ func makeJSONRPCClangServer(
     clang: toolchain.clang)
 
   connectionToClient.start(handler: client)
-  connection.start(receiveHandler: client)
+  connection.start(receiveHandler: client) {
+    // FIXME: keep the pipes alive until we close the connection. This
+    // should be fixed systemically.
+    withExtendedLifetime((clientToServer, serverToClient)) {}
+  }
 
   let process = Foundation.Process()
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -520,6 +520,10 @@ extension SourceKitServer {
 
   func shutdown(_ request: Request<ShutdownRequest>) {
     _prepareForExit()
+    for service in languageService.values {
+      service.shutdown()
+    }
+    languageService = [:]
     request.reply(VoidResponse())
   }
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -21,6 +21,7 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   func initializeSync(_ initialize: InitializeRequest) throws -> InitializeResult
   func clientInitialized(_ initialized: InitializedNotification)
+  func shutdown()
 
   // MARK: - Text synchronization
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -237,6 +237,10 @@ class ConnectionTests: XCTestCase {
       conn.start(receiveHandler: DummyHandler(), closeHandler: {
         // We get an error from XCTest if this is fulfilled more than once.
         expectation.fulfill()
+
+        // FIXME: keep the pipes alive until we close the connection. This
+        // should be fixed systemically.
+        withExtendedLifetime((to, from)) {}
       })
 
       to.fileHandleForWriting.closeFile()


### PR DESCRIPTION
* Shutdown toolchain connections on exit. This also fixes [SR-11309](https://bugs.swift.org/browse/SR-11309).
* Fix reference cycle for build system manager delegate.