### PR TITLE
SourceKitLSP: normalise paths for clangd

### DIFF
--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -420,7 +420,7 @@ extension ClangLanguageServerShim {
     if let compileCommand = clangBuildSettings?.compileCommand {
       let note = DidChangeConfigurationNotification(settings: .clangd(
         ClangWorkspaceSettings(
-          compilationDatabaseChanges: [url.path: compileCommand])))
+          compilationDatabaseChanges: [AbsolutePath(url.path).pathString: compileCommand])))
       forwardNotificationToClangdOnQueue(note)
     }
   }


### PR DESCRIPTION
Ensure that we use the native path representation for clangd rather than
the POSIX spelling.  This is required to map the command for the source
file.