### PR TITLE
SKCore: support executable extensions on different platforms

### DIFF
--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -127,18 +127,20 @@ extension Toolchain {
 
     var foundAny = false
 
-    let clangPath = binPath.appending(component: "clang")
+    let execExt = Platform.currentPlatform?.executableExtension ?? ""
+
+    let clangPath = binPath.appending(component: "clang\(execExt)")
     if fs.isExecutableFile(clangPath) {
       self.clang = clangPath
       foundAny = true
     }
-    let clangdPath = binPath.appending(component: "clangd")
+    let clangdPath = binPath.appending(component: "clangd\(execExt)")
     if fs.isExecutableFile(clangdPath) {
       self.clangd = clangdPath
       foundAny = true
     }
 
-    let swiftcPath = binPath.appending(component: "swiftc")
+    let swiftcPath = binPath.appending(component: "swiftc\(execExt)")
     if fs.isExecutableFile(swiftcPath) {
       self.swiftc = swiftcPath
       foundAny = true

--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -19,6 +19,14 @@ extension Platform {
     switch self {
     case .darwin: return ".dylib"
     case .linux, .android: return ".so"
+    case .windows: return ".dll"
+    }
+  }
+
+  public var executableExtension: String {
+    switch self {
+    case .windows: return ".exe"
+    case .linux, .android, .darwin: return ""
     }
   }
 }

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -516,14 +516,16 @@ private func makeToolchain(
     }
   }
 
+  let execExt = Platform.currentPlatform?.executableExtension ?? ""
+
   if clang {
-    makeExec(binPath.appending(component: "clang"))
+    makeExec(binPath.appending(component: "clang\(execExt)"))
   }
   if clangd {
-    makeExec(binPath.appending(component: "clangd"))
+    makeExec(binPath.appending(component: "clangd\(execExt)"))
   }
   if swiftc {
-    makeExec(binPath.appending(component: "swiftc"))
+    makeExec(binPath.appending(component: "swiftc\(execExt)"))
   }
 
   let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? ".so"


### PR DESCRIPTION
Similar to the dylib extension, introduce executable extensions.  This
is required for Windows which uses a `.exe` suffix for the executables.