### PR TITLE
Send token with WorkDoneProgress

### DIFF
--- a/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
+++ b/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
@@ -10,9 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum WorkDoneProgress: NotificationType, Hashable {
+public struct WorkDoneProgress: NotificationType, Hashable {
   public static var method: String = "$/progress"
 
+  /// The progress token provided by the client or server.
+  public var token: ProgressToken
+
+  /// The progress data.
+  public var value: WorkDoneProgressKind
+
+  public init(token: ProgressToken, value: WorkDoneProgressKind) {
+    self.token = token
+    self.value = value
+  }
+}
+
+public enum WorkDoneProgressKind: Codable, Hashable {
   case begin(WorkDoneProgressBegin)
   case report(WorkDoneProgressReport)
   case end(WorkDoneProgressEnd)

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -1034,21 +1034,33 @@ final class CodingTests: XCTestCase {
   }
 
   func testWorkDoneProgress() {
-    checkCoding(WorkDoneProgress.begin(WorkDoneProgressBegin(title: "My Work")), json: """
+    checkCoding(WorkDoneProgress(token: ProgressToken.integer(3), value: WorkDoneProgressKind.begin(WorkDoneProgressBegin(title: "My Work"))), json: """
+    {
+      "token" : 3,
+      "value" : {
+        "kind" : "begin",
+        "title" : "My Work"
+      }
+    }
+    """)
+  }
+
+  func testWorkDoneProgressType() {
+    checkCoding(WorkDoneProgressKind.begin(WorkDoneProgressBegin(title: "My Work")), json: """
     {
       "kind" : "begin",
       "title" : "My Work"
     }
     """)
 
-    checkCoding(WorkDoneProgress.report(WorkDoneProgressReport(message: "Still working")), json: """
+    checkCoding(WorkDoneProgressKind.report(WorkDoneProgressReport(message: "Still working")), json: """
     {
       "kind" : "report",
       "message" : "Still working"
     }
     """)
 
-    checkCoding(WorkDoneProgress.end(WorkDoneProgressEnd()), json: """
+    checkCoding(WorkDoneProgressKind.end(WorkDoneProgressEnd()), json: """
     {
       "kind" : "end"
     }


### PR DESCRIPTION
This fixes the [$/progress](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#progress) notification, as it requires that the ProgressToken is sent with the value.

`swift test` works, theoretically it should probably be called `ProgressParams`, but it wouldn't reflect that it is a notification, so I just changed the enum to `WorkDoneProgressType`