### PR TITLE
Include module names in call hierarchy items

### DIFF
--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -69,12 +69,13 @@ final class CallHierarchyTests: XCTestCase {
       Location(badUTF16: ws.testLoc(name))
     }
 
-    func item(_ name: String, _ kind: SymbolKind, usr: String, at locName: String) -> CallHierarchyItem {
+    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", usr: String, at locName: String) -> CallHierarchyItem {
       let location = loc(locName)
       return CallHierarchyItem(
         name: name,
         kind: kind,
         tags: nil,
+        detail: detail,
         uri: location.uri,
         range: location.range,
         selectionRange: location.range,


### PR DESCRIPTION
Similar to type hierarchy (see #582), this small patch includes module names in the detail field of call hierarchy items too:

![image](https://user-images.githubusercontent.com/30873659/178084648-6cdea5bd-6c4e-4c36-b613-8fa34f948000.png)