### PR TITLE
Expose diagnostic educational notes as diagnostic codes

### DIFF
--- a/Editors/vscode/package-lock.json
+++ b/Editors/vscode/package-lock.json
@@ -5,15 +5,15 @@
     "requires": true,
     "dependencies": {
         "@types/node": {
-            "version": "8.10.64",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.64.tgz",
-            "integrity": "sha512-/EwBIb+imu8Qi/A3NF9sJ9iuKo7yV+pryqjmeRqaU0C4wBAOhas5mdvoYeJ5PCKrh6thRSJHdoasFqh3BQGILA==",
+            "version": "14.14.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.13.tgz",
+            "integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==",
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
-            "integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
             "dev": true
         },
         "ansi-styles": {
@@ -49,8 +49,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "boolbase": {
             "version": "1.0.0",
@@ -62,7 +61,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -115,20 +113,19 @@
             "dev": true
         },
         "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "css-select": {
             "version": "1.2.0",
-            "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
@@ -283,6 +280,14 @@
             "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
             "dev": true
         },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
         "markdown-it": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -320,7 +325,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -357,13 +361,13 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -379,7 +383,7 @@
         },
         "parse-semver": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
@@ -397,7 +401,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -474,7 +478,7 @@
         },
         "tunnel": {
             "version": "0.0.4",
-            "resolved": "http://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
             "dev": true
         },
@@ -489,9 +493,9 @@
             }
         },
         "typescript": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-            "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
             "dev": true
         },
         "uc.micro": {
@@ -519,15 +523,15 @@
             "dev": true
         },
         "vsce": {
-            "version": "1.79.5",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.79.5.tgz",
-            "integrity": "sha512-KZFOthGwxWFwoGqwrkzfTfyCZGuniTofnJ1a/dCzQ2HP93u1UuCKrTQyGT+SuGHu8sNqdBYNe0hb9GC3qCN7fg==",
+            "version": "1.81.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.81.1.tgz",
+            "integrity": "sha512-1yWAYRxTx/PKSFZnuELe7GPyIo70H/XKJqf6wGikofUK3f3TCNGI6F9xkTQFvXKNe0AygUuxN7kITyPIQGMP+w==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^7.2.0",
                 "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.1",
-                "commander": "^2.8.1",
+                "commander": "^6.1.0",
                 "denodeify": "^1.2.1",
                 "glob": "^7.0.6",
                 "leven": "^3.1.0",
@@ -547,37 +551,54 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-            "integrity": "sha1-p7907zJU0KDCcvqxXIISjjeLO+k="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
         },
         "vscode-languageclient": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.2.tgz",
-            "integrity": "sha1-o0GntKxAPkgfAR7UVyhUZG6JaMQ=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
             "requires": {
-                "vscode-languageserver-protocol": "^3.10.3"
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.4",
+                "vscode-languageserver-protocol": "3.16.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
-            "integrity": "sha1-cQ2OQhGbs6/7FBbh4QS9a01QNZU=",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
             "requires": {
-                "vscode-jsonrpc": "^4.0.0",
-                "vscode-languageserver-types": "3.13.0"
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-            "integrity": "sha1-twSwJM7wWfezJmEcmbnIdTwKGLQ="
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yauzl": {
             "version": "2.10.0",

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -7,7 +7,7 @@
     "repository": "https://github.com/apple/sourcekit-lsp",
     "license": "SEE LICENSE IN LICENSE.txt",
     "engines": {
-        "vscode": "^1.28.0"
+        "vscode": "^1.52.0"
     },
     "categories": [
         "Programming Languages"
@@ -27,13 +27,13 @@
         "createDevPackage": "npm install && ./node_modules/.bin/vsce package -o ./out/sourcekit-lsp-vscode-dev.vsix"
     },
     "dependencies": {
-        "vscode-languageclient": "^4.0.0"
+        "vscode-languageclient": "^7.0.0"
     },
     "devDependencies": {
-        "@types/node": "^8.10.64",
-        "typescript": "^4.0.2",
-        "vsce": "^1.79.5",
-        "@types/vscode": "^1.28.0"
+        "@types/node": "^14.14.13",
+        "typescript": "^4.1.3",
+        "vsce": "^1.81.1",
+        "@types/vscode": "^1.52.0"
     },
     "contributes": {
         "configuration": {

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -1,6 +1,6 @@
 'use strict';
 import * as vscode from 'vscode';
-import * as langclient from 'vscode-languageclient';
+import * as langclient from 'vscode-languageclient/node';
 
 export function activate(context: vscode.ExtensionContext) {
 

--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -360,10 +360,15 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     /// **LSP Extension from clangd**.
     public var codeActionsInline: Bool? = nil
 
+    /// Whether the client supports a `codeDescription` property.
+    public var codeDescriptionSupport: Bool? = nil
+
     public init(relatedInformation: Bool? = nil,
-                codeActionsInline: Bool? = nil) {
+                codeActionsInline: Bool? = nil,
+                codeDescriptionSupport: Bool? = nil) {
       self.relatedInformation = relatedInformation
       self.codeActionsInline = codeActionsInline
+      self.codeDescriptionSupport = codeDescriptionSupport
     }
   }
 

--- a/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
@@ -24,6 +24,17 @@ public enum DiagnosticCode: Hashable {
   case string(String)
 }
 
+/// Captures a description of a diagnostic error code.
+public struct CodeDescription: Codable, Hashable {
+
+  /// A URI to open with more information about the diagnostic.
+  public var href: DocumentURI
+
+  public init(href: DocumentURI) {
+    self.href = href
+  }
+}
+
 /// A diagnostic message such a compiler error or warning.
 public struct Diagnostic: Codable, Hashable {
 
@@ -37,6 +48,9 @@ public struct Diagnostic: Codable, Hashable {
   /// The "code" of the diagnostice, which might be a number or string, typically providing a unique
   /// way to reference the diagnostic in e.g. documentation.
   public var code: DiagnosticCode?
+
+  /// An optional description of the diagnostic code.
+  public var codeDescription: CodeDescription?
 
   /// A human-readable description of the source of this diagnostic, e.g. "sourcekitd"
   public var source: String?
@@ -55,6 +69,7 @@ public struct Diagnostic: Codable, Hashable {
     range: Range<Position>,
     severity: DiagnosticSeverity?,
     code: DiagnosticCode? = nil,
+    codeDescription: CodeDescription? = nil,
     source: String?,
     message: String,
     relatedInformation: [DiagnosticRelatedInformation]? = nil,
@@ -63,6 +78,7 @@ public struct Diagnostic: Codable, Hashable {
     self._range = CustomCodable<PositionRange>(wrappedValue: range)
     self.severity = severity
     self.code = code
+    self.codeDescription = codeDescription
     self.source = source
     self.message = message
     self.relatedInformation = relatedInformation

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -35,6 +35,14 @@ public final class SKDResponseArray {
     }
     return true
   }
+
+  /// Attempt to access the item at `index` as a string.
+  public subscript(index: Int) -> String? {
+    if let cstr = sourcekitd.api.variant_array_get_string(array, index) {
+      return String(cString: cstr)
+    }
+    return nil
+  }
 }
 
 extension SKDResponseArray: CustomStringConvertible {

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -29,6 +29,7 @@ public struct sourcekitd_keys {
   public let doc_brief: sourcekitd_uid_t
   public let doc_full_as_xml: sourcekitd_uid_t
   public let edits: sourcekitd_uid_t
+  public let educational_note_paths: sourcekitd_uid_t
   public let endcolumn: sourcekitd_uid_t
   public let endline: sourcekitd_uid_t
   public let filepath: sourcekitd_uid_t
@@ -87,6 +88,7 @@ public struct sourcekitd_keys {
     doc_brief = api.uid_get_from_cstr("key.doc.brief")!
     doc_full_as_xml = api.uid_get_from_cstr("key.doc.full_as_xml")!
     edits = api.uid_get_from_cstr("key.edits")!
+    educational_note_paths = api.uid_get_from_cstr("key.educational_note_paths")!
     endcolumn = api.uid_get_from_cstr("key.endcolumn")!
     endline = api.uid_get_from_cstr("key.endline")!
     filepath = api.uid_get_from_cstr("key.filepath")!

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -150,10 +150,15 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
     let stageUID: sourcekitd_uid_t? = response[sourcekitd.keys.diagnostic_stage]
     let stage = stageUID.flatMap { DiagnosticStage($0, sourcekitd: sourcekitd) } ?? .sema
 
+    let supportsCodeDescription =
+           (clientCapabilities.textDocument?.publishDiagnostics?.codeDescriptionSupport == true)
+
     // Note: we make the notification even if there are no diagnostics to clear the current state.
     var newDiags: [CachedDiagnostic] = []
     response[keys.diagnostics]?.forEach { _, diag in
-      if let diag = CachedDiagnostic(diag, in: snapshot) {
+      if let diag = CachedDiagnostic(diag,
+                                     in: snapshot,
+                                     useEducationalNoteAsCode: supportsCodeDescription) {
         newDiags.append(diag)
       }
       return true

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -206,6 +206,12 @@ final class CodingTests: XCTestCase {
     checkCoding(DiagnosticCode.number(123), json: "123")
     checkCoding(DiagnosticCode.string("hi"), json: "\"hi\"")
 
+    checkCoding(CodeDescription(href: DocumentURI(string: "file:///some/path")), json: """
+    {
+      "href" : "file:\\/\\/\\/some\\/path"
+    }
+    """)
+
     let markup = MarkupContent(kind: .plaintext, value: "a")
     checkCoding(HoverResponse(contents: .markupContent(markup), range: nil), json: """
       {

--- a/Tests/SourceKitLSPTests/XCTestManifests.swift
+++ b/Tests/SourceKitLSPTests/XCTestManifests.swift
@@ -112,6 +112,7 @@ extension LocalSwiftTests {
         ("testEditing", testEditing),
         ("testEditingNonURL", testEditingNonURL),
         ("testEditorPlaceholderParsing", testEditorPlaceholderParsing),
+        ("testEducationalNotesAreUsedAsDiagnosticCodes", testEducationalNotesAreUsedAsDiagnosticCodes),
         ("testExcludedDocumentSchemeDiagnostics", testExcludedDocumentSchemeDiagnostics),
         ("testFixitInsert", testFixitInsert),
         ("testFixitsAreIncludedInPublishDiagnostics", testFixitsAreIncludedInPublishDiagnostics),


### PR DESCRIPTION
This is an updated version of https://github.com/apple/sourcekit-lsp/pull/275 which works with both 5.3 and trunk toolchains, and uses the latest version of the Proposed LSP 3.16 spec.

A couple of notes:
- LSP 3.16 still isn't final, but hopefully will be soonish afaict. The "diagnostic links" feature has changed quite a bit since the last version of this PR. Now, the link is contained in an optional `CodeDescription` property on diagnostics.
- Once the spec is final, some of the dependencies of the VSCode extension will need to be updated to take advantage of this change. Using the current version of the extension with this change doesn't break anything, but the codes don't get displayed. Getting users to update might be a problem since they will need to build the extension from source to get the latest features.

![Screen Recording 2020-11-07 at 11 22 34 AM](https://user-images.githubusercontent.com/1946221/98450214-d784a880-20ef-11eb-8fd0-4eed5ddc29d0.gif)
