### PR TITLE
Fix uses of deprecated non-throwing `AbsolutePath.init`

### DIFF
--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -162,7 +162,7 @@ public struct JSONCompilationDatabase: CompilationDatabase, Equatable {
     let url = command.url
     pathToCommands[url, default: []].append(commands.count)
 
-    let canonical = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(url.path)).pathString)
+    let canonical = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: url.path)).pathString)
     if canonical != url {
       pathToCommands[canonical, default: []].append(commands.count)
     }

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -83,7 +83,10 @@ extension ToolchainRegistry {
   /// let tr = ToolchainRegistry()
   /// tr.scanForToolchains()
   /// ```
-  public convenience init(installPath: AbsolutePath? = nil, _ fileSystem: FileSystem) {
+  public convenience init(
+    installPath: AbsolutePath? = nil, 
+    _ fileSystem: FileSystem
+  ) {
     self.init()
     scanForToolchains(installPath: installPath, fileSystem)
   }
@@ -236,13 +239,15 @@ extension ToolchainRegistry {
     installPath: AbsolutePath? = nil,
     environmentVariables: [String] = ["SOURCEKIT_TOOLCHAIN_PATH"],
     xcodes: [AbsolutePath] = [currentXcodeDeveloperPath].compactMap({$0}),
-    xctoolchainSearchPaths: [AbsolutePath] = [
-      AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains"),
-      AbsolutePath("/Library/Developer/Toolchains"),
-    ],
+    xctoolchainSearchPaths: [AbsolutePath]? = nil,
     pathVariables: [String] = ["SOURCEKIT_PATH", "PATH", "Path"],
-    _ fileSystem: FileSystem)
-  {
+    _ fileSystem: FileSystem
+  ) {
+    let xctoolchainSearchPaths = try! xctoolchainSearchPaths ?? [
+      AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains"),
+      AbsolutePath(validating: "/Library/Developer/Toolchains"),
+    ]
+
     queue.sync {
       _scanForToolchains(environmentVariables: environmentVariables, setDefault: true, fileSystem)
       if let installPath = installPath,

--- a/Sources/SKSupport/FileSystem.swift
+++ b/Sources/SKSupport/FileSystem.swift
@@ -16,22 +16,24 @@ import struct TSCBasic.AbsolutePath
 
 /// The home directory of the current user (same as returned by Foundation's `NSHomeDirectory` method).
 public var homeDirectoryForCurrentUser: AbsolutePath {
-  return AbsolutePath(NSHomeDirectory())
+  get throws {
+    return try AbsolutePath(validating: NSHomeDirectory())
+  }
 }
 
 extension AbsolutePath {
 
   /// Inititializes an absolute path from a string, expanding a leading `~` to `homeDirectoryForCurrentUser` first.
-  public init(expandingTilde path: String) {
+  public init(expandingTilde path: String) throws {
     if path.first == "~" {
-      self.init(homeDirectoryForCurrentUser, String(path.dropFirst(2)))
+      try self.init(homeDirectoryForCurrentUser, String(path.dropFirst(2)))
     } else {
-      self.init(path)
+      try self.init(validating: path)
     }
   }
 }
 
 /// The directory to write generated module interfaces
 public var defaultDirectoryForGeneratedInterfaces: AbsolutePath {
-  return AbsolutePath(NSTemporaryDirectory()).appending(component: "GeneratedInterfaces")
+  try! AbsolutePath(validating: NSTemporaryDirectory()).appending(component: "GeneratedInterfaces")
 }

--- a/Sources/SKSupport/FileSystem.swift
+++ b/Sources/SKSupport/FileSystem.swift
@@ -16,9 +16,7 @@ import struct TSCBasic.AbsolutePath
 
 /// The home directory of the current user (same as returned by Foundation's `NSHomeDirectory` method).
 public var homeDirectoryForCurrentUser: AbsolutePath {
-  get throws {
-    return try AbsolutePath(validating: NSHomeDirectory())
-  }
+  try! AbsolutePath(validating: NSHomeDirectory())
 }
 
 extension AbsolutePath {

--- a/Sources/SKTestSupport/FileSystem.swift
+++ b/Sources/SKTestSupport/FileSystem.swift
@@ -23,7 +23,7 @@ extension FileSystem {
   ///   - files: Dictionary from path (relative to root) to contents.
   public func createFiles(root: AbsolutePath = .root, files: [String: ByteString]) throws {
     for (path, contents) in files {
-      let path = AbsolutePath(path, relativeTo: root)
+      let path = try AbsolutePath(validating: path, relativeTo: root)
       try createDirectory(path.parentDirectory, recursive: true)
       try writeFileContents(path, bytes: contents)
     }

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -55,8 +55,12 @@ public final class SKSwiftPMTestWorkspace {
   public init(projectDir: URL, tmpDir: URL, toolchain: Toolchain, testServer: TestSourceKitServer? = nil) throws {
     self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
 
-    self.projectDir = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(projectDir.path)).pathString)
-    self.tmpDir = URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(tmpDir.path)).pathString)
+    self.projectDir = URL(
+      fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: projectDir.path)).pathString
+    )
+    self.tmpDir = URL(
+      fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: tmpDir.path)).pathString
+    )
     self.toolchain = toolchain
 
     let fm = FileManager.default
@@ -71,8 +75,8 @@ public final class SKSwiftPMTestWorkspace {
 
     self.sources = try TestSources(rootDirectory: sourceDir)
 
-    let sourcePath = AbsolutePath(sources.rootDirectory.path)
-    let buildPath = AbsolutePath(buildDir.path)
+    let sourcePath = try AbsolutePath(validating: sources.rootDirectory.path)
+    let buildPath = try AbsolutePath(validating: buildDir.path)
     let buildSetup = BuildSetup(configuration: .debug, path: buildPath, flags: BuildFlags())
 
     let swiftpm = try SwiftPMWorkspace(

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -55,7 +55,7 @@ public final class SKTibsTestWorkspace {
       removeTmpDir: removeTmpDir,
       toolchain: TibsToolchain(toolchain))
 
-    initWorkspace(clientCapabilities: clientCapabilities)
+    try initWorkspace(clientCapabilities: clientCapabilities)
   }
 
   public init(
@@ -72,11 +72,11 @@ public final class SKTibsTestWorkspace {
       tmpDir: tmpDir,
       toolchain: TibsToolchain(toolchain))
 
-    initWorkspace(clientCapabilities: clientCapabilities)
+    try initWorkspace(clientCapabilities: clientCapabilities)
   }
 
-  func initWorkspace(clientCapabilities: ClientCapabilities) {
-    let buildPath = AbsolutePath(builder.buildRoot.path)
+  func initWorkspace(clientCapabilities: ClientCapabilities) throws {
+    let buildPath = try AbsolutePath(validating: builder.buildRoot.path)
     let buildSystem = CompilationDatabaseBuildSystem(projectRoot: buildPath)
     let indexDelegate = SourceKitIndexDelegate()
     tibsWorkspace.delegate = indexDelegate

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -416,10 +416,13 @@ extension ClangLanguageServerShim {
 
     // The compile command changed, send over the new one.
     // FIXME: what should we do if we no longer have valid build settings?
-    if let compileCommand = clangBuildSettings?.compileCommand {
+    if 
+      let compileCommand = clangBuildSettings?.compileCommand,
+      let pathString = (try? AbsolutePath(validating: url.path))?.pathString 
+    {
       let note = DidChangeConfigurationNotification(settings: .clangd(
         ClangWorkspaceSettings(
-          compilationDatabaseChanges: [AbsolutePath(url.path).pathString: compileCommand])))
+          compilationDatabaseChanges: [pathString: compileCommand])))
       forwardNotificationToClangdOnQueue(note)
     }
   }

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -236,7 +236,7 @@ extension DocumentManager {
     return orLog("failed to edit document", level: .error) {
       try edit(
         note.textDocument.uri,
-        newVersion: note.textDocument.version ?? -1,
+        newVersion: note.textDocument.version,
         edits: note.contentChanges,
         willEditDocument: willEditDocument,
         updateDocumentTokens: updateDocumentTokens

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1534,8 +1534,11 @@ extension SourceKitServer {
         name = "\(symbol.name): \(conformances.map(\.symbol.name).joined(separator: ", "))"
       }
       // Add the file name and line to the detail string
-      if let url = location.uri.fileURL {
-        detail = "Extension at \(AbsolutePath(url.path).basename):\(location.range.lowerBound.line + 1)"
+      if 
+        let url = location.uri.fileURL, 
+        let basename = (try? AbsolutePath(validating: url.path))?.basename 
+      {
+        detail = "Extension at \(basename):\(location.range.lowerBound.line + 1)"
       } else if let moduleName = moduleName {
         detail = "Extension in \(moduleName)"
       } else {

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -215,7 +215,7 @@ final class CodingTests: XCTestCase {
   }
 
   // SR-16095
-  func testDecodeShutdownWithoutParams() {
+  func testDecodeShutdownWithoutParams() throws {
     let json = """
       {
         "id" : 1,
@@ -226,7 +226,7 @@ final class CodingTests: XCTestCase {
 
     let decoder = JSONDecoder()
     decoder.userInfo = defaultCodingInfo
-    let decodedValue = try! decoder.decode(JSONRPCMessage.self, from: json.data(using: .utf8)!)
+    let decodedValue = try decoder.decode(JSONRPCMessage.self, from: json.data(using: .utf8)!)
 
     guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = decodedValue, let decodedRequest = decodedValueOpaque as? ShutdownRequest else {
       XCTFail("decodedValue \(decodedValue) is not a ShutdownRequest")

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -35,9 +35,9 @@ class ConnectionTests: XCTestCase {
     connection.close()
   }
 
-  func testRound() {
-    let enc = try! JSONEncoder().encode(EchoRequest(string: "a/b"))
-    let dec = try! JSONDecoder().decode(EchoRequest.self, from: enc)
+  func testRound() throws {
+    let enc = try JSONEncoder().encode(EchoRequest(string: "a/b"))
+    let dec = try JSONDecoder().decode(EchoRequest.self, from: enc)
     XCTAssertEqual("a/b", dec.string)
   }
 
@@ -53,7 +53,7 @@ class ConnectionTests: XCTestCase {
     waitForExpectations(timeout: defaultTimeout)
   }
 
-  func testMessageBuffer() {
+  func testMessageBuffer() throws {
     let client = connection.client
     let clientConnection = connection.clientConnection
     let expectation = self.expectation(description: "note received")
@@ -63,8 +63,8 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    let note1 = try! JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
-    let note2 = try! JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
+    let note1 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
+    let note2 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
 
     let note1Str: String = "Content-Length: \(note1.count)\r\n\r\n\(String(data: note1, encoding: .utf8)!)"
     let note2Str: String = "Content-Length: \(note2.count)\r\n\r\n\(String(data: note2, encoding: .utf8)!)"

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -22,10 +22,8 @@ import XCTest
 final class BuildServerBuildSystemTests: XCTestCase {
 
   var root: AbsolutePath {
-    get throws {
-      try AbsolutePath(validating: XCTestCase.sklspInputsDirectory
-        .appendingPathComponent(testDirectoryName, isDirectory: true).path)
-    }
+    try! AbsolutePath(validating: XCTestCase.sklspInputsDirectory
+      .appendingPathComponent(testDirectoryName, isDirectory: true).path)
   } 
   let buildFolder = try! AbsolutePath(validating: NSTemporaryDirectory())
 

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -22,16 +22,24 @@ import XCTest
 final class BuildServerBuildSystemTests: XCTestCase {
 
   var root: AbsolutePath {
-    AbsolutePath(XCTestCase.sklspInputsDirectory
-      .appendingPathComponent(testDirectoryName, isDirectory: true).path)
+    get throws {
+      try AbsolutePath(validating: XCTestCase.sklspInputsDirectory
+        .appendingPathComponent(testDirectoryName, isDirectory: true).path)
+    }
   } 
-  let buildFolder = AbsolutePath(NSTemporaryDirectory())
+  let buildFolder = try! AbsolutePath(validating: NSTemporaryDirectory())
 
   func testServerInitialize() throws {
     let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
-    XCTAssertEqual(buildSystem.indexDatabasePath, AbsolutePath("some/index/db/path", relativeTo: root))
-    XCTAssertEqual(buildSystem.indexStorePath, AbsolutePath("some/index/store/path", relativeTo: root))
+    XCTAssertEqual(
+      buildSystem.indexDatabasePath,
+      try AbsolutePath(validating: "some/index/db/path", relativeTo: root)
+    )
+    XCTAssertEqual(
+      buildSystem.indexStorePath, 
+      try AbsolutePath(validating: "some/index/store/path", relativeTo: root)
+    )
   }
 
   func testSettings() throws {

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -182,15 +182,15 @@ final class CompilationDatabaseTests: XCTestCase {
       ]
       """)
 
-    XCTAssertNotNil(tryLoadCompilationDatabase(directory: try! AbsolutePath(validating: "/a"), fs))
+    XCTAssertNotNil(tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs))
   }
 
-  func testFixedCompilationDatabase() {
+  func testFixedCompilationDatabase() throws {
     let fs = InMemoryFileSystem()
-    try! fs.createDirectory(try! AbsolutePath(validating: "/a"))
+    try fs.createDirectory(try! AbsolutePath(validating: "/a"))
     XCTAssertNil(tryLoadCompilationDatabase(directory: try! AbsolutePath(validating: "/a"), fs))
 
-    try! fs.writeFileContents(try! AbsolutePath(validating: "/a/compile_flags.txt"), bytes: """
+    try fs.writeFileContents(try! AbsolutePath(validating: "/a/compile_flags.txt"), bytes: """
       -xc++
       -I
       libwidget/include/
@@ -200,7 +200,7 @@ final class CompilationDatabaseTests: XCTestCase {
     XCTAssertNotNil(db)
 
     XCTAssertEqual(db![URL(fileURLWithPath: "/a/b")], [
-      CompilationDatabase.Command(directory: try! AbsolutePath(validating: "/a").pathString,
+      CompilationDatabase.Command(directory: try AbsolutePath(validating: "/a").pathString,
                                   filename: "/a/b",
                                   commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"],
                                   output: nil)

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -19,9 +19,9 @@ import struct PackageModel.BuildFlags
 
 final class FallbackBuildSystemTests: XCTestCase {
 
-  func testSwift() {
-    let sdk =  AbsolutePath("/my/sdk")
-    let source = AbsolutePath("/my/source.swift")
+  func testSwift() throws {
+    let sdk = try AbsolutePath(validating: "/my/sdk")
+    let source = try AbsolutePath(validating: "/my/source.swift")
 
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = sdk
@@ -46,9 +46,9 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testSwiftWithCustomFlags() {
-    let sdk =  AbsolutePath("/my/sdk")
-    let source = AbsolutePath("/my/source.swift")
+  func testSwiftWithCustomFlags() throws {
+    let sdk = try AbsolutePath(validating: "/my/sdk")
+    let source = try AbsolutePath(validating: "/my/source.swift")
 
     let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(swiftCompilerFlags: [
       "-Xfrontend",
@@ -75,9 +75,9 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testSwiftWithCustomSDKFlag() {
-    let sdk =  AbsolutePath("/my/sdk")
-    let source = AbsolutePath("/my/source.swift")
+  func testSwiftWithCustomSDKFlag() throws {
+    let sdk = try AbsolutePath(validating: "/my/sdk")
+    let source = try AbsolutePath(validating: "/my/source.swift")
 
     let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(swiftCompilerFlags: [
       "-sdk",
@@ -107,9 +107,9 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testCXX() {
-    let sdk =  AbsolutePath("/my/sdk")
-    let source = AbsolutePath("/my/source.cpp")
+  func testCXX() throws {
+    let sdk = try AbsolutePath(validating: "/my/sdk")
+    let source = try AbsolutePath(validating: "/my/source.cpp")
 
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = sdk
@@ -131,9 +131,9 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testCXXWithCustomFlags() {
-    let sdk =  AbsolutePath("/my/sdk")
-    let source = AbsolutePath("/my/source.cpp")
+  func testCXXWithCustomFlags() throws {
+    let sdk = try AbsolutePath(validating: "/my/sdk")
+    let source = try AbsolutePath(validating: "/my/source.cpp")
 
     let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cxxCompilerFlags: [
       "-v"
@@ -156,9 +156,9 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testCXXWithCustomIsysroot() {
-    let sdk =  AbsolutePath("/my/sdk")
-    let source = AbsolutePath("/my/source.cpp")
+  func testCXXWithCustomIsysroot() throws {
+    let sdk = try AbsolutePath(validating: "/my/sdk")
+    let source = try AbsolutePath(validating: "/my/source.cpp")
 
     let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cxxCompilerFlags: [
       "-isysroot",
@@ -185,8 +185,8 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testC() {
-    let source = AbsolutePath("/my/source.c")
+  func testC() throws {
+    let source = try AbsolutePath(validating: "/my/source.c")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
     XCTAssertEqual(bs.settings(for: source.asURI, .c)?.compilerArguments, [
@@ -194,8 +194,8 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testCWithCustomFlags() {
-    let source = AbsolutePath("/my/source.c")
+  func testCWithCustomFlags() throws {
+    let source = try AbsolutePath(validating: "/my/source.c")
 
     let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cCompilerFlags: [
       "-v"
@@ -208,8 +208,8 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testObjC() {
-    let source = AbsolutePath("/my/source.m")
+  func testObjC() throws {
+    let source = try AbsolutePath(validating: "/my/source.m")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
     XCTAssertEqual(bs.settings(for: source.asURI, .objective_c)?.compilerArguments, [
@@ -217,8 +217,8 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testObjCXX() {
-    let source = AbsolutePath("/my/source.mm")
+  func testObjCXX() throws {
+    let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
     XCTAssertEqual(bs.settings(for: source.asURI, .objective_cpp)?.compilerArguments, [
@@ -226,8 +226,8 @@ final class FallbackBuildSystemTests: XCTestCase {
     ])
   }
 
-  func testUnknown() {
-    let source = AbsolutePath("/my/source.mm")
+  func testUnknown() throws {
+    let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
     XCTAssertNil(bs.settings(for: source.asURI, Language(rawValue: "unknown")))
   }

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -190,10 +190,10 @@ final class SupportTests: XCTestCase {
     }
   }
 
-  func testExpandingTilde() {
-    XCTAssertEqual(AbsolutePath(expandingTilde: "~/foo").basename, "foo")
-    XCTAssertNotEqual(AbsolutePath(expandingTilde: "~/foo").parentDirectory, .root)
-    XCTAssertEqual(AbsolutePath(expandingTilde: "/foo"), AbsolutePath("/foo"))
+  func testExpandingTilde() throws {
+    XCTAssertEqual(try AbsolutePath(expandingTilde: "~/foo").basename, "foo")
+    XCTAssertNotEqual(try AbsolutePath(expandingTilde: "~/foo").parentDirectory, .root)
+    XCTAssertEqual(try AbsolutePath(expandingTilde: "/foo"), try AbsolutePath(validating: "/foo"))
   }
 
   func testResultProjection() {

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -42,10 +42,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testUnparsablePackage() {
+  func testUnparsablePackage() throws {
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
             // swift-tools-version:4.2
@@ -63,10 +63,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testNoToolchain() {
+  func testNoToolchain() throws {
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
             // swift-tools-version:4.2
@@ -87,8 +87,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testBasicSwiftArgs() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
             // swift-tools-version:4.2
@@ -99,7 +99,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -134,11 +134,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testBuildSetup() {
+  func testBuildSetup() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
             // swift-tools-version:4.2
@@ -155,7 +155,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           path: packageRoot.appending(component: "non_default_build_path"),
           flags: BuildFlags(cCompilerFlags: ["-m32"], swiftCompilerFlags: ["-typecheck"]))
 
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -174,11 +174,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testManifestArgs() {
+  func testManifestArgs() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
             // swift-tools-version:4.2
@@ -189,7 +189,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -203,11 +203,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testMultiFileSwift() {
+  func testMultiFileSwift() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-      try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Sources/lib/b.swift": "",
         "pkg/Package.swift": """
@@ -219,7 +219,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -237,11 +237,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testMultiTargetSwift() {
+  func testMultiTargetSwift() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/libA/a.swift": "",
         "pkg/Sources/libB/b.swift": "",
         "pkg/Sources/libC/include/libC.h": "",
@@ -259,7 +259,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -291,11 +291,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testUnknownFile() {
+  func testUnknownFile() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/libA/a.swift": "",
         "pkg/Sources/libB/b.swift": "",
         "pkg/Package.swift": """
@@ -309,7 +309,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -326,8 +326,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testBasicCXXArgs() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.cpp": "",
         "pkg/Sources/lib/b.cpp": "",
         "pkg/Sources/lib/include/a.h": "",
@@ -341,7 +341,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -402,11 +402,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testDeploymentTargetSwift() {
+  func testDeploymentTargetSwift() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
             // swift-tools-version:5.0
@@ -418,7 +418,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
             """
       ])
       let packageRoot = tempDir.appending(component: "pkg")
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.shared,
         fileSystem: fs,
@@ -438,11 +438,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testSymlinkInWorkspaceSwift() {
+  func testSymlinkInWorkspaceSwift() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg_real/Sources/lib/a.swift": "",
         "pkg_real/Package.swift": """
         // swift-tools-version:4.2
@@ -453,12 +453,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = tempDir.appending(component: "pkg")
 
-      try! FileManager.default.createSymbolicLink(
+      try FileManager.default.createSymbolicLink(
         at: URL(fileURLWithPath: packageRoot.pathString),
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString))
 
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -487,11 +487,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testSymlinkInWorkspaceCXX() {
+  func testSymlinkInWorkspaceCXX() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg_real/Sources/lib/a.cpp": "",
         "pkg_real/Sources/lib/b.cpp": "",
         "pkg_real/Sources/lib/include/a.h": "",
@@ -506,12 +506,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let packageRoot = tempDir.appending(component: "pkg")
 
-      try! FileManager.default.createSymbolicLink(
+      try FileManager.default.createSymbolicLink(
         at: URL(fileURLWithPath: packageRoot.pathString),
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString))
 
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -535,8 +535,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testSwiftDerivedSources() throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Sources/lib/a.txt": "",
         "pkg/Package.swift": """
@@ -552,7 +552,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -569,8 +569,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
   func testNestedInvalidPackageSwift() throws {
     let fs = InMemoryFileSystem()
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/Package.swift": "// not a valid package",
         "pkg/Package.swift": """
         // swift-tools-version:4.2
@@ -581,7 +581,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
       let tr = ToolchainRegistry.shared
-      let ws = try! SwiftPMWorkspace(
+      let ws = try SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -397,7 +397,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let headerArgs = try ws._settings(for: header.asURI, .cpp)!.compilerArguments
       checkArgsCommon(headerArgs)
 
-      check("-c", "-x", "c++-header", AbsolutePath(URL(fileURLWithPath: header.pathString).path).pathString,
+      check("-c", "-x", "c++-header", try AbsolutePath(validating: URL(fileURLWithPath: header.pathString).path).pathString,
             arguments: headerArgs)
     }
   }

--- a/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
@@ -16,43 +16,43 @@ import XCTest
 
 final class SourceKitDRegistryTests: XCTestCase {
 
-  func testAdd() {
+  func testAdd() throws {
     let registry = SourceKitDRegistry()
 
-    let a = FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry)
-    let b = FakeSourceKitD.getOrCreate(AbsolutePath("/b"), in: registry)
-    let a2 = FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry)
+    let a = try FakeSourceKitD.getOrCreate(AbsolutePath(validating: "/a"), in: registry)
+    let b = try FakeSourceKitD.getOrCreate(AbsolutePath(validating: "/b"), in: registry)
+    let a2 = try FakeSourceKitD.getOrCreate(AbsolutePath(validating: "/a"), in: registry)
 
     XCTAssert(a === a2)
     XCTAssert(a !== b)
   }
 
-  func testRemove() {
+  func testRemove() throws {
     let registry = SourceKitDRegistry()
 
-    let a = FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry)
-    XCTAssert(registry.remove(AbsolutePath("/a")) === a)
-    XCTAssertNil(registry.remove(AbsolutePath("/a")))
+    let a = FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry)
+    XCTAssert(registry.remove(try AbsolutePath(validating: "/a")) === a)
+    XCTAssertNil(registry.remove(try AbsolutePath(validating: "/a")))
   }
 
-  func testRemoveResurrect() {
+  func testRemoveResurrect() throws {
     let registry = SourceKitDRegistry()
 
     @inline(never)
-    func scope(registry: SourceKitDRegistry) -> Int {
-      let a = FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry)
+    func scope(registry: SourceKitDRegistry) throws -> Int {
+      let a = FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry)
 
-      XCTAssert(a === FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry))
-      XCTAssert(registry.remove(AbsolutePath("/a")) === a)
+      XCTAssert(a === FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry))
+      XCTAssert(registry.remove(try AbsolutePath(validating: "/a")) === a)
       // Resurrected.
-      XCTAssert(a === FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry))
+      XCTAssert(a === FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry))
       // Remove again.
-      XCTAssert(registry.remove(AbsolutePath("/a")) === a)
+      XCTAssert(registry.remove(try AbsolutePath(validating: "/a")) === a)
       return (a as! FakeSourceKitD).token
     }
 
-    let id = scope(registry: registry)
-    let a2 = FakeSourceKitD.getOrCreate(AbsolutePath("/a"), in: registry)
+    let id = try scope(registry: registry)
+    let a2 = FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry)
     XCTAssertNotEqual(id, (a2 as! FakeSourceKitD).token)
   }
 }

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -38,7 +38,7 @@ final class CodeActionTests: XCTestCase {
     return try staticSourceKitTibsWorkspace(name: "SemanticRefactor", clientCapabilities: capabilities)
   }
 
-  func testCodeActionResponseLegacySupport() {
+  func testCodeActionResponseLegacySupport() throws {
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
     let codeAction = CodeAction(title: "1")
     let codeAction2 = CodeAction(title: "2", command: command)
@@ -59,10 +59,10 @@ final class CodeActionTests: XCTestCase {
      }
     """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try! JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
+    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
                                              from: data)
     response = .init(codeActions: [codeAction, codeAction2], clientCapabilities: capabilities)
-    let actions = try! JSONDecoder().decode([CodeAction].self, from: JSONEncoder().encode(response))
+    let actions = try JSONDecoder().decode([CodeAction].self, from: JSONEncoder().encode(response))
     XCTAssertEqual(actions, [codeAction, codeAction2])
 
     capabilityJson =
@@ -72,14 +72,14 @@ final class CodeActionTests: XCTestCase {
     }
     """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try! JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
+    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
                                              from: data)
     response = .init(codeActions: [codeAction, codeAction2], clientCapabilities: capabilities)
-    let commands = try! JSONDecoder().decode([Command].self, from: JSONEncoder().encode(response))
+    let commands = try JSONDecoder().decode([Command].self, from: JSONEncoder().encode(response))
     XCTAssertEqual(commands, [command])
   }
 
-  func testCodeActionResponseIgnoresSupportedKinds() {
+  func testCodeActionResponseIgnoresSupportedKinds() throws {
     // The client guarantees that unsupported kinds will be handled, and in
     // practice some clients use `"codeActionKind":{"valueSet":[]}`, since
     // they support all kinds anyway. So to avoid filtering all actions, we
@@ -106,7 +106,7 @@ final class CodeActionTests: XCTestCase {
     }
     """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try! JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
+    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
                                              from: data)
 
     response = .init(codeActions: actions, clientCapabilities: capabilities)
@@ -124,20 +124,20 @@ final class CodeActionTests: XCTestCase {
     }
     """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try! JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
+    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
                                              from: data)
 
     response = .init(codeActions: actions, clientCapabilities: capabilities)
     XCTAssertEqual(response, .codeActions([unspecifiedAction, refactorAction, quickfixAction]))
   }
 
-  func testCodeActionResponseCommandMetadataInjection() {
+  func testCodeActionResponseCommandMetadataInjection() throws {
     let url = URL(fileURLWithPath: "/a.swift")
     let textDocument = TextDocumentIdentifier(url)
     let expectedMetadata: LSPAny = {
       let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
-      let data = try! JSONEncoder().encode(metadata)
-      return try! JSONDecoder().decode(LSPAny.self, from: data)
+      let data = try JSONEncoder().encode(metadata)
+      return try JSONDecoder().decode(LSPAny.self, from: data)
     }()
     XCTAssertEqual(expectedMetadata, .dictionary(["sourcekitlsp_textDocument": ["uri": "file:///a.swift"]]))
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
@@ -167,12 +167,12 @@ final class CodeActionTests: XCTestCase {
     XCTAssertNil(response)
   }
 
-  func testCommandEncoding() {
+  func testCommandEncoding() throws {
     let dictionary: LSPAny = ["1": [nil, 2], "2": "text", "3": ["4": [1, 2]]]
     let array: LSPAny = [1, [2,"string"], dictionary]
     let arguments: LSPAny = [1, 2.2, "text", nil, array, dictionary]
     let command = Command(title: "Command", command: "command.id", arguments: [arguments, arguments])
-    let decoded = try! JSONDecoder().decode(Command.self, from: JSONEncoder().encode(command))
+    let decoded = try JSONDecoder().decode(Command.self, from: JSONEncoder().encode(command))
     XCTAssertEqual(decoded, command)
   }
 

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -134,7 +134,7 @@ final class CodeActionTests: XCTestCase {
   func testCodeActionResponseCommandMetadataInjection() throws {
     let url = URL(fileURLWithPath: "/a.swift")
     let textDocument = TextDocumentIdentifier(url)
-    let expectedMetadata: LSPAny = {
+    let expectedMetadata: LSPAny = try {
       let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
       let data = try JSONEncoder().encode(metadata)
       return try JSONDecoder().decode(LSPAny.self, from: data)

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -37,7 +37,7 @@ final class CompilationDatabaseTests: XCTestCase {
     let compilationDatabaseUrl = ws.builder.buildRoot.appendingPathComponent("compile_commands.json")
 
     _ = try ws.sources.edit({ builder in
-      let compilationDatabase = try JSONCompilationDatabase(file: AbsolutePath(compilationDatabaseUrl.path))
+      let compilationDatabase = try JSONCompilationDatabase(file: AbsolutePath(validating: compilationDatabaseUrl.path))
       let newCommands = compilationDatabase.allCommands.map { (command: CompilationDatabaseCompileCommand) -> CompilationDatabaseCompileCommand in
         var command = command
         command.commandLine.removeAll(where: { $0 == "-DFOO" })

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -18,15 +18,15 @@ import TSCBasic
 
 final class CompilationDatabaseTests: XCTestCase {
   func testModifyCompilationDatabase() throws {
-    let ws = try! mutableSourceKitTibsTestWorkspace(name: "ClangCrashRecoveryBuildSettings")!
+    let ws = try mutableSourceKitTibsTestWorkspace(name: "ClangCrashRecoveryBuildSettings")!
     let loc = ws.testLoc("loc")
 
-    try! ws.openDocument(loc.url, language: .cpp)
+    try ws.openDocument(loc.url, language: .cpp)
 
     // Do a sanity check and verify that we get the expected result from a hover response before modifing the compile commands.
 
     let highlightRequest = DocumentHighlightRequest(textDocument: loc.docIdentifier, position: Position(line: 9, utf16index: 3))
-    let preChangeHighlightResponse = try! ws.sk.sendSync(highlightRequest)
+    let preChangeHighlightResponse = try ws.sk.sendSync(highlightRequest)
     XCTAssertEqual(preChangeHighlightResponse, [
       DocumentHighlight(range: Position(line: 3, utf16index: 5)..<Position(line: 3, utf16index: 8), kind: .text),
       DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text)
@@ -65,7 +65,7 @@ final class CompilationDatabaseTests: XCTestCase {
     // Updating the build settings takes a few seconds.
     // Send code completion requests every second until we receive correct results.
     for _ in 0..<30 {
-      let postChangeHighlightResponse = try! ws.sk.sendSync(highlightRequest)
+      let postChangeHighlightResponse = try ws.sk.sendSync(highlightRequest)
 
       if postChangeHighlightResponse == expectedPostEditHighlight {
         didReceiveCorrectHighlight = true

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -102,9 +102,9 @@ final class SKTests: XCTestCase {
 
     let call = ws.testLoc("aaa:call")
     XCTAssertEqual(Set(refs), [
-      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(locDef.url.path)).pathString), line: locDef.line, utf8Column: locDef.utf8Column, utf16Column: locDef.utf16Column)),
-      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(locRef.url.path)).pathString), line: locRef.line, utf8Column: locRef.utf8Column, utf16Column: locRef.utf16Column)),
-      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(call.url.path)).pathString), line: call.line, utf8Column: call.utf8Column, utf16Column: call.utf16Column)),
+      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: locDef.url.path)).pathString), line: locDef.line, utf8Column: locDef.utf8Column, utf16Column: locDef.utf16Column)),
+      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: locRef.url.path)).pathString), line: locRef.line, utf8Column: locRef.utf8Column, utf16Column: locRef.utf16Column)),
+      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: call.url.path)).pathString), line: call.line, utf8Column: call.utf8Column, utf16Column: call.utf16Column)),
     ])
   }
 

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -96,8 +96,8 @@ final class WorkspaceTests: XCTestCase {
     ])
   }
 
-  func testMultipleClangdWorkspaces() {
-    guard let ws = try! staticSourceKitTibsWorkspace(name: "ClangModules") else { return }
+  func testMultipleClangdWorkspaces() throws {
+    guard let ws = try staticSourceKitTibsWorkspace(name: "ClangModules") else { return }
 
     let loc = ws.testLoc("main_file")
 
@@ -108,15 +108,15 @@ final class WorkspaceTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try! ws.openDocument(loc.url, language: .objective_c)
+    try ws.openDocument(loc.url, language: .objective_c)
 
     waitForExpectations(timeout: defaultTimeout)
 
-    let otherWs = try! staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings", server: ws.testServer)!
+    let otherWs = try staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings", server: ws.testServer)!
     assert(ws.testServer === otherWs.testServer, "Sanity check: The two workspaces should be opened in the same server")
     let otherLoc = otherWs.testLoc("loc")
 
-    try! otherWs.openDocument(otherLoc.url, language: .cpp)
+    try otherWs.openDocument(otherLoc.url, language: .cpp)
 
     // Do a sanity check and verify that we get the expected result from a hover response before crashing clangd.
 
@@ -126,7 +126,7 @@ final class WorkspaceTests: XCTestCase {
     ]
 
     let highlightRequest = DocumentHighlightRequest(textDocument: otherLoc.docIdentifier, position: Position(line: 9, utf16index: 3))
-    let highlightResponse = try! otherWs.sk.sendSync(highlightRequest)
+    let highlightResponse = try otherWs.sk.sendSync(highlightRequest)
     XCTAssertEqual(highlightResponse, expectedHighlightResponse)
   }
 


### PR DESCRIPTION
These warnings appeared after an update to TSC deprecated this initializer.