### PR TITLE
[5.7] Empty TextEdits now return nil

### DIFF
--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -100,6 +100,12 @@ extension TextEdit {
       // Snippets are only suppored in code completion.
       // Remove SourceKit placeholders from Fix-Its because they can't be represented in the editor properly.
       let replacementWithoutPlaceholders = rewriteSourceKitPlaceholders(inString: replacement, clientSupportsSnippets: false)
+
+      // If both the replacement without placeholders and the fixit are empty, no TextEdit should be created.
+      if (replacementWithoutPlaceholders.isEmpty && length == 0) {
+        return nil
+      }
+
       self.init(range: position..<endPosition, newText: replacementWithoutPlaceholders)
     } else {
       return nil


### PR DESCRIPTION
Cherry-picks https://github.com/apple/sourcekit-lsp/pull/602 to release/5.7.

---

This adds a check when creating a `TextEdit` to return `nil` if both the fixit and the replacement being used to create a `TextEdit` are empty. A `TextEdit` being created like this can cause a crash.

Resolves https://github.com/apple/sourcekit-lsp/issues/635