### PR TITLE
SourceKitLSPTests: remove many cases of forced unwrapping

### DIFF
--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -393,8 +393,8 @@ final class BuildSystemTests: XCTestCase {
     }
   }
 
-  func testMainFilesChanged() {
-    let ws = try! mutableSourceKitTibsTestWorkspace(name: "MainFiles")!
+  func testMainFilesChanged() throws {
+    let ws = try mutableSourceKitTibsTestWorkspace(name: "MainFiles")!
     let unique_h = ws.testLoc("unique").docIdentifier.uri
 
     ws.testServer.client.allowUnexpectedNotification = false
@@ -406,7 +406,7 @@ final class BuildSystemTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try! ws.openDocument(unique_h.fileURL!, language: .cpp)
+    try ws.openDocument(unique_h.fileURL!, language: .cpp)
     wait(for: [expectation], timeout: defaultTimeout)
 
     let use_d = self.expectation(description: "update settings to d.cpp")
@@ -419,7 +419,7 @@ final class BuildSystemTests: XCTestCase {
       use_d.fulfill()
     }
 
-    try! ws.buildAndIndex()
+    try ws.buildAndIndex()
     wait(for: [use_d], timeout: defaultTimeout)
 
     let use_c = self.expectation(description: "update settings to c.cpp")
@@ -432,7 +432,7 @@ final class BuildSystemTests: XCTestCase {
       use_c.fulfill()
     }
 
-    try! ws.edit(rebuild: true) { (changes, _) in
+    try ws.edit(rebuild: true) { (changes, _) in
       changes.write("""
         // empty
         """, to: ws.testLoc("d_func").url)

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -601,7 +601,7 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual("Remove 'foo ='", CodeAction.fixitTitle(replace: "foo =", with: ""))
   }
 
-  func testFixitsAreReturnedFromCodeActions() {
+  func testFixitsAreReturnedFromCodeActions() throws {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
@@ -626,7 +626,7 @@ final class LocalSwiftTests: XCTestCase {
       context: CodeActionContext(diagnostics: [diagnostic], only: nil),
       textDocument: TextDocumentIdentifier(uri)
     )
-    let response = try! sk.sendSync(request)
+    let response = try sk.sendSync(request)
 
     XCTAssertNotNil(response)
     guard case .codeActions(let codeActions) = response else {
@@ -651,7 +651,7 @@ final class LocalSwiftTests: XCTestCase {
       command: nil))
   }
 
-  func testFixitsAreReturnedFromCodeActionsNotes() {
+  func testFixitsAreReturnedFromCodeActionsNotes() throws {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
@@ -676,7 +676,7 @@ final class LocalSwiftTests: XCTestCase {
       context: CodeActionContext(diagnostics: [diagnostic], only: nil),
       textDocument: TextDocumentIdentifier(uri)
     )
-    let response = try! sk.sendSync(request)
+    let response = try sk.sendSync(request)
 
     XCTAssertNotNil(response)
     guard case .codeActions(let codeActions) = response else {
@@ -706,7 +706,7 @@ final class LocalSwiftTests: XCTestCase {
     }
   }
 
-  func testMuliEditFixitCodeActionPrimary() {
+  func testMuliEditFixitCodeActionPrimary() throws {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
@@ -730,7 +730,7 @@ final class LocalSwiftTests: XCTestCase {
       context: CodeActionContext(diagnostics: [diagnostic], only: nil),
       textDocument: TextDocumentIdentifier(uri)
     )
-    let response = try! sk.sendSync(request)
+    let response = try sk.sendSync(request)
 
     XCTAssertNotNil(response)
     guard case .codeActions(let codeActions) = response else {
@@ -749,7 +749,7 @@ final class LocalSwiftTests: XCTestCase {
     ])
   }
 
-  func testMuliEditFixitCodeActionNote() {
+  func testMuliEditFixitCodeActionNote() throws {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
@@ -776,7 +776,7 @@ final class LocalSwiftTests: XCTestCase {
       context: CodeActionContext(diagnostics: [diagnostic], only: nil),
       textDocument: TextDocumentIdentifier(uri)
     )
-    let response = try! sk.sendSync(request)
+    let response = try sk.sendSync(request)
 
     XCTAssertNotNil(response)
     guard case .codeActions(let codeActions) = response else {
@@ -1273,7 +1273,7 @@ final class LocalSwiftTests: XCTestCase {
     }
   }
 
-  func testDocumentSymbolHighlight() {
+  func testDocumentSymbolHighlight() throws {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let uri = DocumentURI(url)
 
@@ -1292,14 +1292,14 @@ final class LocalSwiftTests: XCTestCase {
       """)))
 
     do {
-      let resp = try! sk.sendSync(DocumentHighlightRequest(
+      let resp = try sk.sendSync(DocumentHighlightRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 0, utf16index: 0)))
       XCTAssertEqual(resp?.count, 0)
     }
 
     do {
-      let resp = try! sk.sendSync(DocumentHighlightRequest(
+      let resp = try sk.sendSync(DocumentHighlightRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 1, utf16index: 6)))
       XCTAssertEqual(resp?.count, 1)
@@ -1312,7 +1312,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(DocumentHighlightRequest(
+      let resp = try sk.sendSync(DocumentHighlightRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 2, utf16index: 6)))
       XCTAssertEqual(resp?.count, 2)
@@ -1331,7 +1331,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(DocumentHighlightRequest(
+      let resp = try sk.sendSync(DocumentHighlightRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 3, utf16index: 6)))
       XCTAssertEqual(resp?.count, 3)

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 final class MainFilesProviderTests: XCTestCase {
 
-  func testMainFilesChanged() {
+  func testMainFilesChanged() throws {
     let ws = try! mutableSourceKitTibsTestWorkspace(name: "MainFiles")!
     let indexDelegate = SourceKitIndexDelegate()
     ws.tibsWorkspace.delegate = indexDelegate
@@ -52,7 +52,7 @@ final class MainFilesProviderTests: XCTestCase {
     XCTAssertEqual(ws.index.mainFilesContainingFile(shared_h), [])
     XCTAssertEqual(ws.index.mainFilesContainingFile(bridging), [])
 
-    try! ws.buildAndIndex()
+    try ws.buildAndIndex()
 
     XCTAssertEqual(ws.index.mainFilesContainingFile(a), [a])
     XCTAssertEqual(ws.index.mainFilesContainingFile(b), [b])
@@ -64,7 +64,7 @@ final class MainFilesProviderTests: XCTestCase {
 
     wait(for: [mainFilesDelegate.expectation], timeout: defaultTimeout)
 
-    try! ws.edit { changes, _ in
+    try ws.edit { changes, _ in
       changes.write("""
         #include "bridging.h"
         void d_new(void) { bridging(); }
@@ -77,7 +77,7 @@ final class MainFilesProviderTests: XCTestCase {
     }
 
     mainFilesDelegate.expectation = expectation(description: "main files changed after edit")
-    try! ws.buildAndIndex()
+    try ws.buildAndIndex()
 
     XCTAssertEqual(ws.index.mainFilesContainingFile(unique_h), [c])
     XCTAssertEqual(ws.index.mainFilesContainingFile(shared_h), [])

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -85,24 +85,24 @@ final class SwiftCompletionTests: XCTestCase {
       text: text ?? self.text)))
   }
 
-  func testCompletionClientFilter() {
-    testCompletionBasic(options: SKCompletionOptions(serverSideFiltering: false, maxResults: nil))
+  func testCompletionClientFilter() throws {
+    try testCompletionBasic(options: SKCompletionOptions(serverSideFiltering: false, maxResults: nil))
   }
 
-  func testCompletionServerFilter() {
-    testCompletionBasic(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
+  func testCompletionServerFilter() throws {
+    try testCompletionBasic(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
   }
 
-  func testCompletionDefaultFilter() {
-    testCompletionBasic(options: SKCompletionOptions())
+  func testCompletionDefaultFilter() throws {
+    try testCompletionBasic(options: SKCompletionOptions())
   }
 
-  func testCompletionBasic(options: SKCompletionOptions) {
+  func testCompletionBasic(options: SKCompletionOptions) throws {
     initializeServer(options: options)
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(url: url)
 
-    let selfDot = try! sk.sendSync(CompletionRequest(
+    let selfDot = try sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
       position: Position(line: 5, utf16index: 9)))
 
@@ -121,7 +121,7 @@ final class SwiftCompletionTests: XCTestCase {
     }
 
     for col in 10...12 {
-      let inIdent = try! sk.sendSync(CompletionRequest(
+      let inIdent = try sk.sendSync(CompletionRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 5, utf16index: col)))
       guard let abc = inIdent.items.first(where: { $0.label == "abc" }) else {
@@ -139,13 +139,13 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(abc.insertTextFormat, .plain)
     }
 
-    let after = try! sk.sendSync(CompletionRequest(
+    let after = try sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
       position: Position(line: 6, utf16index: 0)))
     XCTAssertNotEqual(after, selfDot)
   }
 
-  func testCompletionSnippetSupport() {
+  func testCompletionSnippetSupport() throws {
     var capabilities = CompletionCapabilities()
     capabilities.completionItem = CompletionCapabilities.CompletionItem(snippetSupport: true)
 
@@ -153,22 +153,22 @@ final class SwiftCompletionTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(url: url)
 
-    func getTestMethodCompletion(_ position: Position, label: String) -> CompletionItem? {
-      let selfDot = try! sk.sendSync(CompletionRequest(
+    func getTestMethodCompletion(_ position: Position, label: String) throws -> CompletionItem? {
+      let selfDot = try sk.sendSync(CompletionRequest(
         textDocument: TextDocumentIdentifier(url),
         position: position))
       return selfDot.items.first { $0.label == label }
     }
 
-    func getTestMethodACompletion() -> CompletionItem? {
-      return getTestMethodCompletion(Position(line: 5, utf16index: 9), label: "test(a: Int)")
+    func getTestMethodACompletion() throws -> CompletionItem? {
+      return try getTestMethodCompletion(Position(line: 5, utf16index: 9), label: "test(a: Int)")
     }
 
-    func getTestMethodBCompletion() -> CompletionItem? {
-      return getTestMethodCompletion(Position(line: 9, utf16index: 9), label: "test(b: Int)")
+    func getTestMethodBCompletion() throws -> CompletionItem? {
+      return try getTestMethodCompletion(Position(line: 9, utf16index: 9), label: "test(b: Int)")
     }
 
-    var test = getTestMethodACompletion()
+    var test = try getTestMethodACompletion()
     XCTAssertNotNil(test)
     if let test = test {
       XCTAssertEqual(test.kind, .method)
@@ -179,7 +179,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
 
-    test = getTestMethodBCompletion()
+    test = try getTestMethodBCompletion()
     XCTAssertNotNil(test)
     if let test = test {
       XCTAssertEqual(test.kind, .method)
@@ -195,7 +195,7 @@ final class SwiftCompletionTests: XCTestCase {
     initializeServer(capabilities: capabilities)
     openDocument(url: url)
 
-    test = getTestMethodACompletion()
+    test = try getTestMethodACompletion()
     XCTAssertNotNil(test)
     if let test = test {
       XCTAssertEqual(test.kind, .method)
@@ -206,7 +206,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.insertTextFormat, .plain)
     }
 
-    test = getTestMethodBCompletion()
+    test = try getTestMethodBCompletion()
     XCTAssertNotNil(test)
     if let test = test {
       XCTAssertEqual(test.kind, .method)
@@ -219,39 +219,39 @@ final class SwiftCompletionTests: XCTestCase {
     }
   }
 
-  func testCompletionPositionClientFilter() {
-    testCompletionPosition(options: SKCompletionOptions(serverSideFiltering: false, maxResults: nil))
+  func testCompletionPositionClientFilter() throws {
+    try testCompletionPosition(options: SKCompletionOptions(serverSideFiltering: false, maxResults: nil))
   }
 
-  func testCompletionPositionServerFilter() {
-    testCompletionPosition(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
+  func testCompletionPositionServerFilter() throws {
+    try testCompletionPosition(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
   }
 
-  func testCompletionPosition(options: SKCompletionOptions) {
+  func testCompletionPosition(options: SKCompletionOptions) throws {
     initializeServer(options: options)
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(text: "foo", url: url)
 
     for col in 0 ... 3 {
-      let inOrAfterFoo = try! sk.sendSync(CompletionRequest(
+      let inOrAfterFoo = try sk.sendSync(CompletionRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 0, utf16index: col)))
       XCTAssertEqual(inOrAfterFoo.isIncomplete, options.serverSideFiltering)
       XCTAssertFalse(inOrAfterFoo.items.isEmpty)
     }
 
-    let outOfRange1 = try! sk.sendSync(CompletionRequest(
+    let outOfRange1 = try sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
       position: Position(line: 0, utf16index: 4)))
     XCTAssertTrue(outOfRange1.isIncomplete)
 
-    let outOfRange2 = try! sk.sendSync(CompletionRequest(
+    let outOfRange2 = try sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
       position: Position(line: 1, utf16index: 0)))
     XCTAssertTrue(outOfRange2.isIncomplete)
   }
 
-  func testCompletionOptional() {
+  func testCompletionOptional() throws {
     initializeServer()
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let text = """
@@ -264,7 +264,7 @@ final class SwiftCompletionTests: XCTestCase {
     openDocument(text: text, url: url)
 
     for col in 2...4 {
-      let response = try! sk.sendSync(CompletionRequest(
+      let response = try sk.sendSync(CompletionRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 4, utf16index: col)))
 
@@ -277,7 +277,7 @@ final class SwiftCompletionTests: XCTestCase {
     }
   }
 
-  func testCompletionOverride() {
+  func testCompletionOverride() throws {
     initializeServer()
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let text = """
@@ -290,7 +290,7 @@ final class SwiftCompletionTests: XCTestCase {
     """
     openDocument(text: text, url: url)
 
-    let response = try! sk.sendSync(CompletionRequest(
+    let response = try sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
       position: Position(line: 4, utf16index: 7)))
     guard let item = response.items.first(where: { $0.label == "foo()" }) else {
@@ -302,7 +302,7 @@ final class SwiftCompletionTests: XCTestCase {
     XCTAssertEqual(item.textEdit, TextEdit(range: Position(line: 4, utf16index: 2)..<Position(line: 4, utf16index: 7), newText: "override func foo() {\n\n}"))
   }
 
-  func testCompletionOverrideInNewLine() {
+  func testCompletionOverrideInNewLine() throws {
     initializeServer()
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     let text = """
@@ -316,7 +316,7 @@ final class SwiftCompletionTests: XCTestCase {
     """
     openDocument(text: text, url: url)
 
-    let response = try! sk.sendSync(CompletionRequest(
+    let response = try sk.sendSync(CompletionRequest(
       textDocument: TextDocumentIdentifier(url),
       position: Position(line: 5, utf16index: 2)))
     guard let item = response.items.first(where: { $0.label == "foo()" }) else {
@@ -328,7 +328,7 @@ final class SwiftCompletionTests: XCTestCase {
     XCTAssertEqual(item.textEdit, TextEdit(range: Position(line: 5, utf16index: 2)..<Position(line: 5, utf16index: 2), newText: "override func foo() {\n\n}"))
   }
 
-  func testMaxResults() {
+  func testMaxResults() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(text: """
@@ -345,12 +345,12 @@ final class SwiftCompletionTests: XCTestCase {
       """, url: url)
 
     // Server-wide option
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 9)))))
 
     // Explicit option
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 9),
                                                 sourcekitlspOptions:
@@ -360,7 +360,7 @@ final class SwiftCompletionTests: XCTestCase {
 
     // MARK: Limited
 
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 9),
                                                 sourcekitlspOptions:
@@ -368,14 +368,14 @@ final class SwiftCompletionTests: XCTestCase {
                                                     serverSideFiltering: true,
                                                     maxResults: 1000)))))
 
-    XCTAssertEqual(3, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(3, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 9),
                                                 sourcekitlspOptions:
                                                   SKCompletionOptions(
                                                     serverSideFiltering: true,
                                                     maxResults: 3)))))
-    XCTAssertEqual(1, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 9),
                                                 sourcekitlspOptions:
@@ -384,7 +384,7 @@ final class SwiftCompletionTests: XCTestCase {
                                                     maxResults: 1)))))
 
     // 0 also means unlimited
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 9),
                                                 sourcekitlspOptions:
@@ -394,14 +394,14 @@ final class SwiftCompletionTests: XCTestCase {
 
     // MARK: With filter='f'
 
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 10),
                                                 sourcekitlspOptions:
                                                   SKCompletionOptions(
                                                     serverSideFiltering: true,
                                                     maxResults: nil)))))
-    XCTAssertEqual(3, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(3, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 10),
                                                 sourcekitlspOptions:
@@ -411,7 +411,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   }
 
-  func testRefilterAfterIncompleteResults() {
+  func testRefilterAfterIncompleteResults() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: 20))
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(text: """
@@ -427,28 +427,28 @@ final class SwiftCompletionTests: XCTestCase {
       }
       """, url: url)
 
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 10),
                                                 context:CompletionContext(triggerKind: .invoked)))))
 
-    XCTAssertEqual(3, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(3, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 11),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(2, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(2, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 12),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(1, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 13),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(0, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(0, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 14),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(2, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(2, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 12),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
@@ -460,19 +460,19 @@ final class SwiftCompletionTests: XCTestCase {
                                           textDocument: TextDocumentIdentifier(url),
                                           position: Position(line: 7, utf16index: 0),
                                           context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions))))
-    XCTAssertEqual(1, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 13),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
 
     // Trigger kind changed => OK (20 is maxResults since we're outside the member completion)
-    XCTAssertEqual(20, try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(20, try sk.sendSync(CompletionRequest(
                                         textDocument: TextDocumentIdentifier(url),
                                         position: Position(line: 7, utf16index: 0),
                                           context:CompletionContext(triggerKind: .invoked))).items.count)
   }
 
-  func testRefilterAfterIncompleteResultsWithEdits() {
+  func testRefilterAfterIncompleteResultsWithEdits() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(#function)/a.swift")
     openDocument(text: """
@@ -489,13 +489,13 @@ final class SwiftCompletionTests: XCTestCase {
       """, url: url)
 
     // 'f'
-    XCTAssertEqual(5, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 10),
                                                 context:CompletionContext(triggerKind: .invoked)))))
 
     // 'fz'
-    XCTAssertEqual(0, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(0, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 11),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
@@ -506,7 +506,7 @@ final class SwiftCompletionTests: XCTestCase {
                 .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "A ")]))
 
     // 'fA'
-    XCTAssertEqual(1, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 11),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
@@ -523,7 +523,7 @@ final class SwiftCompletionTests: XCTestCase {
                 .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "Ab")]))
 
     // 'fAb'
-    XCTAssertEqual(1, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 11),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
@@ -534,7 +534,7 @@ final class SwiftCompletionTests: XCTestCase {
                 .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "")]))
 
     // 'fb'
-    XCTAssertEqual(2, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(2, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 11),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
@@ -545,7 +545,7 @@ final class SwiftCompletionTests: XCTestCase {
                 .init(range: Position(line: 7, utf16index: 11)..<Position(line: 7, utf16index: 11), text: "d")]))
 
     // 'fbd'
-    XCTAssertEqual(1, countFs(try! sk.sendSync(CompletionRequest(
+    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
                                                 textDocument: TextDocumentIdentifier(url),
                                                 position: Position(line: 7, utf16index: 12),
                                                 context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))


### PR DESCRIPTION
When running the test suite on Windows, these forced unwraps would fail.
Adopt `throws` on the cases and be more lenient of the failure as that
is reported as a test failure.  This allows us to run the test suite to
completion even if it fails.