### PR TITLE
Import Glibc in SKDResponse

### DIFF
--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -11,6 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+#if canImport(Glibc)
+import Glibc
+#endif
 
 public final class SKDResponse {
   public let response: sourcekitd_response_t?


### PR DESCRIPTION
In https://github.com/apple/sourcekit-lsp/pull/357 we forgot to update SDKReponse.swift. This PR fixes that.

From https://github.com/apple/sourcekit-lsp/pull/357:

These files rely on Glibc declarations in their public interface, even though they don’t import Glibc. Currently, these declarations are discovered through CoreFoundation, but due to implementation details, Swift canonicalizes the declarations and at the end uses declarations from Glibc (which is imported by other files in the module).

This is fragile as Foundation now relies on implementation details of Glibc, which in fact we are trying to change in apple/swift#32404.

This PR fixes the issue by explicitly importing Glibc in affected files.