### PR TITLE
Log to stderr instead of sending window/logMessage

### DIFF
--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -178,10 +178,6 @@ struct Main: ParsableCommand {
       _Exit(0)
     })
 
-    Logger.shared.addLogHandler { message, _ in
-      clientConnection.send(LogMessageNotification(type: .log, message: message))
-    }
-
     dispatchMain()
   }
 }


### PR DESCRIPTION
- clangd itself already logs to stderr so sourcekit-lsp
  should do the same for consistency (unless we want to
  capture clangd's stderr and forward it in the LSP)

- Editors such as VS Code will show stderr output in the same
  output channel where it shows logMessage + traces
