### PR TITLE
Provide Data Types in Document Outline; Provide Code Documentation in `CompletionItem`

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
@@ -63,6 +63,7 @@ public struct CompletionItem: Codable, Hashable {
   {
     self.label = label
     self.detail = detail
+    self.documentation = documentation
     self.sortText = sortText
     self.filterText = filterText
     self.textEdit = textEdit

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -137,6 +137,7 @@ extension SwiftLanguageServer {
       var filterName: String? = value[self.keys.name]
       let insertText: String? = value[self.keys.sourcetext]
       let typeName: String? = value[self.keys.typename]
+      let docBrief: String? = value[self.keys.doc_brief]
 
       let clientCompletionCapabilities = self.clientCapabilities.textDocument?.completion
       let clientSupportsSnippets = clientCompletionCapabilities?.completionItem?.snippetSupport == true
@@ -173,6 +174,7 @@ extension SwiftLanguageServer {
         label: name,
         kind: kind?.asCompletionItemKind(self.values) ?? .value,
         detail: typeName,
+        documentation: docBrief != nil ? .markupContent(MarkupContent(kind: .markdown, value: docBrief!)) : nil,
         sortText: nil,
         filterText: filterName,
         textEdit: textEdit,

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -564,7 +564,7 @@ extension SwiftLanguageServer {
           children = nil
         }
         return DocumentSymbol(name: name,
-                              detail: nil,
+                              detail: value[self.keys.typename] as String?,
                               kind: kind,
                               deprecated: nil,
                               range: range,

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -422,7 +422,7 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
       ),
       DocumentSymbol(
         name: "computedVariable",
-        detail: nil,
+        detail: "Int",
         kind: .variable,
         deprecated: nil,
         range: range(from: (10, 0), to: (10, 38)),
@@ -540,7 +540,7 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
           ),
           DocumentSymbol(
             name: "computedProperty",
-            detail: nil,
+            detail: "Int",
             kind: .property,
             deprecated: nil,
             range: range(from: (21, 2), to: (21, 40)),
@@ -576,7 +576,7 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
           ),
           DocumentSymbol(
             name: "staticComputedProperty",
-            detail: nil,
+            detail: "Int",
             kind: .property,
             deprecated: nil,
             range: range(from: (25, 2), to: (25, 53)),
@@ -585,7 +585,7 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
           ),
           DocumentSymbol(
             name: "classProperty",
-            detail: nil,
+            detail: "Int",
             kind: .property,
             deprecated: nil,
             range: range(from: (26, 2), to: (26, 43)),
@@ -620,7 +620,7 @@ func initialize(capabilities: DocumentSymbolCapabilities) {
               ),
               DocumentSymbol(
                 name: "localComputedVariable",
-                detail: nil,
+                detail: "Int",
                 kind: .variable,
                 deprecated: nil,
                 range: range(from: (30, 4), to: (30, 47)),

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -23,6 +23,7 @@ final class SwiftCompletionTests: XCTestCase {
   /// Base document text to use for completion tests.
   let text: String = """
     struct S {
+      /// Documentation for `abc`.
       var abc: Int
 
       func test(a: Int) {
@@ -103,7 +104,7 @@ final class SwiftCompletionTests: XCTestCase {
 
     let selfDot = try! sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 4, utf16index: 9)))
+      position: Position(line: 5, utf16index: 9)))
 
     XCTAssertEqual(selfDot.isIncomplete, options.serverSideFiltering)
     XCTAssertGreaterThanOrEqual(selfDot.items.count, 2)
@@ -112,8 +113,9 @@ final class SwiftCompletionTests: XCTestCase {
     if let abc = abc {
       XCTAssertEqual(abc.kind, .property)
       XCTAssertEqual(abc.detail, "Int")
+      XCTAssertEqual(abc.documentation, .markupContent(MarkupContent(kind: .markdown, value: "Documentation for abc.")))
       XCTAssertEqual(abc.filterText, "abc")
-      XCTAssertEqual(abc.textEdit, TextEdit(range: Position(line: 4, utf16index: 9)..<Position(line: 4, utf16index: 9), newText: "abc"))
+      XCTAssertEqual(abc.textEdit, TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "abc"))
       XCTAssertEqual(abc.insertText, "abc")
       XCTAssertEqual(abc.insertTextFormat, .plain)
     }
@@ -121,7 +123,7 @@ final class SwiftCompletionTests: XCTestCase {
     for col in 10...12 {
       let inIdent = try! sk.sendSync(CompletionRequest(
         textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 4, utf16index: col)))
+        position: Position(line: 5, utf16index: col)))
       guard let abc = inIdent.items.first(where: { $0.label == "abc" }) else {
         XCTFail("No completion item with label 'abc'")
         return
@@ -130,15 +132,16 @@ final class SwiftCompletionTests: XCTestCase {
       // If we switch to server-side filtering this will change.
       XCTAssertEqual(abc.kind, .property)
       XCTAssertEqual(abc.detail, "Int")
+      XCTAssertEqual(abc.documentation, .markupContent(MarkupContent(kind: .markdown, value: "Documentation for abc.")))
       XCTAssertEqual(abc.filterText, "abc")
-      XCTAssertEqual(abc.textEdit, TextEdit(range: Position(line: 4, utf16index: 9)..<Position(line: 4, utf16index: col), newText: "abc"))
+      XCTAssertEqual(abc.textEdit, TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: col), newText: "abc"))
       XCTAssertEqual(abc.insertText, "abc")
       XCTAssertEqual(abc.insertTextFormat, .plain)
     }
 
     let after = try! sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 5, utf16index: 0)))
+      position: Position(line: 6, utf16index: 0)))
     XCTAssertNotEqual(after, selfDot)
   }
 
@@ -158,11 +161,11 @@ final class SwiftCompletionTests: XCTestCase {
     }
 
     func getTestMethodACompletion() -> CompletionItem? {
-      return getTestMethodCompletion(Position(line: 4, utf16index: 9), label: "test(a: Int)")
+      return getTestMethodCompletion(Position(line: 5, utf16index: 9), label: "test(a: Int)")
     }
 
     func getTestMethodBCompletion() -> CompletionItem? {
-      return getTestMethodCompletion(Position(line: 8, utf16index: 9), label: "test(b: Int)")
+      return getTestMethodCompletion(Position(line: 9, utf16index: 9), label: "test(b: Int)")
     }
 
     var test = getTestMethodACompletion()
@@ -171,7 +174,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(a:)")
-        XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 4, utf16index: 9)..<Position(line: 4, utf16index: 9), newText: "test(a: ${1:Int})"))
+        XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "test(a: ${1:Int})"))
       XCTAssertEqual(test.insertText, "test(a: ${1:Int})")
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
@@ -182,7 +185,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(:)")
-      XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 8, utf16index: 9)..<Position(line: 8, utf16index: 9), newText: "test(${1:b: Int})"))
+      XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 9, utf16index: 9)..<Position(line: 9, utf16index: 9), newText: "test(${1:b: Int})"))
       XCTAssertEqual(test.insertText, "test(${1:b: Int})")
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
@@ -198,7 +201,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(a:)")
-      XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 4, utf16index: 9)..<Position(line: 4, utf16index: 9), newText: "test(a: )"))
+      XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "test(a: )"))
       XCTAssertEqual(test.insertText, "test(a: )")
       XCTAssertEqual(test.insertTextFormat, .plain)
     }
@@ -210,7 +213,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(:)")
       // FIXME:
-        XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 8, utf16index: 9)..<Position(line: 8, utf16index: 9), newText: "test()"))
+        XCTAssertEqual(test.textEdit, TextEdit(range: Position(line: 9, utf16index: 9)..<Position(line: 9, utf16index: 9), newText: "test()"))
       XCTAssertEqual(test.insertText, "test()")
       XCTAssertEqual(test.insertTextFormat, .plain)
     }


### PR DESCRIPTION
## Provide Data Types in Document Outline

Before:

<img width="521" alt="DetailDocumentSymbol-Before" src="https://user-images.githubusercontent.com/51171427/128436110-19856d3a-5890-4e57-bd2b-b54eb42807b8.png">

After: 

<img width="518" alt="DetailDocumentSymbol-After" src="https://user-images.githubusercontent.com/51171427/128436169-9e90fb56-775f-4414-be05-d2795616586d.png">


### Problems

* SourceKit doesn’t provide the `typename` field for variables with inferred types, like `let a = “string”`, it's only provided for `let a: String = "string"`. Function parameters always have a type, but they also are ignored by SourceKit. Is there a way to tell SourceKit to use the inferred types?

## Provide Code Documentation in `CompletionItem`

Before:

<img width="451" alt="CodeCompletionDocBrief-Before" src="https://user-images.githubusercontent.com/51171427/128436184-46d994c4-0812-45e1-95e8-f6e66a282902.png">

After:

<img width="819" alt="CodeCompletionDocBrief-After" src="https://user-images.githubusercontent.com/51171427/128436209-e6d55be5-0fcd-4465-ae89-bea02f0b8855.png">

### Problems/Questions

* Is it possible to retrieve the _full_ documentation (perhaps `doc_full_as_xml`) for completion suggestions, not just `doc_brief`?
* SourceKit removes markdown in `doc_brief`.