### PR TITLE
SourceKitD,SourceKitLSP: replace use of `Lock` with `NSLock`

### DIFF
--- a/Sources/SourceKitD/SourceKitDImpl.swift
+++ b/Sources/SourceKitD/SourceKitDImpl.swift
@@ -40,7 +40,7 @@ public final class SourceKitDImpl: SourceKitD {
   public let values: sourcekitd_values
 
   /// Lock protecting private state.
-  let lock: Lock = Lock()
+  let lock: NSLock = NSLock()
 
   /// List of notification handlers that will be called for each notification.
   private var _notificationHandlers: [WeakSKDNotificationHandler] = []

--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -10,7 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import TSCBasic
+
+extension NSLock {
+  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
+  internal func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try body()
+  }
+}
 
 /// The set of known SourceKitD instances, uniqued by path.
 ///
@@ -24,7 +34,7 @@ import TSCBasic
 public final class SourceKitDRegistry {
 
   /// Mutex protecting mutable state in the registry.
-  let lock: Lock = Lock()
+  let lock: NSLock = NSLock()
 
   /// Mapping from path to active SourceKitD instance.
   var active: [AbsolutePath: SourceKitD] = [:]

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -22,6 +22,15 @@ import TSCBasic
 import WinSDK
 #endif
 
+extension NSLock {
+  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
+  fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try body()
+  }
+}
+
 /// A thin wrapper over a connection to a clangd server providing build setting handling.
 ///
 /// In addition, it also intercepts notifications and replies from clangd in order to do things
@@ -46,7 +55,7 @@ final class ClangLanguageServerShim: LanguageServer, ToolchainLanguageServer {
   private var buildSettingsByFile: [DocumentURI: ClangBuildSettings] = [:]
 
   /// Lock protecting `buildSettingsByFile`.
-  private var lock: Lock = Lock()
+  private var lock: NSLock = NSLock()
 
   /// The current state of the `clangd` language server.
   /// Changing the property automatically notified the state change handlers.


### PR DESCRIPTION
Replace the use of the deprecated `Lock` from swift-tools-support-core
with `NSLock`.  The benefit of the deprecated interface was the
`withLock` function which is easily replicated and very unlikely to
change.  By doing so we avoid the warnings about `Lock` being deprecated
when building SourceKit-LSP.