### PR TITLE
Add rpath of /usr/lib/swift and swift-5.5 compatibility library

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -107,9 +107,9 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace) -> List[str]:
 
     if platform.system() == 'Darwin':
         swiftpm_args += [
-            # Relative library rpath for swift; will only be used when /usr/lib/swift
-            # is not available.
+            '-Xlinker', '-rpath', '-Xlinker', '/usr/lib/swift',
             '-Xlinker', '-rpath', '-Xlinker', '@executable_path/../lib/swift/macosx',
+            '-Xlinker', '-rpath', '-Xlinker', '@executable_path/../lib/swift-5.5/macosx',
         ]
     else:
         swiftpm_args += [


### PR DESCRIPTION
Without it, sourcekit-lsp crashes on launch with the same errors as in https://github.com/apple/swift-package-manager/issues/5467.