### PR TITLE
Revert "Allow double dash for IndexStore-related CLI arguments"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -232,7 +232,7 @@ if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
     .package(url: "https://github.com/apple/indexstore-db.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-package-manager.git", .branch("master")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.0")),
   ]
 } else {
   package.dependencies += [

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -103,16 +103,16 @@ struct Main: ParsableCommand {
   var clangdOptions = [String]()
 
   @Option(
-    name: [.long, .customLong("index-store-path", withSingleDash: true)],
+    name: .customLong("index-store-path", withSingleDash: true),
     help: "Override index-store-path from the build system"
   )
   var indexStorePath: AbsolutePath?
 
   @Option(
-    name: [.long, .customLong("index-db-path", withSingleDash: true)],
+    name: .customLong("index-db-path", withSingleDash: true),
     help: "Override index-database-path from the build system"
   )
-  var indexDBPath: AbsolutePath?
+  var indexDatabasePath: AbsolutePath?
 
   @Option(
     help: "Whether to enable server-side filtering in code-completion"
@@ -135,7 +135,7 @@ struct Main: ParsableCommand {
     serverOptions.buildSetup.flags.swiftCompilerFlags = buildFlagsSwift
     serverOptions.clangdOptions = clangdOptions
     serverOptions.indexOptions.indexStorePath = indexStorePath
-    serverOptions.indexOptions.indexDatabasePath = indexDBPath
+    serverOptions.indexOptions.indexDatabasePath = indexDatabasePath
     serverOptions.completionOptions.serverSideFiltering = completionServerSideFiltering
     serverOptions.completionOptions.maxResults = completionMaxResults
 


### PR DESCRIPTION
Reverts apple/sourcekit-lsp#306

Per https://github.com/apple/swift-package-manager/pull/2909 we need to roll back to swift-argument-parser 0.3.0, and the double-dash change is not compatible with that (it crashes at runtime).

I also discovered that the version of swift-argument-parser being used when building swift.org toolchains is not considering the Package.swift requirements: it is actually taking whatever version is specified in https://github.com/apple/swift/blob/db6e3af0023a3e7fdb15204ba95e3a63a53f6deb/utils/update_checkout/update-checkout-config.json#L66.  Right now that happens to be 0.3.0, but it's specified manually.  We will need to update that version before re-applying this change.