### PR TITLE
Tests: replace use of `sleep` with `Thread.sleep(forTimeInterval:)`

### DIFF
--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 import XCTest
 import SKCore
@@ -70,7 +71,7 @@ final class CompilationDatabaseTests: XCTestCase {
         didReceiveCorrectHighlight = true
         break
       }
-      sleep(1)
+      Thread.sleep(forTimeInterval: 1)
     }
 
     XCTAssert(didReceiveCorrectHighlight)

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 import XCTest
 
@@ -212,7 +213,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
         didReceiveCorrectCompletions = true
         break
       }
-      sleep(1)
+      Thread.sleep(forTimeInterval: 1)
     }
 
     XCTAssert(didReceiveCorrectCompletions)

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 import LSPTestSupport
 import SourceKitLSP
@@ -190,7 +191,7 @@ final class WorkspaceTests: XCTestCase {
         didReceiveCorrectWorkspaceMembership = true
         break
       }
-      sleep(1)
+      Thread.sleep(forTimeInterval: 1)
     }
 
     XCTAssert(didReceiveCorrectWorkspaceMembership)


### PR DESCRIPTION
Replace the use of `sleep` which is a POSIX construct for the portable
`Thread.sleep(forTimeInterval:)` which has similar semantics but allows
the code to be built for other platforms.  This allows us to finally
build the test suite for Windows.