### PR TITLE
Synchronously send error response on message decoding failure

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -315,10 +315,7 @@ public final class JSONRPCConnection {
 
   private func sendMessageSynchronously(_ messageData: Data) {
     let header = "Content-Length: \(messageData.count)\r\n\r\n"
-    guard let headerData = header.data(using: .utf8) else {
-      log("error encoding header", level: .error)
-      return
-    }
+    let headerData = header.data(using: .utf8)!
     let stdOutHandle = FileHandle(fileDescriptor: sendIO.fileDescriptor)
     stdOutHandle.write(headerData + messageData)
   }

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -173,7 +173,8 @@ public final class JSONRPCConnection {
     return ready
   }
   
-  private func send(_ message: JSONRPCMessage, async: Bool = true) {
+  /// *Public for testing*
+  public func _send(_ message: JSONRPCMessage, async: Bool = true) {
     send(async: async) { encoder in
       try encoder.encode(message)
     }
@@ -215,7 +216,7 @@ public final class JSONRPCConnection {
         switch error.messageKind {
           case .request:
             if let id = error.id {
-              send(.errorResponse(ResponseError(error), id: id))
+              _send(.errorResponse(ResponseError(error), id: id))
               continue MESSAGE_LOOP
             }
           case .response:
@@ -233,7 +234,7 @@ public final class JSONRPCConnection {
               continue MESSAGE_LOOP
             }
           case .unknown:
-            send(.errorResponse(ResponseError(error), id: nil),
+            _send(.errorResponse(ResponseError(error), id: nil),
                  async: false) // synchronous because the following fatalError
             break
         }
@@ -243,7 +244,7 @@ public final class JSONRPCConnection {
       } catch {
         let responseError = ResponseError(code: .parseError,
                                           message: "Failed to decode message. \(error.localizedDescription)")
-        send(.errorResponse(responseError, id: nil),
+        _send(.errorResponse(responseError, id: nil),
              async: false) // synchronous because the following fatalError
         // FIXME: graceful shutdown?
         fatalError("fatal error encountered decoding message \(error)")

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -96,7 +96,7 @@ extension JSONRPCMessage: Codable {
 
         self = .response(result, id: id)
 
-      case (let id?, nil, _, let error?):
+      case (let id, nil, _, let error?):
         msgKind = .response
         self = .errorResponse(error, id: id)
 

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -17,7 +17,7 @@ public enum JSONRPCMessage {
   case notification(NotificationType)
   case request(_RequestType, id: RequestID)
   case response(ResponseType, id: RequestID)
-  case errorResponse(ResponseError, id: RequestID)
+  case errorResponse(ResponseError, id: RequestID?)
 }
 
 extension CodingUserInfoKey {

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -126,6 +126,17 @@ final class CodingTests: XCTestCase {
       "jsonrpc" : "2.0"
     }
     """)
+    
+    checkMessageCoding(ResponseError.cancelled, id: nil, json: """
+    {
+      "error" : {
+        "code" : -32800,
+        "message" : "request cancelled"
+      },
+      "id" : null,
+      "jsonrpc" : "2.0"
+    }
+    """)
   }
 
   func testMessageDecodingError() {
@@ -255,7 +266,7 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
   }
 }
 
-private func checkMessageCoding(_ value: ResponseError, id: RequestID, json: String, file: StaticString = #file, line: UInt = #line) {
+private func checkMessageCoding(_ value: ResponseError, id: RequestID?, json: String, file: StaticString = #file, line: UInt = #line) {
   checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
 
     guard case JSONRPCMessage.errorResponse(let decodedValue, let decodedID) = $0 else {

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -158,10 +158,6 @@ final class CodingTests: XCTestCase {
     {"jsonrpc":"2.0","result":{}}
     """)
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification"), json: """
-    {"jsonrpc":"2.0","error":{"code":-32000,"message":""}}
-    """)
-
     checkMessageDecodingError(MessageDecodingError.methodNotFound("unknown", messageKind: .notification), json: """
     {"jsonrpc":"2.0","method":"unknown"}
     """)

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -211,6 +211,20 @@ class ConnectionTests: XCTestCase {
 
     waitForExpectations(timeout: 10)
   }
+  
+  func testSendSynchronouslyBeforeClose() {
+    let client = connection.client
+
+    let expectation = self.expectation(description: "received notification")
+    client.handleNextNotification { (note: Notification<EchoNotification>) in
+      expectation.fulfill()
+    }
+    let notification = EchoNotification(string: "about to close!")
+    connection.serverConnection._send(.notification(notification), async: false)
+    connection.serverConnection.close()
+
+    waitForExpectations(timeout: 10)
+  }
 
   /// We can explicitly close a connection, but the connection also
   /// automatically closes itself if the pipe is closed (or has an error).

--- a/Tests/LanguageServerProtocolJSONRPCTests/XCTestManifests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/XCTestManifests.swift
@@ -35,6 +35,7 @@ extension ConnectionTests {
         ("testRound", testRound),
         ("testSendAfterClose", testSendAfterClose),
         ("testSendBeforeClose", testSendBeforeClose),
+        ("testSendSynchronouslyBeforeClose", testSendSynchronouslyBeforeClose),
         ("testUnexpectedResponse", testUnexpectedResponse),
         ("testUnknownNotification", testUnknownNotification),
         ("testUnknownRequest", testUnknownRequest),


### PR DESCRIPTION
* Replaces two logs since those don't result in response messages anymore
* Adds a func for sending messages synchronously, to get the two messages out before fatalError