### PR TITLE
SKSwiftPMWorkspace: make `testBasicCXXArgs` pass on Windows

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -378,7 +378,11 @@ extension SwiftPMWorkspace {
 
     var args = td.basicArguments()
 
-    let compilePath = td.compilePaths().first(where: { $0.source == path })
+    let nativePath: AbsolutePath =
+        URL(fileURLWithPath: path.pathString).withUnsafeFileSystemRepresentation {
+          AbsolutePath(String(cString: $0!))
+        }
+    let compilePath = td.compilePaths().first(where: { $0.source == nativePath })
     if let compilePath = compilePath {
       args += [
         "-MD",


### PR DESCRIPTION
We would previously fail to correctly build the GNU dependency outputs
on Windows since we were checking the file system representation of the
path against the internal path representation.  This fixes the
generation of that command as well as the additional checks in the test
case to allow the test case to succeed on Windows.