### PR TITLE
[5.4] Adjust the SwiftPMWorkspaceTests.testMultiTargetSwift() test to account for the SwiftPM fix for SR-12050

### DIFF
--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -267,9 +267,18 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let arguments = ws.settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       checkNot(bswift.pathString, arguments: arguments)
-      check(
-        "-I", packageRoot.appending(components: "Sources", "libC", "include").pathString,
-        arguments: arguments)
+      // Temporary conditional to work around revlock between SourceKit-LSP and SwiftPM
+      // as a result of fix for SR-12050.  Can be removed when that fix has been merged.
+      if arguments.joined(separator: " ").contains("-Xcc -I -Xcc") {
+        check(
+          "-Xcc", "-I", "-Xcc", packageRoot.appending(components: "Sources", "libC", "include").pathString,
+          arguments: arguments)
+      }
+      else {
+        check(
+          "-I", packageRoot.appending(components: "Sources", "libC", "include").pathString,
+          arguments: arguments)
+      }
 
       let argumentsB = ws.settings(for: bswift.asURI, .swift)!.compilerArguments
       check(bswift.pathString, arguments: argumentsB)


### PR DESCRIPTION
A SwiftPM fix (apple/swift-package-manager#3215) adds '-Xcc' to the command line generated by SwiftPM and thereby introduces revlock between the SwiftPM fix and SourceKit-LSP. Because of the branch-based dependency of SourceKit-LSP on SwiftPM, this means that SourceKit-LSP's unit test will start failing once that PR is merged. This adds a temporary change to allow SourceKit-LSP to accommodate both command lines. It will be removed once SwiftPM's PR has been merged.

This is the 5.4 nomination for the fix in https://github.com/apple/sourcekit-lsp/pull/362.

(cherry-picked from commit ad735d45ca2077bc49443d7b27604530ed4dd324)