### PR TITLE
build: allow building with dispatch and Foundation from the toolchain

### DIFF
--- a/Sources/LSPLogging/CMakeLists.txt
+++ b/Sources/LSPLogging/CMakeLists.txt
@@ -4,8 +4,10 @@ add_library(LSPLogging
 set_target_properties(LSPLogging PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(LSPLogging PRIVATE
-    Foundation)
+  if(Foundation_FOUND)
+    target_link_libraries(LSPLogging PRIVATE
+      Foundation)
+  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -74,9 +74,14 @@ add_library(LanguageServerProtocol
 set_target_properties(LanguageServerProtocol PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(LanguageServerProtocol PUBLIC
-    swiftDispatch
-    Foundation)
+  if(dispatch_FOUND)
+    target_link_libraries(LanguageServerProtocol PUBLIC
+      swiftDispatch)
+  endif()
+  if(Foundation_FOUND)
+    target_link_libraries(LanguageServerProtocol PUBLIC
+      Foundation)
+  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -42,8 +42,10 @@ target_link_libraries(SourceKitLSP PUBLIC
   SourceKitD
   TSCUtility)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(SourceKitLSP PRIVATE
-    FoundationXML)
+  if(Foundation_FOUND)
+    target_link_libraries(SourceKitLSP PRIVATE
+      FoundationXML)
+  endif()
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -13,8 +13,10 @@ target_link_libraries(sourcekit-lsp PRIVATE
   SourceKitLSP
   TSCUtility)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(sourcekit-lsp PRIVATE
-    FoundationXML)
+  if(Foundation_FOUND)
+    target_link_libraries(sourcekit-lsp PRIVATE
+      FoundationXML)
+  endif()
 endif()
 
 install(TARGETS sourcekit-lsp


### PR DESCRIPTION
This allows building without dispatch and Foundation build roots, which
allows for a multi-phase build.  This is intended to support the Windows
staged build where dispatch and Foundation are part of the SDK and
SourceKit-LSP is part of the devtools.