### PR TITLE
Redo the Folding Range Request on top of the Syntax Tree 

### DIFF
--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -39,18 +39,17 @@ final class FoldingRangeTests: XCTestCase {
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
 
     XCTAssertEqual(ranges, [
-      FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 2, endUTF16Index: 0, kind: .comment),
+      FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 1, endUTF16Index: 18, kind: .comment),
       FoldingRange(startLine: 3, startUTF16Index: 0, endLine: 13, endUTF16Index: 2, kind: .comment),
       FoldingRange(startLine: 14, startUTF16Index: 10, endLine: 27, endUTF16Index: 0, kind: nil),
-      FoldingRange(startLine: 15, startUTF16Index: 2, endLine: 16, endUTF16Index: 0, kind: .comment),
-      FoldingRange(startLine: 16, startUTF16Index: 2, endLine: 17, endUTF16Index: 0, kind: .comment),
+      FoldingRange(startLine: 15, startUTF16Index: 2, endLine: 17, endUTF16Index: 2, kind: .comment),
       FoldingRange(startLine: 17, startUTF16Index: 2, endLine: 19, endUTF16Index: 4, kind: .comment),
       FoldingRange(startLine: 22, startUTF16Index: 21, endLine: 25, endUTF16Index: 2, kind: nil),
-      FoldingRange(startLine: 23, startUTF16Index: 22, endLine: 23, endUTF16Index: 30, kind: nil),
+      FoldingRange(startLine: 23, startUTF16Index: 23, endLine: 23, endUTF16Index: 30, kind: nil),
       FoldingRange(startLine: 26, startUTF16Index: 2, endLine: 26, endUTF16Index: 10, kind: .comment),
-      FoldingRange(startLine: 29, startUTF16Index: 0, endLine: 32, endUTF16Index: 0, kind: .comment),
-      FoldingRange(startLine: 33, startUTF16Index: 0, endLine: 36, endUTF16Index: 0, kind: .comment),
-      FoldingRange(startLine: 37, startUTF16Index: 0, endLine: 38, endUTF16Index: 0, kind: .comment),
+      FoldingRange(startLine: 29, startUTF16Index: 0, endLine: 31, endUTF16Index: 2, kind: .comment),
+      FoldingRange(startLine: 33, startUTF16Index: 0, endLine: 35, endUTF16Index: 2, kind: .comment),
+      FoldingRange(startLine: 37, startUTF16Index: 0, endLine: 37, endUTF16Index: 32, kind: .comment),
       FoldingRange(startLine: 39, startUTF16Index: 0, endLine: 39, endUTF16Index: 11, kind: .comment),
     ])
   }
@@ -66,10 +65,11 @@ final class FoldingRangeTests: XCTestCase {
 
     XCTAssertEqual(ranges, [
       FoldingRange(startLine: 0, endLine: 1, kind: .comment),
-      FoldingRange(startLine: 3, endLine: 12, kind: .comment),
-      FoldingRange(startLine: 14, endLine: 26, kind: nil),
-      FoldingRange(startLine: 17, endLine: 18, kind: .comment),
-      FoldingRange(startLine: 22, endLine: 24, kind: nil),
+      FoldingRange(startLine: 3, endLine: 13, kind: .comment),
+      FoldingRange(startLine: 14, endLine: 27, kind: nil),
+      FoldingRange(startLine: 15, endLine: 17, kind: .comment),
+      FoldingRange(startLine: 17, endLine: 19, kind: .comment),
+      FoldingRange(startLine: 22, endLine: 25, kind: nil),
       FoldingRange(startLine: 29, endLine: 31, kind: .comment),
       FoldingRange(startLine: 33, endLine: 35, kind: .comment),
     ])
@@ -90,8 +90,8 @@ final class FoldingRangeTests: XCTestCase {
     try performTest(withRangeLimit: -100, expecting: 0)
     try performTest(withRangeLimit: 0, expecting: 0)
     try performTest(withRangeLimit: 4, expecting: 4)
-    try performTest(withRangeLimit: 5000, expecting: 13)
-    try performTest(withRangeLimit: nil, expecting: 13)
+    try performTest(withRangeLimit: 5000, expecting: 12)
+    try performTest(withRangeLimit: nil, expecting: 12)
   }
 
   func testNoRanges() throws {


### PR DESCRIPTION
Building upon the infrastructure that requests the lexical structure of the document from SwiftSyntax, redo the folding ranges request using the tree directly. This corrects a number of inconsistencies in the tests mostly due to incorrect SourceLocations in the semantic ASTs and the line comment merging logic.

To extract folding ranges, we were previously opening a temporary document to issue a syntactic structure request to SourceKit.

This change is not NFC - there are a number of quirks of the C++ version of the structure walkers that I think were incorrect and are fixed here. For example, the folding range for the `guard` in the FoldingRangeBase test occurs before the actual `{`! However, this PR does try to recreate the adjacent line comment merging behavior in the C++, but does also correct some bogus source ranges as a result.

Built upon #651 