### PR TITLE
adjust SwiftPMWorkspace to latest SwiftPM APIs

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -91,9 +91,17 @@ public final class SwiftPMWorkspace {
         location.workingDirectory = customWorkingDirectory
     }
 
+      // since we are customizing the workspace location, we need to explicitly pass the mirrors configuration
+    let mirrorsConfiguration = try Workspace.Configuration.Mirrors(
+        forRootPackage: packageRoot,
+        sharedMirrorFile: location.sharedMirrorsConfigurationFile,
+        fileSystem: fileSystem
+    )
+
     self.workspace = try Workspace(
         fileSystem: fileSystem,
         location: location,
+        mirrors: mirrorsConfiguration.mirrors,
         customManifestLoader: ManifestLoader(toolchain: toolchain.configuration, cacheDir: location.workingDirectory),
         resolverUpdateEnabled: false
     )


### PR DESCRIPTION
motivation: do not use deprecated APIs

changes:
* explicitly import TSCBasic since SwiftPM stops re-exporting it
* adjust Workspace creation to use up-to-date APIs