### PR TITLE
readme: update link to clangd

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SourceKit-LSP is still in early development, so you may run into rough edges wit
 | Feature | Status | Notes |
 |---------|:------:|-------|
 | Swift | ✅ | |
-| C/C++/ObjC | ✅ | Uses [clangd](https://clangd.github.io) |
+| C/C++/ObjC | ✅ | Uses [clangd](https://clangd.llvm.org/) |
 | Code completion | ✅ | |
 | Quick Help (Hover) | ✅ | |
 | Diagnostics | ✅ | |


### PR DESCRIPTION
If you follow the current link, you will get a message telling you that "The clangd documentation has moved to clangd.llvm.org". Update link to go to the new location directly.