### PR TITLE
SKSupport: update for `BOOL` conversion on Windows

### DIFF
--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -31,7 +31,7 @@ public final class DLHandle {
   public func close() throws {
     if let handle = rawValue {
       #if os(Windows)
-        guard FreeLibrary(handle) != 0 else {
+        guard FreeLibrary(handle) else {
           throw DLError.close("Failed to FreeLibrary: \(GetLastError())")
         }
       #else


### PR DESCRIPTION
We would fail to build on Windows due to the conversion of `BOOL` to
`Bool`, and then comparing to `0`.  This repairs the build on Windows.