### PR TITLE
Require macOS 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SourceKitLSP",
+    platforms: [.macOS(.v10_15)],
     products: [
       .executable(
         name: "sourcekit-lsp",


### PR DESCRIPTION
Motivation:
The same requirement is being added to SwiftPM as part of https://github.com/apple/swift-package-manager/pull/3202. Without this change SourceKit-LSP will fail to build with error:

```
the library 'SKSwiftPMWorkspace' requires macos 10.10, but depends on the product 'SwiftPM-auto' which requires macos 10.15; consider changing the library 'SKSwiftPMWorkspace' to require macos 10.15 or later, or the product 'SwiftPM-auto' to require macos 10.10 or earlier.
```

Modification:
Require macOS 10.15.

Result:
SourceKit-LSP builds successfully with changeset
https://github.com/apple/swift-package-manager/pull/3202.