### PR TITLE
Add back -no-toolchain-stdlib-rpath when installing sourcekit-lsp on linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,16 @@
 // swift-tools-version:5.5
 
 import PackageDescription
+import Foundation
+
+// When building the toolchain on the CI, don't add the CI's runpath for the
+// final build before installing.
+let sourcekitLSPLinkSettings : [LinkerSetting]
+if ProcessInfo.processInfo.environment["SOURCEKIT_LSP_CI_INSTALL"] != nil {
+  sourcekitLSPLinkSettings = [ .unsafeFlags(["-no-toolchain-stdlib-rpath"], .when(platforms: [.linux, .android])) ]
+} else {
+  sourcekitLSPLinkSettings = []
+}
 
 let package = Package(
     name: "SourceKitLSP",
@@ -36,7 +46,8 @@ let package = Package(
           .product(name: "ArgumentParser", package: "swift-argument-parser"),
           .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         ],
-        exclude: ["CMakeLists.txt"]),
+        exclude: ["CMakeLists.txt"],
+        linkerSettings: sourcekitLSPLinkSettings),
 
       .target(
         name: "SourceKitLSP",
@@ -234,8 +245,6 @@ let package = Package(
 // When building with the swift build-script, use local dependencies whose contents are controlled
 // by the external environment. This allows sourcekit-lsp to take advantage of the automation used
 // for building the swift toolchain, such as `update-checkout`, or cross-repo PR tests.
-
-import Foundation
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -188,6 +188,8 @@ def build_single_product(product: str, swift_exec: str, args: argparse.Namespace
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
+    if args.action == 'install':
+      additional_env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
     cmd = [swift_exec, 'build', '--product', product] + swiftpm_args
     check_call(cmd, additional_env=additional_env, verbose=args.verbose)
 


### PR DESCRIPTION
Pull #597 incorrectly removed this, as it's still needed on ELF platforms.

That pull noted some SPM changes invalidate the need for this flag, but that's irrelevant since this flag is passed directly to the Swift compiler.

As a result of this flag's removal last year, the 5.8 snapshots for linux have this extraneous `/home/build-user/` rpath:
```
> readelf -d swift-5.8-DEVELOPMENT-SNAPSHOT-2022-12-20-a-ubuntu20.04/usr/bin/* | ag "File:|runpath" | ag sourcekit -A1
File: swift-5.8-DEVELOPMENT-SNAPSHOT-2022-12-20-a-ubuntu20.04/usr/bin/sourcekit-lsp
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/swift-nightly-install/usr/lib/swift/linux:$ORIGIN:$ORIGIN/../lib/swift/linux]
```
@ahoppen, please review.