### PR TITLE
[logging] Avoid logging cancellation as warnings/errors

### DIFF
--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -45,7 +45,7 @@ struct CursorInfo {
 }
 
 /// An error from a cursor info request.
-enum CursorInfoError: Error {
+enum CursorInfoError: Error, Equatable {
 
   /// The given URL is not a known document.
   case unknownDocument(DocumentURI)

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -414,7 +414,7 @@ extension SwiftLanguageServer {
     let position = req.params.position
     cursorInfo(uri, position..<position) { result in
       guard let cursorInfo: CursorInfo = result.success ?? nil else {
-        if let error = result.failure {
+        if let error = result.failure, error != .responseError(.cancelled) {
           log("cursor info failed \(uri):\(position): \(error)", level: .warning)
         }
         return req.reply(nil)


### PR DESCRIPTION
Cancellation shows up as an error code, but it is not a real error, so
don't log it like one.

https://bugs.swift.org/browse/SR-13344