### PR TITLE
Add support for diagnostic tags

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
@@ -61,6 +61,9 @@ public struct Diagnostic: Codable, Hashable {
   /// Related diagnostic notes.
   public var relatedInformation: [DiagnosticRelatedInformation]?
 
+  /// Additional metadata about the diagnostic.
+  public var tags: [DiagnosticTag]?
+
   /// All the code actions that address this diagnostic.
   /// **LSP Extension from clangd**.
   public var codeActions: [CodeAction]?
@@ -72,6 +75,7 @@ public struct Diagnostic: Codable, Hashable {
     codeDescription: CodeDescription? = nil,
     source: String?,
     message: String,
+    tags: [DiagnosticTag]? = nil,
     relatedInformation: [DiagnosticRelatedInformation]? = nil,
     codeActions: [CodeAction]? = nil)
   {
@@ -81,9 +85,17 @@ public struct Diagnostic: Codable, Hashable {
     self.codeDescription = codeDescription
     self.source = source
     self.message = message
+    self.tags = tags
     self.relatedInformation = relatedInformation
     self.codeActions = codeActions
   }
+}
+
+/// A small piece of metadata about a diagnostic that lets editors e.g. style the diagnostic
+/// in a special way.
+public enum DiagnosticTag: Int, Codable, Hashable {
+  case unnecessary = 1
+  case deprecated = 2
 }
 
 /// A 'note' diagnostic attached to a primary diagonstic that provides additional information.

--- a/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
@@ -93,9 +93,15 @@ public struct Diagnostic: Codable, Hashable {
 
 /// A small piece of metadata about a diagnostic that lets editors e.g. style the diagnostic
 /// in a special way.
-public enum DiagnosticTag: Int, Codable, Hashable {
-  case unnecessary = 1
-  case deprecated = 2
+public struct DiagnosticTag: RawRepresentable, Codable, Hashable {
+  public var rawValue: Int
+
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+
+  public static let unnecessary: DiagnosticTag = DiagnosticTag(rawValue: 1)
+  public static let deprecated: DiagnosticTag = DiagnosticTag(rawValue: 2)
 }
 
 /// A 'note' diagnostic attached to a primary diagonstic that provides additional information.

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -39,6 +39,17 @@ public final class SKDResponseArray {
     return true
   }
 
+  /// If the `applier` returns `false`, iteration terminates.
+  @discardableResult
+  public func forEachUID(_ applier: (Int, sourcekitd_uid_t) -> Bool) -> Bool {
+    for i in 0..<count {
+      if let uid = sourcekitd.api.variant_array_get_uid(array, i), !applier(i, uid) {
+        return false
+      }
+    }
+    return true
+  }
+
   /// Attempt to access the item at `index` as a string.
   public subscript(index: Int) -> String? {
     if let cstr = sourcekitd.api.variant_array_get_string(array, index) {

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -19,6 +19,7 @@ public struct sourcekitd_keys {
   public let associated_usrs: sourcekitd_uid_t
   public let bodylength: sourcekitd_uid_t
   public let bodyoffset: sourcekitd_uid_t
+  public let categories: sourcekitd_uid_t
   public let categorizededits: sourcekitd_uid_t
   public let column: sourcekitd_uid_t
   public let compilerargs: sourcekitd_uid_t
@@ -34,6 +35,7 @@ public struct sourcekitd_keys {
   public let endline: sourcekitd_uid_t
   public let filepath: sourcekitd_uid_t
   public let fixits: sourcekitd_uid_t
+  public let id: sourcekitd_uid_t
   public let kind: sourcekitd_uid_t
   public let length: sourcekitd_uid_t
   public let line: sourcekitd_uid_t
@@ -78,6 +80,7 @@ public struct sourcekitd_keys {
     associated_usrs = api.uid_get_from_cstr("key.associated_usrs")!
     bodylength = api.uid_get_from_cstr("key.bodylength")!
     bodyoffset = api.uid_get_from_cstr("key.bodyoffset")!
+    categories = api.uid_get_from_cstr("key.categories")!
     categorizededits = api.uid_get_from_cstr("key.categorizededits")!
     column = api.uid_get_from_cstr("key.column")!
     compilerargs = api.uid_get_from_cstr("key.compilerargs")!
@@ -93,6 +96,7 @@ public struct sourcekitd_keys {
     endline = api.uid_get_from_cstr("key.endline")!
     filepath = api.uid_get_from_cstr("key.filepath")!
     fixits = api.uid_get_from_cstr("key.fixits")!
+    id = api.uid_get_from_cstr("key.id")!
     kind = api.uid_get_from_cstr("key.kind")!
     length = api.uid_get_from_cstr("key.length")!
     line = api.uid_get_from_cstr("key.line")!
@@ -166,6 +170,8 @@ public struct sourcekitd_values {
   public let diag_error: sourcekitd_uid_t
   public let diag_warning: sourcekitd_uid_t
   public let diag_note: sourcekitd_uid_t
+  public let diag_category_deprecation: sourcekitd_uid_t
+  public let diag_category_no_usage: sourcekitd_uid_t
   public let diag_stage_parse: sourcekitd_uid_t
   public let diag_stage_sema: sourcekitd_uid_t
 
@@ -259,6 +265,8 @@ public struct sourcekitd_values {
     diag_error = api.uid_get_from_cstr("source.diagnostic.severity.error")!
     diag_warning = api.uid_get_from_cstr("source.diagnostic.severity.warning")!
     diag_note = api.uid_get_from_cstr("source.diagnostic.severity.note")!
+    diag_category_deprecation = api.uid_get_from_cstr("source.diagnostic.category.deprecation")!
+    diag_category_no_usage = api.uid_get_from_cstr("source.diagnostic.category.no_usage")!
     diag_stage_parse = api.uid_get_from_cstr("source.diagnostic.stage.swift.parse")!
     diag_stage_sema = api.uid_get_from_cstr("source.diagnostic.stage.swift.sema")!
 

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -176,6 +176,14 @@ extension Diagnostic {
       }
     }
 
+    var tags: [DiagnosticTag] = []
+    if message.contains("never used") || message.contains("unused") {
+      tags.append(.unnecessary)
+    }
+    if message.contains("deprecated") {
+      tags.append(.deprecated)
+    }
+
     self.init(
       range: Range(position!),
       severity: severity,
@@ -183,6 +191,7 @@ extension Diagnostic {
       codeDescription: codeDescription,
       source: "sourcekitd",
       message: message,
+      tags: tags,
       relatedInformation: notes,
       codeActions: actions)
   }

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -177,11 +177,18 @@ extension Diagnostic {
     }
 
     var tags: [DiagnosticTag] = []
-    if message.contains("never used") || message.contains("unused") {
-      tags.append(.unnecessary)
-    }
-    if message.contains("deprecated") {
-      tags.append(.deprecated)
+    if let categories: SKDResponseArray = diag[keys.categories] {
+      categories.forEachUID { (_, category) in
+        switch category {
+        case values.diag_category_deprecation:
+          tags.append(.deprecated)
+        case values.diag_category_no_usage:
+          tags.append(.unnecessary)
+        default:
+          break
+        }
+        return true
+      }
     }
 
     self.init(

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -650,6 +650,7 @@ final class LocalSwiftTests: XCTestCase {
           code: nil,
           source: "sourcekitd",
           message: "initialization of immutable value \'a\' was never used; consider replacing with assignment to \'_\' or removing it",
+          tags: [.unnecessary],
           relatedInformation: [],
           codeActions: nil)],
       edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -638,21 +638,16 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(quickFixes.count, 1)
     let fixit = quickFixes.first!
 
+    // Diagnostic returned by code actions cannot be recursive
+    var expectedDiagnostic = diagnostic!
+    expectedDiagnostic.codeActions = nil
+
     // Expected Fix-it: Replace `let a` with `_` because it's never used
     let expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 7), newText: "_")
     XCTAssertEqual(fixit, CodeAction(
       title: "Replace 'let a' with '_'",
       kind: .quickFix,
-      diagnostics: [
-        Diagnostic(
-          range: Position(line: 1, utf16index: 6)..<Position(line: 1, utf16index: 6),
-          severity: .warning,
-          code: nil,
-          source: "sourcekitd",
-          message: "initialization of immutable value \'a\' was never used; consider replacing with assignment to \'_\' or removing it",
-          tags: [.unnecessary],
-          relatedInformation: [],
-          codeActions: nil)],
+      diagnostics: [expectedDiagnostic],
       edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
       command: nil))
   }


### PR DESCRIPTION
This PR adds a prototypical implementation of the new diagnostic tags, which are part of LSP since 3.15.0, for Swift:

```typescript
export interface Diagnostic {
  ...
  /**
   * Additional metadata about the diagnostic.
   *
   * @since 3.15.0
   */
  tags?: DiagnosticTag[];
  ...
}

export namespace DiagnosticTag {
  /**
   * Unused or unnecessary code.
   *
   * Clients are allowed to render diagnostics with this tag faded out
   * instead of having an error squiggle.
   */
  export const Unnecessary: 1 = 1;
  /**
   * Deprecated or obsolete code.
   *
   * Clients are allowed to rendered diagnostics with this tag strike through.
   */
  export const Deprecated: 2 = 2;
}
```

These tags are used by editors like VSCode to style unused or deprecated diagnostics separately:

![image](https://user-images.githubusercontent.com/30873659/116768591-e6fa0400-aa37-11eb-9062-5d4e1b2b3c4f.png)