### PR TITLE
[5.7] When receiving a didChangeWorkspaceFolders notification, reopen documents that moved to a different workspace

### DIFF
--- a/Sources/SKTestSupport/INPUTS/ChangeWorkspaceFolders/Package.swift
+++ b/Sources/SKTestSupport/INPUTS/ChangeWorkspaceFolders/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.5
+
+import PackageDescription
+
+let package = Package(
+  name: "package",
+  products: [
+    .library(name: "package", targets: ["package"]),
+    .library(name: "otherPackage", targets: ["otherPackage"]),
+  ],
+  targets: [
+    .target(
+      name: "package",
+      dependencies: []),
+    .target(
+      name: "otherPackage",
+      dependencies: ["package"]),
+  ]
+)

--- a/Sources/SKTestSupport/INPUTS/ChangeWorkspaceFolders/Sources/otherPackage/otherPackage.swift
+++ b/Sources/SKTestSupport/INPUTS/ChangeWorkspaceFolders/Sources/otherPackage/otherPackage.swift
@@ -1,0 +1,5 @@
+import package
+
+func test() {
+  Package() . /*otherPackage:call*/ helloWorld()
+}

--- a/Sources/SKTestSupport/INPUTS/ChangeWorkspaceFolders/Sources/package/package.swift
+++ b/Sources/SKTestSupport/INPUTS/ChangeWorkspaceFolders/Sources/package/package.swift
@@ -1,0 +1,7 @@
+public struct Package {
+  public init() {}
+
+  public func helloWorld() {
+    print("Hello world!")
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -886,6 +886,10 @@ extension SourceKitServer {
   }
 
   func didChangeWorkspaceFolders(_ note: Notification<DidChangeWorkspaceFoldersNotification>) {
+    var preChangeWorkspaces: [DocumentURI: Workspace] = [:]
+    for docUri in self.documentManager.openDocuments {
+      preChangeWorkspaces[docUri] = self.workspaceForDocument(uri: docUri)
+    }
     if let removed = note.params.event.removed {
       self.workspaces.removeAll { workspace in
         return removed.contains(where: { workspaceFolder in
@@ -899,6 +903,31 @@ extension SourceKitServer {
         workspace.buildSystemManager.delegate = self
       }
       self.workspaces.append(contentsOf: newWorkspaces)
+    }
+
+    // For each document that has moved to a different workspace, close it in
+    // the old workspace and open it in the new workspace.
+    for docUri in self.documentManager.openDocuments {
+      let oldWorkspace = preChangeWorkspaces[docUri]
+      let newWorkspace = self.workspaceForDocument(uri: docUri)
+      if newWorkspace !== oldWorkspace {
+        guard let snapshot = documentManager.latestSnapshot(docUri) else {
+          continue
+        }
+        if let oldWorkspace = oldWorkspace {
+          self.closeDocument(DidCloseTextDocumentNotification(
+            textDocument: TextDocumentIdentifier(docUri)
+          ), workspace: oldWorkspace)
+        }
+        if let newWorkspace = newWorkspace {
+          self.openDocument(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
+            uri: docUri,
+            language: snapshot.document.language,
+            version: snapshot.version,
+            text: snapshot.text
+          )), workspace: newWorkspace)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
* **Explanation**: A didChangeWorkspaceFolders notification might cause documents that are already open to now be considered part of a different workspace. To reflect this, close documents whose workspace has changed in the old workspace and re-open them in the new workspace. Without this fix, these documents that switched workspaces weren’t getting any semantic functionality
* **Scope**: SourceKit-LSP after changing workspaces using the `didChangeWorkspaceFolders` notification
* **Risk**: I can’t think of any risk and the current behavior is pretty bad
* **Testing**: Added regression test case
* **Issue**: rdar://94026341 [#557]
* **Reviewer**: @benlangmuir on https://github.com/apple/sourcekit-lsp/pull/558