### PR TITLE
[5.7] Support index store path remappings

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -35,6 +35,9 @@ public final class BuildServerBuildSystem {
   public private(set) var indexDatabasePath: AbsolutePath?
   public private(set) var indexStorePath: AbsolutePath?
 
+  // FIXME: Add support for prefix mappings to the Build Server protocol.
+  public var indexPrefixMappings: [PathPrefixMapping] { return [] }
+
   /// Delegate to handle any build system events.
   public weak var delegate: BuildSystemDelegate? {
     get { return self.handler?.delegate }

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -43,6 +43,9 @@ public protocol BuildSystem: AnyObject {
   /// The path to put the index database, if any.
   var indexDatabasePath: AbsolutePath? { get }
 
+  /// Path remappings for remapping index data for local use.
+  var indexPrefixMappings: [PathPrefixMapping] { get }
+
   /// Delegate to handle any build system events such as file build settings
   /// initial reports as well as changes.
   var delegate: BuildSystemDelegate? { get set }

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -140,6 +140,8 @@ extension BuildSystemManager: BuildSystem {
 
   public var indexDatabasePath: AbsolutePath? { queue.sync { buildSystem?.indexDatabasePath } }
 
+  public var indexPrefixMappings: [PathPrefixMapping] { queue.sync { buildSystem?.indexPrefixMappings ?? [] } }
+
   public var delegate: BuildSystemDelegate? {
     get { queue.sync { _delegate } }
     set { queue.sync { _delegate = newValue } }

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(SKCore STATIC
   FileBuildSettingsChange.swift
   LanguageServer.swift
   MainFilesProvider.swift
+  PathPrefixMapping.swift
   Toolchain.swift
   ToolchainRegistry.swift
   XCToolchainPlist.swift)

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -88,6 +88,8 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     indexStorePath?.parentDirectory.appending(component: "IndexDatabase")
   }
 
+  public var indexPrefixMappings: [PathPrefixMapping] { return [] }
+
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     queue.async {
       self.watchedFiles[uri] = language

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -40,6 +40,8 @@ public final class FallbackBuildSystem: BuildSystem {
 
   public var indexDatabasePath: AbsolutePath? { return nil }
 
+  public var indexPrefixMappings: [PathPrefixMapping] { return [] }
+
   public func settings(for uri: DocumentURI, _ language: Language) -> FileBuildSettings? {
     switch language {
     case .swift:

--- a/Sources/SKCore/PathPrefixMapping.swift
+++ b/Sources/SKCore/PathPrefixMapping.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct PathPrefixMapping {
+  /// Path prefix to be replaced, typically the canonical or hermetic path.
+  public let original: String
+
+  /// Replacement path prefix, typically the path on the local machine.
+  public let replacement: String
+
+  public init(original: String, replacement: String) {
+    self.original = original
+    self.replacement = replacement
+  }
+}

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -240,6 +240,8 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
     return buildPath.appending(components: "index", "db")
   }
 
+  public var indexPrefixMappings: [PathPrefixMapping] { return [] }
+
   /// **Public for testing only**
   public func _settings(
     for uri: DocumentURI,

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -112,12 +112,14 @@ public final class Workspace {
       do {
         let lib = try IndexStoreLibrary(dylibPath: libPath.pathString)
         indexDelegate = SourceKitIndexDelegate()
+        let prefixMappings = indexOptions.indexPrefixMappings ?? buildSystem?.indexPrefixMappings ?? []
         index = try IndexStoreDB(
           storePath: storePath.pathString,
           databasePath: dbPath.pathString,
           library: lib,
           delegate: indexDelegate,
-          listenToUnitEvents: indexOptions.listenToUnitEvents)
+          listenToUnitEvents: indexOptions.listenToUnitEvents,
+          prefixMappings: prefixMappings.map { PathMapping(original: $0.original, replacement: $0.replacement) })
         log("opened IndexStoreDB at \(dbPath) with store path \(storePath)")
       } catch {
         log("failed to open IndexStoreDB: \(error.localizedDescription)", level: .error)
@@ -144,11 +146,22 @@ public struct IndexOptions {
   /// Override the index-database-path provided by the build system.
   public var indexDatabasePath: AbsolutePath?
 
+  /// Override the index prefix mappings provided by the build system.
+  public var indexPrefixMappings: [PathPrefixMapping]?
+
   /// *For Testing* Whether the index should listen to unit events, or wait for
   /// explicit calls to pollForUnitChangesAndWait().
   public var listenToUnitEvents: Bool
 
-  public init(indexStorePath: AbsolutePath? = nil, indexDatabasePath: AbsolutePath? = nil, listenToUnitEvents: Bool = true) {
+  public init(
+    indexStorePath: AbsolutePath? = nil,
+    indexDatabasePath: AbsolutePath? = nil,
+    indexPrefixMappings: [PathPrefixMapping]? = nil,
+    listenToUnitEvents: Bool = true
+  ) {
+    self.indexStorePath = indexStorePath
+    self.indexDatabasePath = indexDatabasePath
+    self.indexPrefixMappings = indexPrefixMappings
     self.listenToUnitEvents = listenToUnitEvents
   }
 }

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -41,6 +41,14 @@ extension AbsolutePath: ExpressibleByArgument {
   }
 }
 
+extension PathPrefixMapping: ExpressibleByArgument {
+  public init?(argument: String) {
+    guard let eqIndex = argument.firstIndex(of: "=") else { return nil }
+    self.init(original: String(argument[..<eqIndex]),
+              replacement: String(argument[argument.index(after: eqIndex)...]))
+  }
+}
+
 extension LogLevel: ExpressibleByArgument {}
 extension BuildConfiguration: ExpressibleByArgument {}
 
@@ -114,6 +122,14 @@ struct Main: ParsableCommand {
   var indexDatabasePath: AbsolutePath?
 
   @Option(
+    name: .customLong("index-prefix-map", withSingleDash: true),
+    parsing: .unconditionalSingleValue,
+    help: "Override the prefix map from the build system, values of form 'remote=local'"
+  )
+  var indexPrefixMappings = [PathPrefixMapping]()
+
+
+  @Option(
     help: "Whether to enable server-side filtering in code-completion"
   )
   var completionServerSideFiltering = true
@@ -135,6 +151,7 @@ struct Main: ParsableCommand {
     serverOptions.clangdOptions = clangdOptions
     serverOptions.indexOptions.indexStorePath = indexStorePath
     serverOptions.indexOptions.indexDatabasePath = indexDatabasePath
+    serverOptions.indexOptions.indexPrefixMappings = indexPrefixMappings
     serverOptions.completionOptions.serverSideFiltering = completionServerSideFiltering
     serverOptions.completionOptions.maxResults = completionMaxResults
 

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -489,6 +489,7 @@ class ManualBuildSystem: BuildSystem {
 
   var indexStorePath: AbsolutePath? { nil }
   var indexDatabasePath: AbsolutePath? { nil }
+  var indexPrefixMappings: [PathPrefixMapping] { return [] }
 
   func buildTargets(reply: @escaping (LSPResult<[BuildTarget]>) -> Void) {
     fatalError()

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -27,6 +27,7 @@ typealias LSPNotification = LanguageServerProtocol.Notification
 final class TestBuildSystem: BuildSystem {
   var indexStorePath: AbsolutePath? = nil
   var indexDatabasePath: AbsolutePath? = nil
+  var indexPrefixMappings: [PathPrefixMapping] = []
 
   weak var delegate: BuildSystemDelegate?
 


### PR DESCRIPTION
This allows sourcekit-lsp to make use of the path remappings recently added to
the index store and IndexStoreDB to remap remote paths into local paths
when loading index data locally.

These remappings can be provided via the `-index-prefix-map` command line flag to sourcekit-lsp or via the `BuildSystem` integration point.

(cherry picked from commit 472a06c88af97135b6faa450c5854e8f1a0ab8de / #562)