### PR TITLE
SKCore: add an additional spelling for `PATH`

### DIFF
--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -225,7 +225,7 @@ extension ToolchainRegistry {
   /// * installPath <-- will override default toolchain
   /// * (Darwin) The currently selected Xcode
   /// * (Darwin) [~]/Library/Developer/Toolchains
-  /// * env SOURCEKIT_PATH, PATH
+  /// * env SOURCEKIT_PATH, PATH (or Path)
   public func scanForToolchains(
     installPath: AbsolutePath? = nil,
     environmentVariables: [String] = ["SOURCEKIT_TOOLCHAIN_PATH"],
@@ -234,7 +234,7 @@ extension ToolchainRegistry {
       AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains"),
       AbsolutePath("/Library/Developer/Toolchains"),
     ],
-    pathVariables: [String] = ["SOURCEKIT_PATH", "PATH"],
+    pathVariables: [String] = ["SOURCEKIT_PATH", "PATH", "Path"],
     _ fileSystem: FileSystem)
   {
     queue.sync {


### PR DESCRIPTION
Windows uses `Path` for the environment variable spelling, but expects
that environment variables are case-insensitive.  Foundation's
implementation treats the environment variables as being case sensitive
and will not properly look up the value  Add a case corrected spelling
for that support.