### PR TITLE
Fix the Pipe handling on Windows to be correct

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -29,14 +29,14 @@ public final class TestJSONRPCConnection {
   public init() {
     clientConnection = JSONRPCConnection(
       protocol: testMessageRegistry,
-      inFD: serverToClient.fileHandleForReading.fileDescriptor,
-      outFD: clientToServer.fileHandleForWriting.fileDescriptor
+      inFD: serverToClient.fileHandleForReading,
+      outFD: clientToServer.fileHandleForWriting
     )
 
     serverConnection = JSONRPCConnection(
       protocol: testMessageRegistry,
-      inFD: clientToServer.fileHandleForReading.fileDescriptor,
-      outFD: serverToClient.fileHandleForWriting.fileDescriptor
+      inFD: clientToServer.fileHandleForReading,
+      outFD: serverToClient.fileHandleForWriting
     )
 
     client = TestClient(server: clientConnection)

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -250,8 +250,8 @@ private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: Absolute
 
   let connection = JSONRPCConnection(
     protocol: BuildServerProtocol.bspRegistry,
-    inFD: serverToClient.fileHandleForReading.fileDescriptor,
-    outFD: clientToServer.fileHandleForWriting.fileDescriptor
+    inFD: serverToClient.fileHandleForReading,
+    outFD: clientToServer.fileHandleForWriting
   )
 
   connection.start(receiveHandler: client) {

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -67,13 +67,13 @@ public final class TestSourceKitServer {
 
         let clientConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
-          inFD: serverToClient.fileHandleForReading.fileDescriptor,
-          outFD: clientToServer.fileHandleForWriting.fileDescriptor
+          inFD: serverToClient.fileHandleForReading,
+          outFD: clientToServer.fileHandleForWriting
         )
         let serverConnection = JSONRPCConnection(
           protocol: MessageRegistry.lspProtocol,
-          inFD: clientToServer.fileHandleForReading.fileDescriptor,
-          outFD: serverToClient.fileHandleForWriting.fileDescriptor
+          inFD: clientToServer.fileHandleForReading,
+          outFD: serverToClient.fileHandleForWriting
         )
 
         client = TestClient(server: clientConnection)

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -293,8 +293,8 @@ func makeJSONRPCClangServer(
 
   let connection = JSONRPCConnection(
     protocol: MessageRegistry.lspProtocol,
-    inFD: clangdToUs.fileHandleForReading.fileDescriptor,
-    outFD: usToClangd.fileHandleForWriting.fileDescriptor
+    inFD: clangdToUs.fileHandleForReading,
+    outFD: usToClangd.fileHandleForWriting
   )
 
   let connectionToClient = LocalConnection()

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -161,8 +161,8 @@ struct Main: ParsableCommand {
 
     let clientConnection = JSONRPCConnection(
       protocol: MessageRegistry.lspProtocol,
-      inFD: fileno(stdin),
-      outFD: realStdout,
+      inFD: FileHandle.standardInput,
+      outFD: FileHandle(fileDescriptor: realStdout, closeOnDealloc: false),
       syncRequests: syncRequests
     )
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -226,8 +226,8 @@ class ConnectionTests: XCTestCase {
 
       let conn = JSONRPCConnection(
         protocol: MessageRegistry(requests: [], notifications: []),
-        inFD: to.fileHandleForReading.fileDescriptor,
-        outFD: from.fileHandleForWriting.fileDescriptor)
+        inFD: to.fileHandleForReading,
+        outFD: from.fileHandleForWriting)
 
       final class DummyHandler: MessageHandler {
         func handle<N: NotificationType>(_: N, from: ObjectIdentifier) {}


### PR DESCRIPTION
This actually addresses the real issue that was ignored earlier about
pipes on Windows.  The FileHandle cannot provide a non-owning file
descriptor (the returned file descriptor would need to be explicitly
`_close`'d by the receiver).  Foundation now vends a `_handle` accessor
to the OS primitive handle.  Use this to create the dispatch loop for
messaging.  We now create the JSONRPCConnection from handles on Windows
which actually should help enable running some of the tests on Windows
as well.