### PR TITLE
[5.8] Add back -no-toolchain-stdlib-rpath when installing sourcekit-lsp on linux

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -188,6 +188,8 @@ def build_single_product(product: str, swift_exec: str, args: argparse.Namespace
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
+    if args.action == 'install':
+      additional_env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
     cmd = [swift_exec, 'build', '--product', product] + swiftpm_args
     check_call(cmd, additional_env=additional_env, verbose=args.verbose)
 


### PR DESCRIPTION
Cherrypick of #715

__Explanation:__ Pull #597 incorrectly removed this, as it's still needed on ELF platforms.

This was fine in 5.7.3, but will regress in 5.8 without this pull:
```
> readelf -d swift-5.*-ubuntu20.04/usr/bin/sourcekit-lsp |ag "File:|runpath"
File: swift-5.7.3-RELEASE-ubuntu20.04/usr/bin/sourcekit-lsp
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-5.8-DEVELOPMENT-SNAPSHOT-2023-03-07-a-ubuntu20.04/usr/bin/sourcekit-lsp
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/swift-nightly-install/usr/lib/swift/linux:$ORIGIN:$ORIGIN/../lib/swift/linux]
```
Note the incorrect `/home/build-user/...` runpath in the 5.8 snapshot, which could be a security issue.

__Scope:__ Only affects the runpath for the sourcekit-lsp executable on linux

__SR Issue:__ None

__Risk:__ None, simply lowers security risk

__Testing:__ The CI was run when this was merged into trunk, including a full toolchain build.

__Reviewer:__ @ahoppen

@airspeedswift, would be good to get this regression corrected before the 5.8 release. I will add an integration test in the coming weeks so that these runpath regressions don't happen again.
