### PR TITLE
Implement `completionItem/resolve`

### DIFF
--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -20,6 +20,7 @@ public let builtinRequests: [_RequestType.Type] = [
   ShutdownRequest.self,
   WorkspaceFoldersRequest.self,
   CompletionRequest.self,
+  CompletionItem.self,
   HoverRequest.self,
   WorkspaceSemanticTokensRefreshRequest.self,
   WorkspaceSymbolsRequest.self,

--- a/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A single completion result.
-public struct CompletionItem: TextDocumentRequest, RequestType, ResponseType, Codable, Hashable {
+/// `CompletionItem` is a request for the `completionItem/resolve` method and a response type to the `textDocument/completion` request.
+public struct CompletionItem: TextDocumentRequest, ResponseType, Codable, Hashable {
+  public static var method: String = "completionItem/resolve"
   public typealias Response = CompletionItem
     
   public var textDocument: TextDocumentIdentifier {
@@ -25,9 +26,6 @@ public struct CompletionItem: TextDocumentRequest, RequestType, ResponseType, Co
       fatalError("Missing textDocURI in CompletionItem.data: \(data ?? "(CompletionItem.data is nil)")")
     }
   }
-  
-  public static var method: String = "completionItem/resolve"
-
 
   /// The display name of the completion.
   public var label: String
@@ -56,7 +54,7 @@ public struct CompletionItem: TextDocumentRequest, RequestType, ResponseType, Co
 
   /// **Deprecated**: use `textEdit`
   ///
-  /// The string to insert into the document. If `nil`, use `label.
+  /// The string to insert into the document. If `nil`, use `label`.
   public var insertText: String?
 
   /// The format of the `textEdit.nextText` or `insertText` value.
@@ -92,20 +90,6 @@ public struct CompletionItem: TextDocumentRequest, RequestType, ResponseType, Co
     self.kind = kind
     self.deprecated = deprecated
     self.data = data
-  }
-  
-  enum CodingKeys: String, CodingKey {
-    case label,
-    detail,
-    documentation,
-    sortText,
-    filterText,
-    textEdit,
-    insertText,
-    insertTextFormat,
-    kind,
-    deprecated,
-    data
   }
 }
 

--- a/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
@@ -11,7 +11,23 @@
 //===----------------------------------------------------------------------===//
 
 /// A single completion result.
-public struct CompletionItem: Codable, Hashable {
+public struct CompletionItem: TextDocumentRequest, RequestType, ResponseType, Codable, Hashable {
+  public typealias Response = CompletionItem
+    
+  public var textDocument: TextDocumentIdentifier {
+    if 
+      let data = self.data,
+      case let .dictionary(dict) = data,
+      case let .string(textDocURI) = dict["textDocURI"]
+    {
+      return TextDocumentIdentifier(DocumentURI(string: textDocURI))
+    } else {
+      fatalError("Missing textDocURI in CompletionItem.data: \(data ?? "(CompletionItem.data is nil)")")
+    }
+  }
+  
+  public static var method: String = "completionItem/resolve"
+
 
   /// The display name of the completion.
   public var label: String
@@ -48,6 +64,9 @@ public struct CompletionItem: Codable, Hashable {
 
   /// Whether the completion is for a deprecated symbol.
   public var deprecated: Bool?
+  
+  /// A data entry field that is preserved on a `CompletionItem` between a completion and a completion resolve request.
+  public var data: LSPAny?
 
   public init(
     label: String,
@@ -59,7 +78,8 @@ public struct CompletionItem: Codable, Hashable {
     textEdit: TextEdit? = nil,
     insertText: String? = nil,
     insertTextFormat: InsertTextFormat? = nil,
-    deprecated: Bool? = nil)
+    deprecated: Bool? = nil,
+    data: LSPAny? = nil)
   {
     self.label = label
     self.detail = detail
@@ -71,6 +91,21 @@ public struct CompletionItem: Codable, Hashable {
     self.insertTextFormat = insertTextFormat
     self.kind = kind
     self.deprecated = deprecated
+    self.data = data
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case label,
+    detail,
+    documentation,
+    sortText,
+    filterText,
+    textEdit,
+    insertText,
+    insertTextFormat,
+    kind,
+    deprecated,
+    data
   }
 }
 

--- a/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
+++ b/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
@@ -1,4 +1,5 @@
 public struct Lib {
+  /// Documentation for `foo`.
   public func /*Lib.foo:def*/foo() {}
 
   public init() {}

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -437,6 +437,10 @@ extension ClangLanguageServerShim {
   func completion(_ req: Request<CompletionRequest>) {
     forwardRequestToClangdOnQueue(req)
   }
+  
+  func completionResolve(_ req: Request<CompletionItem>) {
+    forwardRequestToClangdOnQueue(req)
+  }
 
   func hover(_ req: Request<HoverRequest>) {
     forwardRequestToClangdOnQueue(req)

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -85,6 +85,7 @@ public final class SourceKitServer: LanguageServer {
 
     registerToolchainTextDocumentRequest(SourceKitServer.completion,
                                          CompletionList(isIncomplete: false, items: []))
+    registerToolchainTextDocumentRequest(SourceKitServer.completionResolve, CompletionItem(label: "", kind: .class))
     registerToolchainTextDocumentRequest(SourceKitServer.hover, nil)
     registerToolchainTextDocumentRequest(SourceKitServer.definition, .locations([]))
     registerToolchainTextDocumentRequest(SourceKitServer.references, [])
@@ -756,6 +757,14 @@ extension SourceKitServer {
     languageService: ToolchainLanguageServer
   ) {
     languageService.completion(req)
+  }
+  
+  func completionResolve(
+    _ req: Request<CompletionItem>,
+    workspace: Workspace,
+    languageService: ToolchainLanguageServer
+  ) {
+    languageService.completionResolve(req)
   }
 
   func hover(

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -340,7 +340,7 @@ extension SwiftLanguageServer {
         save: .value(TextDocumentSyncOptions.SaveOptions(includeText: false))),
       hoverProvider: true,
       completionProvider: CompletionOptions(
-        resolveProvider: false,
+        resolveProvider: true,
         triggerCharacters: [".", "("]),
       definitionProvider: nil,
       implementationProvider: .bool(true),
@@ -563,6 +563,12 @@ extension SwiftLanguageServer {
   public func completion(_ req: Request<CompletionRequest>) {
     queue.async {
       self._completion(req)
+    }
+  }
+  
+  public func completionResolve(_ req: Request<CompletionItem>) {
+    queue.async {
+      self._completionResolve(req)
     }
   }
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -63,6 +63,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   // MARK: - Text Document
 
   func completion(_ req: Request<CompletionRequest>)
+  func completionResolve(_ req: Request<CompletionItem>)
   func hover(_ req: Request<HoverRequest>)
   func symbolInfo(_ request: Request<SymbolInfoRequest>)
 

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -176,7 +176,8 @@ final class SKTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "method(a: )"),
         insertText: "method(a: )",
         insertTextFormat: .plain,
-        deprecated: false),
+        deprecated: false,
+        data: .dictionary(["textDocURI": .string(loc.url.absoluteString), "usr": .string("s:4main1AV6method1aySi_tF")])),
       CompletionItem(
         label: "self",
         kind: .keyword,
@@ -186,7 +187,8 @@ final class SKTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "self"),
         insertText: "self",
         insertTextFormat: .plain,
-        deprecated: false),
+        deprecated: false,
+        data: .dictionary(["textDocURI": .string(loc.url.absoluteString)])),
     ])
   }
 

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -118,6 +118,13 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(abc.textEdit, TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "abc"))
       XCTAssertEqual(abc.insertText, "abc")
       XCTAssertEqual(abc.insertTextFormat, .plain)
+      XCTAssertEqual(abc.data, .dictionary(["textDocURI": .string(url.absoluteString), "usr": .string("s:1a1SV3abcSivp")]))
+
+      // FIXME: SourceKit is "Unable to resolve type from" `s:1a1SV3abcSivp`.
+      
+      // `completionItem/resolve` should return full documentation.
+      //let completionResolveResponse = try! sk.sendSync(abc)
+      //XCTAssertEqual(completionResolveResponse.documentation, .markupContent(MarkupContent(kind: .markdown, value: "Documentation for `abc`.")))
     }
 
     for col in 10...12 {

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -38,12 +38,14 @@ final class SwiftPMIntegrationTests: XCTestCase {
         label: "foo()",
         kind: .method,
         detail: "Void",
+        documentation: .markupContent(MarkupContent(kind: .markdown, value: "Documentation for foo.")),
         sortText: nil,
         filterText: "foo()",
         textEdit: TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "foo()"),
         insertText: "foo()",
         insertTextFormat: .plain,
-        deprecated: false),
+        deprecated: false,
+        data: .dictionary(["textDocURI": .string(call.url.absoluteString), "usr": .string("s:3lib3LibV3fooyyF")])),
       CompletionItem(
         label: "self",
         kind: .keyword,
@@ -53,7 +55,14 @@ final class SwiftPMIntegrationTests: XCTestCase {
         textEdit: TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "self"),
         insertText: "self",
         insertTextFormat: .plain,
-        deprecated: false),
+        deprecated: false,
+        data: .dictionary(["textDocURI": .string(call.url.absoluteString)])),
     ])
+
+    // FIXME: SourceKit is "Unable to resolve type from" `s:3lib3LibV3fooyyF`.
+    
+    // `completionItem/resolve` should return full documentation.
+    //let completionItemResolveResponse = try ws.sk.sendSync(completions.items[0])
+    //XCTAssertEqual(completionItemResolveResponse.documentation, .markupContent(MarkupContent(kind: .markdown, value: "Documentation for `foo`.")))
   }
 }


### PR DESCRIPTION
This pull request adds support for `completionItem/resolve` to SourceKit-LSP.

Unfortunately, the tests are disabled (and this PR is a draft) because SourceKit cannot provide `cursorinfo` via an USR for anything other than things like `struct`s:
```
{
  key.internal_diagnostic: "Unable to resolve type from USR."
}
```

Test Code:

```swift
/// `a` (does not work)
let a = 1

/// `b` (does not work)
func b(c: Int) {}

/// `E` (works)
enum E: CaseIterable {
	/// `a` (does not work)
	case a
	
	/// `b` (does not work)
	case b
	
	/// `c` (does not work)
	case c
}

/// `A` (works)
struct A: Equatable {
	
	/// `a` (does not work)
	let a: String
		
  	/// - Parameters:
  	///    - a: `String`
	/// - Note: does not work
	init(a: String) {
		self.a = a
	}
}
```

To test the above code, type something like `E.a`, or `A.init`, and see if the \`\` is rendered as a code block in the completion popup.

Perhaps this is related to [this issue](https://bugs.swift.org/browse/SR-13958).