### PR TITLE
[5.9] Change version dependency on `swift-argument-parser` to from `upToNextMinor` to `upToNextMajor`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -252,7 +252,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     .package(name: "IndexStoreDB", url: "https://github.com/apple/indexstore-db.git", .branch("release/5.9")),
     .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.9")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.9")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
     .package(url: "https://github.com/apple/swift-syntax.git", .branch("release/5.9")),
   ]
 } else {


### PR DESCRIPTION
This will make SourceKit-LSP more tolerant with regard to which swift-argument-parser version it needs, resulting in fewer version conflicts for people who depend on SourceKit-LSP as a package dependency.
