### PR TITLE
build: update the CMakeLists.txt after #376

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(LanguageServerProtocol
 
   Notifications/CancelRequestNotification.swift
   Notifications/ConfigurationNotification.swift
+  Notifications/DidChangeWatchedFilesNotification.swift
   Notifications/DidChangeWorkspaceFoldersNotification.swift
   Notifications/ExitNotification.swift
   Notifications/InitializedNotification.swift
@@ -36,9 +37,11 @@ add_library(LanguageServerProtocol
   Requests/InitializeRequest.swift
   Requests/PollIndexRequest.swift
   Requests/ReferencesRequest.swift
+  Requests/RegisterCapabilityRequest.swift
   Requests/ShowMessageRequest.swift
   Requests/ShutdownRequest.swift
   Requests/SymbolInfoRequest.swift
+  Requests/UnregisterCapabilityRequest.swift
   Requests/WorkspaceFoldersRequest.swift
   Requests/WorkspaceSymbolsRequest.swift
 
@@ -49,6 +52,8 @@ add_library(LanguageServerProtocol
   SupportTypes/CompletionItemKind.swift
   SupportTypes/Diagnostic.swift
   SupportTypes/DocumentURI.swift
+  SupportTypes/FileEvent.swift
+  SupportTypes/FileSystemWatcher.swift
   SupportTypes/FoldingRangeKind.swift
   SupportTypes/Language.swift
   SupportTypes/Location.swift
@@ -57,6 +62,7 @@ add_library(LanguageServerProtocol
   SupportTypes/LSPAny.swift
   SupportTypes/MarkupContent.swift
   SupportTypes/Position.swift
+  SupportTypes/RegistrationOptions.swift
   SupportTypes/ServerCapabilities.swift
   SupportTypes/SKCompletionOptions.swift
   SupportTypes/SymbolKind.swift


### PR DESCRIPTION
Update the source file list for the new files.  This repairs the
bootstrap build on Windows.