### PR TITLE
Rename SwiftPMConfig to Workspace.Configuration

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -101,17 +101,17 @@ public final class SwiftPMWorkspace {
 
     let triple = toolchain.triple
 
-    let swiftPMConfiguration: PackageModel.BuildConfiguration
+    let buildConfiguration: PackageModel.BuildConfiguration
     switch buildSetup.configuration {
     case .debug:
-      swiftPMConfiguration = .debug
+      buildConfiguration = .debug
     case .release:
-      swiftPMConfiguration = .release
+      buildConfiguration = .release
     }
 
     self.buildParameters = BuildParameters(
       dataPath: buildPath.appending(component: triple.tripleString),
-      configuration: swiftPMConfiguration,
+      configuration: buildConfiguration,
       toolchain: toolchain,
       flags: buildSetup.flags)
 

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -87,13 +87,15 @@ public final class SwiftPMWorkspace {
 
     let buildPath: AbsolutePath = buildSetup.path ?? packageRoot.appending(component: ".build")
 
+    let workspaceConfiguration = try Workspace.Configuration(path: packageRoot.appending(components: ".swiftpm", "config"), fs: fileSystem)
+
     self.workspace = Workspace(
       dataPath: buildPath,
       editablesPath: packageRoot.appending(component: "Packages"),
       pinsFile: packageRoot.appending(component: "Package.resolved"),
       manifestLoader: ManifestLoader(manifestResources: toolchain.manifestResources, cacheDir: buildPath),
       delegate: BuildSettingProviderWorkspaceDelegate(),
-      config: SwiftPMConfig(path: packageRoot.appending(components: ".swiftpm", "config"), fs: fileSystem),
+        config: workspaceConfiguration,
       fileSystem: fileSystem,
       skipUpdate: true)
 


### PR DESCRIPTION
This PR corresponds to public API changes in https://github.com/apple/swift-package-manager/pull/3002, where `SwiftPMConfig` is renamed to `Workspace.Configuration` and its designated initializer now `throws`.

As it stands, CI will fail because the package manifest points to the `main` branch of @apple/swift-package-manager, which currently doesn't include this API change.

(This PR also makes an additional change with 84df7d38609e170962419bd114bfc47ca9c4f4d3 to rename a local variable that's misleadingly named. This is entirely severable, and you're welcome to back that out to be considered in a separate patch)