### PR TITLE
 Add syntax highlighting to the code blocks in the markdown returned by SourceKit.

### DIFF
--- a/Sources/SourceKitLSP/Swift/CommentXML.swift
+++ b/Sources/SourceKitLSP/Swift/CommentXML.swift
@@ -75,7 +75,7 @@ private struct XMLToMarkdown {
     switch node.name {
     case "Declaration":
       newlineIfNeeded(count: 2)
-      out += "```\n"
+      out += "```swift\n"
       toMarkdown(node.children)
       out += "\n```\n\n---\n"
       
@@ -125,7 +125,7 @@ private struct XMLToMarkdown {
     case "CodeListing":
       lineNumber = 0
       newlineIfNeeded(count: 2)
-      out += "```\n"
+      out += "```\(node.attributes?.first(where: { $0.name == "language" })?.stringValue ?? "")\n"
       toMarkdown(node.children, separator: "\n")
       out += "```"
 

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -802,7 +802,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Declaration>func foo(_ bar: <Type usr="fake">Baz</Type>)</Declaration>
       """), """
-      ```
+      ```swift
       func foo(_ bar: Baz)
       ```
 
@@ -812,7 +812,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Declaration>func foo() -&gt; <Type>Bar</Type></Declaration>
       """), """
-      ```
+      ```swift
       func foo() -> Bar
       ```
 
@@ -822,7 +822,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Declaration>func replacingOccurrences&lt;Target, Replacement&gt;(of target: Target, with replacement: Replacement, options: <Type usr="s:SS">String</Type>.<Type usr="s:SS10FoundationE14CompareOptionsa">CompareOptions</Type> = default, range searchRange: <Type usr="s:Sn">Range</Type>&lt;<Type usr="s:SS">String</Type>.<Type usr="s:SS5IndexV">Index</Type>&gt;? = default) -&gt; <Type usr="s:SS">String</Type> where Target : <Type usr="s:Sy">StringProtocol</Type>, Replacement : <Type usr="s:Sy">StringProtocol</Type></Declaration>
       """), """
-      ```
+      ```swift
       func replacingOccurrences<Target, Replacement>(of target: Target, with replacement: Replacement, options: String.CompareOptions = default, range searchRange: Range<String.Index>? = default) -> String where Target : StringProtocol, Replacement : StringProtocol
       ```
 
@@ -835,7 +835,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Class><Declaration>var foo</Declaration></Class>
       """), """
-      ```
+      ```swift
       var foo
       ```
 
@@ -846,7 +846,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Class><Name>foo</Name><Declaration>var foo</Declaration></Class>
       """), """
-      ```
+      ```swift
       var foo
       ```
 
@@ -856,7 +856,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Class><USR>asdf</USR><Declaration>var foo</Declaration><Name>foo</Name></Class>
       """), """
-      ```
+      ```swift
       var foo
       ```
 
@@ -874,7 +874,7 @@ final class LocalSwiftTests: XCTestCase {
       """), """
       FOO
 
-      ```
+      ```swift
       var foo
       ```
 
@@ -1005,7 +1005,7 @@ final class LocalSwiftTests: XCTestCase {
         "</CommentParts>" +
       "</Class>"
       ), """
-      ```
+      ```swift
       struct String
       ```
 
@@ -1018,14 +1018,14 @@ final class LocalSwiftTests: XCTestCase {
 
       You can create new strings A *string literal* i
 
-      ```
+      ```swift
       1.\tlet greeting = "Welcome!"
       2.\t
       ```
 
       ...
 
-      ```
+      ```swift
       1.\tlet greeting = "Welcome!"
       2.\t
       ```

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1176,7 +1176,7 @@ final class LocalSwiftTests: XCTestCase {
         XCTAssertEqual(content.kind, .markdown)
         XCTAssertEqual(content.value, """
           S
-          ```
+          ```swift
           struct S
           ```
 
@@ -1228,7 +1228,7 @@ final class LocalSwiftTests: XCTestCase {
         XCTAssertEqual(content.kind, .markdown)
         XCTAssertEqual(content.value, ##"""
           test(\_:\_:)
-          ```
+          ```swift
           func test(_ a: Int, _ b: Int)
           ```
 
@@ -1253,7 +1253,7 @@ final class LocalSwiftTests: XCTestCase {
         XCTAssertEqual(content.kind, .markdown)
         XCTAssertEqual(content.value, ##"""
           \*%\*(\_:\_:)
-          ```
+          ```swift
           func *%* (lhs: String, rhs: String)
           ```
 


### PR DESCRIPTION
This pull request adds syntax highlighting to the code blocks in the markdown returned by SourceKit.

Before this change, Language Server clients would either guess the language of the code block based on the opened file in the editor, or would not provide highlighting at all.

Before:

<img width="1130" alt="Screen Shot 2021-07-13 at 10 35 48 PM" src="https://user-images.githubusercontent.com/51171427/125552017-356702c0-1360-46c2-9203-8d27f2c3b80c.png">

After:

<img width="1123" alt="Screen Shot 2021-07-13 at 10 26 24 PM" src="https://user-images.githubusercontent.com/51171427/125551980-9f347936-f03a-4f7b-a220-feafe31595aa.png">