### PR TITLE
[5.7] Close temporarily opened documents

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -659,14 +659,23 @@ extension SwiftLanguageServer {
       return completion(.failure(.unknown(msg)))
     }
 
+    let helperDocumentName = "DocumentSymbols:" + snapshot.document.uri.pseudoPath
     let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
     skreq[keys.request] = self.requests.editor_open
-    skreq[keys.name] = "DocumentSymbols:" + snapshot.document.uri.pseudoPath
+    skreq[keys.name] = helperDocumentName
     skreq[keys.sourcetext] = snapshot.text
     skreq[keys.syntactic_only] = 1
 
     let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
       guard let self = self else { return }
+
+      defer {
+        let closeHelperReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+        closeHelperReq[self.keys.request] = self.requests.editor_close
+        closeHelperReq[self.keys.name] = helperDocumentName
+        _ = self.sourcekitd.send(closeHelperReq, .global(qos: .utility), reply: { _ in })
+      }
+
       guard let dict = result.success else {
         return completion(.failure(ResponseError(result.failure!)))
       }
@@ -756,14 +765,23 @@ extension SwiftLanguageServer {
         return
       }
 
+      let helperDocumentName = "DocumentColor:" + snapshot.document.uri.pseudoPath
       let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
       skreq[keys.request] = self.requests.editor_open
-      skreq[keys.name] = "DocumentColor:" + snapshot.document.uri.pseudoPath
+      skreq[keys.name] = helperDocumentName
       skreq[keys.sourcetext] = snapshot.text
       skreq[keys.syntactic_only] = 1
 
       let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
         guard let self = self else { return }
+
+        defer {
+          let closeHelperReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+          closeHelperReq[keys.request] = self.requests.editor_close
+          closeHelperReq[keys.name] = helperDocumentName
+          _ = self.sourcekitd.send(closeHelperReq, .global(qos: .utility), reply: { _ in })
+        }
+
         guard let dict = result.success else {
           req.reply(.failure(ResponseError(result.failure!)))
           return
@@ -962,14 +980,23 @@ extension SwiftLanguageServer {
         return
       }
 
+      let helperDocumentName = "FoldingRanges:" + snapshot.document.uri.pseudoPath
       let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
       skreq[keys.request] = self.requests.editor_open
-      skreq[keys.name] = "FoldingRanges:" + snapshot.document.uri.pseudoPath
+      skreq[keys.name] = helperDocumentName
       skreq[keys.sourcetext] = snapshot.text
       skreq[keys.syntactic_only] = 1
 
       let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
         guard let self = self else { return }
+
+        defer {
+          let closeHelperReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+          closeHelperReq[keys.request] = self.requests.editor_close
+          closeHelperReq[keys.name] = helperDocumentName
+          _ = self.sourcekitd.send(closeHelperReq, .global(qos: .utility), reply: { _ in })
+        }
+
         guard let dict = result.success else {
           req.reply(.failure(ResponseError(result.failure!)))
           return


### PR DESCRIPTION
* **Explanation**: To satisfy certain kinds of semantic requests, we open a source document with a temporary prefix but forgot to close them afterwards. This caused issues on Windows where these files are opened exclusively This fixes an issue for SourceKit-LSP on Windows where these files are opened exclusively and couldn’t be modified anymore.
* **Scope**: May affect pretty much all of SourceKit-LSP
* **Risk**: Low, not closing the documents was just an oversight
* **Testing**: @compnerd verified that the Windows issue no longer occurs with this fix
* **Issue**: #553 (rdar://93154201)
* **Reviewer**: @benlangmuir on https://github.com/apple/sourcekit-lsp/pull/566

