### PR TITLE
Clarify renaming capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SourceKit-LSP is still in early development, so you may run into rough edges wit
 | Find References | ✅ | |
 | Background Indexing | ❌ | Build project to update the index using [Indexing While Building](#indexing-while-building) |
 | Workspace Symbols | ✅ | |
-| Global Rename | ❌ | |
+| Rename | ❌ | |
 | Local Refactoring | ✅ | |
 | Formatting | ❌ | |
 | Folding | ✅ | |


### PR DESCRIPTION
It's misleading to qualify "**Global** Rename" as not implemented because neither global nor local rename work. It's more straightforward and clear to say that renaming is not supported at all.

From what I can tell the current wording could be related to a time where local renaming used to work as a refactor action item (https://github.com/apple/sourcekit-lsp/pull/172); this is merely a guess since I was not following this repository's development back then.