### PR TITLE
Adjust diagnostic ranges on edits

### DIFF
--- a/Sources/SourceKitLSP/RangeAdjuster.swift
+++ b/Sources/SourceKitLSP/RangeAdjuster.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+/// Given an edit event, the `RangeAdjuster` can adjust ranges in the pre-edit
+/// document to the corresponding ranges in the post-edit document
+struct RangeAdjuster {
+  /// The edit that ranges should be adjusted for
+  let editRange: Range<Position>
+
+  /// Number of lines that ranges after the `editRange` should be moved down (or up if negative).
+  let lineDelta: Int
+
+  /// Number of UTF-16 indicies that ranges, which are on the last line of `editRange` but after the UTF-16 column of `editRange` should be shifted to the right (or left if negative).
+  let lastLineCharDelta: Int
+
+  init?(edit: TextDocumentContentChangeEvent) {
+    guard let editRange = edit.range else {
+      return nil
+    }
+    self.editRange = editRange
+
+    let replacedLineCount = 1 + editRange.upperBound.line - editRange.lowerBound.line
+    let newLines = edit.text.split(separator: "\n", omittingEmptySubsequences: false)
+    let upperUtf16IndexAfterEdit = (
+      newLines.count == 1 ? editRange.lowerBound.utf16index : 0
+    ) + newLines.last!.utf16.count
+    self.lastLineCharDelta = upperUtf16IndexAfterEdit - editRange.upperBound.utf16index
+    self.lineDelta = newLines.count - replacedLineCount // may be negative
+  }
+
+  /// Adjust the pre-edit `range` to the corresponding range in the post-edit document.
+  /// If the range overlaps with the edit, returns `nil`.
+  func adjust(_ range: Range<Position>) -> Range<Position>? {
+    if range.overlaps(editRange) {
+      return nil
+    }
+    let lineOffset: Int
+    let charOffset: Int
+    if range.lowerBound.line == editRange.upperBound.line,
+       range.lowerBound.utf16index >= editRange.upperBound.utf16index {
+      lineOffset = lineDelta
+      charOffset = lastLineCharDelta
+    } else if range.lowerBound.line > editRange.upperBound.line {
+      lineOffset = lineDelta
+      charOffset = 0
+    } else {
+      lineOffset = 0
+      charOffset = 0
+    }
+    let newStart = Position(line: range.lowerBound.line + lineOffset, utf16index: range.lowerBound.utf16index + charOffset)
+    let newEnd = Position(line: range.upperBound.line + lineOffset, utf16index: range.upperBound.utf16index + charOffset)
+    return newStart..<newEnd
+  }
+}

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -254,9 +254,24 @@ extension DiagnosticRelatedInformation {
   }
 }
 
+extension Diagnostic {
+  func withRange(_ newRange: Range<Position>) -> Diagnostic {
+    var updated = self
+    updated.range = newRange
+    return updated
+  }
+}
+
 struct CachedDiagnostic {
   var diagnostic: Diagnostic
   var stage: DiagnosticStage
+
+  func withRange(_ newRange: Range<Position>) -> CachedDiagnostic {
+    return CachedDiagnostic(
+      diagnostic: self.diagnostic.withRange(newRange),
+      stage: self.stage
+    )
+  }
 }
 
 extension CachedDiagnostic {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -257,6 +257,20 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
     }
   }
 
+  /// Shift the ranges of all current diagnostics in the document with the given `uri` to account for `edit`.
+  private func adjustDiagnosticRanges(of uri: DocumentURI, for edit: TextDocumentContentChangeEvent) {
+    guard let rangeAdjuster = RangeAdjuster(edit: edit) else {
+      return
+    }
+    currentDiagnostics[uri] = currentDiagnostics[uri]?.compactMap({ cachedDiag in
+      if let adjustedRange = rangeAdjuster.adjust(cachedDiag.diagnostic.range) {
+        return cachedDiag.withRange(adjustedRange)
+      } else {
+        return nil
+      }
+    })
+  }
+
   /// Publish diagnostics for the given `snapshot`. We withhold semantic diagnostics if we are using
   /// fallback arguments.
   ///
@@ -527,6 +541,8 @@ extension SwiftLanguageServer {
 
         req[keys.sourcetext] = edit.text
         lastResponse = try? self.sourcekitd.sendSync(req)
+
+        self.adjustDiagnosticRanges(of: note.textDocument.uri, for: edit)
       } updateDocumentTokens: { (after: DocumentSnapshot) in
         if let dict = lastResponse {
           return self.updatedLexicalTokens(response: dict, for: after)

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
@@ -47,20 +47,6 @@ public struct SyntaxHighlightingToken: Hashable {
     self.init(range: range, kind: kind, modifiers: modifiers)
   }
 
-  /// Shifts the token to start at the given position while preserving its length.
-  public mutating func move(to newStart: Position) {
-    let length = utf16length
-    range = newStart..<Position(line: newStart.line, utf16index: newStart.utf16index + length)
-  }
-
-  /// Shifts the token by a certain number of lines/characters.
-  public mutating func move(lineDelta: Int = 0, utf16indexDelta: Int = 0) {
-    var newStart = start
-    newStart.line += lineDelta
-    newStart.utf16index += utf16indexDelta
-    move(to: newStart)
-  }
-
   /// The token type.
   ///
   /// Represented using an int to make the conversion to

--- a/Tests/SourceKitLSPTests/DiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/DiagnosticsTests.swift
@@ -22,7 +22,13 @@ final class DiagnosticsTests: XCTestCase {
   /// The primary interface to make requests to the SourceKitServer.
   var sk: TestClient! = nil
 
+  private var uri: DocumentURI!
+  private var textDocument: TextDocumentIdentifier { TextDocumentIdentifier(uri) }
+  private var version: Int!
+
   override func setUp() {
+    version = 0
+    uri = DocumentURI(URL(fileURLWithPath: "/DiagnosticsTests/\(UUID()).swift"))
     connection = TestSourceKitServer()
     sk = connection.client
     let documentCapabilities = TextDocumentClientCapabilities()
@@ -43,11 +49,22 @@ final class DiagnosticsTests: XCTestCase {
   
   private func openDocument(text: String) {
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(URL(fileURLWithPath: "/DiagnosticsTests/\(UUID()).swift")),
+      uri: uri,
       language: .swift,
-      version: 0,
+      version: version,
       text: text
     )))
+    version += 1
+  }
+
+  private func editDocument(changes: [TextDocumentContentChangeEvent]) {
+    sk.send(DidChangeTextDocumentNotification(
+      textDocument: VersionedTextDocumentIdentifier(
+        uri,
+        version: version
+      ),
+      contentChanges: changes
+    ))
   }
 
   func testUnknownIdentifierDiagnostic() {
@@ -73,5 +90,100 @@ final class DiagnosticsTests: XCTestCase {
     """)
 
     self.wait(for: [syntacticDiagnosticsReceived, semanticDiagnosticsReceived], timeout: 5)
+  }
+
+  func testRangeShiftAfterNewlineAdded() {
+    let initialSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after open received")
+    let initialSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after open received")
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      // Unresolved identifier is not a syntactic diagnostic.
+      XCTAssertEqual(note.params.diagnostics, [])
+      initialSyntacticDiagnosticsReceived.fulfill()
+    }
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      initialSemanticDiagnosticsReceived.fulfill()
+    }
+
+    openDocument(text: """
+    func foo() {
+      invalid
+    }
+    """)
+
+    self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: 5)
+
+    let editedSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after edit received")
+    let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      // We should report the semantic diagnostic reported by the edit range-shifted
+      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9))
+      editedSyntacticDiagnosticsReceived.fulfill()
+    }
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9))
+      editedSemanticDiagnosticsReceived.fulfill()
+    }
+
+    editDocument(changes: [
+      TextDocumentContentChangeEvent(range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0), rangeLength: 0, text: "\n")
+    ])
+
+    self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: 5)
+  }
+
+  func testRangeShiftAfterNewlineRemoved() {
+    let initialSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after open received")
+    let initialSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after open received")
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      // Unresolved identifier is not a syntactic diagnostic.
+      XCTAssertEqual(note.params.diagnostics, [])
+      initialSyntacticDiagnosticsReceived.fulfill()
+    }
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9))
+      initialSemanticDiagnosticsReceived.fulfill()
+    }
+
+    openDocument(text: """
+
+    func foo() {
+      invalid
+    }
+    """)
+
+    self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: 5)
+
+    let editedSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after edit received")
+    let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      // We should report the semantic diagnostic reported by the edit range-shifted
+      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      editedSyntacticDiagnosticsReceived.fulfill()
+    }
+
+    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      editedSemanticDiagnosticsReceived.fulfill()
+    }
+
+    editDocument(changes: [
+      TextDocumentContentChangeEvent(range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 0), rangeLength: 1, text: "")
+    ])
+
+    self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: 5)
   }
 }

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -561,19 +561,27 @@ final class SemanticTokensTests: XCTestCase {
     """
     openDocument(text: text)
 
+    let expectedBefore = [
+      SyntaxHighlightingToken(line: 0, utf16index: 0, length: 3, kind: .keyword),
+      SyntaxHighlightingToken(line: 0, utf16index: 4, length: 1, kind: .identifier),
+      SyntaxHighlightingToken(line: 0, utf16index: 7, length: 6, kind: .struct, modifiers: [.defaultLibrary]),
+      SyntaxHighlightingToken(line: 0, utf16index: 16, length: 6, kind: .string)
+    ]
     let before = performSemanticTokensRequest()
+    XCTAssertEqual(before, expectedBefore)
 
     let pos = Position(line: 0, utf16index: 0)
     let editText = " "
     editDocument(range: pos..<pos, text: editText, expectRefresh: false)
 
     let after = performSemanticTokensRequest()
-    let expected: [Token] = before.map {
-      var token = $0
-      token.move(utf16indexDelta: editText.utf16.count)
-      return token
-    }
-    XCTAssertEqual(after, expected)
+    let expectedAfter = [
+      SyntaxHighlightingToken(line: 0, utf16index: 1, length: 3, kind: .keyword),
+      SyntaxHighlightingToken(line: 0, utf16index: 5, length: 1, kind: .identifier),
+      SyntaxHighlightingToken(line: 0, utf16index: 8, length: 6, kind: .struct, modifiers: [.defaultLibrary]),
+      SyntaxHighlightingToken(line: 0, utf16index: 17, length: 6, kind: .string)
+    ]
+    XCTAssertEqual(after, expectedAfter)
   }
 
   func testInsertSpaceAfterToken() {
@@ -598,18 +606,22 @@ final class SemanticTokensTests: XCTestCase {
     """
     openDocument(text: text)
 
+    let expectedBefore = [
+      SyntaxHighlightingToken(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: [.defaultLibrary]),
+      SyntaxHighlightingToken(line: 0, utf16index: 11, length: 5, kind: .string)
+    ]
     let before = performSemanticTokensRequest()
+    XCTAssertEqual(before, expectedBefore)
 
     let pos = Position(line: 0, utf16index: 0)
     editDocument(range: pos..<pos, text: "\n", expectRefresh: false)
 
     let after = performSemanticTokensRequest()
-    let expected: [Token] = before.map {
-      var token = $0
-      token.move(lineDelta: 1)
-      return token
-    }
-    XCTAssertEqual(after, expected)
+    let expectedAfter = [
+      SyntaxHighlightingToken(line: 1, utf16index: 0, length: 10, kind: .function, modifiers: [.defaultLibrary]),
+      SyntaxHighlightingToken(line: 1, utf16index: 11, length: 5, kind: .string)
+    ]
+    XCTAssertEqual(after, expectedAfter)
   }
 
   func testRemoveNewline() {
@@ -632,11 +644,11 @@ final class SemanticTokensTests: XCTestCase {
     editDocument(range: start..<end, text: "", expectRefresh: false)
 
     let after = performSemanticTokensRequest()
-    let expectedAfter: [Token] = expectedBefore.map {
-      var token = $0
-      token.move(to: Position(line: 0, utf16index: token.start.utf16index))
-      return token
-    }
+    let expectedAfter = [
+      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+      Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
+      Token(line: 0, utf16index: 8, length: 5, kind: .string),
+    ]
     XCTAssertEqual(after, expectedAfter)
   }
 


### PR DESCRIPTION
When an edit is submitted to the LSP server, adjust all cached diagnostics to the corresponding ranges after the edit in the same fashion that we already do it for inlay type hints.