### PR TITLE
Increase timeout for semantic diagnostics in tests

### DIFF
--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -217,7 +217,7 @@ final class SKTests: XCTestCase {
     }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 5)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: 30)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/sourcekit-lsp/pull/469 to release/5.7. A previous attempt to cherry-pick targeted `main` instead of `release/5.7` 🤦 

* **Explanation**: AFAICT getting semantic diagnostics takes more than 5 seconds if a specific SDK/compiler combination is used for the first time, increase the timeout to make the test pass.
* **Scope**: Only affects test
* **Risk**: Super low (only affects tests, increases timeout)
* **Testing**: Verified that tests pass locally
* **Reviewer**: @benlangmuir on https://github.com/apple/sourcekit-lsp/pull/469