### PR TITLE
Adopt swift-argument-parser for argument parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(TSC QUIET)
 find_package(IndexStoreDB QUIET)
 find_package(SwiftPM QUIET)
 find_package(LLBuild QUIET)
+find_package(ArgumentParser CONFIG REQUIRED)
 
 include(SwiftSupport)
 

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
       .target(
         name: "sourcekit-lsp",
         dependencies: [
+          "ArgumentParser",
           "LanguageServerProtocolJSONRPC",
           "SourceKitLSP",
           "SwiftToolsSupport-auto",
@@ -231,11 +232,13 @@ if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
     .package(url: "https://github.com/apple/indexstore-db.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.0")),
   ]
 } else {
   package.dependencies += [
     .package(path: "../indexstore-db"),
     .package(path: "../swiftpm"),
     .package(path: "../swiftpm/swift-tools-support-core"),
+    .package(path: "../swift-argument-parser")
   ]
 }

--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -115,10 +115,13 @@ public final class Logger {
     }
   }
 
-  public func setLogLevel(environmentVariable: String) {
+  public func setLogLevel(environmentVariable: String) -> Bool {
     if let string = ProcessInfo.processInfo.environment[environmentVariable] {
       setLogLevel(string)
+      return true
     }
+
+    return false
   }
 
   public func setLogLevel(_ logLevel: String) {

--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -115,13 +115,10 @@ public final class Logger {
     }
   }
 
-  public func setLogLevel(environmentVariable: String) -> Bool {
+  public func setLogLevel(environmentVariable: String) {
     if let string = ProcessInfo.processInfo.environment[environmentVariable] {
       setLogLevel(string)
-      return true
     }
-
-    return false
   }
 
   public func setLogLevel(_ logLevel: String) {

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 add_executable(sourcekit-lsp
   main.swift)
 target_link_libraries(sourcekit-lsp PRIVATE
+  ArgumentParser
   LanguageServerProtocolJSONRPC
   SourceKitLSP
   TSCUtility)

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -22,13 +22,6 @@ import SKSupport
 import SourceKitLSP
 import TSCBasic
 import TSCLibc
-import TSCUtility
-
-extension LogLevel: ArgumentKind {
-  public static var completion: ShellCompletion {
-    return ShellCompletion.none
-  }
-}
 
 extension AbsolutePath: ExpressibleByArgument {
   public init?(argument: String) {

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
+import Csourcekitd // Not needed here, but fixes debugging...
 import Dispatch
 import Foundation
 import LanguageServerProtocol
@@ -18,7 +20,6 @@ import LSPLogging
 import SKCore
 import SKSupport
 import SourceKitLSP
-import Csourcekitd // Not needed here, but fixes debugging...
 import TSCBasic
 import TSCLibc
 import TSCUtility
@@ -29,123 +30,174 @@ extension LogLevel: ArgumentKind {
   }
 }
 
+extension AbsolutePath: ExpressibleByArgument {
+  public init?(argument: String) {
+    if let cwd = localFileSystem.currentWorkingDirectory {
+      self.init(argument, relativeTo: cwd)
+    } else {
+      guard let path = try? AbsolutePath(validating: argument) else {
+        return nil
+      }
+      self = path
+    }
+  }
+
+  public static var defaultCompletionKind: CompletionKind {
+    // This type is most commonly used to select a directory, not a file.
+    // Specify '.file()' in an argument declaration when necessary.
+    .directory
+  }
+}
+
 struct CommandLineOptions {
   /// Options for the server.
   var serverOptions: SourceKitServer.Options = SourceKitServer.Options()
 
-  /// Whether to wait for a response before handling the next request.
   var syncRequests: Bool = false
 }
 
-func parseArguments() throws -> CommandLineOptions {
-  let arguments = Array(ProcessInfo.processInfo.arguments.dropFirst())
-  let parser = ArgumentParser(usage: "[options]", overview: "Language Server Protocol implementation for Swift and C-based languages")
-  let loggingOption = parser.add(option: "--log-level", kind: LogLevel.self, usage: "Set the logging level (debug|info|warning|error) [default: \(LogLevel.default)]")
-  let syncOption = parser.add(option: "--sync", kind: Bool.self) // For testing.
-  let buildConfigurationOption = parser.add(option: "--configuration", shortName: "-c", kind: BuildConfiguration.self, usage: "Build with configuration (debug|release) [default: debug]")
-  let buildPathOption = parser.add(option: "--build-path", kind: PathArgument.self, usage: "Specify build/cache directory")
-  let buildFlagsCc = parser.add(option: "-Xcc", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all C compiler invocations")
-  let buildFlagsCxx = parser.add(option: "-Xcxx", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all C++ compiler invocations")
-  let buildFlagsLinker = parser.add(option: "-Xlinker", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all linker invocations")
-  let buildFlagsSwift = parser.add(option: "-Xswiftc", kind: [String].self, strategy: .oneByOne, usage: "Pass flag through to all Swift compiler invocations")
-  let clangdOptions = parser.add(option: "-Xclangd", kind: [String].self, strategy: .oneByOne, usage: "Pass options to clangd command-line")
-  let indexStorePath = parser.add(option: "-index-store-path", kind: PathArgument.self, usage: "Override index-store-path from the build system")
-  let indexDatabasePath = parser.add(option: "-index-db-path", kind: PathArgument.self, usage: "Override index-database-path from the build system")
-  let completionServerSideFiltering = parser.add(option: "-completion-server-side-filtering", kind: Bool.self, usage: "Whether to enable server-side filtering in code-completion")
-  let completionMaxResults = parser.add(option: "-completion-max-results", kind: Int.self, usage: "When server-side filtering is enabled, the maximum number of results to return")
+extension LogLevel: ExpressibleByArgument {}
+extension BuildConfiguration: ExpressibleByArgument {}
 
-  let parsedArguments = try parser.parse(arguments)
+struct Main: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    abstract: "Language Server Protocol implementation for Swift and C-based languages"
+  )
 
-  var result = CommandLineOptions()
+  /// Whether to wait for a response before handling the next request.
+  /// Used for testing.
+  @Flag(name: .customLong("sync"))
+  var syncRequests = false
 
-  if let config = parsedArguments.get(buildConfigurationOption) {
-    result.serverOptions.buildSetup.configuration = config
-  }
-  if let buildPath = parsedArguments.get(buildPathOption)?.path {
-    result.serverOptions.buildSetup.path = buildPath
-  }
-  if let flags = parsedArguments.get(buildFlagsCc) {
-    result.serverOptions.buildSetup.flags.cCompilerFlags = flags
-  }
-  if let flags = parsedArguments.get(buildFlagsCxx) {
-    result.serverOptions.buildSetup.flags.cxxCompilerFlags = flags
-  }
-  if let flags = parsedArguments.get(buildFlagsLinker) {
-    result.serverOptions.buildSetup.flags.linkerFlags = flags
-  }
-  if let flags = parsedArguments.get(buildFlagsSwift) {
-    result.serverOptions.buildSetup.flags.swiftCompilerFlags = flags
+  @Option(help: "Set the logging level (debug|info|warning|error)")
+  var logLevel: LogLevel = LogLevel.default
+
+  @Option(
+    name: [.customLong("configuration"), .customShort("c")],
+    help: "Build with configuration (debug|release)"
+  )
+  var buildConfiguration = BuildConfiguration.debug
+
+  @Option(help: "Specify build/cache directory")
+  var buildPath: AbsolutePath?
+
+  @Option(
+    name: .customLong("Xcc", withSingleDash: true),
+    parsing: .unconditionalSingleValue,
+    help: "Pass flag through to all C compiler invocations"
+  )
+  var buildFlagsCc = [String]()
+
+  @Option(
+    name: .customLong("Xcxx", withSingleDash: true),
+    parsing: .unconditionalSingleValue,
+    help: "Pass flag through to all C++ compiler invocations"
+  )
+  var buildFlagsCxx = [String]()
+
+  @Option(
+    name: .customLong("Xlinker", withSingleDash: true),
+    parsing: .unconditionalSingleValue,
+    help: "Pass flag through to all linker invocations"
+  )
+  var buildFlagsLinker = [String]()
+
+  @Option(
+    name: .customLong("Xswiftc", withSingleDash: true),
+    parsing: .unconditionalSingleValue,
+    help: "Pass flag through to all Swift compiler invocations"
+  )
+  var buildFlagsSwift = [String]()
+
+  @Option(
+    name: .customLong("Xclangd", withSingleDash: true),
+    parsing: .unconditionalSingleValue,
+    help: "Pass options to clangd command-line"
+  )
+  var clangdOptions = [String]()
+
+  @Option(
+    name: .customLong("index-store-path", withSingleDash: true),
+    help: "Override index-store-path from the build system"
+  )
+  var indexStorePath: AbsolutePath?
+
+  @Option(
+    name: .customLong("index-db-path", withSingleDash: true),
+    help: "Override index-database-path from the build system"
+  )
+  var indexDatabasePath: AbsolutePath?
+
+  @Option(
+    name: .customLong("completion-server-side-filtering", withSingleDash: true),
+    help: "Whether to enable server-side filtering in code-completion"
+  )
+  var completionServerSideFiltering = true
+
+  @Option(
+    name: .customLong("completion-max-results", withSingleDash: true),
+    help: "When server-side filtering is enabled, the maximum number of results to return"
+  )
+  var completionMaxResults = 200
+
+  func mapOptions() -> SourceKitServer.Options {
+    var serverOptions = SourceKitServer.Options()
+
+    serverOptions.buildSetup.configuration = buildConfiguration
+    serverOptions.buildSetup.path = buildPath
+    serverOptions.buildSetup.flags.cCompilerFlags = buildFlagsCc
+    serverOptions.buildSetup.flags.cxxCompilerFlags = buildFlagsCxx
+    serverOptions.buildSetup.flags.linkerFlags = buildFlagsLinker
+    serverOptions.buildSetup.flags.swiftCompilerFlags = buildFlagsSwift
+    serverOptions.clangdOptions = clangdOptions
+    serverOptions.indexOptions.indexStorePath = indexStorePath
+    serverOptions.indexOptions.indexDatabasePath = indexDatabasePath
+    serverOptions.completionOptions.serverSideFiltering = completionServerSideFiltering
+    serverOptions.completionOptions.maxResults = completionMaxResults
+
+    return serverOptions
   }
 
-  if let options = parsedArguments.get(clangdOptions) {
-    result.serverOptions.clangdOptions = options
-  }
+  func run() throws {
+    if !Logger.shared.setLogLevel(environmentVariable: "SOURCEKIT_LOGGING") {
+      Logger.shared.currentLevel = logLevel
+    }
 
-  if let path = parsedArguments.get(indexStorePath)?.path {
-    result.serverOptions.indexOptions.indexStorePath = path
-  }
-  if let path = parsedArguments.get(indexDatabasePath)?.path {
-    result.serverOptions.indexOptions.indexDatabasePath = path
-  }
+    // Dup stdout and redirect the fd to stderr so that a careless print()
+    // will not break our connection stream.
+    let realStdout = dup(STDOUT_FILENO)
+    if realStdout == -1 {
+      fatalError("failed to dup stdout: \(strerror(errno)!)")
+    }
+    if dup2(STDERR_FILENO, STDOUT_FILENO) == -1 {
+      fatalError("failed to redirect stdout -> stderr: \(strerror(errno)!)")
+    }
 
-  if let logLevel = parsedArguments.get(loggingOption) {
-    Logger.shared.currentLevel = logLevel
-  } else {
-    Logger.shared.setLogLevel(environmentVariable: "SOURCEKIT_LOGGING")
-  }
+    let clientConnection = JSONRPCConnection(
+      protocol: MessageRegistry.lspProtocol,
+      inFD: STDIN_FILENO,
+      outFD: realStdout,
+      syncRequests: syncRequests
+    )
 
-  if let sync = parsedArguments.get(syncOption) {
-    result.syncRequests = sync
-  }
+    let installPath = AbsolutePath(Bundle.main.bundlePath)
+    ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFileSystem)
 
-  if let serverSideFiltering = parsedArguments.get(completionServerSideFiltering) {
-    result.serverOptions.completionOptions.serverSideFiltering = serverSideFiltering
-  }
-  if let maxResults = parsedArguments.get(completionMaxResults) {
-    result.serverOptions.completionOptions.maxResults = maxResults
-  }
+    let server = SourceKitServer(client: clientConnection, options: mapOptions(), onExit: {
+      clientConnection.close()
+    })
+    clientConnection.start(receiveHandler: server, closeHandler: {
+      server.prepareForExit()
+      // Use _Exit to avoid running static destructors due to SR-12668.
+      _Exit(0)
+    })
 
-  return result
+    Logger.shared.addLogHandler { message, _ in
+      clientConnection.send(LogMessageNotification(type: .log, message: message))
+    }
+
+    dispatchMain()
+  }
 }
 
-let options: CommandLineOptions
-do {
-  options = try parseArguments()
-} catch {
-  fputs("error: \(error)\n", TSCLibc.stderr)
-  exit(1)
-}
-
-// Dup stdout and redirect the fd to stderr so that a careless print()
-// will not break our connection stream.
-let realStdout = dup(STDOUT_FILENO)
-if realStdout == -1 {
-  fatalError("failed to dup stdout: \(strerror(errno)!)")
-}
-if dup2(STDERR_FILENO, STDOUT_FILENO) == -1 {
-  fatalError("failed to redirect stdout -> stderr: \(strerror(errno)!)")
-}
-
-let clientConnection = JSONRPCConnection(
-  protocol: MessageRegistry.lspProtocol,
-  inFD: STDIN_FILENO,
-  outFD: realStdout,
-  syncRequests: options.syncRequests)
-
-let installPath = AbsolutePath(Bundle.main.bundlePath)
-ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFileSystem)
-
-let server = SourceKitServer(client: clientConnection, options: options.serverOptions, onExit: {
-  clientConnection.close()
-})
-clientConnection.start(receiveHandler: server, closeHandler: {
-  server.prepareForExit()
-  // Use _Exit to avoid running static destructors due to SR-12668.
-  _Exit(0)
-})
-
-Logger.shared.addLogHandler { message, _ in
-  clientConnection.send(LogMessageNotification(type: .log, message: message))
-}
-
-dispatchMain()
+Main.main()


### PR DESCRIPTION
After https://github.com/apple/swift-package-manager/pull/2653 is merged, I think it would make sense for SourceKit-LSP to adopt the new `ArgumentParser` module as well. I've kept the new completion server arguments as single-dash options (such as `-completion-server-side-filtering`), but as these weren't released in 5.3, I think it's a good opportunity for making them double-dash options for consistency, let me know what you think.

CC @natecook1000 