### PR TITLE
Only send response to ShutdownRequest when all toolchain servers have shut down

### DIFF
--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -329,13 +329,14 @@ extension ClangLanguageServerShim {
     forwardNotificationToClangdOnQueue(initialized)
   }
 
-  public func shutdown() {
+  public func shutdown(callback: @escaping () -> Void) {
     queue.async {
       _ = self.clangd.send(ShutdownRequest(), queue: self.queue) { [weak self] _ in
         self?.clangd.send(ExitNotification())
         if let localConnection = self?.client as? LocalConnection {
           localConnection.close()
         }
+        callback()
       }
     }
   }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -384,7 +384,7 @@ extension SwiftLanguageServer {
     // Nothing to do.
   }
 
-  public func shutdown() {
+  public func shutdown(callback: @escaping () -> Void) {
     queue.async {
       if let session = self.currentCompletionSession {
         session.close()
@@ -392,6 +392,7 @@ extension SwiftLanguageServer {
       }
       self.sourcekitd.removeNotificationHandler(self)
       self.client.close()
+      callback()
     }
   }
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -31,7 +31,8 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   func initializeSync(_ initialize: InitializeRequest) throws -> InitializeResult
   func clientInitialized(_ initialized: InitializedNotification)
-  func shutdown()
+  /// `callback` will be called when the server has finished shutting down.
+  func shutdown(callback: @escaping () -> Void)
 
   /// Add a handler that is called whenever the state of the language server changes.
   func addStateChangeHandler(handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void)


### PR DESCRIPTION
Especially in test we would sometimes end up in situations where the SourceKitServer (i.e. the main sourcekit-lsp handler) is being deallocated before clangd has finished shutting down. This can result in clangd sending us notifications while SourceKitServer is halfway deallocated and thus cause crashes due to memory corruption.

To fix the issue, wait until all toolchain servers have shut down before sending a response to the ShutdownRequest.

This should fix SourceKit-LSP test failures on Linux like https://ci.swift.org/job/swift-package-manager-Linux-smoke-test/93/console