### PR TITLE
[Discussion] Add scheme change handler to reduce index visibility

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -957,19 +957,19 @@ extension SourceKitServer {
     workspace.buildSystemManager.buildTargetOutputPaths(targets: targets) { response in
       switch response {
       case .success(let items):
-        let uniFilesToRemove = self.schemeOutputs.values.flatMap {$0}
-        workspace.index?.removeUnitOutFilePaths(uniFilesToRemove, waitForProcessing: false)
+        let unitOutputsToRemove = self.schemeOutputs.values.flatMap {$0}
+        workspace.index?.removeUnitOutFilePaths(unitOutputsToRemove, waitForProcessing: false)
         self.schemeOutputs.removeAll()
-        var unitFilesToAdd: [String] = []
+        var unitOutputsToAdd: [String] = []
         items.forEach { item in
           item.outputPaths.forEach { outputPathURI in
             if outputPathURI.pseudoPath.hasSuffix(".o") {
-              unitFilesToAdd.append(outputPathURI.pseudoPath)
+              unitOutputsToAdd.append(outputPathURI.pseudoPath)
               self.schemeOutputs[item.target] = self.schemeOutputs[item.target, default:[]] + [outputPathURI.pseudoPath]
             }
           }
         }
-        workspace.index?.addUnitOutFilePaths(unitFilesToAdd, waitForProcessing: false)
+        workspace.index?.addUnitOutFilePaths(unitOutputsToAdd, waitForProcessing: false)
       case .failure(_):
         break
       }


### PR DESCRIPTION
`SourcekitServer` will handle scheme change, caching outputs and reduce index visibility accordingly. the term "Build scheme" here refers to the build targets user desire to focus on
It's unclear yet what endpoint we are going to use for this. so the remaining work includes:
- connect to the correct endpoint
- Initialize indexstoredb with explicit mode (or according to build server/ide's ability to provide build scheme)