### PR TITLE
ToolchainRegistryTests: avoid identity checks for `localFileSystem`

### DIFF
--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -520,7 +520,7 @@ private func makeToolchain(
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
 ) {
-  precondition(!clang && !swiftc && !clangd || fs === localFileSystem || !shouldChmod,
+  precondition(!clang && !swiftc && !clangd || !shouldChmod,
     "Cannot make toolchain binaries exectuable with InMemoryFileSystem")
 
   // tiny PE binary from: https://archive.is/w01DO


### PR DESCRIPTION
We'd like to remove `AnyObject` requirement from `FileSystem` in https://github.com/apple/swift-tools-support-core/pull/410, which will make identity checks on `any FileSystem` impossible. These checks were an anti-pattern anyway, especially in tests, which should be flexible enough to support an arbitrary file system implementation. If certain behavior is not available on `FileSystem` we should modify that protocol instead.