### PR TITLE
Translate placeholders to LSP snippets in CodeActions

### DIFF
--- a/Sources/SKTestSupport/INPUTS/Fixit/Fixit.swift
+++ b/Sources/SKTestSupport/INPUTS/Fixit/Fixit.swift
@@ -1,0 +1,7 @@
+protocol MyProto {
+  func foo()
+}
+
+struct /*MyStruct:def*/MyStruct: MyProto {
+
+}

--- a/Sources/SKTestSupport/INPUTS/Fixit/project.json
+++ b/Sources/SKTestSupport/INPUTS/Fixit/project.json
@@ -1,0 +1,1 @@
+{ "sources": ["Fixit.swift"] }

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -142,7 +142,7 @@ extension SwiftLanguageServer {
       let clientCompletionCapabilities = self.clientCapabilities.textDocument?.completion
       let clientSupportsSnippets = clientCompletionCapabilities?.completionItem?.snippetSupport == true
       let text = insertText.map {
-        self.rewriteSourceKitPlaceholders(inString: $0, clientSupportsSnippets: clientSupportsSnippets)
+        rewriteSourceKitPlaceholders(inString: $0, clientSupportsSnippets: clientSupportsSnippets)
       }
       let isInsertTextSnippet = clientSupportsSnippets && text != insertText
 
@@ -186,26 +186,6 @@ extension SwiftLanguageServer {
       return true
     }
 
-    return result
-  }
-
-  func rewriteSourceKitPlaceholders(inString string: String, clientSupportsSnippets: Bool) -> String {
-    var result = string
-    var index = 1
-    while let start = result.range(of: EditorPlaceholder.placeholderPrefix) {
-      guard let end = result[start.upperBound...].range(of: EditorPlaceholder.placeholderSuffix) else {
-        log("invalid placeholder in \(string)", level: .debug)
-        return string
-      }
-      let rawPlaceholder = String(result[start.lowerBound..<end.upperBound])
-      guard let displayName = EditorPlaceholder(rawPlaceholder)?.displayName else {
-        log("failed to decode placeholder \(rawPlaceholder) in \(string)", level: .debug)
-        return string
-      }
-      let placeholder = clientSupportsSnippets ? "${\(index):\(displayName)}" : ""
-      result.replaceSubrange(start.lowerBound..<end.upperBound, with: placeholder)
-      index += 1
-    }
     return result
   }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -293,13 +293,15 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
 
     let supportsCodeDescription =
            (clientCapabilities.textDocument?.publishDiagnostics?.codeDescriptionSupport == true)
+    let supportsSnippets = (self.clientCapabilities.textDocument?.completion?.completionItem?.snippetSupport == true)
 
     // Note: we make the notification even if there are no diagnostics to clear the current state.
     var newDiags: [CachedDiagnostic] = []
     response[keys.diagnostics]?.forEach { _, diag in
       if let diag = CachedDiagnostic(diag,
                                      in: snapshot,
-                                     useEducationalNoteAsCode: supportsCodeDescription) {
+                                     useEducationalNoteAsCode: supportsCodeDescription,
+                                     clientSupportsSnippets: supportsSnippets) {
         newDiags.append(diag)
       }
       return true


### PR DESCRIPTION
Previously, we would insert `<#code#>` placeholders when inserting missing protocol requirements (both via the Fix-It and the refactor command). Translate them to LSP placeholders before inserting them.

rdar://92161144