### PR TITLE
Log error before fatalError(...) when message decoding fails

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -229,13 +229,17 @@ public final class JSONRPCConnection {
               continue MESSAGE_LOOP
             }
           case .unknown:
+            log("error decoding message: \(error.message)", level: .error)
             break
         }
         // FIXME: graceful shutdown?
+        Logger.shared.flush()
         fatalError("fatal error encountered decoding message \(error)")
 
       } catch {
+        log("error decoding message: \(error.localizedDescription)", level: .error)
         // FIXME: graceful shutdown?
+        Logger.shared.flush()
         fatalError("fatal error encountered decoding message \(error)")
       }
     }


### PR DESCRIPTION
* Uses `log(...)` to give the client some feedback before terminating the process in response to an undecodable message