### PR TITLE
Format Links in the Documentation Markdown from SourceKit

### DIFF
--- a/Sources/SourceKitLSP/Swift/CommentXML.swift
+++ b/Sources/SourceKitLSP/Swift/CommentXML.swift
@@ -157,6 +157,16 @@ private struct XMLToMarkdown {
       toMarkdown(node.children)
       out += "\n\n"
 
+    case "Link":
+      if let href = node.attributes?.first(where: { $0.name == "href" })?.stringValue {
+        out += "[" 
+        toMarkdown(node.children)
+        out += "](\(href))"
+      } else {
+        // Not a valid link.
+        toMarkdown(node.children)
+      }
+
     default:
       toMarkdown(node.children)
     }

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -819,6 +819,16 @@ final class LocalSwiftTests: XCTestCase {
       ---
 
       """)
+	  XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+      <Link href="https://example.com">My Link</Link>
+      """), """
+      [My Link](https://example.com)
+      """)
+    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+      <Link>My Invalid Link</Link>
+      """), """
+      My Invalid Link
+      """)
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Declaration>func replacingOccurrences&lt;Target, Replacement&gt;(of target: Target, with replacement: Replacement, options: <Type usr="s:SS">String</Type>.<Type usr="s:SS10FoundationE14CompareOptionsa">CompareOptions</Type> = default, range searchRange: <Type usr="s:Sn">Range</Type>&lt;<Type usr="s:SS">String</Type>.<Type usr="s:SS5IndexV">Index</Type>&gt;? = default) -&gt; <Type usr="s:SS">String</Type> where Target : <Type usr="s:Sy">StringProtocol</Type>, Replacement : <Type usr="s:Sy">StringProtocol</Type></Declaration>
       """), """


### PR DESCRIPTION
This pull request adds formatting for links in the markdown documentation from SourceKit.

Before:

<img width="930" alt="Before" src="https://user-images.githubusercontent.com/51171427/125688213-fbd99e7b-0b09-4ef0-a599-1a28096b7aa1.png">

After:

<img width="906" alt="After" src="https://user-images.githubusercontent.com/51171427/125688250-4f69ffe3-3e8c-4cc8-bb06-cf5219fb8059.png">