### PR TITLE
Reload the workspace state if workspace-state.json changes

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -353,6 +353,9 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 
   public func filesDidChange(_ events: [FileEvent]) {
     queue.async {
+      if events.contains(where: { $0.uri.fileURL?.lastPathComponent == "workspace-state.json" }) {
+        self.workspace.reloadWorkspaceState(warningHandler: { _ in })
+      }
       if events.contains(where: { self.fileEventShouldTriggerPackageReload(event: $0) }) {
         orLog {
           // TODO: It should not be necessary to reload the entire package just to get build settings for one file.

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -589,6 +589,7 @@ extension SourceKitServer {
       return FileSystemWatcher(globPattern: "**/*.\(fileExtension)", kind: [.create, .delete])
     }
     watchers.append(FileSystemWatcher(globPattern: "**/Package.swift", kind: [.change]))
+    watchers.append(FileSystemWatcher(globPattern: "**/workspace-state.json", kind: [.change]))
     registry.registerDidChangeWatchedFiles(watchers: watchers) {
       self.dynamicallyRegisterCapability($0, registry)
     }


### PR DESCRIPTION
Depends on https://github.com/apple/swift-package-manager/pull/4310

---

Previously, sourcekit-lsp wouldn’t take into account changes to the workspace state (like `swift package edit`) after it was launched.

Fixes rdar://89551074 [SR-15918]
Fixes rdar://89082936 [SR-15875]