### PR TITLE
SKCore,SKTestSupport: adjust test server handling

### DIFF
--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargetOutputs/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargetOutputs/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import sys
 
@@ -70,7 +68,7 @@ while True:
     if response:
         responseStr = json.dumps(response)
         try:
-            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.buffer.write(f"Content-Length: {len(responseStr)}\r\n\r\n{responseStr}".encode('utf-8'))
             sys.stdout.flush()
         except IOError:
             # stdout closed, time to quit

--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargetSources/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargetSources/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import sys
 
@@ -93,7 +91,7 @@ while True:
     if response:
         responseStr = json.dumps(response)
         try:
-            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.buffer.write(f"Content-Length: {len(responseStr)}\r\n\r\n{responseStr}".encode('utf-8'))
             sys.stdout.flush()
         except IOError:
             # stdout closed, time to quit

--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargets/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargets/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import sys
 
@@ -89,7 +87,7 @@ while True:
     if response:
         responseStr = json.dumps(response)
         try:
-            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.buffer.write(f"Content-Length: {len(responseStr)}\r\n\r\n{responseStr}".encode('utf-8'))
             sys.stdout.flush()
         except IOError:
             # stdout closed, time to quit

--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testBuildTargetsChanged/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import sys
@@ -8,7 +6,7 @@ import sys
 def send(data):
     dataStr = json.dumps(data)
     try:
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+        sys.stdout.buffer.write(f"Content-Length: {len(dataStr)}\r\n\r\n{dataStr}".encode('utf-8'))
         sys.stdout.flush()
     except IOError:
         # stdout closed, time to quit

--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testFileRegistration/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import sys
@@ -8,7 +6,7 @@ import sys
 def send(data):
     dataStr = json.dumps(data)
     try:
-        sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(dataStr), dataStr))
+        sys.stdout.buffer.write(f"Content-Length: {len(dataStr)}\r\n\r\n{dataStr}".encode('utf-8'))
         sys.stdout.flush()
     except IOError:
         # stdout closed, time to quit

--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testServerInitialize/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import sys
 
@@ -55,7 +53,7 @@ while True:
     if response:
         responseStr = json.dumps(response)
         try:
-            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.buffer.write(f"Content-Length: {len(responseStr)}\r\n\r\n{responseStr}".encode('utf-8'))
             sys.stdout.flush()
         except IOError:
             # stdout closed, time to quit

--- a/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
+++ b/Sources/SKTestSupport/INPUTS/BuildServerBuildSystemTests.testSettings/server.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import sys
@@ -76,7 +74,7 @@ while True:
     if response:
         responseStr = json.dumps(response)
         try:
-            sys.stdout.write("Content-Length: {}\r\n\r\n{}".format(len(responseStr), responseStr))
+            sys.stdout.buffer.write(f"Content-Length: {len(responseStr)}\r\n\r\n{responseStr}".encode('utf-8'))
             sys.stdout.flush()
         except IOError:
             # stdout closed, time to quit


### PR DESCRIPTION
The test system depended on the shebang to locate the python
interpreter.  However, this is not a portable system.  Instead, prefer
to explicitly search for the interpreter prior to the execution.  This
enables supporting execution of the script support on all platforms. A
secondary change of the printed string is required for Windows. Python
will replace `\n` with `\r\n` resulting in `\r\n` being emitted as
`\r\r\n` on Windows breaking the expectations on the receiver.  Adjust
this by explicitly writing out a binary string to the raw underlying
buffer to avoid the translation.