### PR TITLE
Add missing Windows switch case to Platform.swift

### DIFF
--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -19,6 +19,7 @@ extension Platform {
     switch self {
     case .darwin: return ".dylib"
     case .linux, .android: return ".so"
+    case .windows: return ".dll"
     }
   }
 }


### PR DESCRIPTION
After the release of the latest TSC which contains apple/swift-tools-support-core#137, SourceKit-LSP fails to build because of the missing `switch` case in `Platform.swift`.