### PR TITLE
Increase timeout for semantic diagnostics in tests

### DIFF
--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -217,7 +217,7 @@ final class SKTests: XCTestCase {
     }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 5)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: 30)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }


### PR DESCRIPTION
AFAICT getting semantic diagnostics takes more than 5 seconds if a specific SDK/compiler combination is used for the first time, increase the timeout to make the test pass.