### PR TITLE
SourceKitLSP: use `AbsolutePath` to compute the filename

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1480,8 +1480,8 @@ extension SourceKitServer {
         name = "\(symbol.name): \(conformances.map(\.symbol.name).joined(separator: ", "))"
       }
       // Add the file name and line to the detail string
-      if let fileName = location.uri.pseudoPath.split(separator: "/").last {
-        detail = "Extension at \(fileName):\(location.range.lowerBound.line + 1)"
+      if let url = location.uri.fileURL {
+        detail = "Extension at \(AbsolutePath(url.path).basename):\(location.range.lowerBound.line + 1)"
       } else if let moduleName = moduleName {
         detail = "Extension in \(moduleName)"
       } else {


### PR DESCRIPTION
Rather than treating the filename as an opaque string and splitting on `/`, use `AbsolutePath` to perform the `basename` operation on the path. This ensures that we split the path properly on platforms which do not use the POSIX path separator `/`.