### PR TITLE
Import `CRT` to resolve `free` on Windows

### DIFF
--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 public final class SKDRequestArray {

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 public final class SKDRequestDictionary {

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 public final class SKDResponse {

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 public final class SKDResponseArray {

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(CRT)
+import CRT
 #endif
 
 public final class SKDResponseDictionary {


### PR DESCRIPTION
```
S:\sourcekit-lsp\Sources\SourceKitD\SKDResponse.swift:55:13: error: cannot find 'free' in scope
    defer { free(ptr) }
            ^~~~
S:\sourcekit-lsp\Sources\SourceKitD\SKDResponseArray.swift:65:13: error: cannot find 'free' in scope
    defer { free(ptr) }
            ^~~~
S:\sourcekit-lsp\Sources\SourceKitD\SKDRequestArray.swift:39:13: error: cannot find 'free' in scope
    defer { free(ptr) }
            ^~~~
S:\sourcekit-lsp\Sources\SourceKitD\SKDRequestDictionary.swift:64:13: error: cannot find 'free' in scope
    defer { free(ptr) }
            ^~~~
S:\sourcekit-lsp\Sources\SourceKitD\SKDResponseDictionary.swift:64:13: error: cannot find 'free' in scope
    defer { free(ptr) }
```