### PR TITLE
Fix a nondeterministic test failure in crash recovery

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1100,20 +1100,18 @@ extension SwiftLanguageServer: SKDNotificationHandler {
         // Reset the document manager to reflect that.
         self.documentManager = DocumentManager()
       }
-    }
-    
-    guard let dict = notification.value else {
-      log(notification.description, level: .error)
-      return
-    }
 
-    logAsync(level: .debug) { _ in notification.description }
+      guard let dict = notification.value else {
+        log(notification.description, level: .error)
+        return
+      }
 
-    if let kind: sourcekitd_uid_t = dict[self.keys.notification],
-       kind == self.values.notification_documentupdate,
-       let name: String = dict[self.keys.name] {
+      logAsync(level: .debug) { _ in notification.description }
 
-      self.queue.async {
+      if let kind: sourcekitd_uid_t = dict[self.keys.notification],
+         kind == self.values.notification_documentupdate,
+         let name: String = dict[self.keys.name] {
+
         let uri: DocumentURI
         if name.starts(with: "/") {
           // If sourcekitd returns us a path, translate it back into a URL

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -84,7 +84,7 @@ final class CrashRecoveryTests: XCTestCase {
 
     sourcekitdServer._crash()
 
-    self.wait(for: [sourcekitdCrashed], timeout: 5)
+    self.wait(for: [sourcekitdCrashed], timeout: 15)
     self.wait(for: [sourcekitdRestarted], timeout: 30)
 
     // Check that we have syntactic functionality again
@@ -130,7 +130,7 @@ final class CrashRecoveryTests: XCTestCase {
     let addCrashPragma = TextDocumentContentChangeEvent(range: loc.position..<loc.position, rangeLength: 0, text: "#pragma clang __debug crash\n")
     ws.sk.send(DidChangeTextDocumentNotification(textDocument: VersionedTextDocumentIdentifier(loc.docUri, version: 3), contentChanges: [addCrashPragma]))
 
-    self.wait(for: [clangdCrashed], timeout: 5)
+    self.wait(for: [clangdCrashed], timeout: 15)
 
     // Once clangds has crashed, remove the pragma again to allow it to restart
     let removeCrashPragma = TextDocumentContentChangeEvent(range: loc.position..<Position(line: 1, utf16index: 0), rangeLength: 28, text: "")
@@ -140,7 +140,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
 
   func testClangdCrashRecovery() throws {
-    throw XCTSkip("failing on rebranch - rdar://73717447")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!
@@ -178,7 +177,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
     
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() throws {
-    throw XCTSkip("failing on rebranch - rdar://73717447")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings")!
@@ -212,7 +210,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
   
   func testPreventClangdCrashLoop() throws {
-    throw XCTSkip("failing on rebranch - rdar://73717447")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!


### PR DESCRIPTION
In some cases (especially if the system is under heavy load), sourcekitd's crash is scheduled while the document update is in progress. In this case, the SwiftLanguageServer's queue is blocked until the document update is handled, which only happens once semantic editor functionality has been restored.
Because the queue is blocked waiting for the document update to be handled, we don't receive the crash notification within 5 seconds. Increasing the timeout to 15 seconds to allow for 10 seconds semantic functionality delay fixes the issue.

While I haven't been able to reproduce rdar://73717447 (test failure in https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-incremental-RA-macos/45/), I suspect a similar issue occurs for clang crash recovery and increasing the timeout there should also resolve the issue.

This commit also unifies the two async blocks in SwiftLanguageServer's notification handling into one. While it isn't strictly related to the issue described above, there should be less room for errors if we disallow scheduling of other blocks on the queue in between a notification handling and document update handling.