### PR TITLE
[5.8] Update for SwiftSyntax if/switch expression work

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1083,7 +1083,7 @@ extension SwiftLanguageServer {
             end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
         }
 
-        override func visit(_ node: SwitchStmtSyntax) -> SyntaxVisitorContinueKind {
+        override func visit(_ node: SwitchExprSyntax) -> SyntaxVisitorContinueKind {
           return self.addFoldingRange(
             start: node.cases.position.utf8Offset,
             end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)


### PR DESCRIPTION
*5.8 cherry-pick of https://github.com/apple/sourcekit-lsp/pull/672*
