### PR TITLE
Increase default timeout to 60 seconds

### DIFF
--- a/Sources/LSPTestSupport/Timeouts.swift
+++ b/Sources/LSPTestSupport/Timeouts.swift
@@ -14,4 +14,4 @@ import Foundation
 
 /// The default duration how long tests should wait for responses from
 /// SourceKit-LSP / sourcekitd / clangd. 
-public let defaultTimeout: TimeInterval = 15
+public let defaultTimeout: TimeInterval = 60


### PR DESCRIPTION
The reduced timeout of 15 seconds was causing issues in CI.