### PR TITLE
Ensure there are always newlines in a generated markdown comment

### DIFF
--- a/Sources/SourceKitLSP/Swift/CommentXML.swift
+++ b/Sources/SourceKitLSP/Swift/CommentXML.swift
@@ -128,6 +128,7 @@ private struct XMLToMarkdown {
       out += "```\(node.attributes?.first(where: { $0.name == "language" })?.stringValue ?? "")\n"
       toMarkdown(node.children, separator: "\n")
       out += "```"
+      newlineIfNeeded(count: 2)
 
     case "zCodeLineNumbered":
       lineNumber += 1

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -917,6 +917,8 @@ final class LocalSwiftTests: XCTestCase {
       ```
       a
       ```
+
+
       """)
 
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
@@ -925,6 +927,8 @@ final class LocalSwiftTests: XCTestCase {
       ```
       1.\ta
       ```
+
+
       """)
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing>
@@ -933,6 +937,8 @@ final class LocalSwiftTests: XCTestCase {
       1.\ta
       2.\tb
       ```
+
+      
       """)
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
       <Class><CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing><CodeListing><zCodeLineNumbered>c</zCodeLineNumbered><zCodeLineNumbered>d</zCodeLineNumbered></CodeListing></Class>
@@ -946,6 +952,8 @@ final class LocalSwiftTests: XCTestCase {
       1.\tc
       2.\td
       ```
+
+
       """)
 
     XCTAssertEqual(try! xmlDocumentationToMarkdown("""
@@ -1038,6 +1046,8 @@ final class LocalSwiftTests: XCTestCase {
       1.\tlet greeting = "Welcome!"
       2.\t
       ```
+
+
       """)
 
     XCTAssertEqual(try! xmlDocumentationToMarkdown(
@@ -1079,6 +1089,45 @@ final class LocalSwiftTests: XCTestCase {
     ### Throws
 
     Error.missingDocument if the document is not open.
+    """)
+
+    XCTAssertEqual(try! xmlDocumentationToMarkdown(
+      "<Class>" +
+        "<Name>S</Name>" +
+        "<USR>s:1a1SV</USR>" +
+        "<Declaration>struct S</Declaration>" +
+        "<CommentParts>" +
+          "<Discussion>" +
+            #"<CodeListing language="swift">"# +
+              "<zCodeLineNumbered>" +
+                "<![CDATA[let S = 12456]]>" +
+              "</zCodeLineNumbered>" +
+              "<zCodeLineNumbered></zCodeLineNumbered>" +
+            "</CodeListing>" +
+            "<rawHTML>" +
+              "<![CDATA[<h2>]]>" +
+            "</rawHTML>Title<rawHTML>" +
+              "<![CDATA[</h2>]]>" +
+            "</rawHTML>" +
+            "<Para>Details.</Para>" +
+          "</Discussion>" +
+        "</CommentParts>" +
+      "</Class>"), """
+    ```swift
+    struct S
+    ```
+
+    ---
+    ### Discussion
+
+    ```swift
+    1.\tlet S = 12456
+    2.\t
+    ```
+
+    <h2>Title</h2>
+
+    Details.
     """)
   }
 


### PR DESCRIPTION
Fixes #690
Fixes rdar://103911070