### PR TITLE
Add --destination option for cross-compiled projects

### DIFF
--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -10,17 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKSupport
 import TSCBasic
 import TSCUtility
-import SKSupport
 
 /// Build configuration
 public struct BuildSetup {
-
   /// Default configuration
-  public static let `default` = BuildSetup(configuration: .debug,
-                                           path: nil,
-                                           flags: BuildFlags())
+  public static let `default` =
+    BuildSetup(configuration: .debug, path: nil, destinationFile: nil, flags: BuildFlags())
 
   /// Build configuration (debug|release).
   public var configuration: BuildConfiguration
@@ -31,9 +29,18 @@ public struct BuildSetup {
   /// Additional build flags
   public var flags: BuildFlags
 
-  public init(configuration: BuildConfiguration, path: AbsolutePath?, flags: BuildFlags) {
+  /// Path to the destination.json file that describes build destination settings
+  public var destinationFile: AbsolutePath?
+
+  public init(
+    configuration: BuildConfiguration,
+    path: AbsolutePath?,
+    destinationFile: AbsolutePath? = nil,
+    flags: BuildFlags
+  ) {
     self.configuration = configuration
     self.path = path
+    self.destinationFile = destinationFile
     self.flags = flags
   }
 }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -82,7 +82,13 @@ public final class SwiftPMWorkspace {
         throw Error.cannotDetermineHostToolchain
     }
 
-    let destination = try Destination.hostDestination(destinationToolchainBinDir)
+    let destination: Destination
+    if let destinationFile = buildSetup.destinationFile {
+      destination = try Destination(fromFile: destinationFile)
+    } else {
+      destination = try Destination.hostDestination(destinationToolchainBinDir)
+    }
+
     let toolchain = try UserToolchain(destination: destination)
 
     let buildPath: AbsolutePath = buildSetup.path ?? packageRoot.appending(component: ".build")

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -124,11 +124,17 @@ struct Main: ParsableCommand {
   )
   var completionMaxResults = 200
 
+  @Option(
+    help: "Path to the destination.json file that describes build destination settings"
+  )
+  var destination: AbsolutePath?
+
   func mapOptions() -> SourceKitServer.Options {
     var serverOptions = SourceKitServer.Options()
 
     serverOptions.buildSetup.configuration = buildConfiguration
     serverOptions.buildSetup.path = buildPath
+    serverOptions.buildSetup.destinationFile = destination
     serverOptions.buildSetup.flags.cCompilerFlags = buildFlagsCc
     serverOptions.buildSetup.flags.cxxCompilerFlags = buildFlagsCxx
     serverOptions.buildSetup.flags.linkerFlags = buildFlagsLinker


### PR DESCRIPTION
Currently SourceKit-LSP can't be used for projects that can't be compiled on a host platform and need to be cross-compiled with an appropriate destination file passed to `swift build`. This PR adds a `--destination` option to SourceKit-LSP that is then passed to SwiftPM workspaces, which in my undestanding is equivalent to passing `--destination` to the underlying `swift build` invocations.