### PR TITLE
Allow scheme selection to reduce index visibility

### DIFF
--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -54,6 +54,10 @@
                     },
                     "description": "Arguments to pass to sourcekit-lsp. Argument keys and values should be provided as separate entries in the array e.g. ['--log-level', 'debug']"
                 },
+                "sourcekit-lsp.initializationOptions": {
+                    "type": "object",
+                    "description": "Additional initialization options to pass to sourcekit-lsp"
+                },
                 "sourcekit-lsp.toolchainPath": {
                     "type": "string",
                     "default": "",
@@ -68,6 +72,16 @@
                         "verbose"
                     ],
                     "description": "Traces the communication between VS Code and the SourceKit-LSP language server."
+                },
+                "sourcekit-lsp.indexVisibility.targets": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Restrict visibility of index symbols to the given targets. Targets are in the form of Target Identifier object defined in https://build-server-protocol.github.io/docs/specification.html#build-target-identifier. Use when SourceKit-LSP language server is initialized with explicit index loading mode"
+                },
+                "sourcekit-lsp.indexVisibility.includeTargetDependencies": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, transitive dependency targets' index will also be visibile. Use when SourceKit-LSP language server is initialized with explicit index loading mode"
                 }
             }
         }

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -76,7 +76,10 @@
                 "sourcekit-lsp.indexVisibility.targets": {
                     "type": "array",
                     "default": [],
-                    "description": "Restrict visibility of index symbols to the given targets. Targets are in the form of Target Identifier object defined in https://build-server-protocol.github.io/docs/specification.html#build-target-identifier. Use when SourceKit-LSP language server is initialized with explicit index loading mode"
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Restrict visibility of index symbols to the given targets in the form of URIs. Use when SourceKit-LSP language server is initialized with explicit index loading mode"
                 },
                 "sourcekit-lsp.indexVisibility.includeTargetDependencies": {
                     "type": "boolean",

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -18,6 +18,12 @@ export function activate(context: vscode.ExtensionContext) {
 
     const serverOptions: langclient.ServerOptions = sourcekit;
 
+    let synchronizeOptions: langclient.SynchronizeOptions = {
+        configurationSection: [
+            'sourcekit-lsp.indexVisibility'
+        ]
+    }
+
     let clientOptions: langclient.LanguageClientOptions = {
         documentSelector: [
             'swift',
@@ -26,7 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
             'objective-c',
             'objective-cpp'
         ],
-        synchronize: undefined
+        synchronize: synchronizeOptions,
+        initializationOptions: config.get<any>('initializationOptions', {})
     };
 
     const client = new langclient.LanguageClient('sourcekit-lsp', 'SourceKit Language Server', serverOptions, clientOptions);

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -37,8 +37,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(client.start());
 
-    client.onNotification
-
     console.log('SourceKit-LSP is now active!');
 
     client.onReady().then(() => {

--- a/Sources/BuildServerProtocol/BuildTargets.swift
+++ b/Sources/BuildServerProtocol/BuildTargets.swift
@@ -79,14 +79,6 @@ public struct BuildTarget: Codable, Hashable {
   }
 }
 
-public struct BuildTargetIdentifier: Codable, Hashable {
-  public var uri: URI
-
-  public init(uri: URI) {
-    self.uri = uri
-  }
-}
-
 public struct BuildTargetTag: Codable, Hashable, RawRepresentable {
   public var rawValue: String
 
@@ -208,6 +200,11 @@ public struct OutputsItem: Codable, Hashable {
 
   /// The output paths for sources that belong to this build target.
   public var outputPaths: [URI]
+  
+  public init(target: BuildTargetIdentifier, outputPaths: [URI]) {
+    self.target = target
+    self.outputPaths = outputPaths
+  }
 }
 
 /// The build target changed notification is sent from the server to the client

--- a/Sources/SourceKitLSP/SourceKitServer+IndexVisibility.swift
+++ b/Sources/SourceKitLSP/SourceKitServer+IndexVisibility.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import BuildServerProtocol
+
+extension SourceKitServer {
+
+  public func onIndexVisibilityChange(settings: IndexVisibility, workspace: Workspace) {
+    guard workspace.explicitIndexMode else {
+      return
+    }
+    
+    if settings.includeTargetDependencies {
+      collectTransitiveDependencies(
+        targets: settings.targets,
+        workspace: workspace) { targets in
+          self.limitIndexVisibility(targets: targets, workspace: workspace)
+      }
+    } else {
+      self.limitIndexVisibility(targets: settings.targets, workspace: workspace)
+    }
+  }
+  
+  func collectTransitiveDependencies(
+    targets: [BuildTargetIdentifier],
+    workspace: Workspace,
+    callback: @escaping ([BuildTargetIdentifier]) -> Void
+  ) {
+    workspace.buildSystemManager.buildTargets { targetsResponse in
+      guard case let .success(targetGraph) = targetsResponse else {
+        callback([])
+        return
+      }
+      let targetMap = targetGraph.reduce(into: [BuildTargetIdentifier: BuildTarget]()) {
+        $0[$1.id] = $1
+      }
+      var topLevelTargets = targets
+      var transitiveDeps = Set<BuildTargetIdentifier>()
+      while !topLevelTargets.isEmpty {
+        let targetID = topLevelTargets.removeLast()
+        if !transitiveDeps.contains(targetID), let target = targetMap[targetID] {
+          topLevelTargets.append(contentsOf: target.dependencies)
+        }
+        transitiveDeps.insert(targetID)
+      }
+      callback(Array(transitiveDeps))
+    }
+  }
+  
+  func limitIndexVisibility(targets: [BuildTargetIdentifier], workspace: Workspace) {
+    workspace.buildSystemManager.buildTargetOutputPaths(targets: targets) { response in
+      guard let items = response.success else { return }
+      let currentOutputs = self.schemeOutputs
+      let newOutputs = items.reduce(into: Set<URI>()) {
+        $0 = $0.union($1.outputPaths)
+      }
+      self.schemeOutputs = newOutputs
+      let outputsToRemove = currentOutputs.subtracting(newOutputs).compactMap {$0.fileURL?.path}
+      let outputsToAdd = newOutputs.subtracting(currentOutputs).compactMap {$0.fileURL?.path}
+      workspace.index?.removeUnitOutFilePaths(outputsToRemove, waitForProcessing: false)
+      workspace.index?.addUnitOutFilePaths(outputsToAdd, waitForProcessing: false)
+    }
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -565,7 +565,9 @@ extension SourceKitServer {
     switch notification.params.settings {
     case .sourcekitlsp(let settings):
       if let indexVisibility = settings.indexVisibility {
-        onIndexVisibilityChange(settings: indexVisibility, workspace: workspace)
+        queue.async {
+          self.onIndexVisibilityChange(settings: indexVisibility, workspace: workspace)
+        }
       }
     default:
       break

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -41,6 +41,10 @@ public final class Workspace {
 
   /// The source code index, if available.
   public var index: IndexStoreDB? = nil
+  
+  /// Indicate if indexStoreDB supports explicit unit outputs
+  /// TODO: Ideally this state could be exposed by indexStoreDB itself
+  public let explicitIndexMode: Bool
 
   /// Open documents.
   public let documentManager: DocumentManager = DocumentManager()
@@ -55,7 +59,8 @@ public final class Workspace {
     buildSetup: BuildSetup,
     underlyingBuildSystem: BuildSystem?,
     index: IndexStoreDB?,
-    indexDelegate: SourceKitIndexDelegate?)
+    indexDelegate: SourceKitIndexDelegate?,
+    explicitIndexMode: Bool = false)
   {
     self.buildSetup = buildSetup
     self.rootUri = rootUri
@@ -67,6 +72,7 @@ public final class Workspace {
       mainFilesProvider: index)
     indexDelegate?.registerMainFileChanged(bsm)
     self.buildSystemManager = bsm
+    self.explicitIndexMode = explicitIndexMode
   }
 
   /// Creates a workspace for a given root `URL`, inferring the `ExternalWorkspace` if possible.
@@ -114,6 +120,7 @@ public final class Workspace {
           databasePath: dbPath.pathString,
           library: lib,
           delegate: indexDelegate,
+          useExplicitOutputUnits: indexOptions.explicitIndexMode,
           listenToUnitEvents: indexOptions.listenToUnitEvents)
         log("opened IndexStoreDB at \(dbPath) with store path \(storePath)")
       } catch {
@@ -128,7 +135,8 @@ public final class Workspace {
       buildSetup: buildSetup,
       underlyingBuildSystem: buildSystem,
       index: index,
-      indexDelegate: indexDelegate)
+      indexDelegate: indexDelegate,
+      explicitIndexMode: indexOptions.explicitIndexMode)
   }
 }
 
@@ -139,12 +147,14 @@ public struct IndexOptions {
 
   /// Override the index-database-path provided by the build system.
   public var indexDatabasePath: AbsolutePath?
+  
+  public var explicitIndexMode: Bool = false
 
   /// *For Testing* Whether the index should listen to unit events, or wait for
   /// explicit calls to pollForUnitChangesAndWait().
   public var listenToUnitEvents: Bool
 
-  public init(indexStorePath: AbsolutePath? = nil, indexDatabasePath: AbsolutePath? = nil, listenToUnitEvents: Bool = true) {
+  public init(indexStorePath: AbsolutePath? = nil, indexDatabasePath: AbsolutePath? = nil, explicitIndexMode: Bool = false, listenToUnitEvents: Bool = true) {
     self.listenToUnitEvents = listenToUnitEvents
   }
 }

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -149,6 +149,37 @@ final class CodingTests: XCTestCase {
         "compilationDatabasePath" : "foo"
       }
       """)
+    
+    let targetUrl = URL(string: "target://path/to:target")!
+    let targetUri = DocumentURI(targetUrl)
+    checkDecoding(
+      json: """
+      {
+        "sourcekit-lsp" : {
+          "indexVisibility" : {
+            "targets": [
+              {"uri": "target:\\/\\/path\\/to:target"}
+            ],
+            "includeTargetDependencies": true
+          }
+        }
+      }
+      """, expected: WorkspaceSettingsChange.sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility:IndexVisibility(targets: [BuildTargetIdentifier(uri: targetUri)], includeTargetDependencies: true)))
+    )
+    
+    // Targets can be empty
+    checkDecoding(
+      json: """
+      {
+        "sourcekit-lsp" : {
+          "indexVisibility" : {
+            "targets": [],
+            "includeTargetDependencies": true
+          }
+        }
+      }
+      """, expected: WorkspaceSettingsChange.sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility:IndexVisibility(targets: [], includeTargetDependencies: true)))
+    )
 
     // FIXME: should probably be "unknown"; see comment in WorkspaceSettingsChange decoder.
     checkDecoding(json: """

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -152,33 +152,38 @@ final class CodingTests: XCTestCase {
     
     let targetUrl = URL(string: "target://path/to:target")!
     let targetUri = DocumentURI(targetUrl)
-    checkDecoding(
+    checkCoding(
+      WorkspaceSettingsChange.sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility:IndexVisibility(targets: [BuildTargetIdentifier(uri: targetUri)], includeTargetDependencies: true))),
       json: """
       {
         "sourcekit-lsp" : {
           "indexVisibility" : {
-            "targets": [
-              {"uri": "target:\\/\\/path\\/to:target"}
-            ],
-            "includeTargetDependencies": true
+            "includeTargetDependencies" : true,
+            "targets" : [
+              {
+                "uri" : "target:\\/\\/path\\/to:target"
+              }
+            ]
           }
         }
       }
-      """, expected: WorkspaceSettingsChange.sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility:IndexVisibility(targets: [BuildTargetIdentifier(uri: targetUri)], includeTargetDependencies: true)))
-    )
+      """)
     
     // Targets can be empty
-    checkDecoding(
+    checkCoding(
+      WorkspaceSettingsChange.sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility:IndexVisibility(targets: [], includeTargetDependencies: true))),
       json: """
       {
         "sourcekit-lsp" : {
           "indexVisibility" : {
-            "targets": [],
-            "includeTargetDependencies": true
+            "includeTargetDependencies" : true,
+            "targets" : [
+
+            ]
           }
         }
       }
-      """, expected: WorkspaceSettingsChange.sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility:IndexVisibility(targets: [], includeTargetDependencies: true)))
+      """
     )
 
     // FIXME: should probably be "unknown"; see comment in WorkspaceSettingsChange decoder.

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -36,6 +36,12 @@ final class TestBuildSystem: BuildSystem {
   /// Files currently being watched by our delegate.
   var watchedFiles: Set<DocumentURI> = []
 
+  /// Mock response for `BuildTargets` request
+  var targets: [BuildTarget] = []
+
+  /// Mock response for `BuildTargetOutputPaths` request
+  var targetOutputs: (([BuildTargetIdentifier]) -> [OutputsItem])? = nil
+
   func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     watchedFiles.insert(uri)
 
@@ -55,7 +61,7 @@ final class TestBuildSystem: BuildSystem {
   }
 
   func buildTargets(reply: @escaping (LSPResult<[BuildTarget]>) -> Void) {
-    reply(.failure(buildTargetsNotSupported))
+    reply(.success(targets))
   }
 
   func buildTargetSources(targets: [BuildTargetIdentifier], reply: @escaping (LSPResult<[SourcesItem]>) -> Void) {
@@ -63,7 +69,11 @@ final class TestBuildSystem: BuildSystem {
   }
 
   func buildTargetOutputPaths(targets: [BuildTargetIdentifier], reply: @escaping (LSPResult<[OutputsItem]>) -> Void) {
-    reply(.failure(buildTargetsNotSupported))
+    if let targetOutputs = targetOutputs {
+      reply(.success(targetOutputs(targets)))
+    } else {
+      reply(.failure(buildTargetsNotSupported))
+    }
   }
 }
 

--- a/Tests/SourceKitLSPTests/TargetVisibilityChangeTests.swift
+++ b/Tests/SourceKitLSPTests/TargetVisibilityChangeTests.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import BuildServerProtocol
+import LanguageServerProtocol
+import LSPTestSupport
+import SKCore
+import SKTestSupport
+import SourceKitLSP
+import TSCBasic
+import XCTest
+
+final class IndexVisibilityChangeTests: XCTestCase {
+
+  /// Connection and lifetime management for the service.
+  var testServer: TestSourceKitServer! = nil
+
+  /// The primary interface to make requests to the SourceKitServer.
+  var sk: TestClient! = nil
+
+  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
+  var workspace: Workspace! = nil
+
+  /// The build system that we use to verify SourceKitServer behavior.
+  var buildSystem: TestBuildSystem! = nil
+
+  override func setUp() {
+    testServer = TestSourceKitServer()
+    buildSystem = TestBuildSystem()
+
+    let server = testServer.server!
+    workspace = Workspace(
+      rootUri: nil,
+      clientCapabilities: ClientCapabilities(),
+      toolchainRegistry: ToolchainRegistry.shared,
+      buildSetup: TestSourceKitServer.serverOptions.buildSetup,
+      underlyingBuildSystem: buildSystem,
+      index: nil,
+      indexDelegate: nil,
+      explicitIndexMode: true)
+
+    server.workspace = workspace
+    workspace.buildSystemManager.delegate = server
+
+    sk = testServer.client
+    _ = try! sk.sendSync(InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+        trace: .off,
+        workspaceFolders: nil))
+  }
+
+  override func tearDown() {
+    buildSystem = nil
+    workspace = nil
+    sk = nil
+    testServer = nil
+  }
+
+  func testSchemeChanged() {
+    let targetGraph = mockBuildTargetGraph(targetStringRepr: [
+         "target://a:a": [],
+         "target://b:b": ["target://a:a"],
+         "target://c:c": ["target://b:b"],
+         "target://d:d": [],
+       ])
+
+    buildSystem.targets = targetGraph
+
+    let targetOutputResponse: (([BuildTargetIdentifier]) -> [OutputsItem]) = { (targets: [BuildTargetIdentifier]) in
+      return targets.compactMap { (targetIdentifier: BuildTargetIdentifier) in
+        let outputFile = URI(string: "file:///" + targetIdentifier.uri.stringValue.split(separator: ":").last! + ".swift")
+        return OutputsItem(target: targetIdentifier, outputPaths: [outputFile])
+      }
+    }
+    buildSystem.targetOutputs = targetOutputResponse
+
+    sk.allowUnexpectedNotification = false
+
+    let targetURI = DocumentURI(string: "target://c:c")
+    let newSettings = IndexVisibility(targets: [BuildTargetIdentifier(uri: targetURI)], includeTargetDependencies: true)
+    let schemeChange: WorkspaceSettingsChange = .sourcekitlsp(SourceKitLSPWorkspaceSettings(indexVisibility: newSettings))
+
+    sk.send(DidChangeConfigurationNotification(settings: schemeChange))
+
+    // Unfortunately there's no callback for scheme change notification from sourcekit server, waiting here for the result
+    let expectation = self.expectation(description: "Waiting for scheme change notification handling")
+    let result = XCTWaiter.wait(for: [expectation], timeout: 1)
+    if result == .timedOut {
+      XCTAssertEqual(testServer.server?.schemeOutputs, Set([
+        URI(string: "file:///a.swift"),
+        URI(string: "file:///b.swift"),
+        URI(string: "file:///c.swift"),
+      ]))
+    } else {
+      fatalError("Interrupted while waiting for scheme change notification")
+    }
+  }
+
+  private func mockBuildTargetGraph(targetStringRepr: [String: [String]]) -> [BuildTarget] {
+    return targetStringRepr.reduce(into: [BuildTarget]()) {
+      $0.append(mockBuildTarget(targetID: $1.key, depsID: $1.value))
+    }
+  }
+
+  private func mockBuildTarget(targetID: String, depsID: [String]) -> BuildTarget {
+    return BuildTarget(
+      id: BuildTargetIdentifier(uri: DocumentURI(string: targetID)),
+      displayName: nil,
+      baseDirectory: nil,
+      tags: [],
+      capabilities: BuildTargetCapabilities(canCompile: false, canTest: false, canRun: false),
+      languageIds: [],
+      dependencies: depsID.map {BuildTargetIdentifier(uri: DocumentURI(string: $0))}
+    )
+  }
+}


### PR DESCRIPTION
Add scheme change event type to `DidChangeConfigurationNotification` and `-explicit-index-loading` option to the server launch args.
- Server launched with `-explicit-index-loading` option can now handle scheme change event, by launching IndexStoreDB under explicit mode
- Upon scheme change notification, language server will query target graph from build server with `workspace/buildTargets` protocol, find all transitive dependency targets, then query all outputs with `buildTarget/outputPath` protocol
- Added scheme configuration for vscode extension