### PR TITLE
SKCore: allow non python build servers

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -119,7 +119,7 @@ public final class BuildServerBuildSystem {
   private func initializeBuildServer() throws {
     var serverPath = AbsolutePath(serverConfig.argv[0], relativeTo: projectRoot)
     var flags = Array(serverConfig.argv[1...])
-    if serverPath.suffix == "py" {
+    if serverPath.suffix == ".py" {
       flags = [serverPath.pathString] + flags
       guard let interpreterPath =
           lookupExecutablePath(filename: executable("python3"),


### PR DESCRIPTION
The commit https://github.com/apple/sourcekit-lsp/commit/79105208d53c727e109e5cc556ca533c384ee4a2 made build servers Python only. This pull requests adjusts server handling logic to use python interpreter only for the scripts with ".py" extension. 