### PR TITLE
[5.7] Reload the workspace state if workspace-state.json changes

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -353,6 +353,9 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 
   public func filesDidChange(_ events: [FileEvent]) {
     queue.async {
+      if events.contains(where: { $0.uri.fileURL?.lastPathComponent == "workspace-state.json" }) {
+        self.workspace.reloadWorkspaceState(warningHandler: { _ in })
+      }
       if events.contains(where: { self.fileEventShouldTriggerPackageReload(event: $0) }) {
         orLog {
           // TODO: It should not be necessary to reload the entire package just to get build settings for one file.

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -585,9 +585,10 @@ extension SourceKitServer {
     }
 
     /// This must be a superset of the files that return true for SwiftPM's `Workspace.fileAffectsSwiftOrClangBuildSettings`.
-    let watchers = FileRuleDescription.builtinRules.flatMap({ $0.fileTypes }).map { fileExtension in
+    var watchers = FileRuleDescription.builtinRules.flatMap({ $0.fileTypes }).map { fileExtension in
       return FileSystemWatcher(globPattern: "**/*.\(fileExtension)", kind: [.create, .delete])
     }
+    watchers.append(FileSystemWatcher(globPattern: "**/workspace-state.json", kind: [.change]))
     registry.registerDidChangeWatchedFiles(watchers: watchers) {
       self.dynamicallyRegisterCapability($0, registry)
     }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/sourcekit-lsp/pull/472 to release/5.7

Depends on https://github.com/apple/swift-package-manager/pull/4329

---

Previously, sourcekit-lsp wouldn’t take into account changes to the workspace state (like `swift package edit`) after it was launched.

Fixes rdar://89551074 [SR-15918]
Fixes rdar://89082936 [SR-15875]
