### PR TITLE
Update macOS minimum deployment target from 10.15.0 to 10.15.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SourceKitLSP",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS("10.15.4")],
     products: [
       .executable(
         name: "sourcekit-lsp",


### PR DESCRIPTION
### Motivation

This will allow use of Swift-friendlier `Foundation.FileHandle` APIs in SwiftPM, which have an availability of 10.15.4.  Because SourceKit-LSP uses libSwiftPM, it needs to have as new of a deployment target as SwiftPM does.

This has no change in behavior in SourceKit-LSP, but will allow SwiftPM to increase its deployment target correspondingly.