### PR TITLE
Fix use of deprecated `AbsolutePath` and `RelativePath` initializers

### DIFF
--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -49,8 +49,8 @@ extension XCToolchainPlist {
   init(fromDirectory path: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
 #if os(macOS)
     let plistNames = [
-      RelativePath("ToolchainInfo.plist"), // Xcode
-      RelativePath("Info.plist"), // Swift.org
+      try RelativePath(validating: "ToolchainInfo.plist"), // Xcode
+      try RelativePath(validating: "Info.plist"), // Swift.org
     ]
 
     var missingPlistPath: AbsolutePath?

--- a/Sources/SKSupport/FileSystem.swift
+++ b/Sources/SKSupport/FileSystem.swift
@@ -24,7 +24,7 @@ extension AbsolutePath {
   /// Inititializes an absolute path from a string, expanding a leading `~` to `homeDirectoryForCurrentUser` first.
   public init(expandingTilde path: String) throws {
     if path.first == "~" {
-      try self.init(homeDirectoryForCurrentUser, String(path.dropFirst(2)))
+      try self.init(homeDirectoryForCurrentUser, validating: String(path.dropFirst(2)))
     } else {
       try self.init(validating: path)
     }


### PR DESCRIPTION
Non-throwing overloads are deprecated, we should use throwing ones with `validating:` argument label.