### PR TITLE
Disable clangd crash recovery tests on Linux

### DIFF
--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -152,6 +152,7 @@ final class CrashRecoveryTests: XCTestCase {
   }
 
   func testClangdCrashRecovery() throws {
+    try XCTSkipUnless(isDarwinHost, "Crashing sporadically rdar://78035044")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!
@@ -189,6 +190,7 @@ final class CrashRecoveryTests: XCTestCase {
   }
     
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() throws {
+    try XCTSkipUnless(isDarwinHost, "Crashing sporadically rdar://78035044")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings")!
@@ -222,6 +224,7 @@ final class CrashRecoveryTests: XCTestCase {
   }
   
   func testPreventClangdCrashLoop() throws {
+    try XCTSkipUnless(isDarwinHost, "Crashing sporadically rdar://78035044")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!


### PR DESCRIPTION
Until we can fix whatever is sporadically crashing in CI.

rdar://78035044