### PR TITLE
LSP: always use FSR for URI

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -36,7 +36,9 @@ public struct DocumentURI: Codable, Hashable {
   /// fallback mode that drops semantic functionality.
   public var pseudoPath: String {
     if storage.isFileURL {
-      return storage.path
+      return storage.withUnsafeFileSystemRepresentation {
+        String(cString: $0!)
+      }
     } else {
       return storage.absoluteString
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1392,7 +1392,7 @@ extension SwiftLanguageServer: SKDNotificationHandler {
         // unhandled.
 #if os(Windows)
         let isPath: Bool = name.withCString(encodedAs: UTF16.self) {
-          PathIsUNCW($0) || (0...25) ~= PathGetDriveNumberW($0)
+          !PathIsURLW($0)
         }
 #else
         let isPath: Bool = name.starts(with: "/")


### PR DESCRIPTION
When converting the URI to a path string, ensure that we convert to the
file system representation.  This is important as this ensures that we
are always passing SourceKit the native path string.  With this change,
the code completion behaviour for the LSP test suite on Windows is
repaired.