### PR TITLE
Implement server-side support for inlay hints using CollectVariableType

### DIFF
--- a/Editors/vscode/src/inlayHints.ts
+++ b/Editors/vscode/src/inlayHints.ts
@@ -53,9 +53,9 @@ const hintStyle: InlayHintStyle = {
 
     makeDecoration: (hint, converter) => ({
         range: converter.asRange({
-            start: hint.position,
-            end: { ...hint.position, character: hint.position.character + 1 } }
-        ),
+            start: { ...hint.position, character: hint.position.character - 1 },
+            end: hint.position
+        }),
         renderOptions: {
             after: {
                 // U+200C is a zero-width non-joiner to prevent the editor from

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -32,6 +32,9 @@ public final class SKDResponseDictionary {
   public subscript(key: sourcekitd_uid_t?) -> Int? {
     return Int(sourcekitd.api.variant_dictionary_get_int64(dict, key))
   }
+  public subscript(key: sourcekitd_uid_t?) -> Bool? {
+    return sourcekitd.api.variant_dictionary_get_bool(dict, key)
+  }
   public subscript(key: sourcekitd_uid_t?) -> sourcekitd_uid_t? {
     return sourcekitd.api.variant_dictionary_get_uid(dict, key)
   }

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -68,6 +68,7 @@ public struct sourcekitd_keys {
   public let variable_length: sourcekitd_uid_t
   public let variable_type: sourcekitd_uid_t
   public let variable_type_explicit: sourcekitd_uid_t
+  public let variable_type_list: sourcekitd_uid_t
 
   // Code Completion options.
   public let codecomplete_options: sourcekitd_uid_t
@@ -137,6 +138,7 @@ public struct sourcekitd_keys {
     variable_length = api.uid_get_from_cstr("key.variable_length")!
     variable_type = api.uid_get_from_cstr("key.variable_type")!
     variable_type_explicit = api.uid_get_from_cstr("key.variable_type_explicit")!
+    variable_type_list = api.uid_get_from_cstr("key.variable_type_list")!
 
     // Code Completion options
     codecomplete_options = api.uid_get_from_cstr("key.codecomplete.options")!

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -64,6 +64,10 @@ public struct sourcekitd_keys {
   public let text: sourcekitd_uid_t
   public let typename: sourcekitd_uid_t
   public let usr: sourcekitd_uid_t
+  public let variable_offset: sourcekitd_uid_t
+  public let variable_length: sourcekitd_uid_t
+  public let variable_type: sourcekitd_uid_t
+  public let variable_type_explicit: sourcekitd_uid_t
 
   // Code Completion options.
   public let codecomplete_options: sourcekitd_uid_t
@@ -129,6 +133,10 @@ public struct sourcekitd_keys {
     text = api.uid_get_from_cstr("key.text")!
     typename = api.uid_get_from_cstr("key.typename")!
     usr = api.uid_get_from_cstr("key.usr")!
+    variable_offset = api.uid_get_from_cstr("key.variable_offset")!
+    variable_length = api.uid_get_from_cstr("key.variable_length")!
+    variable_type = api.uid_get_from_cstr("key.variable_type")!
+    variable_type_explicit = api.uid_get_from_cstr("key.variable_type_explicit")!
 
     // Code Completion options
     codecomplete_options = api.uid_get_from_cstr("key.codecomplete.options")!
@@ -155,6 +163,7 @@ public struct sourcekitd_requests {
   public let codecomplete_close: sourcekitd_uid_t
   public let cursorinfo: sourcekitd_uid_t
   public let expression_type: sourcekitd_uid_t
+  public let variable_type: sourcekitd_uid_t
   public let relatedidents: sourcekitd_uid_t
   public let semantic_refactoring: sourcekitd_uid_t
 
@@ -169,6 +178,7 @@ public struct sourcekitd_requests {
     codecomplete_close = api.uid_get_from_cstr("source.request.codecomplete.close")!
     cursorinfo = api.uid_get_from_cstr("source.request.cursorinfo")!
     expression_type = api.uid_get_from_cstr("source.request.expression.type")!
+    variable_type = api.uid_get_from_cstr("source.request.variable.type")!
     relatedidents = api.uid_get_from_cstr("source.request.relatedidents")!
     semantic_refactoring = api.uid_get_from_cstr("source.request.semantic.refactoring")!
   }

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(SourceKitLSP PRIVATE
   Swift/SourceKitD+ResponseError.swift
   Swift/SwiftCommand.swift
   Swift/SwiftLanguageServer.swift)
+  Swift/VariableTypeInfo.swift
 set_target_properties(SourceKitLSP PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 # TODO(compnerd) reduce the exposure here, why is everything PUBLIC-ly linked?

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1061,16 +1061,12 @@ extension SwiftLanguageServer {
     }
 
     let uri = req.params.textDocument.uri
-    variableTypeInfos(uri) { infosResult in
+    variableTypeInfos(uri, req.params.range) { infosResult in
       do {
         let infos = try infosResult.get()
         let hints = infos
           .lazy
-          .filter { info in
-            // TODO: Include range in CollectVariableType request directly
-            (req.params.range?.contains(info.range.upperBound) ?? true)
-            && !info.hasExplicitType
-          }
+          .filter { !$0.hasExplicitType }
           .map { info in
             InlayHint(
               position: info.range.upperBound,

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -20,6 +20,8 @@ struct VariableTypeInfo {
   var range: Range<Position>
   /// The printed type of the variable.
   var printedType: String
+  /// Whether the variable has an explicit type annotation in the source file.
+  var hasExplicitType: Bool
 
   init?(_ dict: SKDResponseDictionary, in snapshot: DocumentSnapshot) {
     let keys = dict.sourcekitd.keys
@@ -28,12 +30,14 @@ struct VariableTypeInfo {
           let length: Int = dict[keys.variable_length],
           let startIndex = snapshot.positionOf(utf8Offset: offset),
           let endIndex = snapshot.positionOf(utf8Offset: offset + length),
-          let printedType: String = dict[keys.variable_type] else {
+          let printedType: String = dict[keys.variable_type],
+          let hasExplicitType: Bool = dict[keys.variable_type_explicit] else {
       return nil
     }
 
     self.range = startIndex..<endIndex
     self.printedType = printedType
+    self.hasExplicitType = hasExplicitType
   }
 }
 

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import LanguageServerProtocol
+import SourceKitD
+
+/// A typed variable as returned by sourcekitd's CollectVariableType.
+struct VariableTypeInfo {
+  /// Range of the variable identifier in the source file.
+  var range: Range<Position>
+  /// The printed type of the variable.
+  var printedType: String
+
+  init?(_ dict: SKDResponseDictionary, in snapshot: DocumentSnapshot) {
+    let keys = dict.sourcekitd.keys
+
+    guard let offset: Int = dict[keys.variable_offset],
+          let length: Int = dict[keys.variable_length],
+          let startIndex = snapshot.positionOf(utf8Offset: offset),
+          let endIndex = snapshot.positionOf(utf8Offset: offset + length),
+          let printedType: String = dict[keys.variable_type] else {
+      return nil
+    }
+
+    self.range = startIndex..<endIndex
+    self.printedType = printedType
+  }
+}

--- a/Tests/SourceKitLSPTests/InlayHintsTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintsTests.swift
@@ -169,5 +169,33 @@ final class InlayHintsTests: XCTestCase {
     XCTAssertEqual(hints, [])
   }
 
-  // TODO: Add test for closure parameters
+  func testClosureParams() {
+    let text = """
+    func f(x: Int) {}
+
+    let g = { (x: Int) in }
+    let h: (String) -> String = { x in x }
+    let i: (Double, Double) -> Double = { (x, y) in
+      x + y
+    }
+    """
+    let hints = performInlayHintsRequest(text: text)
+    XCTAssertEqual(hints, [
+      InlayHint(
+        position: Position(line: 3, utf16index: 31),
+        category: .type,
+        label: "String"
+      ),
+      InlayHint(
+        position: Position(line: 4, utf16index: 40),
+        category: .type,
+        label: "Double"
+      ),
+      InlayHint(
+        position: Position(line: 4, utf16index: 43),
+        category: .type,
+        label: "Double"
+      )
+    ])
+  }
 }

--- a/Tests/SourceKitLSPTests/InlayHintsTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintsTests.swift
@@ -182,6 +182,11 @@ final class InlayHintsTests: XCTestCase {
     let hints = performInlayHintsRequest(text: text)
     XCTAssertEqual(hints, [
       InlayHint(
+        position: Position(line: 2, utf16index: 5),
+        category: .type,
+        label: "(Int) -> ()"
+      ),
+      InlayHint(
         position: Position(line: 3, utf16index: 31),
         category: .type,
         label: "String"

--- a/Tests/SourceKitLSPTests/InlayHintsTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintsTests.swift
@@ -67,18 +67,15 @@ final class InlayHintsTests: XCTestCase {
     let x = 4
     var y = "test" + "123"
     """
-    // FIXME: These type hints should ideally be displayed after the variable name
-    // rather than after the expression. Once the implementation is updated (e.g.
-    // by using a new SourceKit request), these tests should be updated too.
     let hints = performInlayHintsRequest(text: text)
     XCTAssertEqual(hints, [
       InlayHint(
-        position: Position(line: 0, utf16index: 9),
+        position: Position(line: 0, utf16index: 5),
         category: .type,
         label: "Int"
       ),
       InlayHint(
-        position: Position(line: 1, utf16index: 22),
+        position: Position(line: 1, utf16index: 5),
         category: .type,
         label: "String"
       ),
@@ -102,12 +99,12 @@ final class InlayHintsTests: XCTestCase {
     let hints = performInlayHintsRequest(text: text, range: range)
     XCTAssertEqual(hints, [
       InlayHint(
-        position: Position(line: 6, utf16index: 23),
+        position: Position(line: 6, utf16index: 10),
         category: .type,
         label: "Bool"
       ),
       InlayHint(
-        position: Position(line: 7, utf16index: 43),
+        position: Position(line: 7, utf16index: 12),
         category: .type,
         label: "Int"
       )
@@ -133,27 +130,27 @@ final class InlayHintsTests: XCTestCase {
     let hints = performInlayHintsRequest(text: text)
     XCTAssertEqual(hints, [
       InlayHint(
-        position: Position(line: 1, utf16index: 24),
+        position: Position(line: 1, utf16index: 20),
         category: .type,
         label: "Int"
       ),
       InlayHint(
-        position: Position(line: 2, utf16index: 33),
+        position: Position(line: 2, utf16index: 25),
         category: .type,
         label: "String"
       ),
       InlayHint(
-        position: Position(line: 6, utf16index: 36),
+        position: Position(line: 6, utf16index: 20),
         category: .type,
         label: "String"
       ),
       InlayHint(
-        position: Position(line: 7, utf16index: 33),
+        position: Position(line: 7, utf16index: 25),
         category: .type,
         label: "Int"
       ),
       InlayHint(
-        position: Position(line: 11, utf16index: 31),
+        position: Position(line: 11, utf16index: 25),
         category: .type,
         label: "Double"
       ),
@@ -169,20 +166,8 @@ final class InlayHintsTests: XCTestCase {
     }
     """
     let hints = performInlayHintsRequest(text: text)
-    // FIXME: Explicitly type-annotated variable bindings shouldn't have
-    // an inlay hint. Once we move to the new SourceKit request (as detailed
-    // in the other comment above), we should receive the empty array here.
-    XCTAssertEqual(hints, [
-      InlayHint(
-        position: Position(line: 0, utf16index: 21),
-        category: .type,
-        label: "String"
-      ),
-      InlayHint(
-        position: Position(line: 3, utf16index: 17),
-        category: .type,
-        label: "Int"
-      )
-    ])
+    XCTAssertEqual(hints, [])
   }
+
+  // TODO: Add test for closure parameters
 }

--- a/Tests/SourceKitLSPTests/XCTestManifests.swift
+++ b/Tests/SourceKitLSPTests/XCTestManifests.swift
@@ -95,6 +95,7 @@ extension InlayHintsTests {
     // to regenerate.
     static let __allTests__InlayHintsTests = [
         ("testBindings", testBindings),
+        ("testClosureParams", testClosureParams),
         ("testEmpty", testEmpty),
         ("testExplicitTypeAnnotation", testExplicitTypeAnnotation),
         ("testFields", testFields),


### PR DESCRIPTION
This is an early draft of support for inlay hints that uses the new [`CollectVariableType`](https://github.com/apple/swift/pull/37867) SourceKit request.

### Implementation Progress

- [x] Add UIDs and structures for `CollectVariableType`
- [x] Support ranged `CollectVariableType` requests
- [x] Reimplement inlay hints using `CollectVariableType`
- [x] Update existing tests
- [x] Add new test for inlay hints on closure parameters

> Note that this also requires a very recent build of the Swift toolchain, otherwise the tests will fail