### PR TITLE
Globally ignore SIGPIPE on Linux

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(LanguageServerProtocolJSONRPC
+  DisableSigpipe.swift
   JSONRPCConnection.swift
   MessageCoding.swift
   MessageSplitting.swift)

--- a/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+#if canImport(Glibc)
+import Glibc
+#endif
+
+#if os(Linux) || os(Android)
+// This is a lazily initialised global variable that when read for the first time, will ignore SIGPIPE.
+private let globallyIgnoredSIGPIPE: Bool = {
+    /* no F_SETNOSIGPIPE on Linux :( */
+    _ = Glibc.signal(SIGPIPE, SIG_IGN)
+    return true
+}()
+
+internal func globallyDisableSigpipe() {
+  let haveWeIgnoredSIGPIEThisIsHereToTriggerIgnoringIt = globallyIgnoredSIGPIPE
+  guard haveWeIgnoredSIGPIEThisIsHereToTriggerIgnoringIt else {
+    fatalError("globallyIgnoredSIGPIPE should always be true")
+  }
+}
+
+#endif

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -63,6 +63,12 @@ public final class JSONRPCConnection {
     outFD: FileHandle,
     syncRequests: Bool = false)
   {
+#if os(Linux) || os(Android)
+    // We receive a `SIGPIPE` if we write to a pipe that points to a crashed process. This in particular happens if the target of a `JSONRPCConnection` has crashed and we try to send it a message.
+    // On Darwin, `DispatchIO` ignores `SIGPIPE` for the pipes handled by it, but that features is not available on Linux.
+    // Instead, globally ignore `SIGPIPE` on Linux to prevent us from crashing if the `JSONRPCConnection`'s target crashes.
+    globallyDisableSigpipe()
+#endif
     state = .created
     self.messageRegistry = messageRegistry
     self.syncRequests = syncRequests

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -152,7 +152,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
 
   func testClangdCrashRecovery() throws {
-    try XCTSkipUnless(isDarwinHost, "rdar://75580936 failing on Linux in CI sometimes")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!
@@ -190,7 +189,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
     
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() throws {
-    try XCTSkipUnless(isDarwinHost, "rdar://75580936 failing on Linux in CI sometimes")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings")!
@@ -224,7 +222,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
   
   func testPreventClangdCrashLoop() throws {
-    try XCTSkipUnless(isDarwinHost, "rdar://75580936 failing on Linux in CI sometimes")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!


### PR DESCRIPTION
We receive a `SIGPIPE` if we write to a pipe that points to a crashed process. This in particular happens if the target of a `JSONRPCConnection` has crashed and we try to send it a message.
On Darwin, `DispatchIO` ignores `SIGPIPE` for the pipes handled by it, but that features is not available on Linux.
Instead, globally ignore `SIGPIPE` on Linux to prevent us from crashing if the `JSONRPCConnection`'s target crashes.

Fixes rdar://75580936