### PR TITLE
Re-enable SKTests.testDependenciesUpdatedCXXTibs test

### DIFF
--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -245,10 +245,6 @@ final class SKTests: XCTestCase {
   }
 
   func testDependenciesUpdatedCXXTibs() throws {
-    // SR-12378: this is failing occassionally in CI. Disabling while we
-    // investigate and fix.
-#if false
-
     guard let ws = try mutableSourceKitTibsTestWorkspace(name: "GeneratedHeader") else { return }
     defer { withExtendedLifetime(ws) {} } // Keep workspace alive for callbacks.
     guard let server = ws.testServer.server else {
@@ -295,7 +291,6 @@ final class SKTests: XCTestCase {
     if finished != .completed {
       fatalError("error \(finished) waiting for post-build diagnostics notification")
     }
-#endif
   }
 
   func testClangdGoToInclude() throws {


### PR DESCRIPTION
The test is not failing locally for me. Let’s see if it’s still failing in CI.

rdar://95598365