### PR TITLE
Several changes in build-script-helper.py to support building SourceKit-LSP in a unified build

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+
+ignore =
+    E501,

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -47,10 +47,14 @@ def check_call(cmd: List[str], additional_env: Dict[str, str] = {}, verbose: boo
     subprocess.check_call(cmd, env=env_with_additional_env(additional_env), stderr=subprocess.STDOUT)
 
 
-def check_output(cmd: List[str], additional_env: Dict[str, str] = {}, verbose: bool = False) -> str:
+def check_output(cmd: List[str], additional_env: Dict[str, str] = {}, capture_stderr: bool = True, verbose: bool = False) -> str:
     if verbose:
         print_cmd(cmd=cmd, additional_env=additional_env)
-    return subprocess.check_output(cmd, env=env_with_additional_env(additional_env), stderr=subprocess.STDOUT, encoding='utf-8')
+    if capture_stderr:
+        stderr = subprocess.STDOUT
+    else:
+        stderr = subprocess.DEVNULL
+    return subprocess.check_output(cmd, env=env_with_additional_env(additional_env), stderr=stderr, encoding='utf-8')
 
 # -----------------------------------------------------------------------------
 # SwiftPM wrappers
@@ -61,7 +65,7 @@ def swiftpm_bin_path(swift_exec: str, swiftpm_args: List[str], additional_env: D
     Return the path of the directory that contains the binaries produced by this package.
     """
     cmd = [swift_exec, 'build', '--show-bin-path'] + swiftpm_args
-    return check_output(cmd, additional_env=additional_env, verbose=verbose).strip()
+    return check_output(cmd, additional_env=additional_env, capture_stderr=False, verbose=verbose).strip()
 
 
 def get_build_target(swift_exec: str, args: argparse.Namespace) -> str:

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -91,7 +91,7 @@ def get_build_target(swift_exec: str, args: argparse.Namespace) -> str:
 def get_swiftpm_options(swift_exec: str, args: argparse.Namespace) -> List[str]:
     swiftpm_args = [
         '--package-path', args.package_path,
-        '--build-path', args.build_path,
+        '--scratch-path', args.build_path,
         '--configuration', args.configuration,
     ]
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -215,18 +215,12 @@ def install_binary(exe: str, source_dir: str, install_dir: str, verbose: bool) -
 
 
 def install(swift_exec: str, args: argparse.Namespace) -> None:
+    build_single_product('sourcekit-lsp', swift_exec, args)
+
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
-
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args=swiftpm_args, additional_env=additional_env)
-    swiftpm_args += ['-Xswiftc', '-no-toolchain-stdlib-rpath']
-    check_call([
-        swift_exec, 'build'
-    ] + swiftpm_args, additional_env=additional_env)
-
-    if not args.install_prefixes:
-        args.install_prefixes = [args.toolchain]
-
+    
     for prefix in args.install_prefixes:
         install_binary('sourcekit-lsp', bin_path, os.path.join(prefix, 'bin'), verbose=args.verbose)
 
@@ -295,6 +289,10 @@ def parse_args() -> argparse.Namespace:
     args.package_path = os.path.abspath(args.package_path)
     args.build_path = os.path.abspath(args.build_path)
     args.toolchain = os.path.abspath(args.toolchain)
+
+    if args.action == 'install':
+        if not args.install_prefixes:
+            args.install_prefixes = [args.toolchain]
 
     return args
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -157,13 +157,13 @@ def get_swiftpm_environment_variables(swift_exec: str, args: argparse.Namespace)
     return env
 
 
-def build(swift_exec: str, args: argparse.Namespace) -> None:
+def build_single_product(product: str, swift_exec: str, args: argparse.Namespace) -> None:
     """
     Build one product in the package
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     env = get_swiftpm_environment_variables(swift_exec, args)
-    cmd = [swift_exec, 'build'] + swiftpm_args
+    cmd = [swift_exec, 'build', '--product', product] + swiftpm_args
     check_call(cmd, env=env, verbose=args.verbose)
 
 
@@ -215,7 +215,11 @@ def handle_invocation(swift_exec: str, args: argparse.Namespace) -> None:
     Depending on the action in 'args', build the package, installs the package or run tests.
     """
     if args.action == 'build':
-        build(swift_exec, args)
+        # Build SourceKitLSPPackageTests to build all source code in sourcekit-lsp.
+        # Build _SourceKitLSP and sourcekit-lsp because they are products (dylib, executable) that can be used from the build.
+        products = ["SourceKitLSPPackageTests", "_SourceKitLSP", "sourcekit-lsp"]
+        for product in products:
+            build_single_product(product, swift_exec, args)
     elif args.action == 'test':
         run_tests(swift_exec, args)
     elif args.action == 'install':

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -73,6 +73,9 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace) -> List[str]:
         '--configuration', args.configuration,
     ]
 
+    if args.multiroot_data_file:
+        swiftpm_args += ['--multiroot-data-file', args.multiroot_data_file]
+
     if args.verbose:
         swiftpm_args += ['--verbose']
 
@@ -247,6 +250,7 @@ def parse_args() -> argparse.Namespace:
         parser.add_argument('--verbose', '-v', action='store_true', help='enable verbose output')
         parser.add_argument('--cross-compile-host', help='cross-compile for another host instead')
         parser.add_argument('--cross-compile-config', help='an SPM JSON destination file containing Swift cross-compilation flags')
+        parser.add_argument('--multiroot-data-file', help='path to an Xcode workspace to create a unified build of all of Swift\'s SwiftPM projects')
 
     if sys.version_info >= (3, 7, 0):
         subparsers = parser.add_subparsers(title='subcommands', dest='action', required=True, metavar='action')

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -214,10 +214,6 @@ def handle_invocation(swift_exec: str, args: argparse.Namespace) -> None:
     """
     Depending on the action in 'args', build the package, installs the package or run tests.
     """
-    if not args.no_clean:
-        print('Cleaning ' + args.build_path)
-        shutil.rmtree(args.build_path, ignore_errors=True)
-
     if args.action == 'build':
         build(swift_exec, args)
     elif args.action == 'test':


### PR DESCRIPTION
This PR contains a couple of small changes that are necessary to build SourceKit-LSP in a unified SwiftPM build, removing the need to build indexstore-db twice (once for indexstore-db testing and once for SourceKit-LSP testing).

- Don’t clean build directory prior to building
  - AFAICT cleaning the build directory prior to building was done to work around a bug in SwiftPM at some point. I don’t think that it’s needed anymore.
- Explicitly build all targets
  - When we build SourceKit-LSP in a unified SwiftPM workspace, a simple `swift build` invocation will build all products in the unified workspace (not just SourceKit-LSP products).
- Add a `--multiroot-data-file` option to build sourcekit-lsp in a unified build
- Print environment variables that were specified when executing commands
  - Just some logging improvement
- Add flake8 configuration
  - I formatted the build script according to these rules, maybe we can keep that formatting in the future
- Don’t pass -no-toolchain-stdlib-rpath when installing sourcekit-lsp
  - Since https://github.com/apple/swift-package-manager/pull/4208 SwiftPM no longer adds rpath to the toolchain libraries, so we don’t need to exclude them.
- Ignore stderr when retrieving SwifitPM’s bin path
  - I just noticed that since https://github.com/apple/sourcekit-lsp/pull/598 the bin-path computation was wrong because the returned bin path included warnings about `--build-path` being deprecated in favor of `--scratch-path`
- Rename `--build-path` to `--scratch-path` in SwiftPM invocation
  - `--build-path` has been deprectated in favor of `--scratch-path` in SwiftPM.

