### PR TITLE
Add support for fixed compilation database (compile_flags.txt)

### DIFF
--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -87,9 +87,10 @@ public struct FixedCompilationDatabase: CompilationDatabase, Equatable {
   public var allCommands: AnySequence<Command> { AnySequence([]) }
   
   private let fixedArgs: [String]
+  private let directory: String
 
   public subscript(path: URL) -> [Command] {
-    [Command(directory: "", filename: path.path, commandLine: fixedArgs + [path.path])]
+    [Command(directory: directory, filename: path.path, commandLine: fixedArgs + [path.path])]
   }
 }
 
@@ -100,6 +101,7 @@ extension FixedCompilationDatabase {
   }
 
   public init(file: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
+    self.directory = file.dirname
     let bytes = try fileSystem.readFileContents(file)
 
     var fixedArgs: [String] = ["clang"]

--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -68,9 +68,54 @@ public func tryLoadCompilationDatabase(
   directory: AbsolutePath,
   _ fileSystem: FileSystem = localFileSystem
 ) -> CompilationDatabase? {
-  // TODO: Support fixed compilation database (compile_flags.txt).
-  return try? JSONCompilationDatabase(directory: directory, fileSystem)
+  return
+    (try? JSONCompilationDatabase(directory: directory, fileSystem))
+    ?? (try? FixedCompilationDatabase(directory: directory, fileSystem))
 }
+
+/// Fixed clang-compatible compilation database (compile_flags.txt).
+///
+/// Each line in the file becomes a command line argument. Example:
+/// ```
+/// -xc++
+/// -I
+/// libwidget/include/
+/// ```
+///
+/// See https://clang.llvm.org/docs/JSONCompilationDatabase.html under Alternatives
+public struct FixedCompilationDatabase: CompilationDatabase, Equatable {
+  public var allCommands: AnySequence<Command> { AnySequence([]) }
+  
+  private let fixedArgs: [String]
+
+  public subscript(path: URL) -> [Command] {
+    [Command(directory: "", filename: path.path, commandLine: fixedArgs + [path.path])]
+  }
+}
+
+extension FixedCompilationDatabase {
+  public init(directory: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
+    let path = directory.appending(component: "compile_flags.txt")
+    try self.init(file: path, fileSystem)
+  }
+
+  public init(file: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
+    let bytes = try fileSystem.readFileContents(file)
+
+    var fixedArgs: [String] = ["clang"]
+    try bytes.withUnsafeData { data in
+      guard let fileContents = String(data: data, encoding: .utf8) else {
+        throw CompilationDatabaseDecodingError.fixedDatabaseDecordingError
+      }
+      
+      fileContents.enumerateLines { line, _ in
+        fixedArgs.append(line.trimmingCharacters(in: .whitespacesAndNewlines))
+      }
+    }
+    self.fixedArgs = fixedArgs
+  }
+}
+
 
 /// The JSON clang-compatible compilation database.
 ///
@@ -150,6 +195,7 @@ extension JSONCompilationDatabase {
 
 enum CompilationDatabaseDecodingError: Error {
   case missingCommandOrArguments
+  case fixedDatabaseDecordingError
 }
 
 extension CompilationDatabase.Command: Codable {

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -187,6 +187,25 @@ final class CompilationDatabaseTests: XCTestCase {
     XCTAssertNotNil(tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fs))
   }
 
+  func testFixedCompilationDatabase() {
+    let fs = InMemoryFileSystem()
+    try! fs.createDirectory(AbsolutePath("/a"))
+    XCTAssertNil(tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fs))
+
+    try! fs.writeFileContents(AbsolutePath("/a/compile_flags.txt"), bytes: """
+      -xc++
+      -I
+      libwidget/include/
+      """)
+
+    let db = tryLoadCompilationDatabase(directory: AbsolutePath("/a"), fs)
+    XCTAssertNotNil(db)
+
+    XCTAssertEqual(db![URL(fileURLWithPath: "/a/b")], [
+      CompilationDatabase.Command(directory: "", filename: "/a/b", commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"], output: nil)
+    ])
+  }
+
   func testCompilationDatabaseBuildSystem() {
     checkCompilationDatabaseBuildSystem("""
     [

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -202,7 +202,7 @@ final class CompilationDatabaseTests: XCTestCase {
     XCTAssertNotNil(db)
 
     XCTAssertEqual(db![URL(fileURLWithPath: "/a/b")], [
-      CompilationDatabase.Command(directory: "", filename: "/a/b", commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"], output: nil)
+      CompilationDatabase.Command(directory: "/a", filename: "/a/b", commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"], output: nil)
     ])
   }
 

--- a/Tests/SKCoreTests/XCTestManifests.swift
+++ b/Tests/SKCoreTests/XCTestManifests.swift
@@ -57,6 +57,7 @@ extension CompilationDatabaseTests {
         ("testCompilationDatabaseBuildSystemIndexStoreSwift4", testCompilationDatabaseBuildSystemIndexStoreSwift4),
         ("testDecodeCompDBCommand", testDecodeCompDBCommand),
         ("testEncodeCompDBCommand", testEncodeCompDBCommand),
+        ("testFixedCompilationDatabase", testFixedCompilationDatabase),
         ("testJSONCompilationDatabaseCoding", testJSONCompilationDatabaseCoding),
         ("testJSONCompilationDatabaseFromDirectory", testJSONCompilationDatabaseFromDirectory),
         ("testJSONCompilationDatabaseLookup", testJSONCompilationDatabaseLookup),


### PR DESCRIPTION
This small change adds support for fixed compilation database (compile_flags.txt), ideal for simple codebases that do not use CMake with an auto-generated compile_commands.json file.

See clangd's [compilation database documentation](https://clang.llvm.org/docs/JSONCompilationDatabase.html) under Alternatives.

@benlangmuir 