### PR TITLE
[swiftpm] Avoid ambiguous reference to delegate type

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -44,7 +44,7 @@ public final class SwiftPMWorkspace {
   }
 
   /// Delegate to handle any build system events.
-  public weak var delegate: BuildSystemDelegate? = nil
+  public weak var delegate: SKCore.BuildSystemDelegate? = nil
 
   let workspacePath: AbsolutePath
   let packageRoot: AbsolutePath


### PR DESCRIPTION
SwiftPM introduced a type with the same name, so qualify ours to avoid
the conflict.