### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -98,5 +98,6 @@ add_library(LanguageServerProtocol STATIC
 set_target_properties(LanguageServerProtocol PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(LanguageServerProtocol PUBLIC
+  TSCBasic
   $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)


### PR DESCRIPTION
Add a dependency on TSCBasic for LanguageServerProtocol.  This dependency was added recently via an `import` and was updated in Package.swift but was missed in the CMake build.