### PR TITLE
[5.5] [swiftpm] Add derived sources to module compiler arguments

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -355,7 +355,7 @@ extension SwiftPMWorkspace {
       args += ["-parse-as-library"]
     }
     args += ["-c"]
-    args += td.target.sources.paths.map { $0.pathString }
+    args += td.sources.map { $0.pathString }
     args += ["-I", buildPath.pathString]
     args += td.compileArguments()
 


### PR DESCRIPTION
Now that swiftpm has derived sources, for example the resource bundle
accessor generated for `Bundle.module`, we need to ensure they get added
to compiler arguments for the module as seen by sourcekit-lsp. Luckily
there is now a convenient ".sources" property on the target description.

https://bugs.swift.org/browse/SR-14658
(cherry picked from commit 8a6500685a2923e87ca0a9aa1232cd0728ee904b)