### PR TITLE
Reload Swift Package when new file creation is indicated by `DidChangeWatchedFileNotification`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,5 @@ SourceKit-LSP is still in early development, so you may run into rough edges wit
 
 ### Caveats
 
-* SwiftPM build settings are not updated automatically after files are added/removed.
-	* **Workaround**: close and reopen the project after adding/removing files
-
 * SourceKit-LSP does not update its global index in the background, but instead relies on indexing-while-building to provide data. This only affects global queries like find-references and jump-to-definition.
 	* **Workaround**: build the project to update the index

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -219,6 +219,8 @@ extension BuildServerBuildSystem: BuildSystem {
       }
     }
   }
+
+  public func filesDidChange(_ events: [FileEvent]) {}
 }
 
 private func loadBuildServerConfig(path: AbsolutePath, fileSystem: FileSystem) throws -> BuildServerConfig {

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -59,6 +59,9 @@ public protocol BuildSystem: AnyObject {
   /// Returns the output paths for the requested build targets
   func buildTargetOutputPaths(targets: [BuildTargetIdentifier],
                               reply: @escaping (LSPResult<[OutputsItem]>) -> Void)
+
+  /// Called when files in the project change.
+  func filesDidChange(_ events: [FileEvent])
 }
 
 public let buildTargetsNotSupported =

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -125,6 +125,13 @@ public final class BuildSystemManager {
     self.fallbackSettingsTimeout = fallbackSettingsTimeout
     self.buildSystem?.delegate = self
   }
+
+  public func filesDidChange(_ events: [FileEvent]) {
+    queue.async {
+      self.buildSystem?.filesDidChange(events)
+      self.fallbackBuildSystem?.filesDidChange(events)
+    }
+  }
 }
 
 extension BuildSystemManager: BuildSystem {

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -109,6 +109,8 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
 
     return compdb
   }
+
+  public func filesDidChange(_ events: [FileEvent]) {}
 }
 
 extension CompilationDatabaseBuildSystem {

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -98,4 +98,6 @@ public final class FallbackBuildSystem: BuildSystem {
     args.append(file)
     return FileBuildSettings(compilerArguments: args)
   }
+
+  public func filesDidChange(_ events: [FileEvent]) {}
 }

--- a/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
+++ b/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
@@ -3,3 +3,7 @@ public struct Lib {
 
   public init() {}
 }
+
+func topLevelFunction() {
+  /*Lib.topLevelFunction:body*/
+}

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -133,6 +133,10 @@ extension SKSwiftPMTestWorkspace {
       version: 1,
       text: try sources.sourceCache.get(url))))
   }
+
+  public func closeDocument(_ url: URL) {
+    sk.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(DocumentURI(url))))
+  }
 }
 
 extension XCTestCase {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -21,6 +21,7 @@ import SKSupport
 import TSCBasic
 import TSCLibc
 import TSCUtility
+import PackageLoading
 
 public typealias URL = Foundation.URL
 
@@ -583,11 +584,11 @@ extension SourceKitServer {
         self.dynamicallyRegisterCapability($0, registry)
       }
     }
-    /// Request the client to send us DidChangeWatchedFileNotifications for all new files.
-    /// Currently, these notifications are only handled by SwiftPMWorkspace, which will reload the package when a new file is added.
-    let watchers = [
-      FileSystemWatcher(globPattern: "**", kind: [.create, .delete])
-    ]
+
+    /// This must be a superset of the files that return true for SwiftPM's `Workspace.fileAffectsSwiftOrClangBuildSettings`.
+    let watchers = FileRuleDescription.builtinRules.flatMap({ $0.fileTypes }).map { fileExtension in
+      return FileSystemWatcher(globPattern: "**.\(fileExtension)", kind: [.create, .delete])
+    }
     registry.registerDidChangeWatchedFiles(watchers: watchers) {
       self.dynamicallyRegisterCapability($0, registry)
     }

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -503,6 +503,8 @@ class ManualBuildSystem: BuildSystem {
     reply: @escaping (LSPResult<[OutputsItem]>) -> Void) {
     fatalError()
   }
+
+  func filesDidChange(_ events: [FileEvent]) {}
 }
 
 /// A `BuildSystemDelegate` setup for testing.

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -110,7 +110,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       XCTAssertEqual(ws.buildPath, build)
       XCTAssertNotNil(ws.indexStorePath)
-      let arguments = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
 
       check(
         "-module-name", "lib", "-incremental", "-emit-dependencies",
@@ -165,7 +165,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let build = buildPath(root: packageRoot, config: config, triple: hostTriple)
 
       XCTAssertEqual(ws.buildPath, build)
-      let arguments = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
 
       check("-typecheck", arguments: arguments)
       check("-Xcc", "-m32", arguments: arguments)
@@ -195,7 +195,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let source = resolveSymlinks(packageRoot.appending(component: "Package.swift"))
-      let arguments = try ws.settings(for: source.asURI, .swift)!.compilerArguments
+      let arguments = try ws._settings(for: source.asURI, .swift)!.compilerArguments
 
       check("-swift-version", "4.2", arguments: arguments)
       check(source.pathString, arguments: arguments)
@@ -227,10 +227,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
 
-      let argumentsA = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let argumentsA = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: argumentsA)
       check(bswift.pathString, arguments: argumentsA)
-      let argumentsB = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let argumentsB = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: argumentsB)
       check(bswift.pathString, arguments: argumentsB)
     }
@@ -266,7 +266,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      let arguments = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       checkNot(bswift.pathString, arguments: arguments)
       // Temporary conditional to work around revlock between SourceKit-LSP and SwiftPM
@@ -282,7 +282,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           arguments: arguments)
       }
 
-      let argumentsB = try ws.settings(for: bswift.asURI, .swift)!.compilerArguments
+      let argumentsB = try ws._settings(for: bswift.asURI, .swift)!.compilerArguments
       check(bswift.pathString, arguments: argumentsB)
       checkNot(aswift.pathString, arguments: argumentsB)
       checkNot("-I", packageRoot.appending(components: "Sources", "libC", "include").pathString,
@@ -316,9 +316,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      XCTAssertNotNil(try ws.settings(for: aswift.asURI, .swift))
-      XCTAssertNil(try ws.settings(for: bswift.asURI, .swift))
-      XCTAssertNil(try ws.settings(for: DocumentURI(URL(string: "https://www.apple.com")!), .swift))
+      XCTAssertNotNil(try ws._settings(for: aswift.asURI, .swift))
+      XCTAssertNil(try ws._settings(for: bswift.asURI, .swift))
+      XCTAssertNil(try ws._settings(for: DocumentURI(URL(string: "https://www.apple.com")!), .swift))
     }
   }
 
@@ -375,7 +375,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         checkNot(bcxx.pathString, arguments: arguments)
       }
 
-      let args = try ws.settings(for: acxx.asURI, .cpp)!.compilerArguments
+      let args = try ws._settings(for: acxx.asURI, .cpp)!.compilerArguments
       checkArgsCommon(args)
 
       URL(fileURLWithPath: build.appending(components: "lib.build", "a.cpp.d").pathString)
@@ -393,7 +393,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       }
 
       let header = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
-      let headerArgs = try ws.settings(for: header.asURI, .cpp)!.compilerArguments
+      let headerArgs = try ws._settings(for: header.asURI, .cpp)!.compilerArguments
       checkArgsCommon(headerArgs)
 
       check("-c", "-x", "c++-header", URL(fileURLWithPath: header.pathString).path,
@@ -424,7 +424,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check("-target", arguments: arguments) // Only one!
       let hostTriple = ws.buildParameters.triple
 
@@ -469,8 +469,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         .appending(components: "Sources", "lib", "a.swift")
       let manifest = packageRoot.appending(components: "Package.swift")
 
-      let arguments1 = try ws.settings(for: aswift1.asURI, .swift)?.compilerArguments
-      let arguments2 = try ws.settings(for: aswift2.asURI, .swift)?.compilerArguments
+      let arguments1 = try ws._settings(for: aswift1.asURI, .swift)?.compilerArguments
+      let arguments2 = try ws._settings(for: aswift2.asURI, .swift)?.compilerArguments
       XCTAssertNotNil(arguments1)
       XCTAssertNotNil(arguments2)
       XCTAssertEqual(arguments1, arguments2)
@@ -478,7 +478,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       checkNot(aswift1.pathString, arguments: arguments1 ?? [])
       check(resolveSymlinks(aswift1).pathString, arguments: arguments1 ?? [])
 
-      let argsManifest = try ws.settings(for: manifest.asURI, .swift)?.compilerArguments
+      let argsManifest = try ws._settings(for: manifest.asURI, .swift)?.compilerArguments
       XCTAssertNotNil(argsManifest)
 
       checkNot(manifest.pathString, arguments: argsManifest ?? [])
@@ -519,12 +519,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let ah = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
 
-      let argsCxx = try ws.settings(for: acxx.asURI, .cpp)?.compilerArguments
+      let argsCxx = try ws._settings(for: acxx.asURI, .cpp)?.compilerArguments
       XCTAssertNotNil(argsCxx)
       check(acxx.pathString, arguments: argsCxx ?? [])
       checkNot(resolveSymlinks(acxx).pathString, arguments: argsCxx ?? [])
 
-      let argsH = try ws.settings(for: ah.asURI, .cpp)?.compilerArguments
+      let argsH = try ws._settings(for: ah.asURI, .cpp)?.compilerArguments
       XCTAssertNotNil(argsH)
       checkNot(ah.pathString, arguments: argsH ?? [])
       check(resolveSymlinks(ah).pathString, arguments: argsH ?? [])
@@ -558,7 +558,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try ws.settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       XCTAssertNotNil(arguments.firstIndex(where: {
           $0.hasSuffix(".swift") && $0.contains("DerivedSources")

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -65,6 +65,8 @@ final class TestBuildSystem: BuildSystem {
   func buildTargetOutputPaths(targets: [BuildTargetIdentifier], reply: @escaping (LSPResult<[OutputsItem]>) -> Void) {
     reply(.failure(buildTargetsNotSupported))
   }
+
+  func filesDidChange(_ events: [FileEvent]) {}
 }
 
 final class BuildSystemTests: XCTestCase {

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -56,4 +56,67 @@ final class SwiftPMIntegrationTests: XCTestCase {
         deprecated: false),
     ])
   }
+
+  func testAddFile() throws {
+    guard let ws = try staticSourceKitSwiftPMWorkspace(name: "SwiftPMPackage") else { return }
+    try ws.buildAndIndex()
+
+    /// Add a new file to the project that wasn't built
+    _ = try ws.sources.edit { builder in
+      let otherFile = ws.sources.rootDirectory
+        .appendingPathComponent("Sources")
+        .appendingPathComponent("lib")
+        .appendingPathComponent("other.swift")
+      let otherFileContents = """
+      func baz(l: Lib)  {
+        l . /*newFile:call*/foo()
+      }
+      """
+      builder.write(otherFileContents, to: otherFile)
+    }
+
+    let newFile = ws.testLoc("newFile:call")
+
+    // Check that we don't get cross-file code completion before we send a `DidChangeWatchedFilesNotification` to make sure we didn't include the file in the initial retrieval of build settings.
+    try ws.openDocument(newFile.url, language: .swift)
+
+    let completionsBeforeDidChangeNotification = try withExtendedLifetime(ws) {
+      try ws.sk.sendSync(CompletionRequest(textDocument: newFile.docIdentifier, position: newFile.position))
+    }
+    XCTAssertEqual(completionsBeforeDidChangeNotification.items, [])
+    ws.closeDocument(newFile.url)
+
+    // Send a `DidChangeWatchedFilesNotification` and verify that we now get cross-file code completion.
+    ws.sk.send(DidChangeWatchedFilesNotification(changes: [
+      FileEvent(uri: newFile.docUri, type: .created)
+    ]))
+    try ws.openDocument(newFile.url, language: .swift)
+    
+    let completions = try withExtendedLifetime(ws) {
+      try ws.sk.sendSync(CompletionRequest(textDocument: newFile.docIdentifier, position: newFile.position))
+    }
+
+    XCTAssertEqual(completions.items, [
+      CompletionItem(
+        label: "foo()",
+        kind: .method,
+        detail: "Void",
+        sortText: nil,
+        filterText: "foo()",
+        textEdit: TextEdit(range: Position(line: 1, utf16index: 22)..<Position(line: 1, utf16index: 22), newText: "foo()"),
+        insertText: "foo()",
+        insertTextFormat: .plain,
+        deprecated: false),
+      CompletionItem(
+        label: "self",
+        kind: .keyword,
+        detail: "Lib",
+        sortText: nil,
+        filterText: "self",
+        textEdit: TextEdit(range: Position(line: 1, utf16index: 22)..<Position(line: 1, utf16index: 22), newText: "self"),
+        insertText: "self",
+        insertTextFormat: .plain,
+        deprecated: false),
+    ])
+  }
 }


### PR DESCRIPTION
Implement rudementary support for `DidChangeWatchedFileNotification` for SwiftPM projects: When a file is added, reload the Swift package to compute build settings for the new file.

This enables proper semantic functionality added to the project after the LSP server was started.

Resolves rdar://87149128 [SR-15633](https://bugs.swift.org/browse/SR-15633).