### PR TITLE
Packaging Improvements

### DIFF
--- a/Editors/vscode/.vscodeignore
+++ b/Editors/vscode/.vscodeignore
@@ -1,9 +1,5 @@
-.vscode/**
-.vscode-test/**
-out/test/**
-out/**/*.map
-src/**
+**/*.ts
+**/tsconfig.json
 .gitignore
-tsconfig.json
-vsc-extension-quickstart.md
-tslint.json
+.vscode/
+node_modules/

--- a/Editors/vscode/.vscodeignore
+++ b/Editors/vscode/.vscodeignore
@@ -2,4 +2,5 @@
 **/tsconfig.json
 .gitignore
 .vscode/
+.vscode-test/
 node_modules/

--- a/Editors/vscode/README.md
+++ b/Editors/vscode/README.md
@@ -19,7 +19,8 @@ The following commands build the extension and creates a `.vsix` package in the 
 
 ```
 $ cd Editors/vscode
-$ npm run createDevPackage
+$ npm install
+$ npm run dev-package
 ```
 
 You can install the package from the command-line using the `code` command if available (see [Launching from the command line](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line)).

--- a/Editors/vscode/README.md
+++ b/Editors/vscode/README.md
@@ -26,7 +26,7 @@ $ npm run dev-package
 You can install the package from the command-line using the `code` command if available (see [Launching from the command line](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line)).
 
 ```
-code --install-extension out/sourcekit-lsp-vscode-dev.vsix
+code --install-extension sourcekit-lsp-development.vsix
 ```
 
 Or you can install from within the application using the `Extensions > Install from VSIX...` command from the command palette.

--- a/Editors/vscode/package-lock.json
+++ b/Editors/vscode/package-lock.json
@@ -1087,6 +1087,12 @@
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
             "dev": true
         },
+        "esbuild": {
+            "version": "0.12.9",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.9.tgz",
+            "integrity": "sha512-MWRhAbMOJ9RJygCrt778rz/qNYgA4ZVj6aXnNPxFjs7PmIpb0fuB9Gmg5uWrr6n++XKwwm/RmSz6RR5JL2Ocsw==",
+            "dev": true
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -19,11 +19,14 @@
         "onLanguage:objective-c",
         "onLanguage:objective-cpp"
     ],
-    "main": "./out/extension",
+    "main": "./out/main",
     "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
+        "vscode:prepublish": "npm run -S esbuild-base -- --minify",
+        "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+        "esbuild": "npm run -S esbuild-base -- --sourcemap",
+        "esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
+        "package": "vsce package",
+        "dev-package": "vsce package -o sourcekit-lsp-development.vsix",
         "createDevPackage": "npm install && ./node_modules/.bin/vsce package -o ./out/sourcekit-lsp-vscode-dev.vsix"
     },
     "dependencies": {

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -32,6 +32,7 @@
     "devDependencies": {
         "@types/node": "^14.14.13",
         "@types/vscode": "^1.52.0",
+        "esbuild": "^0.12.9",
         "typescript": "^4.1.3",
         "vsce": "^1.81.1"
     },

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -26,7 +26,7 @@
         "esbuild": "npm run -S esbuild-base -- --sourcemap",
         "esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
         "package": "vsce package",
-        "dev-package": "vsce package -o sourcekit-lsp-development.vsix",
+        "dev-package": "vsce package -o sourcekit-lsp-development.vsix"
     },
     "dependencies": {
         "vscode-languageclient": "^7.0.0"

--- a/Editors/vscode/package.json
+++ b/Editors/vscode/package.json
@@ -27,7 +27,6 @@
         "esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
         "package": "vsce package",
         "dev-package": "vsce package -o sourcekit-lsp-development.vsix",
-        "createDevPackage": "npm install && ./node_modules/.bin/vsce package -o ./out/sourcekit-lsp-vscode-dev.vsix"
     },
     "dependencies": {
         "vscode-languageclient": "^7.0.0"


### PR DESCRIPTION
This updates the packaging for the VSCode extension to use esbuild to merge and minify the JavaScript.  It also fixes the packaging rules to shrink the plugin ~50x (~325 KiB -> 65 KiB).