### PR TITLE
SKSwiftPMWorkspaceTests: use URLs to create symbolic links

### DIFF
--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -441,8 +441,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
 
       try! FileManager.default.createSymbolicLink(
-        atPath: packageRoot.pathString,
-        withDestinationPath: "pkg_real")
+        at: URL(fileURLWithPath: packageRoot.pathString),
+        withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString))
 
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
@@ -494,8 +494,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
 
       try! FileManager.default.createSymbolicLink(
-        atPath: packageRoot.pathString,
-        withDestinationPath: "pkg_real")
+        at: URL(fileURLWithPath: packageRoot.pathString),
+        withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString))
 
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(


### PR DESCRIPTION
This adjusts the SwiftPMWorkspaceTest to use use
`+[FileManager createSymbolicLinkAt:withDestinationURL:]` rather than
`+[FileManager createSymbolicLinkAtPath:withDestination:]` to allow
creating the symbolic link on Windows.  This allows the test to not
crash at runtime on Windows.