### PR TITLE
[build-script-helper] make it run under Python 3 and run tests in parallel on Android

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -18,7 +18,7 @@ def swiftpm_bin_path(swift_exec, swiftpm_args, env=None):
   swiftpm_args = list(filter(lambda arg: arg != '-v' and arg != '--verbose', swiftpm_args))
   cmd = [swift_exec, 'build', '--show-bin-path'] + swiftpm_args
   print(' '.join(cmd))
-  return subprocess.check_output(cmd, env=env).strip()
+  return subprocess.check_output(cmd, env=env, universal_newlines=True).strip()
 
 def get_swiftpm_options(args):
   swiftpm_args = [
@@ -86,15 +86,6 @@ def delete_rpath(rpath, binary):
   subprocess.check_call(cmd)
 
 
-def should_test_parallel():
-  if platform.system() == 'Linux':
-    distro = platform.linux_distribution()
-    if distro[0] != 'Ubuntu':
-      # Workaround hang in Process.run() that hasn't been tracked down yet.
-      return False
-  return True
-
-
 def handle_invocation(swift_exec, args):
   swiftpm_args = get_swiftpm_options(args)
 
@@ -129,8 +120,10 @@ def handle_invocation(swift_exec, args):
     print('Cleaning ' + tests)
     shutil.rmtree(tests, ignore_errors=True)
     test_args = swiftpm_args
-    if should_test_parallel():
-      test_args += ['--parallel']
+    # Running the tests concurrently doesn't work with glibc 2.24 because of a
+    # bug with posix_spawn called from Foundation, so it'll need to be disabled
+    # or fixed when used there, according to @benlangmuir.
+    test_args += ['--parallel']
     swiftpm('test', swift_exec, test_args, env)
   elif args.action == 'install':
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, env)


### PR DESCRIPTION
There's no longer a `platform.linux_distribution()` by default with Python 3.9, so just check for Android early and run the tests in parallel. I haven't seen it hang on Android when running these tests.