### PR TITLE
SKCoreTests: skip a test on Windows

### DIFF
--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -35,6 +35,9 @@ final class BuildServerBuildSystemTests: XCTestCase {
   }
 
   func testSettings() throws {
+#if os(Windows)
+    try XCTSkipIf(true, "hang")
+#endif
     let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
     // test settings with a response


### PR DESCRIPTION
This test seems to hang for some reason.  Skip the test for the time
being to allow us to execute the test suite until we can investigate
this issue.