### PR TITLE
Add dependency on IDEUtils

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,7 @@ let package = Package(
           .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
           .product(name: "SwiftSyntax", package: "swift-syntax"),
           .product(name: "SwiftParser", package: "swift-syntax"),
+          .product(name: "IDEUtils", package: "swift-syntax"),
         ],
         exclude: ["CMakeLists.txt"]),
 

--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -12,6 +12,7 @@
 
 import LanguageServerProtocol
 import SwiftSyntax
+import IDEUtils
 
 /// Syntax highlighting tokens for a particular document.
 public struct DocumentTokens {


### PR DESCRIPTION
Reflect for the fact that SyntaxClassifier has moved to a new `IDEUtils` module.