### PR TITLE
[5.6] Don't report duplicate folding ranges

### DIFF
--- a/Sources/SKTestSupport/INPUTS/FoldingRange/FoldingRangeDuplicateRanges.swift
+++ b/Sources/SKTestSupport/INPUTS/FoldingRange/FoldingRangeDuplicateRanges.swift
@@ -1,0 +1,3 @@
+func foo() {
+    print("/*fr:duplicateRanges*/")
+}

--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -104,4 +104,22 @@ final class FoldingRangeTests: XCTestCase {
 
     XCTAssertEqual(ranges?.count, 0)
   }
+
+  func testDontReportDuplicateRangesRanges() throws {
+    // In this file the range of the call to `print` and the range of the argument "/*fr:duplicateRanges*/" are the same.
+    // Test that we only report the folding range once.
+    let capabilities = FoldingRangeCapabilities()
+
+    guard let (ws, url) = try initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:duplicateRanges") else { return }
+
+    let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
+    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+
+    let expected = [
+      FoldingRange(startLine: 0, startUTF16Index: 12, endLine: 2, endUTF16Index: 0, kind: nil),
+      FoldingRange(startLine: 1, startUTF16Index: 10, endLine: 1, endUTF16Index: 34, kind: nil),
+    ]
+
+    XCTAssertEqual(ranges, expected)
+  }
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/sourcekit-lsp/pull/442 to release/5.6.

---

I’m not entirely sure when this started occurring but when retrieving folding ranges for e.g.
```
func foo() {
    print("someText")
}
```
SourceKit reports the folding range of `"someText"` twice: Once as the body of the call to `print` and once as the body of the first argument. Each folding range on its own makes sense because you might want to collapse either all arguments or only a single argument. But it doesn’t make sense to report the same range twice and this is causing SourceKit-LSP tests to fail.

rdar://88172766