### PR TITLE
Update `inlayHintProvider` registration

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -106,7 +106,7 @@ public struct ServerCapabilities: Codable, Hashable {
   public var semanticTokensProvider: SemanticTokensOptions?
 
   /// Whether the server supports the `textDocument/inlayHint` family of requests.
-  public var inlayHintProvider: InlayHintOptions?
+  public var inlayHintProvider: ValueOrBool<InlayHintOptions>?
 
   /// Whether the server provides selection range support.
   public var selectionRangeProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>?
@@ -151,7 +151,7 @@ public struct ServerCapabilities: Codable, Hashable {
     callHierarchyProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     typeHierarchyProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     semanticTokensProvider: SemanticTokensOptions? = nil,
-    inlayHintProvider: InlayHintOptions? = nil,
+    inlayHintProvider: ValueOrBool<InlayHintOptions>? = nil,
     selectionRangeProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     linkedEditingRangeProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     monikerProvider: ValueOrBool<MonikerOptions>? = nil,

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -696,8 +696,16 @@ extension SourceKitServer {
         self.dynamicallyRegisterCapability($0, registry)
       }
     }
-    if let inlayHintOptions = server.inlayHintProvider {
-      registry.registerInlayHintIfNeeded(options: inlayHintOptions, for: languages) {
+    if let inlayHintProvider = server.inlayHintProvider,
+       inlayHintProvider.isSupported {
+      let options: InlayHintOptions
+      switch inlayHintProvider {
+      case .bool(_):
+        options = InlayHintOptions()
+      case .value(let opts):
+        options = opts
+      }
+      registry.registerInlayHintIfNeeded(options: options, for: languages) {
         self.dynamicallyRegisterCapability($0, registry)
       }
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -369,8 +369,8 @@ extension SwiftLanguageServer {
           tokenModifiers: SyntaxHighlightingToken.Modifiers.allModifiers.map { $0.lspName! }),
         range: .bool(true),
         full: .bool(true)),
-      inlayHintProvider: InlayHintOptions(
-        resolveProvider: false)
+      inlayHintProvider: .value(InlayHintOptions(
+        resolveProvider: false))
     ))
   }
 


### PR DESCRIPTION
The LSP API allows a boolean here:
```
	/**
	 * The server provides inlay hints.
	 *
	 * @since 3.17.0
	 */
	inlayHintProvider?: boolean | InlayHintOptions
		 | InlayHintRegistrationOptions;
```

Update our server capabilities to allow this.

Resolves rdar://102913088.