### PR TITLE
Fix code completion in header files

### DIFF
--- a/Sources/SKCore/FileBuildSettings.swift
+++ b/Sources/SKCore/FileBuildSettings.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 
 /// Build settings for a single file.
@@ -27,5 +28,57 @@ public struct FileBuildSettings: Equatable {
   public init(compilerArguments: [String], workingDirectory: String? = nil) {
     self.compilerArguments = compilerArguments
     self.workingDirectory = workingDirectory
+  }
+}
+
+fileprivate let headerExtensions = ["h", "hh", "hpp"]
+
+fileprivate let cExtensions = ["c"]
+fileprivate let cppExtensions = ["cpp", "cc"]
+fileprivate let objcExtensions = ["m"]
+fileprivate let objcppExtensions = ["mm"]
+
+private extension String {
+  var pathExtension: String {
+    return (self as NSString).pathExtension
+  }
+  var pathBasename: String {
+    return (self as NSString).lastPathComponent
+  }
+}
+
+public extension FileBuildSettings {
+  /// Return arguments suitable for use by `newFile`, which must be a header file.
+  ///
+  /// This patches the arguments by searching for the argument corresponding to
+  /// `originalFile` and replacing it.
+  func patching(newFile: String, originalFile: String) -> FileBuildSettings {
+    guard headerExtensions.contains(newFile.pathExtension) else {
+      return self
+    }
+    var arguments = self.compilerArguments
+    let basename = originalFile.pathBasename
+    let fileExtension = originalFile.pathExtension
+    if let index = arguments.lastIndex(where: {
+      // It's possible the arguments use relative paths while the `oldFile` given is
+      // an absolute/real path value. We guess based on suffixes instead of hitting
+      // the file system.
+      $0.hasSuffix(basename) && originalFile.hasSuffix($0)
+    }) {
+      arguments[index] = newFile
+      // The `-x<lang>` flag needs to be before the possible `-c <header file>`
+      // argument in order for Clang to respect it. If there is a pre-existing `-x`
+      // flag though, Clang will honor that one instead since it comes after.
+      if cExtensions.contains(fileExtension) {
+        arguments.insert("-xc-header", at: 0)
+      } else if cppExtensions.contains(fileExtension) {
+        arguments.insert("-xc++-header", at: 0)
+      } else if objcExtensions.contains(fileExtension) {
+        arguments.insert("-xobjective-c-header", at: 0)
+      } else if (objcppExtensions.contains(fileExtension)) {
+        arguments.insert("-xobjective-c++-header", at: 0)
+      }
+    }
+    return FileBuildSettings(compilerArguments: arguments, workingDirectory: self.workingDirectory)
   }
 }

--- a/Sources/SKCore/FileBuildSettings.swift
+++ b/Sources/SKCore/FileBuildSettings.swift
@@ -31,8 +31,6 @@ public struct FileBuildSettings: Equatable {
   }
 }
 
-fileprivate let headerExtensions = ["h", "hh", "hpp"]
-
 fileprivate let cExtensions = ["c"]
 fileprivate let cppExtensions = ["cpp", "cc"]
 fileprivate let objcExtensions = ["m"]
@@ -48,14 +46,11 @@ private extension String {
 }
 
 public extension FileBuildSettings {
-  /// Return arguments suitable for use by `newFile`, which must be a header file.
+  /// Return arguments suitable for use by `newFile`.
   ///
   /// This patches the arguments by searching for the argument corresponding to
   /// `originalFile` and replacing it.
   func patching(newFile: String, originalFile: String) -> FileBuildSettings {
-    guard headerExtensions.contains(newFile.pathExtension) else {
-      return self
-    }
     var arguments = self.compilerArguments
     let basename = originalFile.pathBasename
     let fileExtension = originalFile.pathExtension
@@ -70,13 +65,13 @@ public extension FileBuildSettings {
       // argument in order for Clang to respect it. If there is a pre-existing `-x`
       // flag though, Clang will honor that one instead since it comes after.
       if cExtensions.contains(fileExtension) {
-        arguments.insert("-xc-header", at: 0)
+        arguments.insert("-xc", at: 0)
       } else if cppExtensions.contains(fileExtension) {
-        arguments.insert("-xc++-header", at: 0)
+        arguments.insert("-xc++", at: 0)
       } else if objcExtensions.contains(fileExtension) {
-        arguments.insert("-xobjective-c-header", at: 0)
+        arguments.insert("-xobjective-c", at: 0)
       } else if (objcppExtensions.contains(fileExtension)) {
-        arguments.insert("-xobjective-c++-header", at: 0)
+        arguments.insert("-xobjective-c++", at: 0)
       }
     }
     return FileBuildSettings(compilerArguments: arguments, workingDirectory: self.workingDirectory)

--- a/Sources/SKCore/FileBuildSettings.swift
+++ b/Sources/SKCore/FileBuildSettings.swift
@@ -55,8 +55,8 @@ public extension FileBuildSettings {
     let basename = originalFile.pathBasename
     let fileExtension = originalFile.pathExtension
     if let index = arguments.lastIndex(where: {
-      // It's possible the arguments use relative paths while the `oldFile` given is
-      // an absolute/real path value. We guess based on suffixes instead of hitting
+      // It's possible the arguments use relative paths while the `originalFile` given
+      // is an absolute/real path value. We guess based on suffixes instead of hitting
       // the file system.
       $0.hasSuffix(basename) && originalFile.hasSuffix($0)
     }) {

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -330,8 +330,8 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let initial1 = expectation(description: "initial settings h1 via cpp")
     let initial2 = expectation(description: "initial settings h2 via cpp")
-    let expectedArgsH1 = FileBuildSettings(compilerArguments: ["-xc++-header", cppArg, h1.pseudoPath])
-    let expectedArgsH2 = FileBuildSettings(compilerArguments: ["-xc++-header", cppArg, h2.pseudoPath])
+    let expectedArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h1.pseudoPath])
+    let expectedArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h2.pseudoPath])
     del.expected = [
       (h1, expectedArgsH1, initial1, #file, #line),
       (h2, expectedArgsH2, initial2, #file, #line),
@@ -348,8 +348,8 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[cpp] = FileBuildSettings(compilerArguments: [newCppArg, cpp.pseudoPath])
     let changed1 = expectation(description: "initial settings h1 via cpp")
     let changed2 = expectation(description: "initial settings h2 via cpp")
-    let newArgsH1 = FileBuildSettings(compilerArguments: ["-xc++-header", newCppArg, h1.pseudoPath])
-    let newArgsH2 = FileBuildSettings(compilerArguments: ["-xc++-header", newCppArg, h2.pseudoPath])
+    let newArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", newCppArg, h1.pseudoPath])
+    let newArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", newCppArg, h2.pseudoPath])
     del.expected = [
       (h1, newArgsH1, changed1, #file, #line),
       (h2, newArgsH2, changed2, #file, #line),

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -325,13 +325,16 @@ final class BuildSystemManagerTests: XCTestCase {
     defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
     let del = BSMDelegate(bsm)
 
-    bs.map[cpp] = FileBuildSettings(compilerArguments: ["C++ Main File"])
+    let cppArg = "C++ Main File"
+    bs.map[cpp] = FileBuildSettings(compilerArguments: [cppArg, cpp.pseudoPath])
 
     let initial1 = expectation(description: "initial settings h1 via cpp")
     let initial2 = expectation(description: "initial settings h2 via cpp")
+    let expectedArgsH1 = FileBuildSettings(compilerArguments: ["-xc++-header", cppArg, h1.pseudoPath])
+    let expectedArgsH2 = FileBuildSettings(compilerArguments: ["-xc++-header", cppArg, h2.pseudoPath])
     del.expected = [
-      (h1, bs.map[cpp]!, initial1, #file, #line),
-      (h2, bs.map[cpp]!, initial2, #file, #line),
+      (h1, expectedArgsH1, initial1, #file, #line),
+      (h2, expectedArgsH2, initial2, #file, #line),
     ]
 
     bsm.registerForChangeNotifications(for: h1, language: .c)
@@ -341,12 +344,15 @@ final class BuildSystemManagerTests: XCTestCase {
     // since they are backed by the same underlying cpp file.
     wait(for: [initial1, initial2], timeout: 10, enforceOrder: false)
 
-    bs.map[cpp] = FileBuildSettings(compilerArguments: ["New C++ Main File"])
+    let newCppArg = "New C++ Main File"
+    bs.map[cpp] = FileBuildSettings(compilerArguments: [newCppArg, cpp.pseudoPath])
     let changed1 = expectation(description: "initial settings h1 via cpp")
     let changed2 = expectation(description: "initial settings h2 via cpp")
+    let newArgsH1 = FileBuildSettings(compilerArguments: ["-xc++-header", newCppArg, h1.pseudoPath])
+    let newArgsH2 = FileBuildSettings(compilerArguments: ["-xc++-header", newCppArg, h2.pseudoPath])
     del.expected = [
-      (h1, bs.map[cpp]!, changed1, #file, #line),
-      (h2, bs.map[cpp]!, changed2, #file, #line),
+      (h1, newArgsH1, changed1, #file, #line),
+      (h2, newArgsH2, changed2, #file, #line),
     ]
     bsm.fileBuildSettingsChanged([cpp: .modified(bs.map[cpp]!)])
 


### PR DESCRIPTION
Previously, header files would have their compiler flags inferred
from source files which include them. However, code completion
didn't work properly since the file path in the arguments was
incorrect, pointing to the source file instead of the header file.
