### PR TITLE
[CanonicalOSSA] sourcekit-lsp tests; fix weak reference lifetimes

### DIFF
--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -54,6 +54,10 @@ final class BuildServerBuildSystemTests: XCTestCase {
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "\(fileUrl) settings updated")
     let buildSystemDelegate = TestDelegate(settingsExpectations: [DocumentURI(fileUrl): expectation])
+    defer {
+      // BuildSystemManager has a weak reference to delegate. Keep it alive.
+      _fixLifetime(buildSystemDelegate)
+    }
     buildSystem.delegate = buildSystemDelegate
     buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 
@@ -157,6 +161,10 @@ final class BuildServerBuildSystemTests: XCTestCase {
         kind: .created,
         data: .dictionary(["key": "value"])): expectation,
     ])
+    defer {
+      // BuildSystemManager has a weak reference to delegate. Keep it alive.
+      _fixLifetime(buildSystemDelegate)
+    }
     buildSystem.delegate = buildSystemDelegate
     buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -26,6 +26,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let d = DocumentURI(string: "bsm:d")
 
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [
       a: Set([c]),
       b: Set([c, d]),
@@ -91,6 +95,10 @@ final class BuildSystemManagerTests: XCTestCase {
   func testSettingsMainFile() {
     let a = DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
     let bsm = BuildSystemManager(
@@ -115,6 +123,10 @@ final class BuildSystemManagerTests: XCTestCase {
   func testSettingsMainFileInitialNil() {
     let a = DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
     let bsm = BuildSystemManager(
@@ -137,6 +149,10 @@ final class BuildSystemManagerTests: XCTestCase {
   func testSettingsMainFileWithFallback() {
     let a = DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
     let fallback = FallbackBuildSystem()
@@ -168,6 +184,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let a = DocumentURI(string: "bsm:a.swift")
     let b = DocumentURI(string: "bsm:b.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a]), b: Set([b])]
     let bs = ManualBuildSystem()
     let bsm = BuildSystemManager(
@@ -214,6 +234,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let a = DocumentURI(string: "bsm:a.swift")
     let b = DocumentURI(string: "bsm:b.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a]), b: Set([b])]
     let bs = ManualBuildSystem()
     let bsm = BuildSystemManager(
@@ -250,6 +274,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let cpp1 = DocumentURI(string: "bsm:main.cpp")
     let cpp2 = DocumentURI(string: "bsm:other.cpp")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [
       h: Set([cpp1]),
       cpp1: Set([cpp1]),
@@ -305,6 +333,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let h2 = DocumentURI(string: "bsm:header2.h")
     let cpp = DocumentURI(string: "bsm:main.cpp")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [
       h1: Set([cpp]),
       h2: Set([cpp]),
@@ -350,6 +382,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let b = DocumentURI(string: "bsm:b.swift")
     let c = DocumentURI(string: "bsm:c.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a]), b: Set([b]), c: Set([c])]
     let bs = ManualBuildSystem()
     let bsm = BuildSystemManager(
@@ -400,6 +436,10 @@ final class BuildSystemManagerTests: XCTestCase {
   func testDependenciesUpdated() {
     let a = DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider()
+    defer {
+      // BuildSystemManager has a weak reference to mainFiles. Keep it alive.
+      _fixLifetime(mainFiles)
+    }
     mainFiles.mainFiles = [a: Set([a])]
 
     class DepUpdateDuringRegistrationBS: ManualBuildSystem {

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -53,6 +53,10 @@ final class SourceKitDTests: XCTestCase {
         expectation1.fulfill()
       }
     }
+    // SourceKitDImpl weakly references handlers
+    defer {
+      _fixLifetime(handler1)
+    }
     sourcekitd.addNotificationHandler(handler1)
 
     let expectation2 = expectation(description: "handler 2")
@@ -60,6 +64,10 @@ final class SourceKitDTests: XCTestCase {
       if isExpectedNotification(response) {
         expectation2.fulfill()
       }
+    }
+    // SourceKitDImpl weakly references handlers
+    defer {
+      _fixLifetime(handler2)
     }
     sourcekitd.addNotificationHandler(handler2)
 


### PR DESCRIPTION
Some SourceKit properties are weak references. Several test cases
assign weak references assuming they will outlive subsequent checks
without any subsequent use keeping the reference alive.

The SIL optimizer shortens object lifetimes, breaking the test at
-O. This may even happen at -Onone in the future. The optimizer has
always done this sort of optimization, but enabling OSSA makes it much
more likely to happen in practice.

Fixes rdar://73044531 ([CanonicalOSSA] sourcekit-lsp tests; fix weak
reference lifetimes)

These tests are blocking the OSSA work.