### PR TITLE
SourceKitLSP: change an assert to a check

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -104,7 +104,10 @@ class CodeCompletionSession {
     completion: @escaping  (LSPResult<CompletionList>) -> Void)
   {
     log("\(Self.self) Open: \(self) filter=\(filterText)")
-    assert(snapshot.version == self.snapshot.version, "open must use the original snapshot")
+    guard snapshot.version == self.snapshot.version else {
+        completion(.failure(ResponseError(code: .invalidRequest, message: "open must use the original snapshot")))
+        return
+    }
 
     let req = SKDRequestDictionary(sourcekitd: server.sourcekitd)
     let keys = server.sourcekitd.keys


### PR DESCRIPTION
Rather than asserting, raise an error for the user and abort the
operation.  This is motivated by the desire to get the test suite mostly
working on Windows so that the underlying issues can be worked through
more easily.