### PR TITLE
SKTestSupport,SourceKitLSPTests: use new `swift` member

### DIFF
--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -121,7 +121,7 @@ extension SKSwiftPMTestWorkspace {
 
   func build() throws {
     try TSCBasic.Process.checkNonZeroExit(arguments: [
-      String(toolchain.swiftc!.pathString.dropLast()),
+      toolchain.swift!.pathString,
       "build",
       "--package-path", sources.rootDirectory.path,
       "--build-path", buildDir.path,

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -226,7 +226,7 @@ final class WorkspaceTests: XCTestCase {
     guard let ws = try staticSourceKitSwiftPMWorkspace(name: "ChangeWorkspaceFolders") else { return }
     // Build the package. We can't use ws.buildAndIndex() because that doesn't put the build products in .build where SourceKit-LSP expects them.
     try TSCBasic.Process.checkNonZeroExit(arguments: [
-      String(ToolchainRegistry.shared.default!.swiftc!.pathString.dropLast()),
+      ToolchainRegistry.shared.default!.swift!.pathString,
       "build",
       "--package-path", ws.sources.rootDirectory.path,
       "-Xswiftc", "-index-ignore-system-modules",


### PR DESCRIPTION
Migrate to `swift` member for the swift driver rather than trying to create it by dropping the last character in the path to the swift compiler which may be part of the file extension.