### PR TITLE
SourceKitLSPTests: make some paths absolute for Windows

### DIFF
--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -140,7 +140,11 @@ final class BuildSystemTests: XCTestCase {
   func testClangdDocumentUpdatedBuildSettings() {
     guard haveClangd else { return }
 
+#if os(Windows)
+    let url = URL(fileURLWithPath: "C:/\(UUID())/file.m")
+#else
     let url = URL(fileURLWithPath: "/\(UUID())/file.m")
+#endif
     let doc = DocumentURI(url)
     let args = [url.path, "-DDEBUG"]
     let text = """
@@ -249,7 +253,11 @@ final class BuildSystemTests: XCTestCase {
   func testClangdDocumentFallbackWithholdsDiagnostics() {
     guard haveClangd else { return }
 
+#if os(Windows)
+    let url = URL(fileURLWithPath: "C:/\(UUID())/file.m")
+#else
     let url = URL(fileURLWithPath: "/\(UUID())/file.m")
+#endif
     let doc = DocumentURI(url)
     let args = [url.path, "-DDEBUG"]
     let text = """

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -63,7 +63,11 @@ final class LocalClangTests: XCTestCase {
 
   func testSymbolInfo() {
     guard haveClangd else { return }
+#if os(Windows)
+    let url = URL(fileURLWithPath: "C:/a.cpp")
+#else
     let url = URL(fileURLWithPath: "/a.cpp")
+#endif
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),
@@ -127,7 +131,11 @@ final class LocalClangTests: XCTestCase {
 
   func testFoldingRange() {
     guard haveClangd else { return }
+#if os(Windows)
+    let url = URL(fileURLWithPath: "C:/a.cpp")
+#else
     let url = URL(fileURLWithPath: "/a.cpp")
+#endif
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),
@@ -147,7 +155,11 @@ final class LocalClangTests: XCTestCase {
 
   func testDocumentSymbols() throws {
     guard haveClangd else { return }
+#if os(Windows)
+    let url = URL(fileURLWithPath: "C:/a.cpp")
+#else
     let url = URL(fileURLWithPath: "/a.cpp")
+#endif
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
       uri: DocumentURI(url),


### PR DESCRIPTION
Windows requires absolute paths to have a volume letter associated with them.  Without the path being absolute SourceKit will assert.  Provide custom paths on Windows.