### PR TITLE
build: pin argument-parser to 0.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -232,7 +232,7 @@ if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
     .package(url: "https://github.com/apple/indexstore-db.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.0")),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
This follows the change in apple/swift-package-manager#2909.  Without
this change, it is not possible to build SourceKit-LSP without the local
dependencies as the version conflict prevents a resolution.

Thanks to @owenv for pointing out the change in s-p-m!