### PR TITLE
On ELF platforms, remove the host toolchain rpath from sourcekit-lsp before installing

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -129,6 +129,7 @@ def handle_invocation(swift_exec, args):
     swiftpm('test', swift_exec, test_args, env)
   elif args.action == 'install':
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, env)
+    swiftpm_args += ['-Xswiftc', '-no-toolchain-stdlib-rpath']
     swiftpm('build', swift_exec, swiftpm_args, env)
     install(bin_path, args.toolchain)
   else:


### PR DESCRIPTION
Without this pull, I see this in the latest official trunk snapshot build:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2021-07-15-a-centos8/usr/bin/sourcekit-lsp | ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/swift-nightly-install/usr/lib/swift/linux:$ORIGIN:$ORIGIN/../lib/swift/linux]
```
I've been removing these host `/home/build-user/` CI paths from the linux toolchain component by component, eg apple/swift-package-manager#2703, this is the last remaining piece. No need to check if it's non-Darwin as in that SPM pull, as [this flag does nothing on macOS](https://github.com/apple/swift/blob/1a381683e42836e225ad7c63ca9addd637f5a04d/lib/Driver/DarwinToolChains.cpp#L460).