### PR TITLE
build: force link against dependencies

### DIFF
--- a/Sources/LSPLogging/CMakeLists.txt
+++ b/Sources/LSPLogging/CMakeLists.txt
@@ -3,12 +3,8 @@ add_library(LSPLogging
   Logging.swift)
 set_target_properties(LSPLogging PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(LSPLogging PRIVATE
-      Foundation)
-  endif()
-endif()
+target_link_libraries(LSPLogging PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
 if(BUILD_SHARED_LIBS)
   get_swift_host_arch(swift_arch)

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -92,16 +92,9 @@ add_library(LanguageServerProtocol
   SupportTypes/WorkspaceSettings.swift)
 set_target_properties(LanguageServerProtocol PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(dispatch_FOUND)
-    target_link_libraries(LanguageServerProtocol PUBLIC
-      swiftDispatch)
-  endif()
-  if(Foundation_FOUND)
-    target_link_libraries(LanguageServerProtocol PUBLIC
-      Foundation)
-  endif()
-endif()
+target_link_libraries(LanguageServerProtocol PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
 if(BUILD_SHARED_LIBS)
   get_swift_host_arch(swift_arch)

--- a/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
@@ -8,6 +8,9 @@ set_target_properties(LanguageServerProtocolJSONRPC PROPERTIES
 target_link_libraries(LanguageServerProtocolJSONRPC PRIVATE
   LanguageServerProtocol
   LSPLogging)
+target_link_libraries(LanguageServerProtocolJSONRPC PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
 if(BUILD_SHARED_LIBS)
   get_swift_host_arch(swift_arch)

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -48,12 +48,8 @@ target_link_libraries(SourceKitLSP PUBLIC
   SKSwiftPMWorkspace
   SourceKitD
   TSCUtility)
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(SourceKitLSP PRIVATE
-      FoundationXML)
-  endif()
-endif()
+target_link_libraries(SourceKitLSP PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 
 if(BUILD_SHARED_LIBS)
   get_swift_host_arch(swift_arch)

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -12,12 +12,8 @@ target_link_libraries(sourcekit-lsp PRIVATE
   LanguageServerProtocolJSONRPC
   SourceKitLSP
   TSCUtility)
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(sourcekit-lsp PRIVATE
-      FoundationXML)
-  endif()
-endif()
+target_link_libraries(sourcekit-lsp PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 
 install(TARGETS sourcekit-lsp
   DESTINATION bin)


### PR DESCRIPTION
This will add an additional link request for dispatch and Foundation
libraries.  These are really required on non-Darwin targets, and should
be satisfied either by the library search path or by explicitly
indicating where the dependencies can be found.