### PR TITLE
explicitly import TSCBasic types

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -16,7 +16,14 @@ import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import LSPLogging
 import SKSupport
-import TSCBasic
+
+import func TSCBasic.getEnvSearchPaths
+import func TSCBasic.lookupExecutablePath
+import func TSCBasic.resolveSymlinks
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.FileSystemError
+import var TSCBasic.localFileSystem
 
 enum BuildServerTestError: Error {
     case executableNotFound(String)

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SKSupport
 
+import struct TSCBasic.AbsolutePath
 import struct TSCUtility.BuildFlags
 
 /// Build configuration

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -12,7 +12,8 @@
 
 import BuildServerProtocol
 import LanguageServerProtocol
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
 
 /// Defines how well a `BuildSystem` can handle a file with a given URI.
 public enum FileHandlingCapability: Comparable {

--- a/Sources/SKCore/BuildSystemDelegate.swift
+++ b/Sources/SKCore/BuildSystemDelegate.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import BuildServerProtocol
 import LanguageServerProtocol
-import TSCBasic
 
 /// Handles  build system events, such as file build settings changes.
 public protocol BuildSystemDelegate: AnyObject {

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -13,8 +13,9 @@
 import LanguageServerProtocol
 import BuildServerProtocol
 import LSPLogging
-import TSCBasic
 import Dispatch
+
+import struct TSCBasic.AbsolutePath
 
 /// Status for a given main file.
 enum MainFileStatus: Equatable {

--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -11,8 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 import SKSupport
-import TSCBasic
 import Foundation
+
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
+import func TSCBasic.resolveSymlinks
 
 /// A single compilation database command.
 ///

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -14,9 +14,12 @@ import BuildServerProtocol
 import LanguageServerProtocol
 import LSPLogging
 import SKSupport
-import TSCBasic
 import Dispatch
 import struct Foundation.URL
+
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 /// A `BuildSystem` based on loading clang-compatible compilation database(s).
 ///

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -12,9 +12,11 @@
 
 import BuildServerProtocol
 import LanguageServerProtocol
-import TSCBasic
-import enum TSCUtility.Platform
 import Dispatch
+
+import class TSCBasic.Process
+import struct TSCBasic.AbsolutePath
+import enum TSCUtility.Platform
 
 /// A simple BuildSystem suitable as a fallback when accurate settings are unknown.
 public final class FallbackBuildSystem: BuildSystem {

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -13,8 +13,10 @@
 import LanguageServerProtocol
 import LSPLogging
 import SKSupport
-import TSCBasic
 
+import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
+import var TSCBasic.localFileSystem
 import enum TSCUtility.Platform
 
 /// A Toolchain is a collection of related compilers and libraries meant to be used together to

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -11,9 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 import SKSupport
-import TSCBasic
 import Dispatch
 import Foundation
+
+import func TSCBasic.getEnvSearchPaths
+import class TSCBasic.Process
+import enum TSCBasic.ProcessEnv
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 /// Set of known toolchains.
 ///

--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -10,8 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import Foundation
+
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
+#if os(macOS)
+import struct TSCBasic.RelativePath
+import struct TSCBasic.FileSystemError
+#endif
 
 /// A helper type for decoding the Info.plist or ToolchainInfo.plist file from an .xctoolchain.
 public struct XCToolchainPlist {

--- a/Sources/SKSupport/ByteString.swift
+++ b/Sources/SKSupport/ByteString.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import Foundation
+
+import struct TSCBasic.ByteString
 
 extension ByteString {
 

--- a/Sources/SKSupport/FileSystem.swift
+++ b/Sources/SKSupport/FileSystem.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import Foundation
+
+import struct TSCBasic.AbsolutePath
 
 /// The home directory of the current user (same as returned by Foundation's `NSHomeDirectory` method).
 public var homeDirectoryForCurrentUser: AbsolutePath {

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -24,10 +24,14 @@ import PackageModel
 import SourceControl
 import SKCore
 import SKSupport
-import TSCBasic
 import Workspace
 import Dispatch
 import struct Foundation.URL
+
+import func TSCBasic.resolveSymlinks
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 /// Swift Package Manager build system and workspace support.
 ///

--- a/Sources/SKTestSupport/FileSystem.swift
+++ b/Sources/SKTestSupport/FileSystem.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
 
 extension FileSystem {
 

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -17,11 +17,13 @@ import SKCore
 import IndexStoreDB
 import ISDBTibs
 import ISDBTestSupport
-import TSCBasic
 import XCTest
 import Foundation
 import LSPTestSupport
 
+import class TSCBasic.Process
+import func TSCBasic.resolveSymlinks
+import struct TSCBasic.AbsolutePath
 import struct TSCUtility.BuildFlags
 
 public final class SKSwiftPMTestWorkspace {

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -16,11 +16,11 @@ import SKCore
 import IndexStoreDB
 import ISDBTibs
 import ISDBTestSupport
-import TSCBasic
 import XCTest
 import Foundation
 import LSPTestSupport
 
+import struct TSCBasic.AbsolutePath
 import enum TSCUtility.Platform
 import struct TSCUtility.BuildFlags
 

--- a/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
+++ b/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
@@ -12,7 +12,8 @@
 
 import Foundation
 import LanguageServerProtocol
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
 
 public extension TextDocumentIdentifier {
   init(_ url: URL) {

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -14,7 +14,6 @@
 
 import SKSupport
 import LSPLogging
-import TSCBasic
 import Dispatch
 import Foundation
 

--- a/Sources/SourceKitD/SourceKitDImpl.swift
+++ b/Sources/SourceKitD/SourceKitDImpl.swift
@@ -11,8 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import SKSupport
-import TSCBasic
 import Foundation
+
+import struct TSCBasic.AbsolutePath
 
 /// Wrapper for sourcekitd, taking care of initialization, shutdown, and notification handler
 /// multiplexing.

--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
 
 extension NSLock {
   /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -16,7 +16,8 @@ import LanguageServerProtocolJSONRPC
 import LSPLogging
 import SKCore
 import SKSupport
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -18,9 +18,12 @@ import LanguageServerProtocol
 import LSPLogging
 import SKCore
 import SKSupport
-import TSCBasic
 
 import PackageLoading
+
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 public typealias URL = Foundation.URL
 

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
-import TSCBasic
 import SourceKitD
 
 /// Detailed information about a symbol under the cursor.

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import LanguageServerProtocol
-import TSCBasic
 import SourceKitD
 
 /// Detailed information about the result of a specific refactoring operation.

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -17,7 +17,7 @@ import LSPLogging
 import SKCore
 import SKSupport
 import SourceKitD
-import TSCBasic
+
 #if os(Windows)
 import WinSDK
 #endif

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -16,7 +16,8 @@ import LSPLogging
 import SKCore
 import SKSupport
 import SKSwiftPMWorkspace
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
 
 /// Represents the configuration and state of a project or combination of projects being worked on
 /// together.

--- a/Sources/sourcekit-lsp/main.swift
+++ b/Sources/sourcekit-lsp/main.swift
@@ -20,7 +20,9 @@ import LSPLogging
 import SKCore
 import SKSupport
 import SourceKitLSP
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 extension AbsolutePath: ExpressibleByArgument {
   public init?(argument: String) {


### PR DESCRIPTION
Explicitly import interfaces from TSCBasic which now allows us to identify all the swift-tools-support-core interfaces which are in use in SourceKit-LSP.