### PR TITLE
allow custom per-workspace build flags via initializationOptions

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -574,7 +574,9 @@ extension SourceKitServer {
       let workspacesOptionKey = "workspaces"
       if let workspacesConfig = options[workspacesOptionKey] {
         if case .dictionary(let workspacesConfig) = workspacesConfig {
-          for (workspacePath, workspaceConfig) in workspacesConfig {
+          for (rawWorkspacePath, workspaceConfig) in workspacesConfig {
+            let workspacePath = AbsolutePath(expandingTilde: rawWorkspacePath).pathString
+
             if case .dictionary(let workspaceConfig) = workspaceConfig {
               var buildFlags = BuildFlags()
 


### PR DESCRIPTION
close #564

Opening the PR earlier, before everything is ready, for feedback before continuing to the remaining tasks

# TODO

- [x] Implementation
- [ ] Documentation
- [ ] Tests

Example usage:

```json
{
  "initializationOptions": {
    "workspaces": {
      "/path/to/workspace": {
        "cxxCompilerFlags": [
          "-I/path/to/include",
          "-I/path/to/include"
        ]
      }
    }
  }
}
```
