### PR TITLE
Remove available check below macOS 10.15.4

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -182,7 +182,7 @@ public final class Logger {
 
     var usedOSLog = false
 #if canImport(os)
-    if !disableOSLog, #available(OSX 10.12, *) {
+    if !disableOSLog {
       // If os_log is available, we call it unconditionally since it has its own log-level handling that we respect.
       os_log("%@", type: level.osLogType, message)
       usedOSLog = true

--- a/Sources/LSPTestSupport/CheckCoding.swift
+++ b/Sources/LSPTestSupport/CheckCoding.swift
@@ -20,9 +20,8 @@ import XCTest
 public func checkCoding<T>(_ value: T, json: String, file: StaticString = #filePath, line: UInt = #line) where T: Codable & Equatable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
-  if #available(macOS 10.13, *) {
-   encoder.outputFormatting.insert(.sortedKeys)
-  }
+  encoder.outputFormatting.insert(.sortedKeys)
+  
   let data = try! encoder.encode(WrapFragment(value: value))
   let wrappedStr = String(data: data, encoding: .utf8)!
 
@@ -36,11 +35,7 @@ public func checkCoding<T>(_ value: T, json: String, file: StaticString = #fileP
     .replacingOccurrences(of: "\n  ", with: "\n")
     // Remove trailing whitespace to normalize between corelibs and Apple Foundation.
     .trimmingTrailingWhitespace()
-
-  // Requires sortedKeys. Silently drop the check if it's not available.
-  if #available(macOS 10.13, *) {
-    XCTAssertEqual(json, str, file: file, line: line)
-  }
+  XCTAssertEqual(json, str, file: file, line: line)
 
   let decoder = JSONDecoder()
   let decodedValue = try! decoder.decode(WrapFragment<T>.self, from: data).value
@@ -70,19 +65,13 @@ public func checkDecoding<T>(json: String, expected value: T, file: StaticString
 public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = #filePath, line: UInt = #line, body: (T) -> Void) where T: Codable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
-  if #available(macOS 10.13, *) {
-   encoder.outputFormatting.insert(.sortedKeys)
-  }
+  encoder.outputFormatting.insert(.sortedKeys)
   let data = try! encoder.encode(value)
   let str = String(data: data, encoding: .utf8)!
     // Remove trailing whitespace to normalize between corelibs and Apple Foundation.
     .trimmingTrailingWhitespace()
-
-  // Requires sortedKeys. Silently drop the check if it's not available.
-  if #available(macOS 10.13, *) {
-    XCTAssertEqual(json, str, file: file, line: line)
-  }
-
+  XCTAssertEqual(json, str, file: file, line: line)
+  
   let decoder = JSONDecoder()
   decoder.userInfo = userInfo
   let decodedValue = try! decoder.decode(T.self, from: data)

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -260,13 +260,7 @@ private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: Absolute
     withExtendedLifetime((clientToServer, serverToClient)) {}
   }
   let process = Foundation.Process()
-
-  if #available(OSX 10.13, *) {
-    process.executableURL = serverPath.asURL
-  } else {
-    process.launchPath = serverPath.pathString
-  }
-
+  process.executableURL = serverPath.asURL
   process.arguments = serverFlags
   process.standardOutput = serverToClient
   process.standardInput = clientToServer
@@ -274,12 +268,6 @@ private func makeJSONRPCBuildServer(client: MessageHandler, serverPath: Absolute
     log("build server exited: \(process.terminationReason) \(process.terminationStatus)")
     connection.close()
   }
-
-  if #available(OSX 10.13, *) {
-    try process.run()
-  } else {
-    process.launch()
-  }
-
+  try process.run()
   return connection
 }

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -52,10 +52,8 @@ final class ClangLanguageServerShim: LanguageServer, ToolchainLanguageServer {
   /// Changing the property automatically notified the state change handlers.
   private var state: LanguageServerState {
     didSet {
-      if #available(OSX 10.12, *) {
-        // `state` must only be set from `queue`.
-        dispatchPrecondition(condition: .onQueue(queue))
-      }
+      // `state` must only be set from `queue`.
+      dispatchPrecondition(condition: .onQueue(queue))
       for handler in stateChangeHandlers {
         handler(oldValue, state)
       }
@@ -131,13 +129,7 @@ final class ClangLanguageServerShim: LanguageServer, ToolchainLanguageServer {
     }
 
     let process = Foundation.Process()
-
-    if #available(OSX 10.13, *) {
-      process.executableURL = clangdPath.asURL
-    } else {
-      process.launchPath = clangdPath.pathString
-    }
-
+    process.executableURL = clangdPath.asURL
     process.arguments = [
       "-compile_args_from=lsp",   // Provide compiler args programmatically.
       "-background-index=false",  // Disable clangd indexing, we use the build
@@ -162,12 +154,7 @@ final class ClangLanguageServerShim: LanguageServer, ToolchainLanguageServer {
         }
       }
     }
-
-    if #available(OSX 10.13, *) {
-      try process.run()
-    } else {
-      process.launch()
-    }
+    try process.run()
 #if os(Windows)
     self.hClangd = process.processHandle
 #else

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -120,10 +120,8 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
   
   private var state: LanguageServerState {
     didSet {
-      if #available(OSX 10.12, *) {
-        // `state` must only be set from `queue`.
-        dispatchPrecondition(condition: .onQueue(queue))
-      }
+      // `state` must only be set from `queue`.
+      dispatchPrecondition(condition: .onQueue(queue))
       for handler in stateChangeHandlers {
         handler(oldValue, state)
       }

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -60,21 +60,19 @@ final class CompilationDatabaseTests: XCTestCase {
 
   func testEncodeCompDBCommand() {
     // Requires JSONEncoder.OutputFormatting.sortedKeys
-    if #available(macOS 10.13, *) {
-      func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting.insert(.sortedKeys)
-        let encodedString = try! String(data: encoder.encode(cmd), encoding: .utf8)
-        XCTAssertEqual(encodedString, expected, file: file, line: line)
-      }
-
-      check(.init(directory: "a", filename: "b", commandLine: [], output: "c"), """
-        {"arguments":[],"directory":"a","file":"b","output":"c"}
-        """)
-      check(.init(directory: "a", filename: "b", commandLine: ["c", "d"], output: nil), """
-        {"arguments":["c","d"],"directory":"a","file":"b"}
-        """)
+    func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = #filePath, line: UInt = #line) {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting.insert(.sortedKeys)
+      let encodedString = try! String(data: encoder.encode(cmd), encoding: .utf8)
+      XCTAssertEqual(encodedString, expected, file: file, line: line)
     }
+
+    check(.init(directory: "a", filename: "b", commandLine: [], output: "c"), """
+      {"arguments":[],"directory":"a","file":"b","output":"c"}
+      """)
+    check(.init(directory: "a", filename: "b", commandLine: ["c", "d"], output: nil), """
+      {"arguments":["c","d"],"directory":"a","file":"b"}
+      """)
   }
 
   func testDecodeCompDBCommand() {


### PR DESCRIPTION
Since the Package.swift declare the minimal target for macOS is 10.15.4, we can remove the uncessary available check code
