### PR TITLE
SKCore: use `resolvingSymlinks` to resolve symlinks

### DIFF
--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -162,7 +162,7 @@ public struct JSONCompilationDatabase: CompilationDatabase, Equatable {
     let url = command.url
     pathToCommands[url, default: []].append(commands.count)
 
-    let canonical = url.resolvingSymlinksInPath()
+    let canonical = URL(fileURLWithPath: resolveSymlinks(AbsolutePath(url.path)).pathString)
     if canonical != url {
       pathToCommands[canonical, default: []].append(commands.count)
     }


### PR DESCRIPTION
Rather than using the `resolvingSymlinksInPath` on `URL` use `resolvingSymlink` from tools-support-core as the semantics for the two differ ever so slightly which matters for Windows (the former expands symlinks on the terminal arc iterative where as the latter simply expands the path).