### PR TITLE
LanguageServerProtocolJSONRPCTests: silence a warning

### DIFF
--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -264,7 +264,7 @@ class ConnectionTests: XCTestCase {
       to.fileHandleForWriting.closeFile()
 #if os(Windows)
       // 1 ms was chosen for simplicity.
-      _ = Sleep(1)
+      Sleep(1)
 #else
       // 100 us was chosen empirically to encourage races.
       usleep(100)


### PR DESCRIPTION
`Sleep` is a `void` returning function, which makes the blackhole
redundant.  Remove the unnecessary assignment which also silences
the warning associated with it.