### PR TITLE
SKCoreTests: adjust toolchain library stubs for Windows

### DIFF
--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -560,16 +560,25 @@ private func makeToolchain(
     makeExec(binPath.appending(component: "swiftc\(execExt)"))
   }
 
-  let dylibExt = Platform.currentPlatform?.dynamicLibraryExtension ?? ".so"
+  let dylibSuffix = Platform.currentPlatform?.dynamicLibraryExtension ?? ".so"
 
   if sourcekitd {
     try! fs.createDirectory(libPath.appending(component: "sourcekitd.framework"))
     try! fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd") , bytes: "")
   }
   if sourcekitdInProc {
-    try! fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibExt)") , bytes: "")
+#if os(Windows)
+    try! fs.writeFileContents(binPath.appending(component: "sourcekitdInProc\(dylibSuffix)") , bytes: "")
+#else
+    try! fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibSuffix)") , bytes: "")
+#endif
   }
   if libIndexStore {
-    try! fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibExt)") , bytes: "")
+#if os(Windows)
+    // Windows has a prefix of `lib` on this particular library ...
+    try! fs.writeFileContents(binPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
+#else
+    try! fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
+#endif
   }
 }


### PR DESCRIPTION
The toolchain library runtime components are installed into the binaries directory and the import library (link components) are installed into the lib directory.  Darwin splits the runtime (dylib) and link time (tbd) across the SDK and the installation and Linux uses the same file for both.  Account for the difference on Windows to correct some of the test expectations.