### PR TITLE
Empty TextEdits now return nil to avoid diagnostic crashes

### DIFF
--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -100,6 +100,12 @@ extension TextEdit {
       // Snippets are only suppored in code completion.
       // Remove SourceKit placeholders from Fix-Its because they can't be represented in the editor properly.
       let replacementWithoutPlaceholders = rewriteSourceKitPlaceholders(inString: replacement, clientSupportsSnippets: false)
+
+      // If both the replacement without placeholders and the fixit are empty, no TextEdit should be created.
+      if (replacementWithoutPlaceholders.isEmpty && length == 0) {
+        return nil
+      }
+
       self.init(range: position..<endPosition, newText: replacementWithoutPlaceholders)
     } else {
       return nil


### PR DESCRIPTION
This adds a check when creating a `TextEdit` to return `nil` if both the fixit and the replacement being used to create a `TextEdit` are empty. A `TextEdit` being created like this and then used in a diagnostic can cause a crash.