### PR TITLE
Fix package manifest API `.branch` deprecation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -249,11 +249,11 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(name: "IndexStoreDB", url: "https://github.com/apple/indexstore-db.git", .branch("main")),
-    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(name: "IndexStoreDB", url: "https://github.com/apple/indexstore-db.git", branch: "main"),
+    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", branch: "main"),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "main"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2")),
-    .package(url: "https://github.com/apple/swift-syntax.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-syntax.git", branch: "main"),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
With Swift 5.7 we should use `branch:` name argument overload instead.