### PR TITLE
Decrease verbosity of info-level logging

### DIFF
--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -388,6 +388,7 @@ extension BuildSystemManager: BuildSystemDelegate {
 
 extension BuildSystemManager: MainFilesDelegate {
 
+  // FIXME: Consider debouncing/limiting this, seems to trigger often during a build.
   public func mainFilesChanged() {
     queue.async {
       let origWatched = self.watchedFiles

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -69,7 +69,7 @@ extension SourceKitD {
 
   /// Send the given request and synchronously receive a reply dictionary (or error).
   public func sendSync(_ req: SKDRequestDictionary) throws -> SKDResponseDictionary {
-    logAsync { _ in req.description }
+    logRequest(req)
 
     let resp = SKDResponse(api.send_request_sync(req.dict), sourcekitd: self)
 
@@ -88,7 +88,7 @@ extension SourceKitD {
     _ queue: DispatchQueue,
     reply: @escaping (Result<SKDResponseDictionary, SKDError>) -> Void
   ) -> sourcekitd_request_handle_t? {
-    logAsync { _ in req.description }
+    logRequest(req)
 
     var handle: sourcekitd_request_handle_t? = nil
 
@@ -113,6 +113,12 @@ extension SourceKitD {
 
     return handle
   }
+}
+
+private func logRequest(_ request: SKDRequestDictionary) {
+  // FIXME: Ideally we could log the request key here at the info level but the dictionary is
+  // readonly.
+  logAsync(level: .debug) { _ in request.description }
 }
 
 private func logResponse(_ response: SKDResponse) {

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -24,7 +24,7 @@ extension IndexStoreDB: MainFilesProvider {
     } else {
       mainFiles = []
     }
-    log("mainFilesContainingFile(\(uri.pseudoPath)) -> \(mainFiles)")
+    log("mainFilesContainingFile(\(uri.pseudoPath)) -> \(mainFiles)", level: .debug)
     return mainFiles
   }
 }


### PR DESCRIPTION
- Don't log entire LSP notifications/requests for the `info` level,
  instead log of the form:
  - `Notification<method>` e.g. Notification<textDocument/publishDiagnostics>
  - `Request<method(id)>` e.g. Request<textDocument/hover(6)>
  - `Response<method(id)` e.g. Response<textDocument/hover(6)>

- Only log sourcekitd requests/responses at the debug level

Note that clangd has a slightly different form:

```
I[21:16:16.990] --> textDocument/clangd.fileStatus
I[21:16:17.636] <-- textDocument/hover(5)
I[21:16:17.992] --> textDocument/publishDiagnostics
I[21:16:17.992] --> reply:textDocument/codeAction(2) 1006 ms
I[21:16:17.995] --> reply:textDocument/documentSymbol(3) 1009 ms
I[21:16:17.996] --> reply:textDocument/codeAction(4) 1010 ms
I[21:16:17.999] --> reply:textDocument/hover(5) 363 ms
I[21:16:17.999] --> textDocument/clangd.fileStatus
I[21:16:19.544] <-- textDocument/hover(6)
```