### PR TITLE
SourceKitLSPTests: use a UUID in place of `#function`

### DIFF
--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -140,7 +140,7 @@ final class BuildSystemTests: XCTestCase {
   func testClangdDocumentUpdatedBuildSettings() {
     guard haveClangd else { return }
 
-    let url = URL(fileURLWithPath: "/\(#function)/file.m")
+    let url = URL(fileURLWithPath: "/\(UUID())/file.m")
     let doc = DocumentURI(url)
     let args = [url.path, "-DDEBUG"]
     let text = """
@@ -190,7 +190,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentUpdatedBuildSettings() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let doc = DocumentURI(url)
     let args = FallbackBuildSystem(buildSetup: .default).settings(for: doc, .swift)!.compilerArguments
 
@@ -249,7 +249,7 @@ final class BuildSystemTests: XCTestCase {
   func testClangdDocumentFallbackWithholdsDiagnostics() {
     guard haveClangd else { return }
 
-    let url = URL(fileURLWithPath: "/\(#function)/file.m")
+    let url = URL(fileURLWithPath: "/\(UUID())/file.m")
     let doc = DocumentURI(url)
     let args = [url.path, "-DDEBUG"]
     let text = """
@@ -298,7 +298,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentFallbackWithholdsSemanticDiagnostics() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let doc = DocumentURI(url)
 
     // Primary settings must be different than the fallback settings.
@@ -354,7 +354,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentBuildSettingsChangedFalseAlarm() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let doc = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false

--- a/Tests/SourceKitLSPTests/DocumentColorTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentColorTests.swift
@@ -43,7 +43,7 @@ final class DocumentColorTests: XCTestCase {
   }
 
   func performDocumentColorRequest(text: String) -> [ColorInformation] {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),
@@ -56,7 +56,7 @@ final class DocumentColorTests: XCTestCase {
   }
 
   func performColorPresentationRequest(text: String, color: Color, range: Range<Position>) -> [ColorPresentation] {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -46,7 +46,7 @@ final class DocumentSymbolTests: XCTestCase {
   }
 
   func performDocumentSymbolRequest(text: String) -> DocumentSymbolResponse {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -43,7 +43,7 @@ final class InlayHintTests: XCTestCase {
   }
 
   func performInlayHintRequest(text: String, range: Range<Position>? = nil) throws -> [InlayHint] {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -58,7 +58,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEditing() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -344,8 +344,8 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testCrossFileDiagnostics() {
-    let urlA = URL(fileURLWithPath: "/\(#function)/a.swift")
-    let urlB = URL(fileURLWithPath: "/\(#function)/b.swift")
+    let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let urlB = URL(fileURLWithPath: "/\(UUID())/b.swift")
     let uriA = DocumentURI(urlA)
     let uriB = DocumentURI(urlB)
 
@@ -405,7 +405,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDiagnosticsReopen() {
-    let urlA = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uriA = DocumentURI(urlA)
     sk.allowUnexpectedNotification = false
 
@@ -455,7 +455,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEducationalNotesAreUsedAsDiagnosticCodes() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -475,7 +475,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnostics() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -509,7 +509,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnosticsNotes() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -562,7 +562,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitInsert() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.allowUnexpectedNotification = false
@@ -602,7 +602,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActions() throws {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -652,7 +652,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActionsNotes() throws {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -707,7 +707,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionPrimary() throws {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -750,7 +750,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() throws {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic! = nil
@@ -1083,7 +1083,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testSymbolInfo() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
@@ -1156,7 +1156,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHover() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
@@ -1209,7 +1209,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHoverNameEscaping() {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),
@@ -1274,7 +1274,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDocumentSymbolHighlight() throws {
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -99,7 +99,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionBasic(options: SKCompletionOptions) throws {
     initializeServer(options: options)
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(url: url)
 
     let selfDot = try sk.sendSync(CompletionRequest(
@@ -150,7 +150,7 @@ final class SwiftCompletionTests: XCTestCase {
     capabilities.completionItem = CompletionCapabilities.CompletionItem(snippetSupport: true)
 
     initializeServer(capabilities: capabilities)
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(url: url)
 
     func getTestMethodCompletion(_ position: Position, label: String) throws -> CompletionItem? {
@@ -229,7 +229,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionPosition(options: SKCompletionOptions) throws {
     initializeServer(options: options)
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: "foo", url: url)
 
     for col in 0 ... 3 {
@@ -253,7 +253,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOptional() throws {
     initializeServer()
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
     struct Foo {
       let bar: Int
@@ -279,7 +279,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOverride() throws {
     initializeServer()
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
     class Base {
       func foo() {}
@@ -304,7 +304,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOverrideInNewLine() throws {
     initializeServer()
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
     class Base {
       func foo() {}
@@ -330,7 +330,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testMaxResults() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: """
       struct S {
         func f1() {}
@@ -413,7 +413,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testRefilterAfterIncompleteResults() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: 20))
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: """
       struct S {
         func fooAbc() {}
@@ -474,7 +474,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testRefilterAfterIncompleteResultsWithEdits() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
-    let url = URL(fileURLWithPath: "/\(#function)/a.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: """
       struct S {
         func fooAbc() {}
@@ -555,7 +555,7 @@ final class SwiftCompletionTests: XCTestCase {
   /// close waits for its respective open to finish to prevent a session geting stuck open.
   func testSessionCloseWaitsforOpen() throws {
     initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
-    let url = URL(fileURLWithPath: "/\(#function)/file.swift")
+    let url = URL(fileURLWithPath: "/\(UUID())/file.swift")
     openDocument(text: """
       struct S {
         func forSomethingCrazy() {}


### PR DESCRIPTION
Rather than using `#function` use a UUID for the generated unique name.
This avoids placing `:`, `(`, and `)` in the file path which are not
portable characters.