### PR TITLE
[sksupport] Remove unused old TSC argument parsing code

### DIFF
--- a/Sources/SKSupport/BuildConfiguration.swift
+++ b/Sources/SKSupport/BuildConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,11 +15,4 @@ import TSCUtility
 public enum BuildConfiguration: String {
   case debug
   case release
-}
-
-extension BuildConfiguration: StringEnumArgument {
-  /// Type of shell completion to provide for this argument.
-  public static var completion: ShellCompletion {
-    return ShellCompletion.none
-  }
 }


### PR DESCRIPTION
Fixes deprecation warnings while building sourcekit-lsp. We haven't used
this code since we switched to swift-argument-parser, so just delete it.