### PR TITLE
Upgrade Swift Argument Parser to version 1.1.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -238,7 +238,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     .package(name: "IndexStoreDB", url: "https://github.com/apple/indexstore-db.git", .branch("main")),
     .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.2")),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
This PR upgrades the Swift Argument Parser dependency to version 1.1.2. This is the latest version of the dependency and supports new features like async/await via the `AsyncParsableCommand` type.

In order to upgrade this dependency, it must also be upgraded in swift-package-manager and swift-driver.

* swift-driver PR [#1106](https://github.com/apple/swift-driver/pull/1106)
* swift-package-manager PR [#5540](https://github.com/apple/swift-package-manager/pull/5540)

I believe the correct order to merge these PRs would be:

1. swift-driver
2. swift-package-manager (depends on swift-driver)
3. sourcekit-lsp (depends on swift-package-manager)