### PR TITLE
[swiftpm] For development, build a local copy of PackageDescription

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,9 +83,14 @@ let package = Package(
           "BuildServerProtocol",
           "LanguageServerProtocol",
           "SKCore",
-          .product(name: "SwiftPM-auto", package: "SwiftPM")
-        ],
-        exclude: ["CMakeLists.txt"]),
+          .product(name: "SwiftPM-auto", package: "SwiftPM"),
+        ] + (useLocalPackageDescriptionModule() ? [
+          .product(name: "PackageDescription", package: "SwiftPM"),
+        ] : []),
+        exclude: ["CMakeLists.txt"],
+        swiftSettings: useLocalPackageDescriptionModule() ? [
+          .define("USE_LOCAL_PACKAGE_DESCRIPTION_MODULE")
+        ] : []),
 
       .testTarget(
         name: "SKSwiftPMWorkspaceTests",
@@ -247,4 +252,12 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     .package(path: "../swift-tools-support-core"),
     .package(path: "../swift-argument-parser")
   ]
+}
+
+func useLocalPackageDescriptionModule() -> Bool {
+  // By default, create a local PackageDescription module to ensure it stays
+  // in sync with libSwiftPM during development. To install sourcekit-lsp as
+  // part of the toolchain we use the toolchain's own PackageDescription, and
+  // rely on the whole toolchain being built from the same swiftpm sources.
+  return ProcessInfo.processInfo.environment["SWIFTCI_USE_TOOLCHAIN_PACKAGE_DESCRIPTION"] == nil
 }

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -97,6 +97,9 @@ def handle_invocation(swift_exec, args):
   if not args.no_local_deps:
     env['SWIFTCI_USE_LOCAL_DEPS'] = "1"
 
+  # Always use the toolchain's package description module.
+  env['SWIFTCI_USE_TOOLCHAIN_PACKAGE_DESCRIPTION'] = "1"
+
   if args.ninja_bin:
     env['NINJA_BIN'] = args.ninja_bin
 


### PR DESCRIPTION
When developing sourcekit-lsp, it is useful to be able to use a released
version of the swift toolchain. However, because we are using the latest
branch version of libSwiftPM, it may be that the PackageDescription
module packaged with the toolchain is incompatible with that libSwiftPM.
To prevent that problem, we now build our own copy of PackageDescription
and using that instead of the toolchain's. That change is made by
default to allow plain `swift build` and `swift test` invocations to
work without modification. When building as part of the swift toolchain,
we continue to use the toolchain's copy of PackageDescription, because
we know that it is built from the same sources as we are using for
libSwiftPM.

One situation that is not explicitly covered by the above is if
sourcekit-lsp is installed somewhere outside of a swift toolchain. In
that case by default it will try to find a local package description
module next to the sourcekit-lsp binary, but assuming that fails it will
fallback to searching the default toolcahin that it discovers at
runtime, as it does today. If this usecase turns out to be important we
can provide additional ways to control how to find the
PackageDescription module.

rdar://78548287