### PR TITLE
Increase timeout for semantic diagnostics in tests a little bit more

### DIFF
--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -217,7 +217,7 @@ final class SKTests: XCTestCase {
     }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 30)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: 60)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }


### PR DESCRIPTION
30 seconds wasn’t sufficient to fix the failure in CI, 60 should be enough.