### PR TITLE
Re-enable clangd crash recovery tests on Linux

### DIFF
--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -152,7 +152,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
 
   func testClangdCrashRecovery() throws {
-    try XCTSkipUnless(isDarwinHost, "Crashing sporadically rdar://78035044")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!
@@ -190,7 +189,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
     
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() throws {
-    try XCTSkipUnless(isDarwinHost, "Crashing sporadically rdar://78035044")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings")!
@@ -224,7 +222,6 @@ final class CrashRecoveryTests: XCTestCase {
   }
   
   func testPreventClangdCrashLoop() throws {
-    try XCTSkipUnless(isDarwinHost, "Crashing sporadically rdar://78035044")
     try XCTSkipUnless(longTestsEnabled)
 
     let ws = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!


### PR DESCRIPTION
This reverts https://github.com/apple/sourcekit-lsp/pull/394.

The underlying issue in swift-corelibs-foundation has been fixed in https://github.com/apple/swift-corelibs-foundation/pull/3000.