### PR TITLE
Fix warnings for use of `try` in non-throwing context

### DIFF
--- a/Sources/SKSupport/FileSystem.swift
+++ b/Sources/SKSupport/FileSystem.swift
@@ -24,7 +24,7 @@ extension AbsolutePath {
   /// Inititializes an absolute path from a string, expanding a leading `~` to `homeDirectoryForCurrentUser` first.
   public init(expandingTilde path: String) throws {
     if path.first == "~" {
-      try self.init(homeDirectoryForCurrentUser, String(path.dropFirst(2)))
+      self.init(homeDirectoryForCurrentUser, String(path.dropFirst(2)))
     } else {
       try self.init(validating: path)
     }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -129,7 +129,7 @@ public final class SwiftPMWorkspace {
       buildConfiguration = .release
     }
 
-    self.buildParameters = try BuildParameters(
+    self.buildParameters = BuildParameters(
         dataPath: location.scratchDirectory.appending(component: triple.platformBuildPathComponent()),
         configuration: buildConfiguration,
         toolchain: toolchain,


### PR DESCRIPTION
Fixes "No calls to throwing functions occur within 'try' expression" warning that occurs in two difference places when building `SKSupport` and `SKSwiftPMWorkspace` targets.