### PR TITLE
Update Package.swift dependencies for release/5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -235,9 +235,9 @@ import Foundation
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(name: "IndexStoreDB", url: "https://github.com/apple/indexstore-db.git", .branch("main")),
-    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(name: "IndexStoreDB", url: "https://github.com/apple/indexstore-db.git", .branch("release/5.5")),
+    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.5")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.5")),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.0")),
   ]
 } else {


### PR DESCRIPTION
This points our dependencies on swifptm/tsc/indexstore-db to use the
corresponding release/5.5 branch. This affects building sourcekit-lsp as
a normal package, but has no impact on how Swift.org toolchains are
built, since they use the locally checked out sources, which were
already release/5.5, and  not the remote dependencies.