### PR TITLE
Add Package.swift root path to error message

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -152,7 +152,7 @@ public final class SwiftPMWorkspace {
       log("could not find manifest, or not a SwiftPM package: \(path)", level: .warning)
       return nil
     } catch {
-      log("failed to create \(SwiftPMWorkspace.self): \(error)", level: .error)
+      log("failed to create \(SwiftPMWorkspace.self) at \(url.path): \(error)", level: .error)
       return nil
     }
   }


### PR DESCRIPTION
Previously in the case you have an invalid Package.swift file the LSP
log would just show:

```
[2022-07-12 14:57:23.940] failed to create SwiftPMWorkspace: the package does not contain a buildable target
```

With this change it at least hints you towards where the invalid file
is:

```
[2022-07-12 15:00:45.106] failed to create SwiftPMWorkspace /Users/ksmiley/dev/oss-swift/swiftpm/Sources/PackageModel: the package does not contain a buildable target
```