### PR TITLE
LanguageServerProtocolJSONRPC: make Windows path work

### DIFF
--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -161,7 +161,7 @@ struct Main: ParsableCommand {
 
     let clientConnection = JSONRPCConnection(
       protocol: MessageRegistry.lspProtocol,
-      inFD: STDIN_FILENO,
+      inFD: fileno(stdin),
       outFD: realStdout,
       syncRequests: syncRequests
     )


### PR DESCRIPTION
This adjusts the use of Dispatch to build on Windows.  Windows does not
provide `stdout_fileno` and `stderr_fileno`.  However, it is possible to
use `fileno` to get the associated fileno from the descriptor.

Dispatch on Windows does not deal with fd's but rather with handles.
Convert the file descriptor to a handle and pass that off to dispatch.
The handle is a non-owning reference, and should not be closed.
Fortunately, dispatch does not close the handle when the DispatchIO is
closed.