### PR TITLE
Dynamically register completion options for supporting clients

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/RegisterCapabilityRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/RegisterCapabilityRequest.swift
@@ -27,15 +27,15 @@ public struct RegisterCapabilityRequest: RequestType, Hashable {
   public typealias Response = VoidResponse
 
   /// Capability registrations.
-  public var registrations: [Registration]
+  public var registrations: [CapabilityRegistration]
 
-  public init(registrations: [Registration]) {
+  public init(registrations: [CapabilityRegistration]) {
     self.registrations = registrations
   }
 }
 
 /// General parameters to register a capability.
-public struct Registration: Codable, Hashable {
+public struct CapabilityRegistration: Codable, Hashable {
   /// The id used to register the capability which may be used to unregister support.
   public var id: String
 
@@ -51,8 +51,8 @@ public struct Registration: Codable, Hashable {
     self.registerOptions = registerOptions
   }
 
-  /// Create a new `Registration` with a randomly generated id. Save the generated
-  /// id if you wish to unregister the given registration.
+  /// Create a new `CapabilityRegistration` with a randomly generated id. Save
+  /// the generated id if you wish to unregister the given registration.
   public init(method: String, registerOptions: LSPAny?) {
     self.id = UUID().uuidString
     self.method = method

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -80,15 +80,6 @@ public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRe
       dict["allCommitCharacters"] = encode(strings: allCommitCharacters)
     }
   }
-
-  public static func == (lhs: CompletionRegistrationOptions, rhs: CompletionRegistrationOptions) -> Bool {
-    return lhs.textDocumentRegistrationOptions == rhs.textDocumentRegistrationOptions && lhs.completionOptions == rhs.completionOptions
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    textDocumentRegistrationOptions.hash(into: &hasher)
-    completionOptions.hash(into: &hasher)
-  }
 }
 
 /// Describe options to be used when registering for file system change events.

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -41,14 +41,6 @@ public struct TextDocumentRegistrationOptions: RegistrationOptions, Hashable {
     guard let documentSelector = documentSelector else { return }
     dict["documentSelector"] = documentSelector.encodeToLSPAny()
   }
-
-  public static func == (lhs: TextDocumentRegistrationOptions, rhs: TextDocumentRegistrationOptions) -> Bool {
-    return lhs.documentSelector == rhs.documentSelector
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    documentSelector?.hash(into: &hasher)
-  }
 }
 
 /// Protocol for a type which structurally represents`TextDocumentRegistrationOptions`.

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -28,7 +28,7 @@ fileprivate func encode(strings: [String]) -> LSPAny {
 }
 
 /// General text document registration options.
-public class TextDocumentRegistrationOptions: RegistrationOptions, Hashable {
+public struct TextDocumentRegistrationOptions: RegistrationOptions, Hashable {
   /// A document selector to identify the scope of the registration. If not set,
   /// the document selector provided on the client side will be used.
   public var documentSelector: DocumentSelector?
@@ -51,17 +51,25 @@ public class TextDocumentRegistrationOptions: RegistrationOptions, Hashable {
   }
 }
 
+/// Protocol for a type which structurally represents`TextDocumentRegistrationOptions`.
+public protocol TextDocumentRegistrationOptionsProtocol {
+  var textDocumentRegistrationOptions: TextDocumentRegistrationOptions {get}
+}
+
 /// Code completiion registration options.
-public class CompletionRegistrationOptions: TextDocumentRegistrationOptions {
+public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
+  public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions
   public var completionOptions: CompletionOptions
 
   public init(documentSelector: DocumentSelector? = nil, completionOptions: CompletionOptions) {
+    self.textDocumentRegistrationOptions =
+        TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.completionOptions = completionOptions
-    super.init(documentSelector: documentSelector)
   }
 
-  public override func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
-    super.encodeIntoLSPAny(dict: &dict)
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    textDocumentRegistrationOptions.encodeIntoLSPAny(dict: &dict)
+
     if let resolveProvider = completionOptions.resolveProvider {
       dict["resolveProvider"] = .bool(resolveProvider)
     }
@@ -74,11 +82,11 @@ public class CompletionRegistrationOptions: TextDocumentRegistrationOptions {
   }
 
   public static func == (lhs: CompletionRegistrationOptions, rhs: CompletionRegistrationOptions) -> Bool {
-    return lhs.documentSelector == rhs.documentSelector && lhs.completionOptions == rhs.completionOptions
+    return lhs.textDocumentRegistrationOptions == rhs.textDocumentRegistrationOptions && lhs.completionOptions == rhs.completionOptions
   }
 
-  public override func hash(into hasher: inout Hasher) {
-    super.hash(into: &hasher)
+  public func hash(into hasher: inout Hasher) {
+    textDocumentRegistrationOptions.hash(into: &hasher)
     completionOptions.hash(into: &hasher)
   }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -12,12 +12,23 @@
 
 import Foundation
 
-/// An event describing a file change.
-public protocol RegistrationOptions: Codable, LSPAnyCodable, Hashable {
+/// Protocol for capability registration options, which must be encodable to
+/// `LSPAny` so they can be included in a `Registration`.
+public protocol RegistrationOptions: Hashable {
+  func encodeIntoLSPAny(dict: inout [String: LSPAny])
+}
+
+fileprivate func encode(strings: [String]) -> LSPAny {
+  var values = [LSPAny]()
+  values.reserveCapacity(strings.count)
+  for str in strings {
+    values.append(.string(str))
+  }
+  return .array(values)
 }
 
 /// General text document registration options.
-public struct TextDocumentRegistrationOptions: RegistrationOptions {
+public class TextDocumentRegistrationOptions: RegistrationOptions, Hashable {
   /// A document selector to identify the scope of the registration. If not set,
   /// the document selector provided on the client side will be used.
   public var documentSelector: DocumentSelector?
@@ -26,21 +37,49 @@ public struct TextDocumentRegistrationOptions: RegistrationOptions {
     self.documentSelector = documentSelector
   }
 
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
-    guard let selectorValue = dictionary[CodingKeys.documentSelector.stringValue] else {
-      self.documentSelector = nil
-      return
-    }
-    guard case .dictionary(let selectorDictionary) = selectorValue else { return nil }
-    guard let documentSelector = DocumentSelector(fromLSPDictionary: selectorDictionary) else {
-      return nil
-    }
-    self.documentSelector = documentSelector
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    guard let documentSelector = documentSelector else { return }
+    dict["documentSelector"] = documentSelector.encodeToLSPAny()
   }
 
-  public func encodeToLSPAny() -> LSPAny {
-    guard let documentSelector = documentSelector else { return .dictionary([:]) }
-    return .dictionary([CodingKeys.documentSelector.stringValue: documentSelector.encodeToLSPAny()])
+  public static func == (lhs: TextDocumentRegistrationOptions, rhs: TextDocumentRegistrationOptions) -> Bool {
+    return lhs.documentSelector == rhs.documentSelector
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    documentSelector?.hash(into: &hasher)
+  }
+}
+
+/// Code completiion registration options.
+public class CompletionRegistrationOptions: TextDocumentRegistrationOptions {
+  public var completionOptions: CompletionOptions
+
+  public init(documentSelector: DocumentSelector? = nil, completionOptions: CompletionOptions) {
+    self.completionOptions = completionOptions
+    super.init(documentSelector: documentSelector)
+  }
+
+  public override func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    super.encodeIntoLSPAny(dict: &dict)
+    if let resolveProvider = completionOptions.resolveProvider {
+      dict["resolveProvider"] = .bool(resolveProvider)
+    }
+    if let triggerCharacters = completionOptions.triggerCharacters {
+      dict["triggerCharacters"] = encode(strings: triggerCharacters)
+    }
+    if let allCommitCharacters = completionOptions.allCommitCharacters {
+      dict["allCommitCharacters"] = encode(strings: allCommitCharacters)
+    }
+  }
+
+  public static func == (lhs: CompletionRegistrationOptions, rhs: CompletionRegistrationOptions) -> Bool {
+    return lhs.documentSelector == rhs.documentSelector && lhs.completionOptions == rhs.completionOptions
+  }
+
+  public override func hash(into hasher: inout Hasher) {
+    super.hash(into: &hasher)
+    completionOptions.hash(into: &hasher)
   }
 }
 
@@ -53,14 +92,8 @@ public struct DidChangeWatchedFilesRegistrationOptions: RegistrationOptions {
     self.watchers = watchers
   }
 
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
-    guard let watchersLSPAny = dictionary[CodingKeys.watchers.stringValue] else { return nil }
-    guard let watchers = [FileSystemWatcher].init(fromLSPArray: watchersLSPAny) else { return nil }
-    self.watchers = watchers
-  }
-
-  public func encodeToLSPAny() -> LSPAny {
-    return .dictionary([CodingKeys.watchers.stringValue: watchers.encodeToLSPAny()])
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    dict["watchers"] = watchers.encodeToLSPAny()
   }
 }
 
@@ -73,25 +106,7 @@ public struct ExecuteCommandRegistrationOptions: RegistrationOptions {
     self.commands = commands
   }
 
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
-    guard case .array(let commandsArray) = dictionary[CodingKeys.commands.stringValue] else {
-      return nil
-    }
-    var values = [String]()
-    values.reserveCapacity(commandsArray.count)
-    for lspAny in commandsArray {
-      guard case .string(let value) = lspAny else { return nil }
-      values.append(value)
-    }
-    self.commands = values
-  }
-
-  public func encodeToLSPAny() -> LSPAny {
-    var values = [LSPAny]()
-    values.reserveCapacity(commands.count)
-    for command in commands {
-      values.append(.string(command))
-    }
-    return .dictionary([CodingKeys.commands.stringValue: .array(values)])
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    dict["commands"] = encode(strings: commands)
   }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -243,16 +243,23 @@ public enum TextDocumentSyncKind: Int, Codable, Hashable {
 }
 
 public struct CompletionOptions: Codable, Hashable {
-
   /// Whether to use `textDocument/resolveCompletion`
   public var resolveProvider: Bool?
 
   /// The characters that should trigger automatic completion.
-  public var triggerCharacters: [String]
+  public var triggerCharacters: [String]?
 
-  public init(resolveProvider: Bool? = false, triggerCharacters: [String]) {
+  /// The list of all possible characters that commit a completion.
+  public var allCommitCharacters: [String]?
+
+  public init(
+    resolveProvider: Bool? = false,
+    triggerCharacters: [String]? = nil,
+    allCommitCharacters: [String]? = nil
+  ) {
     self.resolveProvider = resolveProvider
     self.triggerCharacters = triggerCharacters
+    self.allCommitCharacters = allCommitCharacters
   }
 }
 

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -90,7 +90,7 @@ public final class SKSwiftPMTestWorkspace {
     let server = testServer.server!
     server.workspace = Workspace(
       rootUri: DocumentURI(sources.rootDirectory),
-      clientCapabilities: ClientCapabilities(),
+      capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
       toolchainRegistry: ToolchainRegistry.shared,
       buildSetup: buildSetup,
       underlyingBuildSystem: swiftpm,

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -69,7 +69,7 @@ public final class SKTibsTestWorkspace {
 
     testServer.server!.workspace = Workspace(
       rootUri: DocumentURI(sources.rootDirectory),
-      clientCapabilities: clientCapabilities,
+      capabilityRegistry: CapabilityRegistry(clientCapabilities: clientCapabilities),
       toolchainRegistry: ToolchainRegistry.shared,
       buildSetup: BuildSetup(configuration: .debug, path: buildPath, flags: BuildFlags()),
       underlyingBuildSystem: buildSystem,

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CMAKE_VERSION VERSION_LESS 3.16)
 endif()
 
 add_library(SourceKitLSP
+  CapabilityRegistry.swift
   DocumentManager.swift
   IndexStoreDB+MainFilesProvider.swift
   SourceKitIndexDelegate.swift

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+/// A class which tracks the client's capabilities as well as our dynamic
+/// capability registrations in order to avoid registering conflicting
+/// capabilities.
+public final class CapabilityRegistry {
+  /// Registered completion options.
+  private var completion: [Registration: CompletionRegistrationOptions] = [:]
+
+  /// Whether dynamic registration is supported for completion.
+  public var completionSupported: Bool = false
+
+  private(set) var clientCapabilities: ClientCapabilities
+
+  public init(clientCapabilities: ClientCapabilities) {
+    self.clientCapabilities = clientCapabilities
+  }
+
+  public func registerCompletion(
+    options: CompletionOptions,
+    for languages: [Language]
+  ) -> Registration {
+    let registrationOptions = CompletionRegistrationOptions(
+      documentSelector: self.documentSelector(for: languages),
+      completionOptions: options)
+    let registration = Registration(
+        method: CompletionRequest.method,
+      registerOptions: self.encode(registrationOptions))
+
+    self.completion[registration] = registrationOptions
+
+    return registration
+  }
+
+  /// Unregister a previously registered registration.
+  public func remove(registration: Registration) {
+    if registration.method == CompletionRequest.method {
+      completion.removeValue(forKey: registration)
+    }
+  }
+
+  public func hasCompletionRegistrations(for languages: [Language]) -> Bool {
+    return self.hasAnyRegistrations(for: languages, in: self.completion)
+  }
+
+  private func documentSelector(for langauges: [Language]) -> DocumentSelector {
+    return DocumentSelector(langauges.map { DocumentFilter(language: $0.rawValue) })
+  }
+
+  private func encode<T: RegistrationOptions>(_ options: T) -> LSPAny {
+    var dict = [String: LSPAny]()
+    options.encodeIntoLSPAny(dict: &dict)
+    return .dictionary(dict)
+  }
+
+  /// Check if we have any text document registration in `registrations` scoped to
+  /// one or more of the given `languages`.
+  private func hasAnyRegistrations(
+    for languages: [Language],
+    in registrations: [Registration: TextDocumentRegistrationOptions]
+  ) -> Bool {
+    var languageIds: Set<String> = []
+    for language in languages {
+      languageIds.insert(language.rawValue)
+    }
+
+    for registration in registrations {
+      guard let filters = registration.value.documentSelector else { continue }
+      for filter in filters {
+        guard let filterLanguage = filter.language else { continue }
+        if languageIds.contains(filterLanguage) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+}

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -13,7 +13,7 @@
 import LanguageServerProtocol
 
 /// Handler responsible for registering a capability with the client.
-public typealias RegistrationHandler = (_ registration: CapabilityRegistration) -> Void
+public typealias ClientRegistrationHandler = (CapabilityRegistration) -> Void
 
 /// A class which tracks the client's capabilities as well as our dynamic
 /// capability registrations in order to avoid registering conflicting
@@ -38,7 +38,7 @@ public final class CapabilityRegistry {
   public func registerCompletionIfNeeded(
     options: CompletionOptions,
     for languages: [Language],
-    handler: RegistrationHandler
+    registerOnClient: ClientRegistrationHandler
   ) {
     guard clientHasDynamicCompletionRegistration && !hasCompletionRegistrations(for: languages) else {
       return
@@ -52,7 +52,7 @@ public final class CapabilityRegistry {
 
     self.completion[registration] = registrationOptions
 
-    handler(registration)
+    registerOnClient(registration)
   }
 
   /// Unregister a previously registered registration, e.g. if no longer needed

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -238,7 +238,7 @@ extension SwiftLanguageServer {
       hoverProvider: true,
       completionProvider: CompletionOptions(
         resolveProvider: false,
-        triggerCharacters: ["."]),
+        triggerCharacters: [".", "("]),
       definitionProvider: nil,
       implementationProvider: .bool(true),
       referencesProvider: nil,

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -31,7 +31,8 @@ public final class Workspace {
   /// The root directory of the workspace.
   public let rootUri: DocumentURI?
 
-  public let clientCapabilities: ClientCapabilities
+  /// Tracks dynamically registered server capabilities as well as the client's capabilities.
+  public let capabilityRegistry: CapabilityRegistry
 
   /// The build system manager to use for documents in this workspace.
   public let buildSystemManager: BuildSystemManager
@@ -50,7 +51,7 @@ public final class Workspace {
 
   public init(
     rootUri: DocumentURI?,
-    clientCapabilities: ClientCapabilities,
+    capabilityRegistry: CapabilityRegistry,
     toolchainRegistry: ToolchainRegistry,
     buildSetup: BuildSetup,
     underlyingBuildSystem: BuildSystem?,
@@ -59,7 +60,7 @@ public final class Workspace {
   {
     self.buildSetup = buildSetup
     self.rootUri = rootUri
-    self.clientCapabilities = clientCapabilities
+    self.capabilityRegistry = capabilityRegistry
     self.index = index
     let bsm = BuildSystemManager(
       buildSystem: underlyingBuildSystem,
@@ -77,7 +78,7 @@ public final class Workspace {
   ///   - toolchainRegistry: The toolchain registry.
   convenience public init(
     rootUri: DocumentURI,
-    clientCapabilities: ClientCapabilities,
+    capabilityRegistry: CapabilityRegistry,
     toolchainRegistry: ToolchainRegistry,
     buildSetup: BuildSetup,
     indexOptions: IndexOptions = IndexOptions()
@@ -123,7 +124,7 @@ public final class Workspace {
 
     self.init(
       rootUri: rootUri,
-      clientCapabilities: clientCapabilities,
+      capabilityRegistry: capabilityRegistry,
       toolchainRegistry: toolchainRegistry,
       buildSetup: buildSetup,
       underlyingBuildSystem: buildSystem,

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -92,7 +92,7 @@ final class BuildSystemTests: XCTestCase {
     let server = testServer.server!
     self.workspace = Workspace(
       rootUri: nil,
-      clientCapabilities: ClientCapabilities(),
+      capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
       toolchainRegistry: ToolchainRegistry.shared,
       buildSetup: TestSourceKitServer.serverOptions.buildSetup,
       underlyingBuildSystem: buildSystem,


### PR DESCRIPTION
Using dynamic registration (when supported by the client) allows
us to provide different completion options for ObjC and Swift
files.

We should be able to expand this to other capabilities in the future
(e.g. semantic highlighting, execute command support).