### PR TITLE
build: repair the build after the TSCUtility changes

### DIFF
--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(SKSupport STATIC
   dlopen.swift)
 set_target_properties(SKSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(SKSupport PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -11,4 +11,5 @@ add_library(SKSupport STATIC
 set_target_properties(SKSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SKSupport PRIVATE
+  TSCBasic
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/SourceKitD/CMakeLists.txt
+++ b/Sources/SourceKitD/CMakeLists.txt
@@ -15,4 +15,6 @@ set_target_properties(SourceKitD PROPERTIES
 target_link_libraries(SourceKitD PRIVATE
   Csourcekitd
   LSPLogging
-  SKSupport)
+  SKSupport
+  TSCBasic
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)


### PR DESCRIPTION
SKSupport now requires a link against Foundation, update the build system to track that dependency.