### PR TITLE
Lightly validate discovered Package.swift files

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -50,6 +50,8 @@ public final class SwiftPMWorkspace {
 
   let workspacePath: AbsolutePath
   let packageRoot: AbsolutePath
+  /// *Public for testing*
+  public var _packageRoot: AbsolutePath { packageRoot }
   var packageGraph: PackageGraph
   let workspace: Workspace
   public let buildParameters: BuildParameters
@@ -545,7 +547,15 @@ private func findPackageDirectory(
   containing path: AbsolutePath,
   _ fileSystem: FileSystem) -> AbsolutePath? {
   var path = path
-  while !fileSystem.isFile(path.appending(component: "Package.swift")) {
+  while true {
+    let packagePath = path.appending(component: "Package.swift")
+    if fileSystem.isFile(packagePath) {
+      let contents = try? fileSystem.readFileContents(packagePath)
+      if contents?.cString.contains("PackageDescription") == true {
+        return path
+      }
+    }
+
     if path.isRoot {
       return nil
     }


### PR DESCRIPTION
Previously if you had a normal source file named Package.swift
sourcekit-lsp would pick it up and fail. Now there is some very light
validation that the file looks valid, checking that it has a
PackageDescription import, before accepting it, otherwise it keeps
looking.