### PR TITLE
build: add the ability to pass in SwiftCollections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(IndexStoreDB QUIET)
 find_package(SwiftPM QUIET)
 find_package(LLBuild QUIET)
 find_package(ArgumentParser CONFIG REQUIRED)
+find_package(SwiftCollections QUIET)
 
 include(SwiftSupport)
 


### PR DESCRIPTION
This allows building against SwiftCollections from a build tree when
building with SwiftPM from a build tree.