### PR TITLE
Add type definition request and types

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(LanguageServerProtocol STATIC
   Requests/ShowMessageRequest.swift
   Requests/ShutdownRequest.swift
   Requests/SymbolInfoRequest.swift
+  Requests/TypeDefinitionRequest.swift
   Requests/TypeHierarchyPrepareRequest.swift
   Requests/TypeHierarchySupertypesRequest.swift
   Requests/TypeHierarchySubtypesRequest.swift

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -49,6 +49,7 @@ public let builtinRequests: [_RequestType.Type] = [
   PrepareRenameRequest.self,
   RenameRequest.self,
   RegisterCapabilityRequest.self,
+  TypeDefinitionRequest.self,
   UnregisterCapabilityRequest.self,
   InlayHintRequest.self,
 

--- a/Sources/LanguageServerProtocol/Requests/TypeDefinitionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/TypeDefinitionRequest.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request to find the type definition(s) of the symbol at the given location.
+///
+/// Looks up the symbol at the given position and returns a list of all type definitions of that
+/// symbol across the whole workspace.
+///
+/// Servers that provide document highlights should set the `textDocument.typeDefinition` server
+/// capability.
+///
+/// - Parameters:
+///   - textDocument: The document in which to lookup the symbol location.
+///   - position: The document location at which to lookup symbol information.
+///
+/// - Returns: The location of the type definition(s).
+public struct TypeDefinitionRequest: TextDocumentRequest, Hashable {
+  public static let method: String = "textDocument/typeDefinition"
+  public typealias Response = LocationsOrLocationLinksResponse?
+
+  /// The document in which to lookup the symbol location.
+  public var textDocument: TextDocumentIdentifier
+
+  /// The document location at which to lookup symbol information.
+  public var position: Position
+
+  public init(textDocument: TextDocumentIdentifier, position: Position) {
+    self.textDocument = textDocument
+    self.position = position
+  }
+}


### PR DESCRIPTION
This request is currently just a skeleton and no-ops when used.

For full support a few things will still be needed:

- For SourceKit support, a valid USR for the symbol's type is returned from `cursorinfo` ([related issue](https://github.com/apple/sourcekit-lsp/issues/548))
- For clangd support, ideally the request should be passsed to clangd and clangd provides support for the request.

This PR is just meant to introduce the types for a typeDefinition request. Implementation will be worked on in the future once there is support in sourcekitd/clangd.