### PR TITLE
Add client-side support for inlay hints in VSCode

### DIFF
--- a/Editors/vscode/package-lock.json
+++ b/Editors/vscode/package-lock.json
@@ -1,8 +1,735 @@
 {
     "name": "sourcekit-lsp",
     "version": "0.0.1",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "sourcekit-lsp",
+            "version": "0.0.1",
+            "license": "SEE LICENSE IN LICENSE.txt",
+            "dependencies": {
+                "vscode-languageclient": "^7.0.0"
+            },
+            "devDependencies": {
+                "@types/node": "^14.14.13",
+                "@types/vscode": "^1.52.0",
+                "typescript": "^4.1.3",
+                "vsce": "^1.81.1"
+            },
+            "engines": {
+                "vscode": "^1.52.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "14.14.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.13.tgz",
+            "integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==",
+            "dev": true
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+            "dev": true
+        },
+        "node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/azure-devops-node-api": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+            "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+            "dev": true,
+            "dependencies": {
+                "os": "0.1.1",
+                "tunnel": "0.0.4",
+                "typed-rest-client": "1.2.0",
+                "underscore": "1.8.3"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/cheerio": {
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+            "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+            "dev": true,
+            "dependencies": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.1",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "node_modules/css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
+                "domutils": "1.5.1",
+                "nth-check": "~1.0.1"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/denodeify": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+            "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
+        "node_modules/dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "node_modules/domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "dependencies": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+            "dev": true
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "dev": true,
+            "dependencies": {
+                "pend": "~1.2.0"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "node_modules/glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/linkify-it": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "dev": true,
+            "dependencies": {
+                "uc.micro": "^1.0.1"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/markdown-it": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "entities": "~2.0.0",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+            "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+            "dev": true
+        },
+        "node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
+        },
+        "node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+            "dev": true
+        },
+        "node_modules/nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/os": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
+            "dev": true
+        },
+        "node_modules/os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "dependencies": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "node_modules/parse-semver": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
+            "dev": true,
+            "dependencies": {
+                "semver": "^5.1.0"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
+        },
+        "node_modules/read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dev": true,
+            "dependencies": {
+                "mute-stream": "~0.0.4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tmp": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+            "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+            "dev": true,
+            "dependencies": {
+                "os-tmpdir": "~1.0.1"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/tunnel": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
+        "node_modules/typed-rest-client": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+            "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+            "dev": true,
+            "dependencies": {
+                "tunnel": "0.0.4",
+                "underscore": "1.8.3"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
+        },
+        "node_modules/underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "dev": true
+        },
+        "node_modules/url-join": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+            "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+            "dev": true
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "node_modules/vsce": {
+            "version": "1.81.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.81.1.tgz",
+            "integrity": "sha512-1yWAYRxTx/PKSFZnuELe7GPyIo70H/XKJqf6wGikofUK3f3TCNGI6F9xkTQFvXKNe0AygUuxN7kITyPIQGMP+w==",
+            "dev": true,
+            "dependencies": {
+                "azure-devops-node-api": "^7.2.0",
+                "chalk": "^2.4.2",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^6.1.0",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "leven": "^3.1.0",
+                "lodash": "^4.17.15",
+                "markdown-it": "^10.0.0",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
+                "tmp": "0.0.29",
+                "typed-rest-client": "1.2.0",
+                "url-join": "^1.1.0",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
+            },
+            "bin": {
+                "vsce": "out/vsce"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "engines": {
+                "node": ">=8.0.0 || >=10.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "dependencies": {
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.4",
+                "vscode-languageserver-protocol": "3.16.0"
+            },
+            "engines": {
+                "vscode": "^1.52.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/semver": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "dependencies": {
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/yazl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+            "dev": true,
+            "dependencies": {
+                "buffer-crc32": "~0.2.3"
+            }
+        }
+    },
     "dependencies": {
         "@types/node": {
             "version": "14.14.13",

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -60,8 +60,8 @@
                 },
                 "sourcekit-lsp.inlayHints.enabled": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Render inlay type annotations in the editor."
+                    "default": false,
+                    "description": "(experimental) Render inlay type annotations in the editor."
                 },
                 "sourcekit-lsp.trace.server": {
                     "type": "string",

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -31,9 +31,9 @@
     },
     "devDependencies": {
         "@types/node": "^14.14.13",
+        "@types/vscode": "^1.52.0",
         "typescript": "^4.1.3",
-        "vsce": "^1.81.1",
-        "@types/vscode": "^1.52.0"
+        "vsce": "^1.81.1"
     },
     "contributes": {
         "configuration": {

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -58,6 +58,11 @@
                     "default": "",
                     "description": "(optional) The path of the swift toolchain. By default, sourcekit-lsp uses the toolchain it is installed in."
                 },
+                "sourcekit-lsp.inlayHints.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Render inlay type annotations in the editor."
+                },
                 "sourcekit-lsp.trace.server": {
                     "type": "string",
                     "default": "off",

--- a/Editors/vscode/src/extension.ts
+++ b/Editors/vscode/src/extension.ts
@@ -1,9 +1,9 @@
 'use strict';
 import * as vscode from 'vscode';
 import * as langclient from 'vscode-languageclient/node';
+import { activateInlayHints } from './inlayHints';
 
-export function activate(context: vscode.ExtensionContext) {
-
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const config = vscode.workspace.getConfiguration('sourcekit-lsp');
 
     const sourcekit: langclient.Executable = {
@@ -35,6 +35,9 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(client.start());
 
     console.log('SourceKit-LSP is now active!');
+
+    await client.onReady();
+    activateInlayHints(context, client);
 }
 
 export function deactivate() {

--- a/Editors/vscode/src/inlayHints.ts
+++ b/Editors/vscode/src/inlayHints.ts
@@ -1,0 +1,200 @@
+'use strict';
+import * as vscode from 'vscode';
+import * as langclient from 'vscode-languageclient/node';
+import { InlayHint, InlayHintsParams, inlayHintsRequest } from './lspExtensions';
+
+// The implementation is loosely based on the rust-analyzer implementation
+// of inlay hints: https://github.com/rust-analyzer/rust-analyzer/blob/master/editors/code/src/inlay_hints.ts
+
+// Note that once support for inlay hints is officially added to LSP/VSCode,
+// this module providing custom decorations will no longer be needed!
+
+export async function activateInlayHints(
+    context: vscode.ExtensionContext,
+    client: langclient.LanguageClient
+): Promise<void> {
+    const config = vscode.workspace.getConfiguration('sourcekit-lsp');
+    let updater: HintsUpdater | null = null;
+
+    const onConfigChange = async () => {
+        const wasEnabled = updater !== null;
+        const isEnabled = config.get<boolean>('inlayHints.enabled', true);
+
+        if (wasEnabled !== isEnabled) {
+            updater?.dispose();
+            if (isEnabled) {
+                updater = new HintsUpdater(client);
+            } else {
+                updater = null;
+            }
+        }
+    };
+
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(onConfigChange));
+    context.subscriptions.push({ dispose: () => updater?.dispose() });
+
+    onConfigChange().catch(console.error);
+}
+
+interface InlayHintStyle {
+    decorationType: vscode.TextEditorDecorationType;
+
+    makeDecoration(hint: InlayHint, converter: langclient.Protocol2CodeConverter): vscode.DecorationOptions;
+}
+
+const hintStyle: InlayHintStyle = {
+    decorationType: vscode.window.createTextEditorDecorationType({
+        after: {
+            color: new vscode.ThemeColor('editorCodeLens.foreground'),
+            fontStyle: 'normal',
+            fontWeight: 'normal'
+        }
+    }),
+
+    makeDecoration: (hint, converter) => ({
+        range: converter.asRange({
+            start: hint.position,
+            end: { ...hint.position, character: hint.position.character + 1 } }
+        ),
+        renderOptions: {
+            after: {
+                // U+200C is a zero-width non-joiner to prevent the editor from
+                // forming a ligature between the code and an inlay hint.
+                contentText: `\u{200c}: ${hint.label}`
+            }
+        }
+    })
+};
+
+interface SourceFile {
+    /** Source of the token for cancelling in-flight inlay hint requests. */
+    inFlightInlayHints: null | vscode.CancellationTokenSource;
+
+    /** Most recently applied decorations. */
+    cachedDecorations: null | vscode.DecorationOptions[];
+
+    /** The source file document in question. */
+    document: vscode.TextDocument;
+}
+
+class HintsUpdater implements vscode.Disposable {
+    private readonly disposables: vscode.Disposable[] = [];
+    private sourceFiles: Map<string, SourceFile> = new Map(); // uri -> SourceFile
+
+    constructor(private readonly client: langclient.LanguageClient) {
+        // Register listeners
+        vscode.window.onDidChangeVisibleTextEditors(this.onDidChangeVisibleTextEditors, this, this.disposables);
+        vscode.workspace.onDidChangeTextDocument(this.onDidChangeTextDocument, this, this.disposables);
+
+        // Set up initial cache
+        this.visibleSourceKitLSPEditors.forEach(editor => this.sourceFiles.set(
+            editor.document.uri.toString(),
+            {
+                document: editor.document,
+                inFlightInlayHints: null,
+                cachedDecorations: null
+            }
+        ));
+
+        this.syncCacheAndRenderHints();
+    }
+
+    private onDidChangeVisibleTextEditors(): void {
+        const newSourceFiles = new Map<string, SourceFile>();
+
+        // Rerender all, even up-to-date editors for simplicity
+        this.visibleSourceKitLSPEditors.forEach(async editor => {
+            const uri = editor.document.uri.toString();
+            const file = this.sourceFiles.get(uri) ?? {
+                document: editor.document,
+                inFlightInlayHints: null,
+                cachedDecorations: null
+            };
+            newSourceFiles.set(uri, file);
+
+            // No text documents changed, so we may try to use the cache
+            if (!file.cachedDecorations) {
+                const hints = await this.fetchHints(file);
+                file.cachedDecorations = this.hintsToDecorations(hints);
+            }
+
+            this.renderDecorations(editor, file.cachedDecorations);
+        });
+
+        // Cancel requests for no longer visible (disposed) source files
+        this.sourceFiles.forEach((file, uri) => {
+            if (!newSourceFiles.has(uri)) {
+                file.inFlightInlayHints?.cancel();
+            }
+        });
+
+        this.sourceFiles = newSourceFiles;
+    }
+
+    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
+        if (event.contentChanges.length !== 0 && this.isSourceKitLSPDocument(event.document)) {
+            this.syncCacheAndRenderHints();
+        }
+    }
+
+    private syncCacheAndRenderHints(): void {
+        this.sourceFiles.forEach(async (file, uri) => {
+            const hints = await this.fetchHints(file);
+
+            const decorations = this.hintsToDecorations(hints);
+            file.cachedDecorations = decorations;
+
+            this.visibleSourceKitLSPEditors.forEach(editor => {
+                if (editor.document.uri.toString() === uri) {
+                    this.renderDecorations(editor, decorations);
+                }
+            });
+        });
+    }
+
+    private get visibleSourceKitLSPEditors(): vscode.TextEditor[] {
+        return vscode.window.visibleTextEditors.filter(e => this.isSourceKitLSPDocument(e.document));
+    }
+
+    private isSourceKitLSPDocument(document: vscode.TextDocument): boolean {
+        // TODO: Add other SourceKit-LSP languages if/once we forward inlay
+        // hint requests to clangd.
+        return document.languageId === 'swift' && document.uri.scheme === 'file';
+    }
+
+    private renderDecorations(editor: vscode.TextEditor, decorations: vscode.DecorationOptions[]): void {
+        editor.setDecorations(hintStyle.decorationType, decorations);
+    }
+
+    private hintsToDecorations(hints: InlayHint[]): vscode.DecorationOptions[] {
+        const converter = this.client.protocol2CodeConverter;
+        return hints.map(h => hintStyle.makeDecoration(h, converter));
+    }
+
+    private async fetchHints(file: SourceFile): Promise<InlayHint[]> {
+        file.inFlightInlayHints?.cancel();
+
+        const tokenSource = new vscode.CancellationTokenSource();
+        file.inFlightInlayHints = tokenSource;
+
+        // TODO: Specify a range
+        const params: InlayHintsParams = {
+            textDocument: { uri: file.document.uri.toString() }
+        }
+
+        try {
+            return await this.client.sendRequest(inlayHintsRequest, params, tokenSource.token);
+        } catch (e) {
+            this.client.outputChannel.appendLine(`Could not fetch inlay hints: ${e}`);
+            return [];
+        } finally {
+            if (file.inFlightInlayHints.token === tokenSource.token) {
+                file.inFlightInlayHints = null;
+            }
+        }
+    }
+
+    dispose(): void {
+        this.disposables.forEach(d => d.dispose());
+    }
+}

--- a/Editors/vscode/src/inlayHints.ts
+++ b/Editors/vscode/src/inlayHints.ts
@@ -13,12 +13,12 @@ export async function activateInlayHints(
     context: vscode.ExtensionContext,
     client: langclient.LanguageClient
 ): Promise<void> {
-    const config = vscode.workspace.getConfiguration('sourcekit-lsp');
     let updater: HintsUpdater | null = null;
 
     const onConfigChange = async () => {
+        const config = vscode.workspace.getConfiguration('sourcekit-lsp');
         const wasEnabled = updater !== null;
-        const isEnabled = config.get<boolean>('inlayHints.enabled', true);
+        const isEnabled = config.get<boolean>('inlayHints.enabled', false);
 
         if (wasEnabled !== isEnabled) {
             updater?.dispose();
@@ -195,6 +195,8 @@ class HintsUpdater implements vscode.Disposable {
     }
 
     dispose(): void {
+        this.sourceFiles.forEach(file => file.inFlightInlayHints?.cancel());
+        this.visibleSourceKitLSPEditors.forEach(editor => this.renderDecorations(editor, []));
         this.disposables.forEach(d => d.dispose());
     }
 }

--- a/Editors/vscode/src/lspExtensions.ts
+++ b/Editors/vscode/src/lspExtensions.ts
@@ -1,0 +1,45 @@
+'use strict';
+import * as langclient from 'vscode-languageclient/node';
+
+// Definitions for non-standard requests used by sourcekit-lsp
+
+export interface InlayHintsParams {
+    /**
+     * The text document.
+     */
+    textDocument: langclient.TextDocumentIdentifier;
+
+    /**
+     * If set, the reange for which inlay hints are
+     * requested. If unset, hints for the entire document
+     * are returned.
+     */
+    range?: langclient.Range;
+
+    /**
+     * The categories of inlay hints that are requested.
+     * If unset, all categories are returned.
+     */
+    only?: string[];
+}
+
+export interface InlayHint {
+    /**
+     * The position within the code that this hint is
+     * attached to.
+     */
+    position: langclient.Position;
+
+    /**
+     * The hint's kind, used for more flexible client-side
+     * styling of the hint.
+     */
+    category?: string;
+
+    /**
+     * The hint's rendered label.
+     */
+    label: string;
+}
+
+export const inlayHintsRequest = new langclient.RequestType<InlayHintsParams, InlayHint[], unknown>('sourcekit-lsp/inlayHints');


### PR DESCRIPTION
For easier reviewability, the client-side implementation of inlay hints for VSCode (originally part of #406) is now in this PR. It implements the new (non-standard) `sourcekit-lsp/inlayHints` request and generates corresponding text decorations for inlay hints:

![image](https://user-images.githubusercontent.com/30873659/120929081-e7955280-c6e7-11eb-94ae-9251d7647e2f.png)

Inlay hints as text decorations on the client side are also a proposed part of the VSCode API, although this implementation does not use it yet, as it is only available in VSCode Insiders builds. More details can be found here:

- https://github.com/microsoft/vscode/blob/394a1ce2db/src/vs/vscode.proposed.d.ts#L2493-L2506 (proposed API)

Once inlay hints become part of LSP, this client-side implementation can be removed completely as VSCode's internal language client will then send inlay hint requests as appropriate.