### PR TITLE
SourceKitLSPTests: replace some `fatalError` with `XCTFail`

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -113,7 +113,10 @@ public final class TestClient: MessageHandler {
   }
 
   public func handleNextNotification<N>(_ handler: @escaping (Notification<N>) -> Void) {
-    precondition(oneShotNotificationHandlers.isEmpty)
+    guard oneShotNotificationHandlers.isEmpty else {
+      XCTFail("unexpected one shot notification handler registered")
+      return
+    }
     appendOneShotNotificationHandler(handler)
   }
 
@@ -178,8 +181,9 @@ extension TestClient: Connection {
     send(notification)
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for notification in response to \(notification)")
+    guard result == .completed else {
+      XCTFail("error \(result) waiting for notification in response to \(notification)")
+      return
     }
   }
 
@@ -206,8 +210,9 @@ extension TestClient: Connection {
     send(notification)
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for notification in response to \(notification)")
+    guard result == .completed else {
+      XCTFail("wait for notification in response to \(notification) failed with \(result)")
+      return
     }
   }
 }

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -170,8 +170,9 @@ final class BuildServerBuildSystemTests: XCTestCase {
     buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for targets changed notification")
+    guard result == .completed else {
+      XCTFail("error \(result) waiting for targets changed notification")
+      return
     }
   }
 }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -183,8 +183,9 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for diagnostics notification")
+    guard result == .completed else {
+      XCTFail("wait for diagnostics failed with \(result)")
+      return
     }
   }
 
@@ -239,8 +240,9 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for diagnostics notification")
+    guard result == .completed else {
+      XCTFail("wait for diagnostics failed with \(result)")
+      return
     }
   }
 
@@ -289,8 +291,9 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for diagnostics notification")
+    guard result == .completed else {
+      XCTFail("wait for diagnostics failed with \(result)")
+      return
     }
   }
 
@@ -344,8 +347,9 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(primarySettings)])
 
     let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    if result != .completed {
-      fatalError("error \(result) waiting for diagnostics notification")
+    guard result == .completed else {
+      XCTFail("wait for diagnostics failed with \(result)")
+      return
     }
   }
 
@@ -383,8 +387,9 @@ final class BuildSystemTests: XCTestCase {
     }
 
     let result = XCTWaiter.wait(for: [expectation], timeout: 1)
-    if result != .completed {
-      fatalError("error \(result) unexpected diagnostics notification")
+    guard result == .completed else {
+      XCTFail("wait for diagnostics failed with \(result)")
+      return
     }
   }
 

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -32,7 +32,8 @@ final class CallHierarchyTests: XCTestCase {
 
     func incomingCalls(at testLoc: TestLocation) throws -> [CallHierarchyIncomingCall] {
       guard let item = try callHierarchy(at: testLoc).first else {
-        fatalError("Call hierarchy at \(testLoc) was empty")
+        XCTFail("call hierarchy at \(testLoc) was empty")
+        return []
       }
       let request = CallHierarchyIncomingCallsRequest(item: item)
       let calls = try ws.sk.sendSync(request)
@@ -41,7 +42,8 @@ final class CallHierarchyTests: XCTestCase {
 
     func outgoingCalls(at testLoc: TestLocation) throws -> [CallHierarchyOutgoingCall] {
       guard let item = try callHierarchy(at: testLoc).first else {
-        fatalError("Call hierarchy at \(testLoc) was empty")
+        XCTFail("call hierarchy at \(testLoc) was empty")
+        return []
       }
       let request = CallHierarchyOutgoingCallsRequest(item: item)
       let calls = try ws.sk.sendSync(request)
@@ -50,11 +52,13 @@ final class CallHierarchyTests: XCTestCase {
 
     func usr(at testLoc: TestLocation) throws -> String {
       guard let item = try callHierarchy(at: testLoc).first else {
-        fatalError("Call hierarchy at \(testLoc) was empty")
+        XCTFail("call hierarchy at \(testLoc) was empty")
+        return ""
       }
       guard case let .dictionary(data) = item.data,
             case let .string(usr) = data["usr"] else {
-        fatalError("Could not find usr in call hierarchy item data dict")
+        XCTFail("unable to find usr in call hierarchy in item data dictionary")
+        return ""
       }
       return usr
     }

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -270,8 +270,9 @@ final class SKTests: XCTestCase {
     try "".write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
     try ws.openDocument(moduleRef.url, language: .c)
     let started = XCTWaiter.wait(for: [startExpectation], timeout: defaultTimeout)
-    if started != .completed {
-      fatalError("error \(started) waiting for initial diagnostics notification")
+    guard started == .completed else {
+      XCTFail("error \(started) waiting for initial diagnostics notification")
+      return
     }
 
     // Update the header file to have the proper contents for our code to build.
@@ -289,8 +290,9 @@ final class SKTests: XCTestCase {
     server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
     let finished = XCTWaiter.wait(for: [finishExpectation], timeout: defaultTimeout)
-    if finished != .completed {
-      fatalError("error \(finished) waiting for post-build diagnostics notification")
+    guard finished == .completed else {
+      XCTFail("error \(finished) waiting for post-build diagnostics notification")
+      return
     }
   }
 

--- a/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
@@ -32,7 +32,8 @@ final class TypeHierarchyTests: XCTestCase {
 
     func supertypes(at testLoc: TestLocation) throws -> [TypeHierarchyItem] {
       guard let item = try typeHierarchy(at: testLoc).first else {
-        fatalError("Type hierarchy at \(testLoc) was empty")
+        XCTFail("Type hierarchy at \(testLoc) was empty")
+        return []
       }
       let request = TypeHierarchySupertypesRequest(item: item)
       let types = try ws.sk.sendSync(request)
@@ -41,7 +42,8 @@ final class TypeHierarchyTests: XCTestCase {
 
     func subtypes(at testLoc: TestLocation) throws -> [TypeHierarchyItem] {
       guard let item = try typeHierarchy(at: testLoc).first else {
-        fatalError("Type hierarchy at \(testLoc) was empty")
+        XCTFail("Type hierarchy at \(testLoc) was empty")
+        return []
       }
       let request = TypeHierarchySubtypesRequest(item: item)
       let types = try ws.sk.sendSync(request)


### PR DESCRIPTION
This replaces many instances of `fatalError` with `XCTFail`.  Although
these code paths should not come to pass, there are currently failures
in the test suite on Windows where these trigger.  By using `XCTFail`
instead, we allow the tests to continue execution which is helpful for
investigating the current state and make progress towards fixing the
issues.