### PR TITLE
convert tests from #file to using #filePath

### DIFF
--- a/Sources/LSPTestSupport/CheckCoding.swift
+++ b/Sources/LSPTestSupport/CheckCoding.swift
@@ -17,7 +17,7 @@ import XCTest
 ///
 /// - parameter value: The value to encode/decode.
 /// - parameter json: The expected json encoding.
-public func checkCoding<T>(_ value: T, json: String, file: StaticString = #file, line: UInt = #line) where T: Codable & Equatable {
+public func checkCoding<T>(_ value: T, json: String, file: StaticString = #filePath, line: UInt = #line) where T: Codable & Equatable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
   if #available(macOS 10.13, *) {
@@ -57,7 +57,7 @@ private struct WrapFragment<T>: Equatable, Codable where T: Equatable & Codable 
 ///
 /// - parameter value: The value to encode/decode.
 /// - parameter json: The expected json encoding.
-public func checkDecoding<T>(json: String, expected value: T, file: StaticString = #file, line: UInt = #line) where T: Codable & Equatable {
+public func checkDecoding<T>(json: String, expected value: T, file: StaticString = #filePath, line: UInt = #line) where T: Codable & Equatable {
 
   let wrappedStr = "{\"value\":\(json)}"
   let data = wrappedStr.data(using: .utf8)!
@@ -67,7 +67,7 @@ public func checkDecoding<T>(json: String, expected value: T, file: StaticString
   XCTAssertEqual(value, decodedValue, file: file, line: line)
 }
 
-public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = #file, line: UInt = #line, body: (T) -> Void) where T: Codable {
+public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = #filePath, line: UInt = #line, body: (T) -> Void) where T: Codable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
   if #available(macOS 10.13, *) {

--- a/Tests/LSPLoggingTests/SupportTests.swift
+++ b/Tests/LSPLoggingTests/SupportTests.swift
@@ -25,8 +25,8 @@ final class SupportTests: XCTestCase {
 
     func check(expected: [(String, LogLevel)], file: StaticString = #file, line: UInt = #line) {
       testLogger.flush()
-      XCTAssert(messages.count == expected.count, "\(messages) does not match expected \(expected)", file: file, line: line)
-      XCTAssert(zip(messages, expected).allSatisfy({ $0.0 == $0.1 }), "\(messages) does not match expected \(expected)", file: file, line: line)
+        XCTAssert(messages.count == expected.count, "\(messages) does not match expected \(expected)", file: (file), line: line)
+        XCTAssert(zip(messages, expected).allSatisfy({ $0.0 == $0.1 }), "\(messages) does not match expected \(expected)", file: (file), line: line)
       messages.removeAll()
     }
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -209,8 +209,8 @@ final class CodingTests: XCTestCase {
 
 let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspProtocol]
 
-private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Request: RequestType & Equatable {
-  checkCoding(JSONRPCMessage.request(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
+private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #filePath, line: UInt = #line) where Request: RequestType & Equatable {
+    checkCoding(JSONRPCMessage.request(value, id: id), json: json, userInfo: defaultCodingInfo, file: (file), line: line) {
 
     guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Request else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -222,8 +222,8 @@ private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: 
   }
 }
 
-private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = #file, line: UInt = #line) where Notification: NotificationType & Equatable {
-  checkCoding(JSONRPCMessage.notification(value), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
+private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = #filePath, line: UInt = #line) where Notification: NotificationType & Equatable {
+    checkCoding(JSONRPCMessage.notification(value), json: json, userInfo: defaultCodingInfo, file: (file), line: line) {
 
     guard case JSONRPCMessage.notification(let decodedValueOpaque) = $0, let decodedValue = decodedValueOpaque as? Notification else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -234,7 +234,7 @@ private func checkMessageCoding<Notification>(_ value: Notification, json: Strin
   }
 }
 
-private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) where Response: ResponseType & Equatable {
+private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json: String, file: StaticString = #filePath, line: UInt = #line) where Response: ResponseType & Equatable {
 
   let callback: JSONRPCMessage.ResponseTypeCallback = {
     return $0 == .string("unknown") ? nil : Response.self
@@ -243,7 +243,7 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
   var codingInfo = defaultCodingInfo
   codingInfo[.responseTypeCallbackKey] = callback
 
-  checkCoding(JSONRPCMessage.response(value, id: id), json: json, userInfo: codingInfo, file: file, line: line) {
+    checkCoding(JSONRPCMessage.response(value, id: id), json: json, userInfo: codingInfo, file: (file), line: line) {
 
     guard case JSONRPCMessage.response(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Response else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -255,8 +255,8 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
   }
 }
 
-private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) {
-  checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
+private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = #filePath, line: UInt = #line) {
+    checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, userInfo: defaultCodingInfo, file: (file), line: line) {
 
     guard case JSONRPCMessage.errorResponse(let decodedValue, let decodedID) = $0 else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -268,7 +268,7 @@ private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: Str
   }
 }
 
-private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo, file: StaticString = #file, line: UInt = #line) {
+private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo, file: StaticString = #filePath, line: UInt = #line) {
   let data = json.data(using: .utf8)!
   let decoder = JSONDecoder()
   decoder.userInfo = userInfo

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -17,7 +17,7 @@ import XCTest
 final class MessageParsingTests: XCTestCase {
 
   func testSplitMessage() {
-    func check(_ string: String, contentLen: Int? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, contentLen: Int? = nil, restLen: Int?, file: StaticString = #filePath, line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let ((content, header), rest) = try! bytes.jsonrpcSplitMessage() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -28,7 +28,7 @@ final class MessageParsingTests: XCTestCase {
       XCTAssertEqual(header.contentLength, contentLen, file: file, line: line)
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
       do {
         _ = try [UInt8](string.utf8).jsonrpcSplitMessage()
         XCTFail("missing expected error", file: file, line: line)
@@ -53,7 +53,7 @@ final class MessageParsingTests: XCTestCase {
   }
 
   func testParseHeader() {
-    func check(_ string: String, header expected: JSONRPCMessageHeader? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, header expected: JSONRPCMessageHeader? = nil, restLen: Int?, file: StaticString = #filePath, line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let (header, rest) = try! bytes.jsonrcpParseHeader() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -63,7 +63,7 @@ final class MessageParsingTests: XCTestCase {
       XCTAssertEqual(header, expected, file: file, line: line)
     }
 
-    func checkErrorBytes(_ bytes: [UInt8], _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkErrorBytes(_ bytes: [UInt8], _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
       do {
         _ = try bytes.jsonrcpParseHeader()
         XCTFail("missing expected error", file: file, line: line)
@@ -74,7 +74,7 @@ final class MessageParsingTests: XCTestCase {
       }
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
       checkErrorBytes([UInt8](string.utf8), expected, file: file, line: line)
     }
 
@@ -95,7 +95,7 @@ final class MessageParsingTests: XCTestCase {
   }
 
   func testParseHeaderField() {
-    func check(_ string: String, keyLen: Int? = nil, valueLen: Int? = nil, restLen: Int?, file: StaticString = #file, line: UInt = #line) {
+    func check(_ string: String, keyLen: Int? = nil, valueLen: Int? = nil, restLen: Int?, file: StaticString = #filePath, line: UInt = #line) {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let (kv, rest) = try! bytes.jsonrpcParseHeaderField() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -112,7 +112,7 @@ final class MessageParsingTests: XCTestCase {
       }
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #file, line: UInt = #line) {
+    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
       do {
         _ = try [UInt8](string.utf8).jsonrpcParseHeaderField()
         XCTFail("missing expected error", file: file, line: line)

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 final class CompilationDatabaseTests: XCTestCase {
   func testSplitShellEscapedCommand() {
-    func check(_ str: String, _ expected: [String], file: StaticString=#file, line: UInt=#line) {
+    func check(_ str: String, _ expected: [String], file: StaticString=#filePath, line: UInt=#line) {
       XCTAssertEqual(splitShellEscapedCommand(str), expected, file: file, line: line)
     }
 
@@ -61,7 +61,7 @@ final class CompilationDatabaseTests: XCTestCase {
   func testEncodeCompDBCommand() {
     // Requires JSONEncoder.OutputFormatting.sortedKeys
     if #available(macOS 10.13, *) {
-      func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = #file, line: UInt = #line) {
+        func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
         let encoder = JSONEncoder()
         encoder.outputFormatting.insert(.sortedKeys)
         let encodedString = try! String(data: encoder.encode(cmd), encoding: .utf8)
@@ -78,7 +78,7 @@ final class CompilationDatabaseTests: XCTestCase {
   }
 
   func testDecodeCompDBCommand() {
-    func check(_ str: String, _ expected: CompilationDatabase.Command, file: StaticString = #file, line: UInt = #line) {
+    func check(_ str: String, _ expected: CompilationDatabase.Command, file: StaticString = #filePath, line: UInt = #line) {
       let cmd = try! JSONDecoder().decode(CompilationDatabase.Command.self, from: str.data(using: .utf8)!)
       XCTAssertEqual(cmd, expected, file: file, line: line)
     }
@@ -305,7 +305,7 @@ final class CompilationDatabaseTests: XCTestCase {
   }
 }
 
-private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, file: StaticString = #file, line: UInt = #line, block: (CompilationDatabaseBuildSystem) -> ()) {
+private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, file: StaticString = #filePath, line: UInt = #line, block: (CompilationDatabaseBuildSystem) -> ()) {
   let fs = InMemoryFileSystem()
   XCTAssertNoThrow(try fs.createDirectory(AbsolutePath("/a")), file: file, line: line)
   XCTAssertNoThrow(try fs.writeFileContents(AbsolutePath("/a/compile_commands.json"), bytes: compdb), file: file, line: line)

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -16,12 +16,12 @@ import XCTest
 
 final class SupportTests: XCTestCase {
 
-  func checkLines(_ string: String, _ expected: [String], file: StaticString = #file, line: UInt = #line) {
+    func checkLines(_ string: String, _ expected: [String], file: StaticString = #filePath, line: UInt = #line) {
     let table = LineTable(string)
     XCTAssertEqual(table.map { String($0) }, expected, file: file, line: line)
   }
 
-  func checkOffsets(_ string: String, _ expected: [Int], file: StaticString = #file, line: UInt = #line) {
+    func checkOffsets(_ string: String, _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
     let table = LineTable(string)
     XCTAssertEqual(table.map { string.utf8.distance(from: string.startIndex, to: $0.startIndex) }, expected, file: file, line: line)
   }
@@ -68,7 +68,7 @@ final class SupportTests: XCTestCase {
     XCTAssertEqual(LineTable("\n")[1], "")
   }
 
-  func checkLineAndColumns(_ table: LineTable, _ utf8Offset: Int, _ expected: (line: Int, utf16Column: Int)?, file: StaticString = #file, line: UInt = #line) {
+    func checkLineAndColumns(_ table: LineTable, _ utf8Offset: Int, _ expected: (line: Int, utf16Column: Int)?, file: StaticString = #filePath, line: UInt = #line) {
     switch (table.lineAndUTF16ColumnOf(utf8Offset: utf8Offset), expected) {
     case (nil, nil):
       break
@@ -79,11 +79,11 @@ final class SupportTests: XCTestCase {
     }
   }
 
-  func checkUTF8OffsetOf(_ table: LineTable, _ query: (line: Int, utf16Column: Int), _ expected: Int?, file: StaticString = #file, line: UInt = #line) {
+    func checkUTF8OffsetOf(_ table: LineTable, _ query: (line: Int, utf16Column: Int), _ expected: Int?, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(table.utf8OffsetOf(line: query.line, utf16Column: query.utf16Column), expected, file: file, line: line)
   }
 
-  func checkUTF16ColumnAt(_ table: LineTable, _ query: (line: Int, utf8Column: Int), _ expected: Int?, file: StaticString = #file, line: UInt = #line) {
+    func checkUTF16ColumnAt(_ table: LineTable, _ query: (line: Int, utf8Column: Int), _ expected: Int?, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(table.utf16ColumnAt(line: query.line, utf8Column: query.utf8Column), expected, file: file, line: line)
   }
 

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -512,7 +512,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 private func checkNot(
   _ pattern: String...,
   arguments: [String],
-  file: StaticString = #file,
+    file: StaticString = #filePath,
   line: UInt = #line)
 {
   if let index = arguments.firstIndex(of: pattern) {
@@ -526,7 +526,7 @@ private func checkNot(
 private func check(
   _ pattern: String...,
   arguments: [String],
-  file: StaticString = #file,
+    file: StaticString = #filePath,
   line: UInt = #line)
 {
   guard let index = arguments.firstIndex(of: pattern) else {


### PR DESCRIPTION
I wandered in an saw a variety of warnings, this iterates through and cleans them up. I wasn't sure of dependencies for supporting older versions of swift for this project, so offering this up as cleanup work.

- converted the use of `#file` to `#filePath` in the tests