### PR TITLE
[gardening] Fix warning about strerror return value

### DIFF
--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -120,10 +120,10 @@ do {
 // will not break our connection stream.
 let realStdout = dup(STDOUT_FILENO)
 if realStdout == -1 {
-  fatalError("failed to dup stdout:  \(strerror(errno))")
+  fatalError("failed to dup stdout: \(strerror(errno)!)")
 }
 if dup2(STDERR_FILENO, STDOUT_FILENO) == -1 {
-  fatalError("failed to redirect stdout -> stderr: \(strerror(errno))")
+  fatalError("failed to redirect stdout -> stderr: \(strerror(errno)!)")
 }
 
 let clientConnection = JSONRPCConnection(


### PR DESCRIPTION
strerror should never return nil, and in the worst case it's already in
a fatalError. Fix the warning about converting an optional value to a
string.