### PR TITLE
[logging] Don't pass arbitrary string to NSLog

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -197,7 +197,7 @@ public final class Logger {
 
     if !self.disableNSLog && !usedOSLog {
       // Fallback to NSLog if os_log isn't available.
-      NSLog(message)
+      NSLog("%@", message)
     } else {
       self.logToStderr(message, level: level)
     }


### PR DESCRIPTION
NSLog expects a format string, so don't pass it arbitrary log strings,
which may contain format specifiers.

Thanks @compnerd and @gwynne for reporting.