### PR TITLE
[5.5] On ELF platforms, remove the host toolchain rpath from sourcekit-lsp before installing

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -129,6 +129,7 @@ def handle_invocation(swift_exec, args):
     swiftpm('test', swift_exec, test_args, env)
   elif args.action == 'install':
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, env)
+    swiftpm_args += ['-Xswiftc', '-no-toolchain-stdlib-rpath']
     swiftpm('build', swift_exec, swiftpm_args, env)
     install(bin_path, args.toolchain)
   else:


### PR DESCRIPTION
Cherry-pick of #417

- Explanation: This removes the build toolchain's rpath for the shipping sourcekit-lsp executable on ELF platforms.
- Scope: Only removes an extraneous rpath from the sourcekit-lsp executable 
- Risk: None
- Testing: This unused host CI rpath has been removed for all other shipping executables and libraries without a problem.
- Reviewer: @benlangmuir