### PR TITLE
remove unnecessary dependency on `TSCLibc`

### DIFF
--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -10,7 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCLibc
+#if os(Windows)
+import CRT
+import WinSDK
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
 
 public final class DLHandle {
   #if os(Windows)
@@ -82,7 +89,7 @@ public func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {
       throw DLError.open("LoadLibraryW failed: \(GetLastError())")
     }
   #else
-    guard let handle = TSCLibc.dlopen(path, mode.rawValue) else {
+    guard let handle = dlopen(path, mode.rawValue) else {
       throw DLError.open(dlerror() ?? "unknown error")
     }
   #endif

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -19,7 +19,7 @@ import LSPLogging
 import SKCore
 import SKSupport
 import TSCBasic
-import TSCLibc
+
 import TSCUtility
 import PackageLoading
 

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -21,7 +21,6 @@ import SKCore
 import SKSupport
 import SourceKitLSP
 import TSCBasic
-import TSCLibc
 
 extension AbsolutePath: ExpressibleByArgument {
   public init?(argument: String) {


### PR DESCRIPTION
This reduces the dependency on the `TSCLibc` module which was not
actually used for anything but for importing the C library in
`SKSupport`.  Although on Apple platforms and Linux this could largely
be dealt with by statically linking, Windows does not support static
linking of Swift content properly yet.  This avoids the dependency on
the library instead.