### PR TITLE
[5.6] Fix a crash on Linux if a ShutdownRequest was sent without params

### DIFF
--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -212,6 +212,29 @@ final class CodingTests: XCTestCase {
     {"jsonrpc":"2.0","id":2,"result":{}}
     """, userInfo: info)
   }
+
+  // SR-16095
+  func testDecodeShutdownWithoutParams() {
+    let json = """
+      {
+        "id" : 1,
+        "jsonrpc" : "2.0",
+        "method" : "shutdown"
+      }
+      """
+
+    let decoder = JSONDecoder()
+    decoder.userInfo = defaultCodingInfo
+    let decodedValue = try! decoder.decode(JSONRPCMessage.self, from: json.data(using: .utf8)!)
+
+    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = decodedValue, let decodedRequest = decodedValueOpaque as? ShutdownRequest else {
+      XCTFail("decodedValue \(decodedValue) is not a ShutdownRequest")
+      return
+    }
+
+    XCTAssertEqual(.number(1), decodedID, "expected request ID 1")
+    XCTAssertEqual(ShutdownRequest(), decodedRequest)
+  }
 }
 
 let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspProtocol]


### PR DESCRIPTION
* **Explanation of the issue**: VSCode is shutting down the sourcekit-lsp server when switching workspaces. On Linux sourcekit-lsp fails to process the shutdown request  and causes VSCode to abort the shutdown process at a point it cannot recover from, thus making it impossible to restart the language server. To recover semantic functionality after switching workspaces, VSCode needs to be restarted. 
* **Explanation of the fix**: Perform a targeted fix: If we don't have 'params' and the request is a ShutdownRequest, manually create a `ShutdownRequest` without any parameters. This issue does not occur on macOS because the underlying bug (SR-16097) only affects Linux: VSCode will send shutdown requests without a 'params' key. On macOS getting the superDecoder for a non-existent container returns an empty decoder, on Linux it throws `DecodingError.keyNotFound`, causing a crash. 
* **Scope**: Only affects the shutdown requests that failed to deserialize before
* **Risk**: Very low
* **Testing**: Added a test case
* **Issue**: rdar://91288093
* **Reviewer**: @benlangmuir on https://github.com/apple/sourcekit-lsp/pull/474