### PR TITLE
SKCore: use `PackageModel.BuildFlags` instead of TSC

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -108,6 +108,7 @@ let package = Package(
           "LanguageServerProtocol",
           "LanguageServerProtocolJSONRPC",
           "SKSupport",
+          .product(name: "SwiftPMDataModel-auto", package: "SwiftPM"),
           .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         ],
         exclude: ["CMakeLists.txt"]),

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -13,7 +13,7 @@
 import SKSupport
 
 import struct TSCBasic.AbsolutePath
-import struct TSCUtility.BuildFlags
+import struct PackageModel.BuildFlags
 
 /// Build configuration
 public struct BuildSetup {

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(SKCore PRIVATE
   BuildServerProtocol
   LanguageServerProtocol
   LanguageServerProtocolJSONRPC
+  PackageModel
   SKSupport
   SourceKitD
   TSCUtility)

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -24,7 +24,7 @@ import LSPTestSupport
 import class TSCBasic.Process
 import func TSCBasic.resolveSymlinks
 import struct TSCBasic.AbsolutePath
-import struct TSCUtility.BuildFlags
+import struct PackageModel.BuildFlags
 
 public final class SKSwiftPMTestWorkspace {
 

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -22,7 +22,7 @@ import LSPTestSupport
 
 import struct TSCBasic.AbsolutePath
 import enum TSCUtility.Platform
-import struct TSCUtility.BuildFlags
+import struct PackageModel.BuildFlags
 
 public typealias URL = Foundation.URL
 

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -15,7 +15,7 @@ import SKCore
 import TSCBasic
 import XCTest
 
-import struct TSCUtility.BuildFlags
+import struct PackageModel.BuildFlags
 
 final class FallbackBuildSystemTests: XCTestCase {
 
@@ -50,7 +50,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let sdk =  AbsolutePath("/my/sdk")
     let source = AbsolutePath("/my/source.swift")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(xswiftc: [
+    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(swiftCompilerFlags: [
       "-Xfrontend",
       "-debug-constraints"
     ]))
@@ -79,7 +79,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let sdk =  AbsolutePath("/my/sdk")
     let source = AbsolutePath("/my/source.swift")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(xswiftc: [
+    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(swiftCompilerFlags: [
       "-sdk",
       "/some/custom/sdk",
       "-Xfrontend",
@@ -135,7 +135,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let sdk =  AbsolutePath("/my/sdk")
     let source = AbsolutePath("/my/source.cpp")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(xcxx: [
+    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cxxCompilerFlags: [
       "-v"
     ]))
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
@@ -160,7 +160,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let sdk =  AbsolutePath("/my/sdk")
     let source = AbsolutePath("/my/source.cpp")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(xcxx: [
+    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cxxCompilerFlags: [
       "-isysroot",
       "/my/custom/sdk",
       "-v"
@@ -197,7 +197,7 @@ final class FallbackBuildSystemTests: XCTestCase {
   func testCWithCustomFlags() {
     let source = AbsolutePath("/my/source.c")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(xcc: [
+    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cCompilerFlags: [
       "-v"
     ]))
     let bs = FallbackBuildSystem(buildSetup: buildSetup)

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -22,7 +22,7 @@ import SKTestSupport
 import TSCBasic
 import XCTest
 
-import struct TSCUtility.BuildFlags
+import struct PackageModel.BuildFlags
 
 final class SwiftPMWorkspaceTests: XCTestCase {
 
@@ -153,7 +153,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let config = BuildSetup(
           configuration: .release,
           path: packageRoot.appending(component: "non_default_build_path"),
-          flags: BuildFlags(xcc: ["-m32"], xcxx: [], xswiftc: ["-typecheck"], xlinker: []))
+          flags: BuildFlags(cCompilerFlags: ["-m32"], swiftCompilerFlags: ["-typecheck"]))
 
       let ws = try! SwiftPMWorkspace(
         workspacePath: packageRoot,


### PR DESCRIPTION
As TSC would like to deprecate `BuildFlags` (https://github.com/apple/swift-tools-support-core/pull/359), let's use new `struct BuildFlags` from SwiftPM's `PackageModel`.