### PR TITLE
SKCore: fix `identifer` typo in comments

### DIFF
--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -25,7 +25,7 @@ import var TSCBasic.localFileSystem
 /// toolchain, such as the contents from `/usr/bin`.
 public final class Toolchain {
 
-  /// The unique toolchain identifer.
+  /// The unique toolchain identifier.
   ///
   /// For an xctoolchain, this is a reverse domain name e.g. "com.apple.dt.toolchain.XcodeDefault".
   /// Otherwise, it is typically derived from `path`.

--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -23,7 +23,7 @@ import struct TSCBasic.FileSystemError
 /// A helper type for decoding the Info.plist or ToolchainInfo.plist file from an .xctoolchain.
 public struct XCToolchainPlist {
 
-  /// The toolchain identifer e.g. "com.apple.dt.toolchain.XcodeDefault".
+  /// The toolchain identifier e.g. "com.apple.dt.toolchain.XcodeDefault".
   public var identifier: String
 
   /// The toolchain's human-readable name.


### PR DESCRIPTION
`identifer` -> `identifier`