### PR TITLE
Adopt to path API changes

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -20,7 +20,9 @@ public struct DocumentURI: Codable, Hashable {
   private let storage: URL
 
   public var nativeURI: Self {
-    DocumentURI(URL(fileURLWithPath: resolveSymlinks(AbsolutePath(self.pseudoPath)).pathString))
+      get throws {
+          DocumentURI(URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: self.pseudoPath)).pathString))
+      }
   }
 
   public var fileURL: URL? {

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -275,8 +275,7 @@ extension BuildServerBuildSystem: BuildSystem {
       return .handled
     }
 
-    let realpath = resolveSymlinks(path)
-    if realpath != path, projectRoot.isAncestorOfOrEqual(to: realpath) {
+    if let realpath = try? resolveSymlinks(path), realpath != path, projectRoot.isAncestorOfOrEqual(to: realpath) {
       return .handled
     }
 

--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -143,7 +143,7 @@ public struct JSONCompilationDatabase: CompilationDatabase, Equatable {
   var commands: [Command] = []
 
   public init(_ commands: [Command] = []) {
-    commands.forEach { add($0) }
+    commands.forEach { try! add($0) }
   }
 
   public subscript(_ url: URL) -> [Command] {
@@ -158,11 +158,11 @@ public struct JSONCompilationDatabase: CompilationDatabase, Equatable {
 
   public var allCommands: AnySequence<Command> { AnySequence(commands) }
 
-  public mutating func add(_ command: Command) {
+  public mutating func add(_ command: Command) throws {
     let url = command.url
     pathToCommands[url, default: []].append(commands.count)
 
-    let canonical = URL(fileURLWithPath: resolveSymlinks(AbsolutePath(url.path)).pathString)
+    let canonical = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(url.path)).pathString)
     if canonical != url {
       pathToCommands[canonical, default: []].append(commands.count)
     }
@@ -175,7 +175,7 @@ extension JSONCompilationDatabase: Codable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     while !container.isAtEnd {
-      self.add(try container.decode(Command.self))
+      try self.add(try container.decode(Command.self))
     }
   }
 

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -55,8 +55,8 @@ public final class SKSwiftPMTestWorkspace {
   public init(projectDir: URL, tmpDir: URL, toolchain: Toolchain, testServer: TestSourceKitServer? = nil) throws {
     self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
 
-    self.projectDir = URL(fileURLWithPath: resolveSymlinks(AbsolutePath(projectDir.path)).pathString)
-    self.tmpDir = URL(fileURLWithPath: resolveSymlinks(AbsolutePath(tmpDir.path)).pathString)
+    self.projectDir = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(projectDir.path)).pathString)
+    self.tmpDir = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(tmpDir.path)).pathString)
     self.toolchain = toolchain
 
     let fm = FileManager.default

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -97,7 +97,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
               targets: [.target(name: "lib", dependencies: [])])
             """
       ])
-      let packageRoot = resolveSymlinks(tempDir.appending(component: "pkg"))
+      let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,
@@ -195,7 +195,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
-      let source = resolveSymlinks(packageRoot.appending(component: "Package.swift"))
+      let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
       let arguments = try ws._settings(for: source.asURI, .swift)!.compilerArguments
 
       check("-swift-version", "4.2", arguments: arguments)
@@ -217,7 +217,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
               targets: [.target(name: "lib", dependencies: [])])
             """
       ])
-      let packageRoot = resolveSymlinks(tempDir.appending(component: "pkg"))
+      let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,
@@ -257,7 +257,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
               ])
             """
       ])
-      let packageRoot = resolveSymlinks(tempDir.appending(component: "pkg"))
+      let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,
@@ -339,7 +339,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
               cxxLanguageStandard: .cxx14)
             """
       ])
-      let packageRoot = resolveSymlinks(tempDir.appending(component: "pkg"))
+      let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,
@@ -477,13 +477,13 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       XCTAssertEqual(arguments1, arguments2)
 
       checkNot(aswift1.pathString, arguments: arguments1 ?? [])
-      check(resolveSymlinks(aswift1).pathString, arguments: arguments1 ?? [])
+      check(try resolveSymlinks(aswift1).pathString, arguments: arguments1 ?? [])
 
       let argsManifest = try ws._settings(for: manifest.asURI, .swift)?.compilerArguments
       XCTAssertNotNil(argsManifest)
 
       checkNot(manifest.pathString, arguments: argsManifest ?? [])
-      check(resolveSymlinks(manifest).pathString, arguments: argsManifest ?? [])
+      check(try resolveSymlinks(manifest).pathString, arguments: argsManifest ?? [])
     }
   }
 
@@ -523,12 +523,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let argsCxx = try ws._settings(for: acxx.asURI, .cpp)?.compilerArguments
       XCTAssertNotNil(argsCxx)
       check(acxx.pathString, arguments: argsCxx ?? [])
-      checkNot(resolveSymlinks(acxx).pathString, arguments: argsCxx ?? [])
+      checkNot(try resolveSymlinks(acxx).pathString, arguments: argsCxx ?? [])
 
       let argsH = try ws._settings(for: ah.asURI, .cpp)?.compilerArguments
       XCTAssertNotNil(argsH)
       checkNot(ah.pathString, arguments: argsH ?? [])
-      check(resolveSymlinks(ah).pathString, arguments: argsH ?? [])
+      check(try resolveSymlinks(ah).pathString, arguments: argsH ?? [])
     }
   }
 
@@ -550,7 +550,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
                   resources: [.copy("a.txt")])])
             """
       ])
-      let packageRoot = resolveSymlinks(tempDir.appending(component: "pkg"))
+      let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,
@@ -579,7 +579,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         targets: [.target(name: "lib", dependencies: [])])
         """
       ])
-      let packageRoot = resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
+      let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
       let tr = ToolchainRegistry.shared
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,
@@ -587,7 +587,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
-      XCTAssertEqual(ws._packageRoot, resolveSymlinks(tempDir.appending(component: "pkg")))
+      XCTAssertEqual(ws._packageRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
     }
   }
 }

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -74,19 +74,19 @@ final class CallHierarchyTests: XCTestCase {
       Location(badUTF16: ws.testLoc(name))
     }
 
-    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", usr: String, at locName: String) -> CallHierarchyItem {
+    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", usr: String, at locName: String) throws -> CallHierarchyItem {
       let location = loc(locName)
       return CallHierarchyItem(
         name: name,
         kind: kind,
         tags: nil,
         detail: detail,
-        uri: location.uri.nativeURI,
+        uri: try location.uri.nativeURI,
         range: location.range,
         selectionRange: location.range,
         data: .dictionary([
           "usr": .string(usr),
-          "uri": .string(location.uri.nativeURI.stringValue)
+          "uri": .string(try location.uri.nativeURI.stringValue)
         ])
       )
     }
@@ -114,27 +114,27 @@ final class CallHierarchyTests: XCTestCase {
 
     XCTAssertEqual(try outgoingCalls(at: testLoc("a")), [])
     XCTAssertEqual(try outgoingCalls(at: testLoc("b")), [
-      outCall(item("a()", .function, usr: aUsr, at: "a"), at: "b->a"),
-      outCall(item("c()", .function, usr: cUsr, at: "c"), at: "b->c"),
-      outCall(item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
+      outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "b->a"),
+      outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "b->c"),
+      outCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
     ])
     XCTAssertEqual(try outgoingCalls(at: testLoc("c")), [
-      outCall(item("a()", .function, usr: aUsr, at: "a"), at: "c->a"),
-      outCall(item("d()", .function, usr: dUsr, at: "d"), at: "c->d"),
-      outCall(item("c()", .function, usr: cUsr, at: "c"), at: "c->c"),
+      outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "c->a"),
+      outCall(try item("d()", .function, usr: dUsr, at: "d"), at: "c->d"),
+      outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->c"),
     ])
 
     // Test incoming call hierarchy
 
     XCTAssertEqual(try incomingCalls(at: testLoc("a")), [
-      inCall(item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->a"),
-      inCall(item("c()", .function, usr: cUsr, at: "c"), at: "c->a"),
+      inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->a"),
+      inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->a"),
     ])
     XCTAssertEqual(try incomingCalls(at: testLoc("b")), [
-      inCall(item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
+      inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
     ])
     XCTAssertEqual(try incomingCalls(at: testLoc("d")), [
-      inCall(item("c()", .function, usr: cUsr, at: "c"), at: "c->d"),
+      inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->d"),
     ])
   }
 }

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -36,9 +36,9 @@ final class ImplementationTests: XCTestCase {
     func testLoc(_ name: String) -> TestLocation {
       ws.testLoc(name)
     }  
-    func loc(_ name: String) -> Location {
+    func loc(_ name: String) throws -> Location {
       let location: TestLocation = ws.testLoc(name)
-      return Location(badUTF16: TestLocation(url: location.docUri.nativeURI.fileURL!, line: location.line, utf8Column: location.utf8Column, utf16Column: location.utf16Column))
+      return Location(badUTF16: TestLocation(url: try location.docUri.nativeURI.fileURL!, line: location.line, utf8Column: location.utf8Column, utf16Column: location.utf16Column))
     }
     
     try XCTAssertEqual(impls(at: testLoc("Protocol")), [loc("StructConformance")])

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -82,7 +82,7 @@ final class SKTests: XCTestCase {
     }
 
     XCTAssertEqual(jump.count, 1)
-    XCTAssertEqual(jump.first?.uri, locDef.docUri.nativeURI)
+    XCTAssertEqual(jump.first?.uri, try locDef.docUri.nativeURI)
     XCTAssertEqual(jump.first?.range.lowerBound, locDef.position)
 
     // MARK: Find references
@@ -94,9 +94,9 @@ final class SKTests: XCTestCase {
 
     let call = ws.testLoc("aaa:call")
     XCTAssertEqual(Set(refs), [
-      Location(TestLocation(url: URL(fileURLWithPath: resolveSymlinks(AbsolutePath(locDef.url.path)).pathString), line: locDef.line, utf8Column: locDef.utf8Column, utf16Column: locDef.utf16Column)),
-      Location(TestLocation(url: URL(fileURLWithPath: resolveSymlinks(AbsolutePath(locRef.url.path)).pathString), line: locRef.line, utf8Column: locRef.utf8Column, utf16Column: locRef.utf16Column)),
-      Location(TestLocation(url: URL(fileURLWithPath: resolveSymlinks(AbsolutePath(call.url.path)).pathString), line: call.line, utf8Column: call.utf8Column, utf16Column: call.utf16Column)),
+      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(locDef.url.path)).pathString), line: locDef.line, utf8Column: locDef.utf8Column, utf16Column: locDef.utf16Column)),
+      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(locRef.url.path)).pathString), line: locRef.line, utf8Column: locRef.utf8Column, utf16Column: locRef.utf16Column)),
+      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(call.url.path)).pathString), line: call.line, utf8Column: call.utf8Column, utf16Column: call.utf16Column)),
     ])
   }
 
@@ -131,7 +131,7 @@ final class SKTests: XCTestCase {
         return nil
       }
       XCTAssertEqual(jump.count, 1)
-      XCTAssertEqual(jump.first?.uri, locDef.docUri.nativeURI)
+      XCTAssertEqual(jump.first?.uri, try locDef.docUri.nativeURI)
       XCTAssertEqual(jump.first?.range.lowerBound, locDef.position)
 
       let tmpContents = try listdir(tmpDir)
@@ -334,7 +334,7 @@ final class SKTests: XCTestCase {
     guard ToolchainRegistry.shared.default?.clangd != nil else { return }
 
     let refLoc = ws.testLoc("Object:ref:main")
-    let expectedDoc = ws.testLoc("Object").docIdentifier.uri.nativeURI
+    let expectedDoc = try ws.testLoc("Object").docIdentifier.uri.nativeURI
     let refPos = Position(line: refLoc.position.line, utf16index: refLoc.utf16Column + 2)
 
     try ws.openDocument(refLoc.url, language: .c)

--- a/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
@@ -84,14 +84,14 @@ final class TypeHierarchyTests: XCTestCase {
       )
     }
 
-    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", at locName: String) -> TypeHierarchyItem {
+    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", at locName: String) throws -> TypeHierarchyItem {
       let location = loc(locName)
       return TypeHierarchyItem(
         name: name,
         kind: kind,
         tags: nil,
         detail: detail,
-        uri: location.uri.nativeURI,
+        uri: try location.uri.nativeURI,
         range: location.range,
         selectionRange: location.range
       )
@@ -100,70 +100,70 @@ final class TypeHierarchyTests: XCTestCase {
     // Test type hierarchy preparation
 
     assertEqualIgnoringData(try typeHierarchy(at: testLoc("P")), [
-      item("P", .interface, at: "P"),
+      try item("P", .interface, at: "P"),
     ])
     assertEqualIgnoringData(try typeHierarchy(at: testLoc("A")), [
-      item("A", .class, at: "A"),
+      try item("A", .class, at: "A"),
     ])
     assertEqualIgnoringData(try typeHierarchy(at: testLoc("S")), [
-      item("S", .struct, at: "S"),
+      try item("S", .struct, at: "S"),
     ])
     assertEqualIgnoringData(try typeHierarchy(at: testLoc("E")), [
-      item("E", .enum, at: "E"),
+      try item("E", .enum, at: "E"),
     ])
 
     // Test supertype hierarchy
 
     assertEqualIgnoringData(try supertypes(at: testLoc("A")), [])
     assertEqualIgnoringData(try supertypes(at: testLoc("B")), [
-      item("A", .class, at: "A"),
-      item("P", .interface, at: "P"),
+      try item("A", .class, at: "A"),
+      try item("P", .interface, at: "P"),
     ])
     assertEqualIgnoringData(try supertypes(at: testLoc("C")), [
-      item("B", .class, at: "B"),
+      try item("B", .class, at: "B"),
     ])
     assertEqualIgnoringData(try supertypes(at: testLoc("D")), [
-      item("A", .class, at: "A"),
+      try item("A", .class, at: "A"),
     ])
     assertEqualIgnoringData(try supertypes(at: testLoc("S")), [
-      item("P", .interface, at: "P"),
-      item("X", .interface, at: "X"), // Retroactive conformance
+      try item("P", .interface, at: "P"),
+      try item("X", .interface, at: "X"), // Retroactive conformance
     ])
     assertEqualIgnoringData(try supertypes(at: testLoc("E")), [
-      item("P", .interface, at: "P"),
-      item("Y", .interface, at: "Y"), // Retroactive conformance
-      item("Z", .interface, at: "Z"), // Retroactive conformance
+      try item("P", .interface, at: "P"),
+      try item("Y", .interface, at: "Y"), // Retroactive conformance
+      try item("Z", .interface, at: "Z"), // Retroactive conformance
     ])
 
     // Test subtype hierarchy (includes extensions)
 
     assertEqualIgnoringData(try subtypes(at: testLoc("A")), [
-      item("B", .class, at: "B"),
-      item("D", .class, at: "D"),
+      try item("B", .class, at: "B"),
+      try item("D", .class, at: "D"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("B")), [
-      item("C", .class, at: "C"),
+      try item("C", .class, at: "C"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("P")), [
-      item("B", .class, at: "B"),
-      item("S", .struct, at: "S"),
-      item("E", .enum, at: "E"),
+      try item("B", .class, at: "B"),
+      try item("S", .struct, at: "S"),
+      try item("E", .enum, at: "E"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("E")), [
-      item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
+      try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("S")), [
-      item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
-      item("S", .null, detail: "Extension at a.swift:16", at: "extS"),
+      try item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
+      try item("S", .null, detail: "Extension at a.swift:16", at: "extS"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("X")), [
-      item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
+      try item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("Y")), [
-      item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
+      try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
     ])
     assertEqualIgnoringData(try subtypes(at: testLoc("Z")), [
-      item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
+      try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
     ])
 
     // Ensure that type hierarchies can be fetched from uses too


### PR DESCRIPTION
We are moving to a better model for TSC's path APIs in apple/swift-tools-support-core#353. The previous API is still available (but deprecated) as much as possible, but since SourceKit-LSP was using `resolveSymlinks` (which is now throwing) quite a bit, there are some changes necessary.