### PR TITLE
BuildServerBuildSystem: share more code across platforms

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -71,14 +71,14 @@ public final class BuildServerBuildSystem {
     let configPath = projectRoot.appending(component: "buildServer.json")
     let config = try loadBuildServerConfig(path: configPath, fileSystem: fileSystem)
 #if os(Windows)
+    let pathEnvironmentVar = "Path"
+#else
+    let pathEnvironmentVar = "PATH"
+#endif
     self.searchPaths =
         getEnvSearchPaths(pathString: ProcessInfo.processInfo.environment["Path"],
                           currentWorkingDirectory: fileSystem.currentWorkingDirectory)
-#else
-    self.searchPaths =
-        getEnvSearchPaths(pathString: ProcessInfo.processInfo.environment["PATH"],
-                          currentWorkingDirectory: fileSystem.currentWorkingDirectory)
-#endif
+
     self.buildFolder = buildFolder
     self.projectRoot = projectRoot
     self.requestQueue = DispatchQueue(label: "build_server_request_queue")


### PR DESCRIPTION
Simply adjust the variable name spelling rather than duplicate the logic.  This is a minor cleanup, NFC.

Co-authored-by: Alex Hoppen <alex@alexhoppen.de>