### PR TITLE
Return a .serverCancelled error code if the server cancels a request 

### DIFF
--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -110,7 +110,7 @@ extension LocalConnection: Connection {
   public func send<Request>(_ request: Request, queue: DispatchQueue, reply: @escaping (LSPResult<Request.Response>) -> Void) -> RequestID where Request: RequestType {
     let id = nextRequestID()
     guard let handler = handler else {
-      queue.async { reply(.failure(.cancelled)) }
+      queue.async { reply(.failure(.serverCancelled)) }
       return id
     }
 

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -101,7 +101,9 @@ public struct ResponseError: Error, Codable, Hashable {
 extension ResponseError {
   // MARK: Convencience properties for common errors.
 
-  public static var cancelled: ResponseError = ResponseError(code: .cancelled, message: "request cancelled")
+  public static var cancelled: ResponseError = ResponseError(code: .cancelled, message: "request cancelled by client")
+
+  public static var serverCancelled: ResponseError = ResponseError(code: .serverCancelled, message: "request cancelled by server")
 
   public static func workspaceNotOpen(_ uri: DocumentURI) -> ResponseError {
     return ResponseError(code: .workspaceNotOpen, message: "No workspace containing '\(uri)' found")

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -404,7 +404,7 @@ extension JSONRPCConnection: Connection {
       let id = nextRequestID()
 
       guard readyToSend() else {
-        reply(.failure(.cancelled))
+        reply(.failure(.serverCancelled))
         return id
       }
 

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -60,11 +60,11 @@ extension SwiftLanguageServer {
     if req.params.context?.triggerKind == .triggerFromIncompleteCompletions {
       guard let currentSession = currentCompletionSession else {
         log("triggerFromIncompleteCompletions with no existing completion session", level: .warning)
-        return req.reply(.failure(.cancelled))
+        return req.reply(.failure(.serverCancelled))
       }
       guard currentSession.uri == snapshot.document.uri, currentSession.utf8StartOffset == offset else {
         log("triggerFromIncompleteCompletions with incompatible completion session; expected \(currentSession.uri)@\(currentSession.utf8StartOffset), but got \(snapshot.document.uri)@\(offset)", level: .warning)
-        return req.reply(.failure(.cancelled))
+        return req.reply(.failure(.serverCancelled))
       }
       session = currentSession
     } else {

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -85,7 +85,7 @@ class CodeCompletionSession {
           switch self.state {
           case .closed, .opening(_):
             // Don't try again.
-            completion(.failure(.cancelled))
+            completion(.failure(.serverCancelled))
           case .open:
             self._update(filterText: filterText, position: position, in: snapshot, options: options, completion: completion)
           }
@@ -134,7 +134,7 @@ class CodeCompletionSession {
         return completion(.failure(ResponseError(result.failure!)))
       }
       if case .closed = self.state {
-        return completion(.failure(.cancelled))
+        return completion(.failure(.serverCancelled))
       }
 
       self.state = .open

--- a/Sources/SourceKitLSP/Swift/SourceKitD+ResponseError.swift
+++ b/Sources/SourceKitLSP/Swift/SourceKitD+ResponseError.swift
@@ -17,7 +17,7 @@ extension ResponseError {
   public init(_ value: SKDError) {
     switch value {
     case .requestCancelled:
-      self = .cancelled
+      self = .serverCancelled
     case .requestFailed(let desc):
       self = .unknown("sourcekitd request failed: \(desc)")
     case .requestInvalid(let desc):

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -584,7 +584,7 @@ extension SwiftLanguageServer {
     let position = req.params.position
     cursorInfo(uri, position..<position) { result in
       guard let cursorInfo: CursorInfo = result.success ?? nil else {
-        if let error = result.failure, error != .responseError(.cancelled) {
+        if let error = result.failure, error != .responseError(.serverCancelled) {
           log("cursor info failed \(uri):\(position): \(error)", level: .warning)
         }
         return req.reply(nil)

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -110,7 +110,7 @@ final class CodingTests: XCTestCase {
     {
       "error" : {
         "code" : -32800,
-        "message" : "request cancelled"
+        "message" : "request cancelled by client"
       },
       "id" : 2,
       "jsonrpc" : "2.0"
@@ -132,7 +132,7 @@ final class CodingTests: XCTestCase {
     {
       "error" : {
         "code" : -32800,
-        "message" : "request cancelled"
+        "message" : "request cancelled by client"
       },
       "id" : null,
       "jsonrpc" : "2.0"

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -189,7 +189,7 @@ class ConnectionTests: XCTestCase {
 
     client.send(EchoNotification(string: "hi"))
     _ = client.send(EchoRequest(string: "yo")) { result in
-      XCTAssertEqual(result, .failure(ResponseError.cancelled))
+      XCTAssertEqual(result, .failure(ResponseError.serverCancelled))
       expectation.fulfill()
     }
 


### PR DESCRIPTION
https://github.com/apple/sourcekit-lsp/pull/669#discussion_r1033864357

`.cancelled` should only be returned if the client requested cancellation.