### PR TITLE
Fix document symbols regression

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/DocumentSymbolRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentSymbolRequest.swift
@@ -91,7 +91,7 @@ public struct DocumentSymbol: Hashable, Codable {
   public var selectionRange: Range<Position>
 
   /// Children of this symbol, e.g. properties of a class.
-  public var children: [DocumentSymbol]
+  public var children: [DocumentSymbol]?
 
   public init(
     name: String,
@@ -100,7 +100,7 @@ public struct DocumentSymbol: Hashable, Codable {
     deprecated: Bool? = nil,
     range: Range<Position>,
     selectionRange: Range<Position>,
-    children: [DocumentSymbol] = [])
+    children: [DocumentSymbol]? = nil)
   {
     self.name = name
     self.detail = detail

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -333,9 +333,6 @@ final class CodingTests: XCTestCase {
     checkCoding(DocumentSymbolResponse.documentSymbols([DocumentSymbol(name: "mySymbol", kind: .function, range: range, selectionRange: range)]), json: """
       [
         {
-          "children" : [
-
-          ],
           "kind" : 12,
           "name" : "mySymbol",
           "range" : \(rangejson.indented(4, skipFirstLine: true)),


### PR DESCRIPTION
This appears to have been accidentally removed in 17f656865ddc7abe6273ec8752b596578232d440, the `children` field is
optional in the LSP spec.