### PR TITLE
adjust API to changes in SwiftPM

### DIFF
--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -41,7 +41,7 @@ public protocol BuildSystem: AnyObject {
   /// IMPORTANT: When first receiving a register request, the `BuildSystem` MUST asynchronously
   /// inform its delegate of any initial settings for the given file via the
   /// `fileBuildSettingsChanged` method, even if unavailable.
-  func registerForChangeNotifications(for: DocumentURI, language: Language) 
+  func registerForChangeNotifications(for: DocumentURI, language: Language)
 
   /// Unregister the given file for build-system level change notifications,
   /// such as command line flag changes, dependency changes, etc.

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -247,9 +247,9 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
     // TODO: Support for change detection (via file watching)
     var settings: FileBuildSettings? = nil
     do {
-        settings = try self.settings(for: uri, language)
+      settings = try self.settings(for: uri, language)
     } catch {
-        log("error computing settings: \(error)")
+      log("error computing settings: \(error)")
     }
     DispatchQueue.global().async {
       if let settings = settings {


### PR DESCRIPTION
motivation: stay with the times

changes:
* use observability system instead of diganostics engine
* some APIs in SwiftPM are now throwing, adjust to this change