### PR TITLE
Set a default timeout duration

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -177,7 +177,7 @@ extension TestClient: Connection {
 
     send(notification)
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 15)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for notification in response to \(notification)")
     }
@@ -205,7 +205,7 @@ extension TestClient: Connection {
 
     send(notification)
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 15)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for notification in response to \(notification)")
     }

--- a/Sources/LSPTestSupport/Timeouts.swift
+++ b/Sources/LSPTestSupport/Timeouts.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The default duration how long tests should wait for responses from
+/// SourceKit-LSP / sourcekitd / clangd. 
+public let defaultTimeout: TimeInterval = 15

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionPerfTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionPerfTests.swift
@@ -36,7 +36,7 @@ class ConnectionPerfTests: PerfTestCase {
         expectation.fulfill()
       }
 
-      waitForExpectations(timeout: 10)
+      waitForExpectations(timeout: defaultTimeout)
     }
   }
 
@@ -48,7 +48,7 @@ class ConnectionPerfTests: PerfTestCase {
         _ = client.send(EchoRequest(string: "hello!")) { _ in
           sema.signal()
         }
-        XCTAssertEqual(sema.wait(timeout: .now() + .seconds(10)), .success)
+        XCTAssertEqual(sema.wait(timeout: .now() + .seconds(Int(defaultTimeout))), .success)
       }
     }
   }
@@ -63,7 +63,7 @@ class ConnectionPerfTests: PerfTestCase {
         }
       })
       for _ in 1...100 {
-        XCTAssertEqual(sema.wait(timeout: .now() + .seconds(10)), .success)
+        XCTAssertEqual(sema.wait(timeout: .now() + .seconds(Int(defaultTimeout))), .success)
       }
     }
   }

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -50,7 +50,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testMessageBuffer() {
@@ -75,7 +75,7 @@ class ConnectionTests: XCTestCase {
 
     clientConnection.send(_rawData: [note1Str.utf8.last!, note2Str.utf8.first!].withUnsafeBytes { DispatchData(bytes: $0) })
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
 
     let expectation2 = self.expectation(description: "note received")
 
@@ -88,7 +88,7 @@ class ConnectionTests: XCTestCase {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
 
     // Close the connection before accessing _requestBuffer, which ensures we don't race.
     connection.serverConnection.close()
@@ -110,7 +110,7 @@ class ConnectionTests: XCTestCase {
       expectation2.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testEchoNote() {
@@ -124,7 +124,7 @@ class ConnectionTests: XCTestCase {
 
     client.send(EchoNotification(string: "hello!"))
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testUnknownRequest() {
@@ -141,7 +141,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testUnknownNotification() {
@@ -161,7 +161,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testUnexpectedResponse() {
@@ -178,7 +178,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testSendAfterClose() {
@@ -198,7 +198,7 @@ class ConnectionTests: XCTestCase {
     connection.clientConnection.close()
     connection.clientConnection.close()
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testSendBeforeClose() {
@@ -213,7 +213,7 @@ class ConnectionTests: XCTestCase {
     server.client.send(EchoNotification(string: "about to close!"))
     connection.serverConnection.close()
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
   
   func testSendSynchronouslyBeforeClose() {
@@ -227,7 +227,7 @@ class ConnectionTests: XCTestCase {
     connection.serverConnection._send(.notification(notification), async: false)
     connection.serverConnection.close()
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   /// We can explicitly close a connection, but the connection also
@@ -272,7 +272,7 @@ class ConnectionTests: XCTestCase {
       conn.close()
 
       withExtendedLifetime(conn) {
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: defaultTimeout)
       }
     }
   }

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -39,7 +39,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testEchoError() {
@@ -57,7 +57,7 @@ class ConnectionTests: XCTestCase {
       expectation2.fulfill()
     }
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 
   func testEchoNote() {
@@ -71,6 +71,6 @@ class ConnectionTests: XCTestCase {
 
     client.send(EchoNotification(string: "hello!"))
 
-    waitForExpectations(timeout: 10)
+    waitForExpectations(timeout: defaultTimeout)
   }
 }

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -13,6 +13,7 @@
 import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
+import LSPTestSupport
 import SKCore
 import SKTestSupport
 import TSCBasic
@@ -61,7 +62,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
     buildSystem.delegate = buildSystemDelegate
     buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: defaultTimeout), .completed)
   }
 
   func testBuildTargets() throws {
@@ -93,7 +94,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
         XCTFail(error.message)
       }
     })
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: defaultTimeout), .completed)
   }
 
   func testBuildTargetSources() throws {
@@ -123,7 +124,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
         XCTFail(error.message)
       }
     })
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: defaultTimeout), .completed)
   }
 
   func testBuildTargetOutputs() throws {
@@ -147,7 +148,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
         XCTFail(error.message)
       }
     })
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 15), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: defaultTimeout), .completed)
   }
 
   func testBuildTargetsChanged() throws {
@@ -168,7 +169,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
     buildSystem.delegate = buildSystemDelegate
     buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 15)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for targets changed notification")
     }

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -105,13 +105,13 @@ final class BuildSystemManagerTests: XCTestCase {
     let initial = expectation(description: "initial settings")
     del.expected = [(a, bs.map[a]!, initial, #file, #line)]
     bsm.registerForChangeNotifications(for: a, language: .swift)
-    wait(for: [initial], timeout: 10, enforceOrder: true)
+    wait(for: [initial], timeout: defaultTimeout, enforceOrder: true)
 
     bs.map[a] = nil
     let changed = expectation(description: "changed settings")
     del.expected = [(a, nil, changed, #file, #line)]
     bsm.fileBuildSettingsChanged([a: .removedOrUnavailable])
-    wait(for: [changed], timeout: 10, enforceOrder: true)
+    wait(for: [changed], timeout: defaultTimeout, enforceOrder: true)
   }
 
   func testSettingsMainFileInitialNil() {
@@ -128,13 +128,13 @@ final class BuildSystemManagerTests: XCTestCase {
     let initial = expectation(description: "initial settings")
     del.expected = [(a, nil, initial, #file, #line)]
     bsm.registerForChangeNotifications(for: a, language: .swift)
-    wait(for: [initial], timeout: 10, enforceOrder: true)
+    wait(for: [initial], timeout: defaultTimeout, enforceOrder: true)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let changed = expectation(description: "changed settings")
     del.expected = [(a, bs.map[a]!, changed, #file, #line)]
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
-    wait(for: [changed], timeout: 10, enforceOrder: true)
+    wait(for: [changed], timeout: defaultTimeout, enforceOrder: true)
   }
 
   func testSettingsMainFileWithFallback() {
@@ -153,19 +153,19 @@ final class BuildSystemManagerTests: XCTestCase {
     let initial = expectation(description: "initial fallback settings")
     del.expected = [(a, fallbackSettings, initial, #file, #line)]
     bsm.registerForChangeNotifications(for: a, language: .swift)
-    wait(for: [initial], timeout: 10, enforceOrder: true)
+    wait(for: [initial], timeout: defaultTimeout, enforceOrder: true)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["non-fallback", "args"])
     let changed = expectation(description: "changed settings")
     del.expected = [(a, bs.map[a]!, changed, #file, #line)]
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
-    wait(for: [changed], timeout: 10, enforceOrder: true)
+    wait(for: [changed], timeout: defaultTimeout, enforceOrder: true)
 
     bs.map[a] = nil
     let revert = expectation(description: "revert to fallback settings")
     del.expected = [(a, fallbackSettings, revert, #file, #line)]
     bsm.fileBuildSettingsChanged([a: .removedOrUnavailable])
-    wait(for: [revert], timeout: 10, enforceOrder: true)
+    wait(for: [revert], timeout: defaultTimeout, enforceOrder: true)
   }
 
   func testSettingsMainFileInitialIntersect() {
@@ -186,18 +186,18 @@ final class BuildSystemManagerTests: XCTestCase {
     let initial = expectation(description: "initial settings")
     del.expected = [(a, bs.map[a]!, initial, #file, #line)]
     bsm.registerForChangeNotifications(for: a, language: .swift)
-    wait(for: [initial], timeout: 10, enforceOrder: true)
+    wait(for: [initial], timeout: defaultTimeout, enforceOrder: true)
     let initialB = expectation(description: "initial settings")
     del.expected = [(b, bs.map[b]!, initialB, #file, #line)]
     bsm.registerForChangeNotifications(for: b, language: .swift)
-    wait(for: [initialB], timeout: 10, enforceOrder: true)
+    wait(for: [initialB], timeout: defaultTimeout, enforceOrder: true)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["xx"])
     bs.map[b] = FileBuildSettings(compilerArguments: ["yy"])
     let changed = expectation(description: "changed settings")
     del.expected = [(a, bs.map[a]!, changed, #file, #line)]
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
-    wait(for: [changed], timeout: 10, enforceOrder: true)
+    wait(for: [changed], timeout: defaultTimeout, enforceOrder: true)
 
     // Test multiple changes.
     bs.map[a] = FileBuildSettings(compilerArguments: ["xxx"])
@@ -212,7 +212,7 @@ final class BuildSystemManagerTests: XCTestCase {
       a:. modified(bs.map[a]!),
       b: .modified(bs.map[b]!)
     ])
-    wait(for: [changedBothA, changedBothB], timeout: 10, enforceOrder: false)
+    wait(for: [changedBothA, changedBothB], timeout: defaultTimeout, enforceOrder: false)
   }
 
   func testSettingsMainFileUnchanged() {
@@ -234,12 +234,12 @@ final class BuildSystemManagerTests: XCTestCase {
     let initialA = expectation(description: "initial settings a")
     del.expected = [(a, bs.map[a]!, initialA, #file, #line)]
     bsm.registerForChangeNotifications(for: a, language: .swift)
-    wait(for: [initialA], timeout: 10, enforceOrder: true)
+    wait(for: [initialA], timeout: defaultTimeout, enforceOrder: true)
 
     let initialB = expectation(description: "initial settings b")
     del.expected = [(b, bs.map[b]!, initialB, #file, #line)]
     bsm.registerForChangeNotifications(for: b, language: .swift)
-    wait(for: [initialB], timeout: 10, enforceOrder: true)
+    wait(for: [initialB], timeout: defaultTimeout, enforceOrder: true)
 
     bs.map[a] = nil
     bs.map[b] = nil
@@ -248,7 +248,7 @@ final class BuildSystemManagerTests: XCTestCase {
     bsm.fileBuildSettingsChanged([
       b: .removedOrUnavailable
     ])
-    wait(for: [changed], timeout: 10, enforceOrder: true)
+    wait(for: [changed], timeout: defaultTimeout, enforceOrder: true)
   }
 
   func testSettingsHeaderChangeMainFile() {
@@ -276,14 +276,14 @@ final class BuildSystemManagerTests: XCTestCase {
     let initial = expectation(description: "initial settings via cpp1")
     del.expected = [(h, bs.map[cpp1]!, initial, #file, #line)]
     bsm.registerForChangeNotifications(for: h, language: .c)
-    wait(for: [initial], timeout: 10, enforceOrder: true)
+    wait(for: [initial], timeout: defaultTimeout, enforceOrder: true)
 
     mainFiles.mainFiles[h] = Set([cpp2])
 
     let changed = expectation(description: "changed settings to cpp2")
     del.expected = [(h, bs.map[cpp2]!, changed, #file, #line)]
     bsm.mainFilesChanged()
-    wait(for: [changed], timeout: 10, enforceOrder: true)
+    wait(for: [changed], timeout: defaultTimeout, enforceOrder: true)
 
     let changed2 = expectation(description: "still cpp2, no update")
     changed2.isInverted = true
@@ -304,7 +304,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let changed4 = expectation(description: "changed settings to []")
     del.expected = [(h, nil, changed4, #file, #line)]
     bsm.mainFilesChanged()
-    wait(for: [changed4], timeout: 10, enforceOrder: true)
+    wait(for: [changed4], timeout: defaultTimeout, enforceOrder: true)
   }
 
   func testSettingsOneMainTwoHeader() {
@@ -342,7 +342,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     // Since the registration is async, it's possible that they get grouped together
     // since they are backed by the same underlying cpp file.
-    wait(for: [initial1, initial2], timeout: 10, enforceOrder: false)
+    wait(for: [initial1, initial2], timeout: defaultTimeout, enforceOrder: false)
 
     let newCppArg = "New C++ Main File"
     bs.map[cpp] = FileBuildSettings(compilerArguments: [newCppArg, cpp.pseudoPath])
@@ -356,7 +356,7 @@ final class BuildSystemManagerTests: XCTestCase {
     ]
     bsm.fileBuildSettingsChanged([cpp: .modified(bs.map[cpp]!)])
 
-    wait(for: [changed1, changed2], timeout: 10, enforceOrder: false)
+    wait(for: [changed1, changed2], timeout: defaultTimeout, enforceOrder: false)
   }
 
   func testSettingsChangedAfterUnregister() {
@@ -388,7 +388,7 @@ final class BuildSystemManagerTests: XCTestCase {
     bsm.registerForChangeNotifications(for: a, language: .swift)
     bsm.registerForChangeNotifications(for: b, language: .swift)
     bsm.registerForChangeNotifications(for: c, language: .swift)
-    wait(for: [initialA, initialB, initialC], timeout: 10, enforceOrder: false)
+    wait(for: [initialA, initialB, initialC], timeout: defaultTimeout, enforceOrder: false)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["new-a"])
     bs.map[b] = FileBuildSettings(compilerArguments: ["new-b"])
@@ -409,7 +409,7 @@ final class BuildSystemManagerTests: XCTestCase {
       c: .modified(bs.map[c]!)
     ])
 
-    wait(for: [changedB], timeout: 10, enforceOrder: false)
+    wait(for: [changedB], timeout: defaultTimeout, enforceOrder: false)
   }
 
   func testDependenciesUpdated() {
@@ -440,13 +440,13 @@ final class BuildSystemManagerTests: XCTestCase {
     del.expectedDependenciesUpdate = [(a, depUpdate1, #file, #line)]
 
     bsm.registerForChangeNotifications(for: a, language: .swift)
-    wait(for: [initial, depUpdate1], timeout: 10, enforceOrder: false)
+    wait(for: [initial, depUpdate1], timeout: defaultTimeout, enforceOrder: false)
 
     let depUpdate2 = expectation(description: "dependencies update 2")
     del.expectedDependenciesUpdate = [(a, depUpdate2, #file, #line)]
 
     bsm.filesDependenciesUpdated([a])
-    wait(for: [depUpdate2], timeout: 10, enforceOrder: false)
+    wait(for: [depUpdate2], timeout: defaultTimeout, enforceOrder: false)
   }
 }
 

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -12,6 +12,7 @@
 
 import ISDBTestSupport
 import LanguageServerProtocol
+import LSPTestSupport
 import LSPLogging
 import SourceKitLSP
 import SourceKitD
@@ -68,7 +69,7 @@ final class CrashRecoveryTests: XCTestCase {
       documentOpened.fulfill()
     })
     try! ws.openDocument(loc.url, language: .swift)
-    self.wait(for: [documentOpened], timeout: 10)
+    self.wait(for: [documentOpened], timeout: defaultTimeout)
 
     // Make a change to the file that's not saved to disk. This way we can check that we re-open the correct in-memory state.
 

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPTestSupport
 import SourceKitD
 import SKCore
 import TSCBasic
@@ -88,7 +89,7 @@ final class SourceKitDTests: XCTestCase {
 
     _ = try! sourcekitd.sendSync(req)
 
-    waitForExpectations(timeout: 15)
+    waitForExpectations(timeout: defaultTimeout)
 
     let close = SKDRequestDictionary(sourcekitd: sourcekitd)
     close[keys.request] = sourcekitd.requests.editor_close

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -181,7 +181,7 @@ final class BuildSystemTests: XCTestCase {
 
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 5)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for diagnostics notification")
     }
@@ -237,7 +237,7 @@ final class BuildSystemTests: XCTestCase {
     }
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 5)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for diagnostics notification")
     }
@@ -287,7 +287,7 @@ final class BuildSystemTests: XCTestCase {
 
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 5)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for diagnostics notification")
     }
@@ -342,7 +342,7 @@ final class BuildSystemTests: XCTestCase {
     }
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(primarySettings)])
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 5)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for diagnostics notification")
     }
@@ -401,7 +401,7 @@ final class BuildSystemTests: XCTestCase {
     }
 
     try! ws.openDocument(unique_h.fileURL!, language: .cpp)
-    wait(for: [expectation], timeout: 15)
+    wait(for: [expectation], timeout: defaultTimeout)
 
     let use_d = self.expectation(description: "update settings to d.cpp")
     ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
@@ -414,7 +414,7 @@ final class BuildSystemTests: XCTestCase {
     }
 
     try! ws.buildAndIndex()
-    wait(for: [use_d], timeout: 15)
+    wait(for: [use_d], timeout: defaultTimeout)
 
     let use_c = self.expectation(description: "update settings to c.cpp")
     ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
@@ -435,7 +435,7 @@ final class BuildSystemTests: XCTestCase {
         """, to: ws.testLoc("c_func").url)
     }
 
-    wait(for: [use_c], timeout: 15)
+    wait(for: [use_c], timeout: defaultTimeout)
   }
 
   private func clangBuildSettings(for uri: DocumentURI) -> FileBuildSettings {

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import LSPTestSupport
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -275,7 +276,7 @@ final class CodeActionTests: XCTestCase {
       semanticDiagnosticsReceived.fulfill()
     }
 
-    self.wait(for: [syntacticDiagnosticsReceived, semanticDiagnosticsReceived], timeout: 30)
+    self.wait(for: [syntacticDiagnosticsReceived, semanticDiagnosticsReceived], timeout: defaultTimeout)
 
     let textDocument = TextDocumentIdentifier(def.url)
     let actionsRequest = CodeActionRequest(range: def.position..<def.position, context: .init(diagnostics: diags), textDocument: textDocument)
@@ -329,6 +330,6 @@ final class CodeActionTests: XCTestCase {
     }
     _ = try ws.sk.sendSync(ExecuteCommandRequest(command: command.command, arguments: command.arguments))
 
-    self.wait(for: [editReceived], timeout: 5)
+    self.wait(for: [editReceived], timeout: defaultTimeout)
   }
 }

--- a/Tests/SourceKitLSPTests/DiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/DiagnosticsTests.swift
@@ -89,7 +89,7 @@ final class DiagnosticsTests: XCTestCase {
     }
     """)
 
-    self.wait(for: [syntacticDiagnosticsReceived, semanticDiagnosticsReceived], timeout: 5)
+    self.wait(for: [syntacticDiagnosticsReceived, semanticDiagnosticsReceived], timeout: defaultTimeout)
   }
 
   func testRangeShiftAfterNewlineAdded() {
@@ -114,7 +114,7 @@ final class DiagnosticsTests: XCTestCase {
     }
     """)
 
-    self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: 5)
+    self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: defaultTimeout)
 
     let editedSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after edit received")
     let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
@@ -136,7 +136,7 @@ final class DiagnosticsTests: XCTestCase {
       TextDocumentContentChangeEvent(range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0), rangeLength: 0, text: "\n")
     ])
 
-    self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: 5)
+    self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: defaultTimeout)
   }
 
   func testRangeShiftAfterNewlineRemoved() {
@@ -162,7 +162,7 @@ final class DiagnosticsTests: XCTestCase {
     }
     """)
 
-    self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: 5)
+    self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: defaultTimeout)
 
     let editedSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after edit received")
     let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
@@ -184,6 +184,6 @@ final class DiagnosticsTests: XCTestCase {
       TextDocumentContentChangeEvent(range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 0), rangeLength: 1, text: "")
     ])
 
-    self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: 5)
+    self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: defaultTimeout)
   }
 }

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -195,7 +195,7 @@ final class LocalClangTests: XCTestCase {
 
     try ws.openDocument(loc.url, language: .cpp)
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 15)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for diagnostics notification")
     }
@@ -230,7 +230,7 @@ final class LocalClangTests: XCTestCase {
       command: command.command, arguments: command.arguments)
     _ = try ws.sk.sendSync(executeCommand)
 
-    let editResult = XCTWaiter.wait(for: [applyEdit], timeout: 15)
+    let editResult = XCTWaiter.wait(for: [applyEdit], timeout: defaultTimeout)
     if editResult != .completed {
       fatalError("error \(editResult) waiting for applyEdit request")
     }
@@ -256,7 +256,7 @@ final class LocalClangTests: XCTestCase {
 
     try ws.openDocument(loc.url, language: .cpp)
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: 15)
+    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
     if result != .completed {
       fatalError("error \(result) waiting for diagnostics notification")
     }
@@ -278,7 +278,7 @@ final class LocalClangTests: XCTestCase {
     try! ws.openDocument(loc.url, language: .objective_c)
 
     withExtendedLifetime(ws) {
-      waitForExpectations(timeout: 15)
+      waitForExpectations(timeout: defaultTimeout)
     }
   }
 
@@ -296,7 +296,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     try ws.openDocument(mainLoc.url, language: .c)
-    waitForExpectations(timeout: 15)
+    waitForExpectations(timeout: defaultTimeout)
 
     let request = DocumentSemanticTokensRequest(textDocument: mainLoc.docIdentifier)
     do {

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -14,6 +14,7 @@ import SourceKitLSP
 import SKCore
 import SKTestSupport
 import LanguageServerProtocol
+import LSPTestSupport
 import IndexStoreDB
 import XCTest
 
@@ -61,7 +62,7 @@ final class MainFilesProviderTests: XCTestCase {
     XCTAssertEqual(ws.index.mainFilesContainingFile(shared_h), [c, d])
     XCTAssertEqual(ws.index.mainFilesContainingFile(bridging), [c])
 
-    wait(for: [mainFilesDelegate.expectation], timeout: 15)
+    wait(for: [mainFilesDelegate.expectation], timeout: defaultTimeout)
 
     try! ws.edit { changes, _ in
       changes.write("""
@@ -82,7 +83,7 @@ final class MainFilesProviderTests: XCTestCase {
     XCTAssertEqual(ws.index.mainFilesContainingFile(shared_h), [])
     XCTAssertEqual(ws.index.mainFilesContainingFile(bridging), [d])
 
-    wait(for: [mainFilesDelegate.expectation], timeout: 15)
+    wait(for: [mainFilesDelegate.expectation], timeout: defaultTimeout)
 
     XCTAssertEqual(ws.index.mainFilesContainingFile(DocumentURI(string: "not:file")), [])
   }

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -18,9 +18,6 @@ import XCTest
 
 private typealias Token = SyntaxHighlightingToken
 
-/// The number of seconds that we wait for a semantic token refresh.
-private let semanticRefreshTimeout: TimeInterval = 60
-
 final class SemanticTokensTests: XCTestCase {
   /// Connection and lifetime management for the service.
   private var connection: TestSourceKitServer! = nil
@@ -106,7 +103,7 @@ final class SemanticTokensTests: XCTestCase {
     )))
     version += 1
 
-    wait(for: [registerCapabilityExpectation, refreshExpectation], timeout: semanticRefreshTimeout)
+    wait(for: [registerCapabilityExpectation, refreshExpectation], timeout: defaultTimeout)
   }
 
   private func editDocument(changes: [TextDocumentContentChangeEvent], expectRefresh: Bool = true) {
@@ -128,7 +125,7 @@ final class SemanticTokensTests: XCTestCase {
     ))
     version += 1
 
-    wait(for: expectations, timeout: semanticRefreshTimeout)
+    wait(for: expectations, timeout: defaultTimeout)
   }
 
   private func editDocument(range: Range<Position>, text: String, expectRefresh: Bool = true) {

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import LSPTestSupport
 import SKCore
 import SKTestSupport
 import XCTest
@@ -217,7 +218,7 @@ final class SKTests: XCTestCase {
     }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 30)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: defaultTimeout)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }
@@ -238,7 +239,7 @@ final class SKTests: XCTestCase {
     }
     server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
-    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: 5)
+    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: defaultTimeout)
     if finished != .completed {
       fatalError("error \(finished) waiting for post-build diagnostics notification")
     }
@@ -272,7 +273,7 @@ final class SKTests: XCTestCase {
     // files without a recently upstreamed extension.
     try "".write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
     try ws.openDocument(moduleRef.url, language: .c)
-    let started = XCTWaiter.wait(for: [startExpectation], timeout: 3)
+    let started = XCTWaiter.wait(for: [startExpectation], timeout: defaultTimeout)
     if started != .completed {
       fatalError("error \(started) waiting for initial diagnostics notification")
     }
@@ -291,7 +292,7 @@ final class SKTests: XCTestCase {
     }
     server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
-    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: 3)
+    let finished = XCTWaiter.wait(for: [finishExpectation], timeout: defaultTimeout)
     if finished != .completed {
       fatalError("error \(finished) waiting for post-build diagnostics notification")
     }

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -602,7 +602,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(1, list.items.count)
     }
 
-    wait(for: [forSomeExpectation, printExpectation], timeout: 10)
+    wait(for: [forSomeExpectation, printExpectation], timeout: defaultTimeout)
 
     // Try code completion for "self.forSome" again to verify that it still works.
     let result = try sk.sendSync(forSomeComplete)

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import LSPTestSupport
 import SourceKitLSP
 import SKCore
 import SKTestSupport
@@ -116,7 +117,7 @@ final class WorkspaceTests: XCTestCase {
 
     try! ws.openDocument(loc.url, language: .objective_c)
 
-    waitForExpectations(timeout: 15)
+    waitForExpectations(timeout: defaultTimeout)
 
     let otherWs = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings", server: ws.testServer)!
     assert(ws.testServer === otherWs.testServer, "Sanity check: The two workspaces should be opened in the same server")
@@ -217,7 +218,7 @@ final class WorkspaceTests: XCTestCase {
       }
     }
 
-    self.wait(for: [receivedResponse], timeout: 30)
+    self.wait(for: [receivedResponse], timeout: defaultTimeout)
   }
 
   func testChangeWorkspaceFolders() throws {


### PR DESCRIPTION
Instead of having ad-hoc timeout durations in all the test cases, specify a default timeout duration that can be used by tests.

This allows us increase the timeout duration for all tests if we discover that e.g. sourcekitd is slower in CI setups.

rdar://91615376