### PR TITLE
Don't log the sourcekit code complete request

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -101,8 +101,6 @@ extension SwiftLanguageServer {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
 
-    logAsync { _ in skreq.description }
-
     let handle = sourcekitd.send(skreq, queue) { [weak self] result in
       guard let self = self else { return }
       guard let dict = result.success else {


### PR DESCRIPTION
Seems to be left over from development; SOURCEKIT_LOGGING is
an alternative to trace this.