### PR TITLE
Fix CMake build by adding missed new files to CMakeLists

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(LanguageServerProtocol STATIC
   Requests/InlineValueRequest.swift
   Requests/LinkedEditingRangeRequest.swift
   Requests/MonikersRequest.swift
+  Requests/OpenInterfaceRequest.swift
   Requests/PollIndexRequest.swift
   Requests/PrepareRenameRequest.swift
   Requests/ReferencesRequest.swift

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(SourceKitLSP PRIVATE
   Swift/Diagnostic.swift
   Swift/EditorPlaceholder.swift
   Swift/ExpressionTypeInfo.swift
+  Swift/OpenInterface.swift
   Swift/SemanticRefactorCommand.swift
   Swift/SemanticRefactoring.swift
   Swift/SourceKitD+ResponseError.swift


### PR DESCRIPTION
The CMake build otherwise currently fails.
e.g. https://ci-external.swift.org/job/swift-driver-PR-windows/227/console