### PR TITLE
Remove deleting toolchain rpath step 

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -82,13 +82,6 @@ def install_binary(exe, source_dir, install_dir, toolchain):
   if platform.system() == 'Darwin':
     result_path = os.path.join(install_dir, exe)
     stdlib_rpath = os.path.join(toolchain, 'lib', 'swift', 'macosx')
-    delete_rpath(stdlib_rpath, result_path)
-
-def delete_rpath(rpath, binary):
-  cmd = ["install_name_tool", "-delete_rpath", rpath, binary]
-  print(' '.join(cmd))
-  subprocess.check_call(cmd)
-
 
 def handle_invocation(swift_exec, args):
   swiftpm_args = get_swiftpm_options(args)


### PR DESCRIPTION
the install script has been broken since https://github.com/apple/swift-package-manager/commit/8876f871413409a3df2ae68f1c3a7d146ee72cfa
which stops adding toolchain rpath for older OSes without system
swift libraries.

```
[647/648] Linking sourcekit-lsp
[648/648] Linking lib_SourceKitLSP.dylib
Build complete! (104.94s)
error: /Applications/Xcode-13.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: no LC_RPATH load command with path: /Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/lib/swift/macosx found in: /Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/bin/sourcekit-lsp (for architecture arm64), required for specified option "-delete_rpath /Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/lib/swift/macosx"
Traceback (most recent call last):
  File "/Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp/Utilities/build-script-helper.py", line 218, in <module>
Cleaning /Users/gha-runner/actions-runner/_work/swift/swift/host-build/Ninja-Release/sourcekitlsp-macosx-arm64
/Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/bin/swift build --show-bin-path --package-path /Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp --build-path /Users/gha-runner/actions-runner/_work/swift/swift/host-build/Ninja-Release/sourcekitlsp-macosx-arm64 --configuration release -Xlinker -rpath -Xlinker @executable_path/../lib/swift/macosx
/Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/bin/swift build --package-path /Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp --build-path /Users/gha-runner/actions-runner/_work/swift/swift/host-build/Ninja-Release/sourcekitlsp-macosx-arm64 --configuration release -Xlinker -rpath -Xlinker @executable_path/../lib/swift/macosx -Xswiftc -no-toolchain-stdlib-rpath
rsync -a /Users/gha-runner/actions-runner/_work/swift/swift/host-build/Ninja-Release/sourcekitlsp-macosx-arm64/arm64-apple-macosx/release/sourcekit-lsp /Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/bin
install_name_tool -delete_rpath /Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/lib/swift/macosx /Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/bin/sourcekit-lsp
    main()
  File "/Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp/Utilities/build-script-helper.py", line 195, in main
    handle_invocation(swift_exec, args)
  File "/Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp/Utilities/build-script-helper.py", line 143, in handle_invocation
    install(bin_path, args.install_prefixes, args.toolchain)
  File "/Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp/Utilities/build-script-helper.py", line 75, in install
    install_binary('sourcekit-lsp', swiftpm_bin_path, os.path.join(prefix, 'bin'), toolchain)
  File "/Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp/Utilities/build-script-helper.py", line 85, in install_binary
    delete_rpath(stdlib_rpath, result_path)
  File "/Users/gha-runner/actions-runner/_work/swift/swift/sourcekit-lsp/Utilities/build-script-helper.py", line 90, in delete_rpath
    subprocess.check_call(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['install_name_tool', '-delete_rpath', '/Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/lib/swift/macosx', '/Users/gha-runner/actions-runner/_work/swift/swift/host-toolchain-sdk/usr/bin/sourcekit-lsp']' returned non-zero exit status 1
ERROR: command terminated with a non-zero exit status 1, aborting
```