### PR TITLE
[5.6] Set didChangedWatchedFiles glob to **/*.ext

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -587,7 +587,7 @@ extension SourceKitServer {
 
     /// This must be a superset of the files that return true for SwiftPM's `Workspace.fileAffectsSwiftOrClangBuildSettings`.
     let watchers = FileRuleDescription.builtinRules.flatMap({ $0.fileTypes }).map { fileExtension in
-      return FileSystemWatcher(globPattern: "**.\(fileExtension)", kind: [.create, .delete])
+      return FileSystemWatcher(globPattern: "**/*.\(fileExtension)", kind: [.create, .delete])
     }
     registry.registerDidChangeWatchedFiles(watchers: watchers) {
       self.dynamicallyRegisterCapability($0, registry)


### PR DESCRIPTION
Cherry-pick https://github.com/apple/sourcekit-lsp/pull/450 to release/5.6

---

* **Explanation**: The file watching implemented by https://github.com/apple/sourcekit-lsp/pull/443 asked the editor to watch for files with glob pattern `**.swift`. Integrating the changes with VSCode surfaced that this didn’t produce any notifications for added/deleted files because `**` can’t match the file the filename. The pattern should have been `**/*.swift`
* **Scope**: Addition or removal of files in third party editors that are hooked up to SourceKit-LSP
* **Risk**: Low, the feature never worked before
* **Testing**: Verified that file watching is working with this change in VSCode
* **Issue**: rdar://88178324