### PR TITLE
SourceKitLSP: add new dependency introduced in SwiftSyntax

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(SourceKitLSP PUBLIC
   SwiftSyntax::SwiftParser
   SwiftSyntax::SwiftDiagnostics
   SwiftSyntax::SwiftSyntax
+  SwiftSyntax::IDEUtils
   TSCUtility)
 target_link_libraries(SourceKitLSP PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)


### PR DESCRIPTION
Add a dependency on IDEUtils that is missing in the build.