### PR TITLE
SwiftLanguageServer: correct path detection on Windows

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1144,7 +1144,7 @@ extension SwiftLanguageServer: SKDNotificationHandler {
         // TODO: this is not completely portable, e.g. MacOS 9 HFS paths are
         // unhandled.
 #if os(Windows)
-        let isPath: Bool = !name.withCString(encodedAs: UTF16.self) {
+        let isPath: Bool = name.withCString(encodedAs: UTF16.self) {
           PathIsUNCW($0) || (0...25) ~= PathGetDriveNumberW($0)
         }
 #else


### PR DESCRIPTION
Correct the polarity of the check.  The path being a UNC path or having a drive letter indicates that it *is* a path, as opposed to the inverted representation that was accidentally committed.