### PR TITLE
Log error if sourcekit-lsp is unable to determine the host OS

### DIFF
--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -148,7 +148,13 @@ extension Toolchain {
     }
 
     // If 'currentPlatform' is nil it's most likely an unknown linux flavor.
-    let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? ".so"
+    let dylibExt: String
+    if let dynamicLibraryExtension = Platform.currentPlatform?.dynamicLibraryExtension {
+      dylibExt = dynamicLibraryExtension
+    } else {
+      log("Could not determine host OS. Falling back to using '.so' as dynamic library extension", level: .error)
+      dylibExt = ".so"
+    }
 
     let sourcekitdPath = libPath.appending(components: "sourcekitd.framework", "sourcekitd")
     if fs.isFile(sourcekitdPath) {


### PR DESCRIPTION
This should have allowed us to catch the issue discussed in https://forums.swift.org/t/making-a-sourcekit-lsp-client-find-references-fails/57426/17 a lot more easily.

rdar://93897062

CC @flowtoolz 