### PR TITLE
Pass manual build arguments that specified using -Xswiftc when starting sourcekit-lsp, to the fallback build system

### DIFF
--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -19,7 +19,11 @@ import Dispatch
 /// A simple BuildSystem suitable as a fallback when accurate settings are unknown.
 public final class FallbackBuildSystem: BuildSystem {
 
-  public init() {}
+  let buildSetup: BuildSetup
+
+  public init(buildSetup: BuildSetup) {
+    self.buildSetup = buildSetup
+  }
 
   /// The path to the SDK.
   public lazy var sdkpath: AbsolutePath? = {
@@ -79,7 +83,8 @@ public final class FallbackBuildSystem: BuildSystem {
 
   func settingsSwift(_ file: String) -> FileBuildSettings {
     var args: [String] = []
-    if let sdkpath = sdkpath {
+    args.append(contentsOf: self.buildSetup.flags.swiftCompilerFlags)
+    if let sdkpath = sdkpath, !args.contains("-sdk") {
       args += [
         "-sdk",
         sdkpath.pathString,
@@ -91,7 +96,15 @@ public final class FallbackBuildSystem: BuildSystem {
 
   func settingsClang(_ file: String, _ language: Language) -> FileBuildSettings {
     var args: [String] = []
-    if let sdkpath = sdkpath {
+    switch language {
+    case .c:
+      args.append(contentsOf: self.buildSetup.flags.cCompilerFlags)
+    case .cpp:
+      args.append(contentsOf: self.buildSetup.flags.cxxCompilerFlags)
+    default:
+      break
+    }
+    if let sdkpath = sdkpath, !args.contains("-isysroot") {
       args += [
         "-isysroot",
         sdkpath.pathString,

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -65,7 +65,7 @@ public final class Workspace {
     self.index = index
     let bsm = BuildSystemManager(
       buildSystem: underlyingBuildSystem,
-      fallbackBuildSystem: FallbackBuildSystem(),
+      fallbackBuildSystem: FallbackBuildSystem(buildSetup: buildSetup),
       mainFilesProvider: index)
     indexDelegate?.registerMainFileChanged(bsm)
     self.buildSystemManager = bsm

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -34,7 +34,7 @@ final class BuildSystemManagerTests: XCTestCase {
     ]
 
     let bsm = BuildSystemManager(
-      buildSystem: FallbackBuildSystem(),
+      buildSystem: FallbackBuildSystem(buildSetup: .default),
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
     defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
@@ -142,7 +142,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider()
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
-    let fallback = FallbackBuildSystem()
+    let fallback = FallbackBuildSystem(buildSetup: .default)
     let bsm = BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: fallback,

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -191,7 +191,7 @@ final class BuildSystemTests: XCTestCase {
   func testSwiftDocumentUpdatedBuildSettings() {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let doc = DocumentURI(url)
-    let args = FallbackBuildSystem().settings(for: doc, .swift)!.compilerArguments
+    let args = FallbackBuildSystem(buildSetup: .default).settings(for: doc, .swift)!.compilerArguments
 
     buildSystem.buildSettingsByFile[doc] = FileBuildSettings(compilerArguments: args)
 
@@ -299,7 +299,7 @@ final class BuildSystemTests: XCTestCase {
     let doc = DocumentURI(url)
 
     // Primary settings must be different than the fallback settings.
-    var primarySettings = FallbackBuildSystem().settings(for: doc, .swift)!
+    var primarySettings = FallbackBuildSystem(buildSetup: .default).settings(for: doc, .swift)!
     primarySettings.compilerArguments.append("-DPRIMARY")
 
     let text = """


### PR DESCRIPTION
Previously, we weren’t respecting these arguments in the fallback build system.

rdar://97044457