### PR TITLE
NFC: add `.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Package.resolved
 /*.sublime-workspace
 /.swiftpm
 .*.sw?
+.vscode


### PR DESCRIPTION
When running tests with VS Code, it creates additional `launch.json` which there's little sense to share between repository clones. Let's prevent it from being committed by accident.