### PR TITLE
Improve FileSystemError by adding associated path

### DIFF
--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -46,14 +46,17 @@ extension XCToolchainPlist {
       RelativePath("Info.plist"), // Swift.org
     ]
 
+    var missingPlistPath: AbsolutePath?
     for plistPath in plistNames.lazy.map({ path.appending($0) }) {
       if fileSystem.isFile(plistPath) {
         try self.init(path: plistPath, fileSystem)
         return
       }
+
+      missingPlistPath = plistPath
     }
 
-    throw FileSystemError.noEntry
+    throw FileSystemError(.noEntry, missingPlistPath)
 #else
     throw Error.unsupportedPlatform
 #endif


### PR DESCRIPTION
Currently `FileSystemError` doesn't have an associated path, which makes diagnosing errors harder. This is going to be fixed in TSC and SwiftPM, but this is a breaking change. Usage of `FileSystemError` is updated in the SourceKit-LSP codebase accordingly.