### PR TITLE
LanguageServerProtocol: add missing file to CMakeLists.txt

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -63,7 +63,9 @@ add_library(LanguageServerProtocol STATIC
   Requests/InlineValueRefreshRequest.swift
   Requests/InlineValueRequest.swift
   Requests/LinkedEditingRangeRequest.swift
+  Sources/LanguageServerProtocol/Messages.swift
   Requests/MonikersRequest.swift
+  Requests/OpenInterfaceRequest.swift
   Requests/PollIndexRequest.swift
   Requests/PrepareRenameRequest.swift
   Requests/ReferencesRequest.swift

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(SourceKitLSP PRIVATE
   Swift/Diagnostic.swift
   Swift/EditorPlaceholder.swift
   Swift/ExpressionTypeInfo.swift
+  Swift/OpenInterface.swift
   Swift/SemanticRefactorCommand.swift
   Swift/SemanticRefactoring.swift
   Swift/SourceKitD+ResponseError.swift


### PR DESCRIPTION
New files added in #668 weren't added to corresponding `CMakeLists.txt` files.