### PR TITLE
Explicitly import Glibc in files that rely on it

### DIFF
--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+#if canImport(Glibc)
+import Glibc
+#endif
 
 public final class SKDRequestArray {
   public let array: sourcekitd_object_t?

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+#if canImport(Glibc)
+import Glibc
+#endif
 
 public final class SKDRequestDictionary {
   public let dict: sourcekitd_object_t?

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+#if canImport(Glibc)
+import Glibc
+#endif
 
 public final class SKDResponseArray {
   public let array: sourcekitd_variant_t

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+#if canImport(Glibc)
+import Glibc
+#endif
 
 public final class SKDResponseDictionary {
   public let dict: sourcekitd_variant_t


### PR DESCRIPTION
These files rely on Glibc declarations in their public interface, even though they don’t import Glibc. Currently, these declarations are discovered through CoreFoundation, but due to implementation details, Swift canonicalizes the declarations and at the end uses declarations from Glibc (which is imported by other files in the module).

This is fragile as Foundation now relies on implementation details of Glibc, which in fact we are trying to change in apple/swift#32404.

This PR fixes the issue by explicitly importing Glibc in affected files.