### PR TITLE
SKCore: make `.` part of the extension

### DIFF
--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -145,21 +145,21 @@ extension Toolchain {
     }
 
     // If 'currentPlatform' is nil it's most likely an unknown linux flavor.
-    let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? "so"
+    let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? ".so"
 
     let sourcekitdPath = libPath.appending(components: "sourcekitd.framework", "sourcekitd")
     if fs.isFile(sourcekitdPath) {
       self.sourcekitd = sourcekitdPath
       foundAny = true
     } else {
-      let sourcekitdPath = libPath.appending(component: "libsourcekitdInProc.\(dylibExt)")
+      let sourcekitdPath = libPath.appending(component: "libsourcekitdInProc\(dylibExt)")
       if fs.isFile(sourcekitdPath) {
         self.sourcekitd = sourcekitdPath
         foundAny = true
       }
     }
 
-    let libIndexStore = libPath.appending(components: "libIndexStore.\(dylibExt)")
+    let libIndexStore = libPath.appending(components: "libIndexStore\(dylibExt)")
     if fs.isFile(libIndexStore) {
       self.libIndexStore = libIndexStore
       foundAny = true

--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -17,8 +17,8 @@ extension Platform {
   /// The file extension used for a dynamic library on this platform.
   public var dynamicLibraryExtension: String {
     switch self {
-    case .darwin: return "dylib"
-    case .linux, .android: return "so"
+    case .darwin: return ".dylib"
+    case .linux, .android: return ".so"
     }
   }
 }

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -526,16 +526,16 @@ private func makeToolchain(
     makeExec(binPath.appending(component: "swiftc"))
   }
 
-  let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? "so"
+  let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? ".so"
 
   if sourcekitd {
     try! fs.createDirectory(libPath.appending(component: "sourcekitd.framework"))
     try! fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd") , bytes: "")
   }
   if sourcekitdInProc {
-    try! fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc.\(dylibExt)") , bytes: "")
+    try! fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibExt)") , bytes: "")
   }
   if libIndexStore {
-    try! fs.writeFileContents(libPath.appending(component: "libIndexStore.\(dylibExt)") , bytes: "")
+    try! fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibExt)") , bytes: "")
   }
 }


### PR DESCRIPTION
This is just a cleanup change to setup the extensions for other targets.
This allows for platforms to have no extensions or an extension which
may or may not include a `.`.