### PR TITLE
Adjust SwiftPMWorkspaceTests/testBuildSetup for apple/swift-package-manager#3636,  which changes the behavior of the -Xcc command-line flag

### DIFF
--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -152,7 +152,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let config = BuildSetup(
           configuration: .release,
           path: packageRoot.appending(component: "non_default_build_path"),
-          flags: BuildFlags(xcc: ["-m32"], xcxx: [], xswiftc: ["-typecheck"], xlinker: []))
+          flags: BuildFlags(xcc: ["-m32"], xcxx: [], xswiftc: ["-Xcc", "-m32", "-typecheck"], xlinker: []))
 
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,


### PR DESCRIPTION
SPM no longer passes `-Xcc` command-line flags to the Swift compiler after that change, so have this test pass the flag in through `-Xswiftc` also.