### PR TITLE
SKTestSupport: form native path for root of test project

### DIFF
--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -53,8 +53,8 @@ public final class SKSwiftPMTestWorkspace {
   public init(projectDir: URL, tmpDir: URL, toolchain: Toolchain, testServer: TestSourceKitServer? = nil) throws {
     self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
 
-    self.projectDir = projectDir
-    self.tmpDir = tmpDir
+    self.projectDir = URL(fileURLWithPath: resolveSymlinks(AbsolutePath(projectDir.path)).pathString)
+    self.tmpDir = URL(fileURLWithPath: resolveSymlinks(AbsolutePath(tmpDir.path)).pathString)
     self.toolchain = toolchain
 
     let fm = FileManager.default


### PR DESCRIPTION
The root of the test project would be in POSIX spelling which would cause mismatches between the formed paths and the value returned from the LSP resulting in test failures on Windows.