### PR TITLE
add note about swift file recognition to vim-lsp section

### DIFF
--- a/Editors/README.md
+++ b/Editors/README.md
@@ -106,7 +106,7 @@ if executable('sourcekit-lsp')
 endif
 ```
 
-
+In order for vim to recognize Swift files, you will need to have a Swift plugin like [swift.vim](https://github.com/keith/swift.vim) installed. Otherwise, `:LspStatus` will show that sourcekit-lsp is not running even if a Swift file is open.
 
 That's it! As a test, open a swift file, put cursor on top of a symbol in normal mode and
 run `:LspDefinition`. More commands are documented [here](https://github.com/prabirshrestha/vim-lsp#supported-commands).

--- a/Editors/README.md
+++ b/Editors/README.md
@@ -96,7 +96,7 @@ All methods below assume `sourcekit-lsp` is in your `PATH`. If it's not then rep
 
 Install [vim-lsp](https://github.com/prabirshrestha/vim-lsp). In your `.vimrc`, configure vim-lsp to use sourcekit-lsp for Swift source files like so:
 
-```
+```viml
 if executable('sourcekit-lsp')
     au User lsp_setup call lsp#register_server({
         \ 'name': 'sourcekit-lsp',
@@ -106,14 +106,22 @@ if executable('sourcekit-lsp')
 endif
 ```
 
-In order for vim to recognize Swift files, you will need to have a Swift plugin like [swift.vim](https://github.com/keith/swift.vim) installed. Otherwise, `:LspStatus` will show that sourcekit-lsp is not running even if a Swift file is open.
+In order for vim to recognize Swift files, you need to configure the filetype. Otherwise, `:LspStatus` will show that sourcekit-lsp is not running even if a Swift file is open.
+
+If you are already using a Swift plugin for vim, like [swift.vim](https://github.com/keith/swift.vim), this may be setup already. Otherwise, you can set the filetype manually:
+
+```viml
+augroup filetype
+  au! BufRead,BufNewFile *.swift set ft=swift
+augroup END
+```
 
 That's it! As a test, open a swift file, put cursor on top of a symbol in normal mode and
 run `:LspDefinition`. More commands are documented [here](https://github.com/prabirshrestha/vim-lsp#supported-commands).
 
 There are many Vim solutions for code completion. For instance, you may want to use LSP for omnifunc:
 
-```
+```viml
 autocmd FileType swift setlocal omnifunc=lsp#complete
 ```
 


### PR DESCRIPTION
I'm not sure whether this is the best way to get sourcekit-lsp working with `vim-lsp`, but it was required for me. Without something like `swift.vim` installed, `vim-lsp` did not recognize `.swift` files as "swift" files. 

If there's some simpler way to tell vim that `*.swift` files are "swift" files (I guess that `swift.vim` must be doing this somewhere internally) then that might be a better suggestion to offer in addition to pointing to `swift.vim`. 