### PR TITLE
SKCoreTests,SKSwiftPMWorkspaceTests: native path spelling changes

### DIFF
--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -200,7 +200,10 @@ final class CompilationDatabaseTests: XCTestCase {
     XCTAssertNotNil(db)
 
     XCTAssertEqual(db![URL(fileURLWithPath: "/a/b")], [
-      CompilationDatabase.Command(directory: "/a", filename: "/a/b", commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"], output: nil)
+      CompilationDatabase.Command(directory: AbsolutePath("/a").pathString,
+                                  filename: "/a/b",
+                                  commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"],
+                                  output: nil)
     ])
   }
 

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -398,7 +398,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let headerArgs = try ws._settings(for: header.asURI, .cpp)!.compilerArguments
       checkArgsCommon(headerArgs)
 
-      check("-c", "-x", "c++-header", URL(fileURLWithPath: header.pathString).path,
+      check("-c", "-x", "c++-header", AbsolutePath(URL(fileURLWithPath: header.pathString).path).pathString,
             arguments: headerArgs)
     }
   }


### PR DESCRIPTION
Adjust a couple of sites to use native path spelling rather than POSIX paths.  This is required to ensure that the tests pass on Windows which uses `\` rather than `/` for the path separator.