### PR TITLE
[5.8] Adjustments because SwiftSyntax cherry-picks most API changes from main to release/5.8

### DIFF
--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -402,7 +402,6 @@ final class SemanticTokensTests: XCTestCase {
       Token(line: 0, utf16index: 5, length: 1, kind: .identifier),
       Token(line: 0, utf16index: 7, length: 1, kind: .identifier),
       Token(line: 0, utf16index: 10, length: 3, kind: .struct, modifiers: .defaultLibrary),
-      Token(line: 0, utf16index: 15, length: 1, kind: .keyword),
       Token(line: 0, utf16index: 17, length: 1, kind: .identifier),
       Token(line: 0, utf16index: 20, length: 6, kind: .struct, modifiers: .defaultLibrary),
     ])


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1285.

This cherry-picks the following PRs to `release/5.8` to update this repo for the SwiftSyntax API changes cherry-picked to `release/5.8` by https://github.com/apple/swift-syntax/pull/1285:
- https://github.com/apple/sourcekit-lsp/pull/692