### PR TITLE
SKCoreTests: make the `IndexStoreDB` tests pass on Windows

### DIFF
--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -222,8 +222,8 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertEqual(buildSystem.indexStorePath, AbsolutePath("/b"))
-      XCTAssertEqual(buildSystem.indexDatabasePath, AbsolutePath("/IndexDatabase"))
+      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexStorePath?.pathString ?? "").path, "/b")
+      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
     }
   }
 
@@ -299,8 +299,8 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertEqual(buildSystem.indexStorePath, AbsolutePath("/b"))
-      XCTAssertEqual(buildSystem.indexDatabasePath, AbsolutePath("/IndexDatabase"))
+      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexStorePath?.pathString ?? "").path, "/b")
+      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
     }
   }
 }


### PR DESCRIPTION
The paths here are not checking the file system representation, use the
internal representation which allows this test to pass on Windows.