### PR TITLE
Forward definition requests when index lookup fails

### DIFF
--- a/Tests/INPUTS/BasicCXX/main.c
+++ b/Tests/INPUTS/BasicCXX/main.c
@@ -1,6 +1,6 @@
 #include /*Object:include:main*/"Object.h"
 
 int main(int argc, const char *argv[]) {
-  struct Object *obj = newObject();
+  struct /*Object:ref:main*/Object *obj = newObject();
   return obj->field;
 }

--- a/Tests/SourceKitLSPTests/XCTestManifests.swift
+++ b/Tests/SourceKitLSPTests/XCTestManifests.swift
@@ -143,6 +143,7 @@ extension SKTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__SKTests = [
+        ("testClangdGoToDefinitionWithoutIndex", testClangdGoToDefinitionWithoutIndex),
         ("testClangdGoToInclude", testClangdGoToInclude),
         ("testCodeCompleteSwiftTibs", testCodeCompleteSwiftTibs),
         ("testDependenciesUpdatedCXXTibs", testDependenciesUpdatedCXXTibs),


### PR DESCRIPTION
If we're unable to look up a definition or declaration via the
index, forward the request to the language service.

This allows clangd to support go to definition or declaration
for symbols defined/declared in the AST.
