### PR TITLE
[5.7] Increase timeout for semantic diagnostics in tests a little bit more

### DIFF
--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -217,7 +217,7 @@ final class SKTests: XCTestCase {
     }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 30)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: 60)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }


### PR DESCRIPTION
* **Explanation**: Increasing the timeout for this test from 5 seconds to 30 seconds in https://github.com/apple/sourcekit-lsp/pull/470 fixed the issue locally, but not in CI. I verified that 60 second is enough.
* **Scope**: SourceKit-LSP test case
* **Risk**: Super low (only affects tests)
* **Testing**: Verified that tests now pass in CI
* **Reviewer**: Waiting for review on https://github.com/apple/sourcekit-lsp/pull/478