### PR TITLE
Set revealOutputChannelOn to Never in the VSCode extension

### DIFF
--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -26,7 +26,8 @@ export function activate(context: vscode.ExtensionContext) {
             'objective-c',
             'objective-cpp'
         ],
-        synchronize: undefined
+        synchronize: undefined,
+        revealOutputChannelOn: langclient.RevealOutputChannelOn.Never
     };
 
     const client = new langclient.LanguageClient('sourcekit-lsp', 'SourceKit Language Server', serverOptions, clientOptions);


### PR DESCRIPTION
The VSCode terminal becomes hard to use if the language server sends a bunch of error messages in quick succession, as the editor keeps switching over to the `Output` tab automatically.

Setting `revealOutputChannelOn` to `Never` disables this behavior. Note that the user can still manually switch to the `Output` to view logs and error messages from the language server.