### PR TITLE
Pull SwiftSyntax into SourceKit-LSP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(LLBuild QUIET)
 find_package(ArgumentParser CONFIG REQUIRED)
 find_package(SwiftCollections QUIET)
 find_package(SwiftSystem CONFIG REQUIRED)
+find_package(SwiftSyntax CONFIG REQUIRED) 
 
 include(SwiftSupport)
 

--- a/Package.swift
+++ b/Package.swift
@@ -241,12 +241,14 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-syntax.git", .branch("main")),
   ]
 } else {
   package.dependencies += [
     .package(name: "IndexStoreDB", path: "../indexstore-db"),
     .package(name: "SwiftPM", path: "../swiftpm"),
     .package(path: "../swift-tools-support-core"),
-    .package(path: "../swift-argument-parser")
+    .package(path: "../swift-argument-parser"),
+    .package(path: "../swift-syntax")
   ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,8 @@ let package = Package(
           "SourceKitD",
           "SKSwiftPMWorkspace",
           .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+          .product(name: "SwiftSyntax", package: "swift-syntax"),
+          .product(name: "SwiftParser", package: "swift-syntax"),
         ],
         exclude: ["CMakeLists.txt"]),
 

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -41,6 +41,11 @@ target_link_libraries(SourceKitLSP PUBLIC
   SKCore
   SKSwiftPMWorkspace
   SourceKitD
+  SwiftSyntax::SwiftBasicFormat
+  SwiftSyntax::SwiftParser
+  SwiftSyntax::SwiftDiagnostics
+  SwiftSyntax::SwiftSyntax
   TSCUtility)
 target_link_libraries(SourceKitLSP PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
+

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -153,17 +153,14 @@ public final class DocumentManager {
           // Remove all tokens in the updated range and shift later ones.
           let rangeAdjuster = RangeAdjuster(edit: edit)!
 
-          document.latestTokens.withMutableTokensOfEachKind { tokens in
-            tokens = Array(tokens.lazy
-              .compactMap {
-                var token = $0
-                if let adjustedRange = rangeAdjuster.adjust(token.range) {
-                  token.range = adjustedRange
-                  return token
-                } else {
-                  return nil
-                }
-              })
+          document.latestTokens.semantic = document.latestTokens.semantic.compactMap {
+            var token = $0
+            if let adjustedRange = rangeAdjuster.adjust(token.range) {
+              token.range = adjustedRange
+              return token
+            } else {
+              return nil
+            }
           }
         } else {
           // Full text replacement.

--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -11,31 +11,100 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import SwiftSyntax
 
 /// Syntax highlighting tokens for a particular document.
 public struct DocumentTokens {
-  /// Lexical tokens, e.g. keywords, raw identifiers, ...
-  public var lexical: [SyntaxHighlightingToken] = []
+  /// The syntax tree representing the entire document.
+  public var syntaxTree: SourceFileSyntax?
   /// Semantic tokens, e.g. variable references, type references, ...
   public var semantic: [SyntaxHighlightingToken] = []
+}
 
-  private var merged: [SyntaxHighlightingToken] {
-    lexical.mergingTokens(with: semantic)
+extension DocumentSnapshot {
+  /// Computes an array of syntax highlighting tokens from the syntax tree that
+  /// have been merged with any semantic tokens from SourceKit. If the provided
+  /// range is non-empty, this function restricts its output to only those
+  /// tokens whose ranges overlap it. If no range is provided, tokens for the
+  /// entire document are returned.
+  ///
+  /// - Parameter range: The range of tokens to restrict this function to, if any.
+  /// - Returns: An array of syntax highlighting tokens.
+  public func mergedAndSortedTokens(in range: Range<Position>? = nil) -> [SyntaxHighlightingToken] {
+    guard let tree = self.tokens.syntaxTree else {
+      return self.tokens.semantic
+    }
+    let range = range.flatMap({ $0.byteSourceRange(in: self) })
+             ?? ByteSourceRange(offset: 0, length: tree.byteSize)
+    return tree
+      .classifications(in: range)
+      .flatMap({ $0.highlightingTokens(in: self) })
+      .mergingTokens(with: self.tokens.semantic)
+      .sorted { $0.start < $1.start }
   }
-  public var mergedAndSorted: [SyntaxHighlightingToken] {
-    merged.sorted { $0.start < $1.start }
-  }
+}
 
-  /// Modifies the syntax highlighting tokens of each kind
-  /// (lexical and semantic) according to `action`.
-  public mutating func withMutableTokensOfEachKind(_ action: (inout [SyntaxHighlightingToken]) -> Void) {
-    action(&lexical)
-    action(&semantic)
+extension Range where Bound == Position {
+  fileprivate func byteSourceRange(in snapshot: DocumentSnapshot) -> ByteSourceRange? {
+    return snapshot.utf8OffsetRange(of: self).map({ ByteSourceRange(offset: $0.startIndex, length: $0.count) })
   }
+}
 
-  // Replace all lexical tokens in `range`.
-  public mutating func replaceLexical(in range: Range<Position>, with newTokens: [SyntaxHighlightingToken]) {
-    lexical.removeAll { $0.range.overlaps(range) }
-    lexical += newTokens
+extension SyntaxClassifiedRange {
+  fileprivate func highlightingTokens(in snapshot: DocumentSnapshot) -> [SyntaxHighlightingToken] {
+    guard let (kind, modifiers) = self.kind.highlightingKindAndModifiers else {
+      return []
+    }
+
+    guard
+      let start: Position = snapshot.positionOf(utf8Offset: self.offset),
+      let end: Position = snapshot.positionOf(utf8Offset: self.endOffset)
+    else {
+      return []
+    }
+
+    let multiLineRange = start..<end
+    let ranges = multiLineRange.splitToSingleLineRanges(in: snapshot)
+
+    return ranges.map {
+      SyntaxHighlightingToken(
+        range: $0,
+        kind: kind,
+        modifiers: modifiers
+      )
+    }
+  }
+}
+
+extension SyntaxClassification {
+  fileprivate var highlightingKindAndModifiers: (SyntaxHighlightingToken.Kind, SyntaxHighlightingToken.Modifiers)? {
+    switch self {
+    case .none:
+      return nil
+    case .editorPlaceholder:
+      return nil
+    case .stringInterpolationAnchor:
+      return nil
+    case .keyword:
+      return (.keyword, [])
+    case .identifier, .typeIdentifier, .dollarIdentifier:
+      return (.identifier, [])
+    case .operatorIdentifier:
+      return (.operator, [])
+    case .integerLiteral, .floatingLiteral:
+      return (.number, [])
+    case .stringLiteral:
+      return (.string, [])
+    case .poundDirectiveKeyword:
+      return (.macro, [])
+    case .buildConfigId, .objectLiteral:
+      return (.macro, [])
+    case .attribute:
+      return (.modifier, [])
+    case .lineComment, .blockComment:
+      return (.comment, [])
+    case .docLineComment, .docBlockComment:
+      return (.comment, .documentation)
+    }
   }
 }

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
@@ -187,7 +187,7 @@ struct SyntaxHighlightingTokenParser {
 
 extension Range where Bound == Position {
   /// Splits a potentially multi-line range to multiple single-line ranges.
-  fileprivate func splitToSingleLineRanges(in snapshot: DocumentSnapshot) -> [Self] {
+  func splitToSingleLineRanges(in snapshot: DocumentSnapshot) -> [Self] {
     if isEmpty {
       return []
     }

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -496,7 +496,7 @@ final class SemanticTokensTests: XCTestCase {
     """
     let tokens = openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 5, kind: .modifier),
+      Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
       Token(line: 0, utf16index: 6, length: 8, kind: .keyword),
       Token(line: 0, utf16index: 15, length: 2, kind: .operator),
       Token(line: 0, utf16index: 19, length: 20, kind: .identifier),


### PR DESCRIPTION
The general idea is to try to use the syntax tree to provide an in-process source of truth about syntactic and structural document requests. Having the syntax tree in process also enables syntactic transformations and analyses that can be used to provide code actions, programmatic language features like (keyword) hovering, etc. both natively in Swift and without having to incur a hop out to SourceKit.

To that end, re-core the "lexical" token stream on top of SwiftSyntax and call into the parser to (re-)generate these "lexical tokens" when the document changes. Leave the semantic tokens alone since they take some non-zero amount of name lookup to fully resolve references to fully replicate.

A follow-on will demonstrate what we can start to do with this infrastructure.