### PR TITLE
Fix `#file` warning when building with Swift 5.3

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -42,7 +42,7 @@ public func logAsync(level: LogLevel = .default, messageProducer: @escaping (_ c
 /// If `level >= Logger.shared.currentLevel`, it will be emitted. However, the converse is not necessarily true: on platforms that provide `os_log`, the message may be emitted by `os_log` according to its own rules about log level.
 ///
 /// - parameter message: The message to print.
-public func logAssertionFailure(_ message: String, file: StaticString = #file, line: UInt = #line) {
+public func logAssertionFailure(_ message: String, file: StaticString = fullFilePath(), line: UInt = #line) {
   Logger.shared.log(message, level: .error)
   assertionFailure(message, file: file, line: line)
 }
@@ -209,3 +209,19 @@ public class AnyLogHandler: LogHandler {
     handler(message, level)
   }
 }
+
+#if compiler(>=5.3)
+public func fullFilePath(_ filePath: StaticString = #filePath) -> StaticString {
+    return filePath
+}
+public func fullFilePath(_ filePath: String = #filePath) -> String {
+    return filePath
+}
+#else
+public func fullFilePath(_ filePath: StaticString = #file) -> StaticString {
+    return filePath
+}
+public func fullFilePath(_ filePath: String = #file) -> String {
+    return filePath
+}
+#endif

--- a/Sources/LSPTestSupport/CheckCoding.swift
+++ b/Sources/LSPTestSupport/CheckCoding.swift
@@ -11,13 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import LSPLogging
 import XCTest
 
 /// Checks the encoding of the given value against the given json string and verifies that decoding the json reproduces the original value (according to its equatable conformance).
 ///
 /// - parameter value: The value to encode/decode.
 /// - parameter json: The expected json encoding.
-public func checkCoding<T>(_ value: T, json: String, file: StaticString = #file, line: UInt = #line) where T: Codable & Equatable {
+public func checkCoding<T>(_ value: T, json: String, file: StaticString = fullFilePath(), line: UInt = #line) where T: Codable & Equatable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
   if #available(macOS 10.13, *) {
@@ -57,7 +58,7 @@ private struct WrapFragment<T>: Equatable, Codable where T: Equatable & Codable 
 ///
 /// - parameter value: The value to encode/decode.
 /// - parameter json: The expected json encoding.
-public func checkDecoding<T>(json: String, expected value: T, file: StaticString = #file, line: UInt = #line) where T: Codable & Equatable {
+public func checkDecoding<T>(json: String, expected value: T, file: StaticString = fullFilePath(), line: UInt = #line) where T: Codable & Equatable {
 
   let wrappedStr = "{\"value\":\(json)}"
   let data = wrappedStr.data(using: .utf8)!
@@ -67,7 +68,7 @@ public func checkDecoding<T>(json: String, expected value: T, file: StaticString
   XCTAssertEqual(value, decodedValue, file: file, line: line)
 }
 
-public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = #file, line: UInt = #line, body: (T) -> Void) where T: Codable {
+public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = fullFilePath(), line: UInt = #line, body: (T) -> Void) where T: Codable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
   if #available(macOS 10.13, *) {

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -10,18 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
-import SKSwiftPMWorkspace
-import LanguageServerProtocol
-import SKCore
+import Foundation
 import IndexStoreDB
-import ISDBTibs
 import ISDBTestSupport
+import ISDBTibs
+import LanguageServerProtocol
+import LSPLogging
+import LSPTestSupport
+import SKCore
+import SKSwiftPMWorkspace
+import SourceKitLSP
 import TSCBasic
 import TSCUtility
 import XCTest
-import Foundation
-import LSPTestSupport
 
 public final class SKSwiftPMTestWorkspace {
 
@@ -137,7 +138,7 @@ extension SKSwiftPMTestWorkspace {
 
 extension XCTestCase {
 
-  public func staticSourceKitSwiftPMWorkspace(name: String, testFile: String = #file) throws -> SKSwiftPMTestWorkspace? {
+  public func staticSourceKitSwiftPMWorkspace(name: String, testFile: String = fullFilePath()) throws -> SKSwiftPMTestWorkspace? {
     let testDirName = testDirectoryName
     let toolchain = ToolchainRegistry.shared.default!
     let workspace = try SKSwiftPMTestWorkspace(

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -10,17 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
-import LanguageServerProtocol
-import SKCore
+import Foundation
 import IndexStoreDB
-import ISDBTibs
 import ISDBTestSupport
+import ISDBTibs
+import LanguageServerProtocol
+import LSPLogging
+import LSPTestSupport
+import SKCore
+import SourceKitLSP
 import TSCBasic
 import TSCUtility
 import XCTest
-import Foundation
-import LSPTestSupport
 
 public typealias URL = Foundation.URL
 
@@ -114,7 +115,7 @@ extension XCTestCase {
     clientCapabilities: ClientCapabilities = .init(),
     tmpDir: URL? = nil,
     removeTmpDir: Bool = true,
-    testFile: String = #file
+    testFile: String = fullFilePath()
   ) throws -> SKTibsTestWorkspace? {
     let testDirName = testDirectoryName
     let workspace = try SKTibsTestWorkspace(
@@ -145,7 +146,7 @@ extension XCTestCase {
     name: String,
     clientCapabilities: ClientCapabilities = .init(),
     tmpDir: URL? = nil,
-    testFile: String = #file
+    testFile: String = fullFilePath()
   ) throws -> SKTibsTestWorkspace? {
     let testDirName = testDirectoryName
     let workspace = try SKTibsTestWorkspace(

--- a/Tests/LSPLoggingTests/SupportTests.swift
+++ b/Tests/LSPLoggingTests/SupportTests.swift
@@ -23,7 +23,7 @@ final class SupportTests: XCTestCase {
       messages.append((message, level))
     }
 
-    func check(expected: [(String, LogLevel)], file: StaticString = #file, line: UInt = #line) {
+    func check(expected: [(String, LogLevel)], file: StaticString = fullFilePath(), line: UInt = #line) {
       testLogger.flush()
       XCTAssert(messages.count == expected.count, "\(messages) does not match expected \(expected)", file: file, line: line)
       XCTAssert(zip(messages, expected).allSatisfy({ $0.0 == $0.1 }), "\(messages) does not match expected \(expected)", file: file, line: line)

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -12,6 +12,7 @@
 
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
+import LSPLogging
 import LSPTestSupport
 import XCTest
 
@@ -209,7 +210,7 @@ final class CodingTests: XCTestCase {
 
 let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspProtocol]
 
-private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Request: RequestType & Equatable {
+private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = fullFilePath(), line: UInt = #line) where Request: RequestType & Equatable {
   checkCoding(JSONRPCMessage.request(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Request else {
@@ -222,7 +223,7 @@ private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: 
   }
 }
 
-private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = #file, line: UInt = #line) where Notification: NotificationType & Equatable {
+private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = fullFilePath(), line: UInt = #line) where Notification: NotificationType & Equatable {
   checkCoding(JSONRPCMessage.notification(value), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.notification(let decodedValueOpaque) = $0, let decodedValue = decodedValueOpaque as? Notification else {
@@ -234,7 +235,7 @@ private func checkMessageCoding<Notification>(_ value: Notification, json: Strin
   }
 }
 
-private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Response: ResponseType & Equatable {
+private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json: String, file: StaticString = fullFilePath(), line: UInt = #line) where Response: ResponseType & Equatable {
 
   let callback: JSONRPCMessage.ResponseTypeCallback = {
     return $0 == .string("unknown") ? nil : Response.self
@@ -255,7 +256,7 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
   }
 }
 
-private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) {
+private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = fullFilePath(), line: UInt = #line) {
   checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.errorResponse(let decodedValue, let decodedID) = $0 else {
@@ -268,7 +269,7 @@ private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: Str
   }
 }
 
-private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo, file: StaticString = #file, line: UInt = #line) {
+private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo, file: StaticString = fullFilePath(), line: UInt = #line) {
   let data = json.data(using: .utf8)!
   let decoder = JSONDecoder()
   decoder.userInfo = userInfo

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -12,12 +12,13 @@
 
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
+import LSPLogging
 import XCTest
 
 final class MessageParsingTests: XCTestCase {
 
   func testSplitMessage() {
-    func check(_ string: String, contentLen: Int? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, contentLen: Int? = nil, restLen: Int?, file: StaticString = fullFilePath(), line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let ((content, header), rest) = try! bytes.jsonrpcSplitMessage() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -28,7 +29,7 @@ final class MessageParsingTests: XCTestCase {
       XCTAssertEqual(header.contentLength, contentLen, file: file, line: line)
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = fullFilePath(), line: UInt = #line) {
       do {
         _ = try [UInt8](string.utf8).jsonrpcSplitMessage()
         XCTFail("missing expected error", file: file, line: line)
@@ -53,7 +54,7 @@ final class MessageParsingTests: XCTestCase {
   }
 
   func testParseHeader() {
-    func check(_ string: String, header expected: JSONRPCMessageHeader? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, header expected: JSONRPCMessageHeader? = nil, restLen: Int?, file: StaticString = fullFilePath(), line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let (header, rest) = try! bytes.jsonrcpParseHeader() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -63,7 +64,7 @@ final class MessageParsingTests: XCTestCase {
       XCTAssertEqual(header, expected, file: file, line: line)
     }
 
-    func checkErrorBytes(_ bytes: [UInt8], _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkErrorBytes(_ bytes: [UInt8], _ expected: MessageDecodingError, file: StaticString = fullFilePath(), line: UInt = #line) {
       do {
         _ = try bytes.jsonrcpParseHeader()
         XCTFail("missing expected error", file: file, line: line)
@@ -74,7 +75,7 @@ final class MessageParsingTests: XCTestCase {
       }
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = fullFilePath(), line: UInt = #line) {
       checkErrorBytes([UInt8](string.utf8), expected, file: file, line: line)
     }
 
@@ -95,7 +96,7 @@ final class MessageParsingTests: XCTestCase {
   }
 
   func testParseHeaderField() {
-    func check(_ string: String, keyLen: Int? = nil, valueLen: Int? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, keyLen: Int? = nil, valueLen: Int? = nil, restLen: Int?, file: StaticString = fullFilePath(), line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let (kv, rest) = try! bytes.jsonrpcParseHeaderField() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -112,7 +113,7 @@ final class MessageParsingTests: XCTestCase {
       }
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = fullFilePath(), line: UInt = #line) {
       do {
         _ = try [UInt8](string.utf8).jsonrpcParseHeaderField()
         XCTFail("missing expected error", file: file, line: line)

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import LSPLogging
 import LSPTestSupport
 import SKCore
 import TSCBasic
@@ -18,7 +19,7 @@ import XCTest
 
 final class CompilationDatabaseTests: XCTestCase {
   func testSplitShellEscapedCommand() {
-    func check(_ str: String, _ expected: [String], file: StaticString=#file, line: UInt=#line) {
+    func check(_ str: String, _ expected: [String], file: StaticString = fullFilePath(), line: UInt = #line) {
       XCTAssertEqual(splitShellEscapedCommand(str), expected, file: file, line: line)
     }
 
@@ -61,7 +62,7 @@ final class CompilationDatabaseTests: XCTestCase {
   func testEncodeCompDBCommand() {
     // Requires JSONEncoder.OutputFormatting.sortedKeys
     if #available(macOS 10.13, *) {
-      func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+      func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = fullFilePath(), line: UInt = #line) {
         let encoder = JSONEncoder()
         encoder.outputFormatting.insert(.sortedKeys)
         let encodedString = try! String(data: encoder.encode(cmd), encoding: .utf8)
@@ -78,7 +79,7 @@ final class CompilationDatabaseTests: XCTestCase {
   }
 
   func testDecodeCompDBCommand() {
-    func check(_ str: String, _ expected: CompilationDatabase.Command, file: StaticString = #file, line: UInt = #line) {
+    func check(_ str: String, _ expected: CompilationDatabase.Command, file: StaticString = fullFilePath(), line: UInt = #line) {
       let cmd = try! JSONDecoder().decode(CompilationDatabase.Command.self, from: str.data(using: .utf8)!)
       XCTAssertEqual(cmd, expected, file: file, line: line)
     }
@@ -305,7 +306,7 @@ final class CompilationDatabaseTests: XCTestCase {
   }
 }
 
-private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, file: StaticString = #file, line: UInt = #line, block: (CompilationDatabaseBuildSystem) -> ()) {
+private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, file: StaticString = fullFilePath(), line: UInt = #line, block: (CompilationDatabaseBuildSystem) -> ()) {
   let fs = InMemoryFileSystem()
   XCTAssertNoThrow(try fs.createDirectory(AbsolutePath("/a")), file: file, line: line)
   XCTAssertNoThrow(try fs.writeFileContents(AbsolutePath("/a/compile_commands.json"), bytes: compdb), file: file, line: line)

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -10,18 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPLogging
 import SKSupport
 import TSCBasic
 import XCTest
 
 final class SupportTests: XCTestCase {
 
-  func checkLines(_ string: String, _ expected: [String], file: StaticString = #file, line: UInt = #line) {
+  func checkLines(_ string: String, _ expected: [String], file: StaticString = fullFilePath(), line: UInt = #line) {
     let table = LineTable(string)
     XCTAssertEqual(table.map { String($0) }, expected, file: file, line: line)
   }
 
-  func checkOffsets(_ string: String, _ expected: [Int], file: StaticString = #file, line: UInt = #line) {
+  func checkOffsets(_ string: String, _ expected: [Int], file: StaticString = fullFilePath(), line: UInt = #line) {
     let table = LineTable(string)
     XCTAssertEqual(table.map { string.utf8.distance(from: string.startIndex, to: $0.startIndex) }, expected, file: file, line: line)
   }
@@ -68,7 +69,7 @@ final class SupportTests: XCTestCase {
     XCTAssertEqual(LineTable("\n")[1], "")
   }
 
-  func checkLineAndColumns(_ table: LineTable, _ utf8Offset: Int, _ expected: (line: Int, utf16Column: Int)?, file: StaticString = #file, line: UInt = #line) {
+  func checkLineAndColumns(_ table: LineTable, _ utf8Offset: Int, _ expected: (line: Int, utf16Column: Int)?, file: StaticString = fullFilePath(), line: UInt = #line) {
     switch (table.lineAndUTF16ColumnOf(utf8Offset: utf8Offset), expected) {
     case (nil, nil):
       break
@@ -79,11 +80,11 @@ final class SupportTests: XCTestCase {
     }
   }
 
-  func checkUTF8OffsetOf(_ table: LineTable, _ query: (line: Int, utf16Column: Int), _ expected: Int?, file: StaticString = #file, line: UInt = #line) {
+  func checkUTF8OffsetOf(_ table: LineTable, _ query: (line: Int, utf16Column: Int), _ expected: Int?, file: StaticString = fullFilePath(), line: UInt = #line) {
     XCTAssertEqual(table.utf8OffsetOf(line: query.line, utf16Column: query.utf16Column), expected, file: file, line: line)
   }
 
-  func checkUTF16ColumnAt(_ table: LineTable, _ query: (line: Int, utf8Column: Int), _ expected: Int?, file: StaticString = #file, line: UInt = #line) {
+  func checkUTF16ColumnAt(_ table: LineTable, _ query: (line: Int, utf8Column: Int), _ expected: Int?, file: StaticString = fullFilePath(), line: UInt = #line) {
     XCTAssertEqual(table.utf16ColumnAt(line: query.line, utf8Column: query.utf8Column), expected, file: file, line: line)
   }
 

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -15,6 +15,7 @@ import SPMBuildCore
 #endif
 import Build
 import LanguageServerProtocol
+import LSPLogging
 import SKCore
 import SKSwiftPMWorkspace
 import SKTestSupport
@@ -512,7 +513,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 private func checkNot(
   _ pattern: String...,
   arguments: [String],
-  file: StaticString = #file,
+  file: StaticString = fullFilePath(),
   line: UInt = #line)
 {
   if let index = arguments.firstIndex(of: pattern) {
@@ -526,7 +527,7 @@ private func checkNot(
 private func check(
   _ pattern: String...,
   arguments: [String],
-  file: StaticString = #file,
+  file: StaticString = fullFilePath(),
   line: UInt = #line)
 {
   guard let index = arguments.firstIndex(of: pattern) else {


### PR DESCRIPTION
Since `#file` is deprecated, using it with Swift 5.3 causes a warning. There's a workaround that delegates to either `#file` or `#filePath` depending on the current compiler version. The workaround is copied from https://github.com/apple/swift-nio/pull/1526. 

Let me know if you think just using `#filePath` everywhere and bumping the requirement to Swift 5.3 in `Package.swift` is a better option. I'm not sure if Swift 5.3 is used on CI for this repository though for that option to work well right now.