### PR TITLE
[LSP] Add `RenameRequest` and `PrepareRenameRequest`

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -43,8 +43,10 @@ add_library(LanguageServerProtocol
   Requests/InitializeRequest.swift
   Requests/InlayHintsRequest.swift
   Requests/PollIndexRequest.swift
+  Requests/PrepareRenameRequest.swift
   Requests/ReferencesRequest.swift
   Requests/RegisterCapabilityRequest.swift
+  Requests/RenameRequest.swift
   Requests/ShowMessageRequest.swift
   Requests/ShutdownRequest.swift
   Requests/SymbolInfoRequest.swift

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -43,6 +43,8 @@ public let builtinRequests: [_RequestType.Type] = [
   CodeActionRequest.self,
   ExecuteCommandRequest.self,
   ApplyEditRequest.self,
+  PrepareRenameRequest.self,
+  RenameRequest.self,
   RegisterCapabilityRequest.self,
   UnregisterCapabilityRequest.self,
 

--- a/Sources/LanguageServerProtocol/Requests/PrepareRenameRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/PrepareRenameRequest.swift
@@ -15,7 +15,7 @@
 /// Looks up the symbol at the given position and returns the range of the symbol the user is renaming,
 /// or null if there is no symbol to be renamed at the given position
 ///
-/// Servers that provide rename preparation should set`prepareProvider` to true in the `renameProvider` server capability.
+/// Servers that provide rename preparation should set `prepareProvider` to true in the `renameProvider` server capability.
 ///
 /// - Parameters:
 ///   - textDocument: The document in which to lookup the symbol location.

--- a/Sources/LanguageServerProtocol/Requests/PrepareRenameRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/PrepareRenameRequest.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request to test the validity of a rename operation at the given location.
+///
+/// Looks up the symbol at the given position and returns the range of the symbol the user is renaming,
+/// or null if there is no symbol to be renamed at the given position
+///
+/// Servers that provide rename preparation should set`prepareProvider` to true in the `renameProvider` server capability.
+///
+/// - Parameters:
+///   - textDocument: The document in which to lookup the symbol location.
+///   - position: The document location at which to lookup symbol information.
+///
+/// - Returns: A range for the symbol, and optionally a placeholder text of the string content to be renamed.
+public struct PrepareRenameRequest: TextDocumentRequest, Hashable {
+  public static let method: String = "textDocument/prepareRename"
+  public typealias Response = PrepareRenameResponse?
+
+  /// The document in which to lookup the symbol location.
+  public var textDocument: TextDocumentIdentifier
+
+  /// The document location at which to lookup symbol information.
+  public var position: Position
+
+  public init(textDocument: TextDocumentIdentifier, position: Position) {
+    self.textDocument = textDocument
+    self.position = position
+  }
+}
+
+public struct PrepareRenameResponse: ResponseType, Hashable {
+  /// The range of the symbol
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
+  
+  /// A placeholder text of the string content to be renamed
+  public var placeholder: String?
+
+  public init(range: Range<Position>, placeholder: String? = nil) {
+    self.range = range
+    self.placeholder = placeholder
+  }
+  
+  public init(from decoder: Decoder) throws {
+    // Try decoding as PrepareRenameResponse
+    do {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.range = try container.decode(PositionRange.self, forKey: .range).wrappedValue
+      self.placeholder = try container.decode(String.self, forKey: .placeholder)
+      return
+    } catch {}
+    
+    // Try decoding as PositionRange
+    do {
+      self.range = try PositionRange(from: decoder).wrappedValue
+      self.placeholder = nil
+      return
+    } catch {}
+    
+    let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected PrepareRenameResponse or PositionRange")
+    throw DecodingError.dataCorrupted(context)
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+    if let placeholder = placeholder {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(_range, forKey: .range)
+      try container.encode(placeholder, forKey: .placeholder)
+    } else {
+      try _range.encode(to: encoder)
+    }
+  }
+  
+  private enum CodingKeys: String, CodingKey {
+    case range
+    case placeholder
+  }
+}

--- a/Sources/LanguageServerProtocol/Requests/RenameRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/RenameRequest.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request to compute a workspace range to rename a symbol. The change is then performed client side.
+///
+/// Looks up the symbol at the given position and returns the range of the symbol the user is renaming,
+/// or null if there is no symbol to be renamed at the given position
+///
+/// Servers that allow renaming should set the `renameProvider` server capability.
+///
+/// - Parameters:
+///   - textDocument: The document in which the selected symbol is.
+///   - position: The document location at which the selected symbol is.
+///   - newName: The new name of the symbol.
+///
+/// - Returns: A workspace edit
+public struct RenameRequest: TextDocumentRequest, Hashable {
+  public static let method: String = "textDocument/rename"
+  public typealias Response = WorkspaceEdit?
+
+  /// The document in which the selected symbol is.
+  public var textDocument: TextDocumentIdentifier
+
+  /// The document location at which the selected symbol is.
+  public var position: Position
+  
+  /// The new name of the symbol. If the given name is not valid the request must return
+  /// a ResponseError with an appropriate message set.
+  public var newName: String
+
+  public init(textDocument: TextDocumentIdentifier, position: Position, newName: String) {
+    self.textDocument = textDocument
+    self.position = position
+    self.newName = newName
+  }
+}

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -303,6 +303,15 @@ final class CodingTests: XCTestCase {
     checkCoding(CompletionItemDocumentation.string("Some documentation"), json: """
       "Some documentation"
       """)
+    
+    checkCoding(PrepareRenameResponse(range: range), json: rangejson)
+    
+    checkCoding(PrepareRenameResponse(range: range, placeholder: "somePlaceholder"), json: """
+      {
+        "placeholder" : "somePlaceholder",
+        "range" : \(rangejson.indented(2, skipFirstLine: true))
+      }
+      """)
 
     checkCoding(LocationsOrLocationLinksResponse.locations([Location(uri: uri, range: range)]), json: """
       [


### PR DESCRIPTION
Add support for renaming in LanguageServerProtocol. Rename options are restricted to pre-3.16 options, the ones added in 3.16, such as prepareSupportDefaultBehavior, aren't supported.
