### PR TITLE
[5.9] Update for SwiftSyntax regex changes

### DIFF
--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -96,6 +96,8 @@ extension SyntaxClassification {
       return (.number, [])
     case .stringLiteral:
       return (.string, [])
+    case .regexLiteral:
+      return (.regexp, [])
     case .poundDirectiveKeyword:
       return (.macro, [])
     case .buildConfigId, .objectLiteral:

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -488,6 +488,17 @@ final class SemanticTokensTests: XCTestCase {
     ])
   }
 
+  func testRegexSemanticTokens() {
+    let text = """
+      let r = /a[bc]*/
+      """
+    let tokens = openAndPerformSemanticTokensRequest(text: text)
+    XCTAssertEqual(tokens, [
+      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+      Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
+      Token(line: 0, utf16index: 8, length: 8, kind: .regexp),
+    ])
+  }
 
   func testOperatorDeclaration() {
     let text = """


### PR DESCRIPTION
*5.9 cherry-pick of https://github.com/apple/sourcekit-lsp/pull/724*

Update for https://github.com/apple/swift-syntax/pull/1486. Low risk, and improves syntax highlighting for regex literals.