### PR TITLE
Fix a crash on Linux if a ShutdownRequest was sent without params

### DIFF
--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -212,6 +212,29 @@ final class CodingTests: XCTestCase {
     {"jsonrpc":"2.0","id":2,"result":{}}
     """, userInfo: info)
   }
+
+  // SR-16095
+  func testDecodeShutdownWithoutParams() {
+    let json = """
+      {
+        "id" : 1,
+        "jsonrpc" : "2.0",
+        "method" : "shutdown"
+      }
+      """
+
+    let decoder = JSONDecoder()
+    decoder.userInfo = defaultCodingInfo
+    let decodedValue = try! decoder.decode(JSONRPCMessage.self, from: json.data(using: .utf8)!)
+
+    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = decodedValue, let decodedRequest = decodedValueOpaque as? ShutdownRequest else {
+      XCTFail("decodedValue \(decodedValue) is not a ShutdownRequest")
+      return
+    }
+
+    XCTAssertEqual(.number(1), decodedID, "expected request ID 1")
+    XCTAssertEqual(ShutdownRequest(), decodedRequest)
+  }
 }
 
 let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspProtocol]


### PR DESCRIPTION
Workaround for SR-16097 to avoid hitting SR-16095: VSCode will send shutdown requests without a 'params' key. On macOS getting the superDecoder for a non-existent container returns an empty decoder, on Linux it throws `DecodingError.keyNotFound`, causing a crash.

Perform a targeted fix: If we don't have 'params' and the request is a ShutdownRequest, manually create a `ShutdownRequest` without any parameters.

rdar://91288093