### PR TITLE
build: build SourceKit-LSP with static linking

### DIFF
--- a/Sources/BuildServerProtocol/CMakeLists.txt
+++ b/Sources/BuildServerProtocol/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(BuildServerProtocol
+add_library(BuildServerProtocol STATIC
   BuildTargets.swift
   FileOptions.swift
   InitializeBuild.swift
@@ -9,15 +9,3 @@ set_target_properties(BuildServerProtocol PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(BuildServerProtocol PRIVATE
   LanguageServerProtocol)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS BuildServerProtocol
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch}
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch}
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:BuildServerProtocol,Swift_MODULE_DIRECTORY>/BuildServerProtocol.swiftdoc
-    $<TARGET_PROPERTY:BuildServerProtocol,Swift_MODULE_DIRECTORY>/BuildServerProtocol.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/LSPLogging/CMakeLists.txt
+++ b/Sources/LSPLogging/CMakeLists.txt
@@ -1,19 +1,7 @@
-add_library(LSPLogging
+add_library(LSPLogging STATIC
   LogLevel.swift
   Logging.swift)
 set_target_properties(LSPLogging PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(LSPLogging PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS LSPLogging
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:LSPLogging,Swift_MODULE_DIRECTORY>/LSPLogging.swiftdoc
-    $<TARGET_PROPERTY:LSPLogging,Swift_MODULE_DIRECTORY>/LSPLogging.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(LanguageServerProtocol
+add_library(LanguageServerProtocol STATIC
   Cancellation.swift
   Connection.swift
   CustomCodable.swift
@@ -95,15 +95,3 @@ set_target_properties(LanguageServerProtocol PROPERTIES
 target_link_libraries(LanguageServerProtocol PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS LanguageServerProtocol
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:LanguageServerProtocol,Swift_MODULE_DIRECTORY>/LanguageServerProtocol.swiftdoc
-    $<TARGET_PROPERTY:LanguageServerProtocol,Swift_MODULE_DIRECTORY>/LanguageServerProtocol.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(LanguageServerProtocolJSONRPC
+add_library(LanguageServerProtocolJSONRPC STATIC
   DisableSigpipe.swift
   JSONRPCConnection.swift
   MessageCoding.swift
@@ -11,15 +11,3 @@ target_link_libraries(LanguageServerProtocolJSONRPC PRIVATE
 target_link_libraries(LanguageServerProtocolJSONRPC PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS LanguageServerProtocolJSONRPC
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:LanguageServerProtocolJSONRPC,Swift_MODULE_DIRECTORY>/LanguageServerProtocolJSONRPC.swiftdoc
-    $<TARGET_PROPERTY:LanguageServerProtocolJSONRPC,Swift_MODULE_DIRECTORY>/LanguageServerProtocolJSONRPC.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(SKCore
+add_library(SKCore STATIC
   BuildServerBuildSystem.swift
   BuildSetup.swift
   BuildSystem.swift
@@ -24,15 +24,3 @@ target_link_libraries(SKCore PRIVATE
   SKSupport
   SourceKitD
   TSCUtility)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS SKCore
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:SKCore,Swift_MODULE_DIRECTORY>/SKCore.swiftdoc
-    $<TARGET_PROPERTY:SKCore,Swift_MODULE_DIRECTORY>/SKCore.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(SKSupport
+add_library(SKSupport STATIC
   BuildConfiguration.swift
   ByteString.swift
   FileSystem.swift
@@ -12,15 +12,3 @@ set_target_properties(SKSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SKSupport PRIVATE
   TSCUtility)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS SKSupport
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:SKSupport,Swift_MODULE_DIRECTORY>/SKSupport.swiftdoc
-    $<TARGET_PROPERTY:SKSupport,Swift_MODULE_DIRECTORY>/SKSupport.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/SKSwiftPMWorkspace/CMakeLists.txt
+++ b/Sources/SKSwiftPMWorkspace/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(SKSwiftPMWorkspace
+add_library(SKSwiftPMWorkspace STATIC
   SwiftPMWorkspace.swift)
 set_target_properties(SKSwiftPMWorkspace PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
@@ -9,15 +9,3 @@ target_link_libraries(SKSwiftPMWorkspace PRIVATE
   SKCore)
 target_link_libraries(SKSwiftPMWorkspace PUBLIC
   Build)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS SKSwiftPMWorkspace
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:SKSwiftPMWorkspace,Swift_MODULE_DIRECTORY>/SKSwiftPMWorkspace.swiftdoc
-    $<TARGET_PROPERTY:SKSwiftPMWorkspace,Swift_MODULE_DIRECTORY>/SKSwiftPMWorkspace.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/SourceKitD/CMakeLists.txt
+++ b/Sources/SourceKitD/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(SourceKitD
+add_library(SourceKitD STATIC
   SKDRequestArray.swift
   SKDRequestDictionary.swift
   SKDResponse.swift
@@ -17,15 +17,3 @@ target_link_libraries(SourceKitD PRIVATE
   LSPLogging
   SKSupport
   TSCUtility)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS SourceKitD
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:SourceKitD,Swift_MODULE_DIRECTORY>/SourceKitD.swiftdoc
-    $<TARGET_PROPERTY:SourceKitD,Swift_MODULE_DIRECTORY>/SourceKitD.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
-endif()

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(SourceKitLSP
+add_library(SourceKitLSP STATIC
   CapabilityRegistry.swift
   DocumentManager.swift
   DocumentTokens.swift
@@ -44,15 +44,3 @@ target_link_libraries(SourceKitLSP PUBLIC
   TSCUtility)
 target_link_libraries(SourceKitLSP PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
-
-if(BUILD_SHARED_LIBS)
-  get_swift_host_arch(swift_arch)
-  install(TARGETS SourceKitLSP
-    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    RUNTIME DESTINATION bin)
-  install(FILES
-    $<TARGET_PROPERTY:SourceKitLSP,Swift_MODULE_DIRECTORY>/SourceKitLSP.swiftdoc
-    $<TARGET_PROPERTY:SourceKitLSP,Swift_MODULE_DIRECTORY>/SourceKitLSP.swiftmodule
-    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
-endif()

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(sourcekit-lsp
 target_link_libraries(sourcekit-lsp PRIVATE
   ArgumentParser
   LanguageServerProtocolJSONRPC
+  SKCore
   SourceKitLSP
   TSCUtility)
 target_link_libraries(sourcekit-lsp PRIVATE


### PR DESCRIPTION
This adjusts the sourcekit-lsp build to use static linking for the
internal libraries.  It is not currently possible to build
SourceKitLSP.dll as that requires re-exporting the interfaces from the
consumed modules.  However, this allows us to reduce the overall size of
the distribution of SourceKit-LSP by ~1 MiB and reduces the
distributed file set.  The values here assume partial static linking of
swift-package-manager, which helps reduce the total size.

Before:

~~~
   228,352 BuildServerProtocol.dll
 1,773,056 LanguageServerProtocol.dll
   114,688 LanguageServerProtocolJSONRPC.dll
    49,152 LSPLogging.dll
   262,656 SKCore.dll
    54,784 SKSupport.dll
    80,896 SKSwiftPMWorkspace.dll
   150,528 SourceKitD.dll
   645,632 SourceKitLSP.dll

    70,144 sourcekit-lsp.exe

 3,429,888 bytes
~~~

After:

~~~
 2,416,640 sourcekit-lsp.exe

 2,416,640 bytes
~~~