### PR TITLE
explicitly indicate the TSCUtility interfaces used

### DIFF
--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -11,8 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import TSCUtility
 import SKSupport
+
+import struct TSCUtility.BuildFlags
 
 /// Build configuration
 public struct BuildSetup {

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -14,7 +14,8 @@ import LanguageServerProtocol
 import LSPLogging
 import SKSupport
 import TSCBasic
-import TSCUtility
+
+import enum TSCUtility.Platform
 
 /// A Toolchain is a collection of related compilers and libraries meant to be used together to
 /// build and edit source code.

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -12,7 +12,6 @@
 
 import SKSupport
 import TSCBasic
-import TSCUtility
 import Dispatch
 import Foundation
 

--- a/Sources/SKSupport/BuildConfiguration.swift
+++ b/Sources/SKSupport/BuildConfiguration.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCUtility
-
 public enum BuildConfiguration: String {
   case debug
   case release

--- a/Sources/SKSupport/Platform.swift
+++ b/Sources/SKSupport/Platform.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCUtility
+import enum TSCUtility.Platform
 
 extension Platform {
 

--- a/Sources/SKTestSupport/HostPlatform.swift
+++ b/Sources/SKTestSupport/HostPlatform.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCUtility
+import enum TSCUtility.Platform
 
 /// Returns true if running on darwin (macOS).
 public var isDarwinHost: Bool {

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -18,10 +18,11 @@ import IndexStoreDB
 import ISDBTibs
 import ISDBTestSupport
 import TSCBasic
-import TSCUtility
 import XCTest
 import Foundation
 import LSPTestSupport
+
+import struct TSCUtility.BuildFlags
 
 public final class SKSwiftPMTestWorkspace {
 

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -17,10 +17,12 @@ import IndexStoreDB
 import ISDBTibs
 import ISDBTestSupport
 import TSCBasic
-import TSCUtility
 import XCTest
 import Foundation
 import LSPTestSupport
+
+import enum TSCUtility.Platform
+import struct TSCUtility.BuildFlags
 
 public typealias URL = Foundation.URL
 

--- a/Sources/SKTestSupport/TestServer.swift
+++ b/Sources/SKTestSupport/TestServer.swift
@@ -12,7 +12,6 @@
 
 import SKSupport
 import SKCore
-import TSCUtility
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SourceKitLSP

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -20,7 +20,6 @@ import SKCore
 import SKSupport
 import TSCBasic
 
-import TSCUtility
 import PackageLoading
 
 public typealias URL = Foundation.URL

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -17,7 +17,6 @@ import SKCore
 import SKSupport
 import SKSwiftPMWorkspace
 import TSCBasic
-import TSCUtility
 
 /// Represents the configuration and state of a project or combination of projects being worked on
 /// together.

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -12,8 +12,9 @@
 
 import SKCore
 import TSCBasic
-import TSCUtility
 import XCTest
+
+import enum TSCUtility.Platform
 
 final class ToolchainRegistryTests: XCTestCase {
   func testDefaultBasic() {

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -20,8 +20,10 @@ import SKCore
 import SKSwiftPMWorkspace
 import SKTestSupport
 import TSCBasic
-import TSCUtility
 import XCTest
+
+import struct TSCUtility.BuildFlags
+import struct TSCUtility.Triple
 
 final class SwiftPMWorkspaceTests: XCTestCase {
 

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -13,10 +13,11 @@
 import SourceKitD
 import SKCore
 import TSCBasic
-import TSCUtility
 import ISDBTibs
 import ISDBTestSupport
 import XCTest
+
+import enum TSCUtility.Platform
 
 final class SourceKitDTests: XCTestCase {
   static var sourcekitdPath: AbsolutePath! = nil


### PR DESCRIPTION
This explicitly identifies the TSCUtility interfaces that SourceKit
depends on.  This helps identify a "burn down list" of interfaces that
remain in TSC(Utility) which are in use.  As these interfaces are
replaced, we can easily monitor the remaining interfaces that are in
use.