### PR TITLE
[5.5] SourceKitLSP: properly handle paths on Windows

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1144,7 +1144,7 @@ extension SwiftLanguageServer: SKDNotificationHandler {
         // TODO: this is not completely portable, e.g. MacOS 9 HFS paths are
         // unhandled.
 #if os(Windows)
-        let isPath: Bool = !name.withCString(encodedAs: UTF16.self) {
+        let isPath: Bool = name.withCString(encodedAs: UTF16.self) {
           PathIsUNCW($0) || (0...25) ~= PathGetDriveNumberW($0)
         }
 #else


### PR DESCRIPTION
This corrects the path identification to include Windows paths properly.
Although this is not entirely ideal due to the platform specific code,
but avoids crashing the SourceKit LSP server if it encounters a space in
the path.