### PR TITLE
[SKSwiftPMWorkspace] Set swiftpm config file when creating Workspace

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -20,6 +20,7 @@ import LSPLogging
 import PackageGraph
 import PackageLoading
 import PackageModel
+import SourceControl
 import SKCore
 import SKSupport
 import Workspace
@@ -92,6 +93,7 @@ public final class SwiftPMWorkspace {
       pinsFile: packageRoot.appending(component: "Package.resolved"),
       manifestLoader: ManifestLoader(manifestResources: toolchain.manifestResources, cacheDir: buildPath),
       delegate: BuildSettingProviderWorkspaceDelegate(),
+      config: SwiftPMConfig(path: packageRoot.appending(components: ".swiftpm", "config"), fs: fileSystem),
       fileSystem: fileSystem,
       skipUpdate: true)
 


### PR DESCRIPTION
This is quite important to set otherwise SourceKit-LSP sets off a wrong
package resolution operation potentially resulting in a wrong swiftpm
package graph.

Ideally, SwiftPM should have APIs that don't force clients to handle all
this configuration but we don't have that today.