### PR TITLE
Use dynamic registration for folding range options

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -74,6 +74,23 @@ public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRe
   }
 }
 
+/// Folding range registration options.
+public struct FoldingRangeRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
+  public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions
+  public var foldingRangeOptions: FoldingRangeOptions
+
+  public init(documentSelector: DocumentSelector? = nil, foldingRangeOptions: FoldingRangeOptions) {
+    self.textDocumentRegistrationOptions =
+        TextDocumentRegistrationOptions(documentSelector: documentSelector)
+    self.foldingRangeOptions = foldingRangeOptions
+  }
+
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    textDocumentRegistrationOptions.encodeIntoLSPAny(dict: &dict)
+    // foldingRangeOptions is currently empty.
+  }
+}
+
 public struct SemanticTokensRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
   /// Method for registration, which defers from the actual requests' methods
   /// since this registration handles multiple requests.

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -275,6 +275,11 @@ public struct CompletionOptions: Codable, Hashable {
   }
 }
 
+public struct FoldingRangeOptions: Codable, Hashable {
+  /// Currently empty in the spec.
+  public init() {}
+}
+
 public struct SignatureHelpOptions: Codable, Hashable {
   /// The characters that trigger signature help automatically.
   public var triggerCharacters: [String]?

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -546,7 +546,7 @@ extension SourceKitServer {
         supportsCodeActions: true
       )),
       colorProvider: .bool(true),
-      foldingRangeProvider: .bool(true),
+      foldingRangeProvider: .bool(!registry.clientHasDynamicFoldingRangeRegistration),
       executeCommandProvider: ExecuteCommandOptions(
         commands: builtinSwiftCommands // FIXME: Clangd commands?
       )
@@ -560,6 +560,11 @@ extension SourceKitServer {
   ) {
     if let completionOptions = server.completionProvider {
       registry.registerCompletionIfNeeded(options: completionOptions, for: languages) {
+        self.dynamicallyRegisterCapability($0, registry)
+      }
+    }
+    if server.foldingRangeProvider?.isSupported == true {
+      registry.registerFoldingRangeIfNeeded(options: FoldingRangeOptions(), for: languages) {
         self.dynamicallyRegisterCapability($0, registry)
       }
     }


### PR DESCRIPTION
Dynamically register because clangd doesn't currently support it, but may in the future. Without this change, we don't provide any code folding in Objective-C files because our empty results override's VS Code's default implementation.