### PR TITLE
Add support for clangd commands

### DIFF
--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -42,6 +42,9 @@ public let builtinRequests: [_RequestType.Type] = [
   ColorPresentationRequest.self,
   CodeActionRequest.self,
   ExecuteCommandRequest.self,
+  ApplyEditRequest.self,
+  RegisterCapabilityRequest.self,
+  UnregisterCapabilityRequest.self,
 
   // MARK: LSP Extension Requests
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -510,8 +510,7 @@ extension ClangLanguageServerShim {
   // MARK: - Other
 
   func executeCommand(_ req: Request<ExecuteCommandRequest>) {
-    //TODO: Implement commands.
-    return req.reply(nil)
+    forwardRequestToClangdOnQueue(req)
   }
 }
 


### PR DESCRIPTION
This adds support for clangd commands for clients which support
dynamic registration (including VS Code), as well as fixes an
issue which prevented clangd's code actions from working.