### PR TITLE
SKTestSupport: adjust imports for warnings/Swift 6 support

### DIFF
--- a/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
+++ b/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 import TSCBasic
 


### PR DESCRIPTION
This adjusts the imports in this particular source file to explicitly import Foundation to allow the use of `URL`.  This is a future error and currently a warning.  This cleans up a warning.