### PR TITLE
[5.9] Rename IDEUtils to SwiftIDEUtils

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
           .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
           .product(name: "SwiftSyntax", package: "swift-syntax"),
           .product(name: "SwiftParser", package: "swift-syntax"),
-          .product(name: "IDEUtils", package: "swift-syntax"),
+          .product(name: "SwiftIDEUtils", package: "swift-syntax"),
         ],
         exclude: ["CMakeLists.txt"]),
 

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(SourceKitLSP PUBLIC
   SwiftSyntax::SwiftParser
   SwiftSyntax::SwiftDiagnostics
   SwiftSyntax::SwiftSyntax
-  SwiftSyntax::IDEUtils)
+  SwiftSyntax::SwiftIDEUtils)
 target_link_libraries(SourceKitLSP PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 

--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -12,7 +12,7 @@
 
 import LanguageServerProtocol
 import SwiftSyntax
-import IDEUtils
+import SwiftIDEUtils
 
 /// Syntax highlighting tokens for a particular document.
 public struct DocumentTokens {


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1571