### PR TITLE
Allow double dash for IndexStore-related CLI arguments

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -232,7 +232,7 @@ if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
     .package(url: "https://github.com/apple/indexstore-db.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.0")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
   ]
 } else {
   package.dependencies += [

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -103,16 +103,16 @@ struct Main: ParsableCommand {
   var clangdOptions = [String]()
 
   @Option(
-    name: .customLong("index-store-path", withSingleDash: true),
+    name: [.long, .customLong("index-store-path", withSingleDash: true)],
     help: "Override index-store-path from the build system"
   )
   var indexStorePath: AbsolutePath?
 
   @Option(
-    name: .customLong("index-db-path", withSingleDash: true),
+    name: [.long, .customLong("index-db-path", withSingleDash: true)],
     help: "Override index-database-path from the build system"
   )
-  var indexDatabasePath: AbsolutePath?
+  var indexDBPath: AbsolutePath?
 
   @Option(
     help: "Whether to enable server-side filtering in code-completion"
@@ -135,7 +135,7 @@ struct Main: ParsableCommand {
     serverOptions.buildSetup.flags.swiftCompilerFlags = buildFlagsSwift
     serverOptions.clangdOptions = clangdOptions
     serverOptions.indexOptions.indexStorePath = indexStorePath
-    serverOptions.indexOptions.indexDatabasePath = indexDatabasePath
+    serverOptions.indexOptions.indexDatabasePath = indexDBPath
     serverOptions.completionOptions.serverSideFiltering = completionServerSideFiltering
     serverOptions.completionOptions.maxResults = completionMaxResults
 


### PR DESCRIPTION
Following up on #304, double dash is now allowed in addition to the single dash option for backward compatibility. This is possible thanks to the fix in Argument Parser 0.3.1.