### PR TITLE
Add boilerplate for pull-model diagnostics

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -526,6 +526,16 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     }
   }
 
+  /// Capabilities specific to 'textDocument/diagnostic'. Since LSP 3.17.0.
+  public struct Diagnostic: Equatable, Hashable, Codable {
+
+    /// Whether implementation supports dynamic registration.
+    public var dynamicRegistration: Bool?
+
+    /// Whether the clients supports related documents for document diagnostic pulls.
+    public var relatedDocumentSupport: Bool?
+  }
+
   // MARK: Properties
 
   public var synchronization: Synchronization? = nil
@@ -575,6 +585,8 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   public var semanticTokens: SemanticTokens? = nil
 
   public var inlayHint: InlayHint? = nil
+  
+  public var diagnostic: Diagnostic? = nil
 
   public init(synchronization: Synchronization? = nil,
               completion: Completion? = nil,
@@ -599,7 +611,8 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
               foldingRange: FoldingRange? = nil,
               callHierarchy: DynamicRegistrationCapability? = nil,
               semanticTokens: SemanticTokens? = nil,
-              inlayHint: InlayHint? = nil) {
+              inlayHint: InlayHint? = nil,
+              diagnostic: Diagnostic? = nil) {
     self.synchronization = synchronization
     self.completion = completion
     self.hover = hover
@@ -624,5 +637,6 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     self.callHierarchy = callHierarchy
     self.semanticTokens = semanticTokens
     self.inlayHint = inlayHint
+    self.diagnostic = diagnostic
   }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -156,6 +156,30 @@ public struct InlayHintRegistrationOptions: RegistrationOptions, TextDocumentReg
   }
 }
 
+/// Describe options to be used when registering for pull diagnostics. Since LSP 3.17.0
+public struct DiagnosticRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol {
+  public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions
+  public var diagnosticOptions: DiagnosticOptions
+  
+  public init(
+    documentSelector: DocumentSelector? = nil,
+    diagnosticOptions: DiagnosticOptions
+  ) {
+    textDocumentRegistrationOptions = TextDocumentRegistrationOptions(documentSelector: documentSelector)
+    self.diagnosticOptions = diagnosticOptions
+  }
+
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    textDocumentRegistrationOptions.encodeIntoLSPAny(dict: &dict)
+
+    dict["interFileDependencies"] = .bool(diagnosticOptions.interFileDependencies)
+    dict["workspaceDiagnostics"] = .bool(diagnosticOptions.workspaceDiagnostics)
+    if let workDoneProgress = diagnosticOptions.workDoneProgress {
+      dict["workDoneProgress"] = .bool(workDoneProgress)
+    }
+  }
+}
+
 /// Describe options to be used when registering for file system change events.
 public struct DidChangeWatchedFilesRegistrationOptions: RegistrationOptions {
   /// The watchers to register.

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -108,6 +108,9 @@ public struct ServerCapabilities: Codable, Hashable {
   /// Whether the server supports the `textDocument/inlayHint` family of requests.
   public var inlayHintProvider: ValueOrBool<InlayHintOptions>?
 
+  /// Whether the server supports the `textDocument/diagnostic` request.
+  public var diagnosticProvider: DiagnosticOptions?
+
   /// Whether the server provides selection range support.
   public var selectionRangeProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>?
 
@@ -152,6 +155,7 @@ public struct ServerCapabilities: Codable, Hashable {
     typeHierarchyProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     semanticTokensProvider: SemanticTokensOptions? = nil,
     inlayHintProvider: ValueOrBool<InlayHintOptions>? = nil,
+    diagnosticProvider: DiagnosticOptions? = nil,
     selectionRangeProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     linkedEditingRangeProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     monikerProvider: ValueOrBool<MonikerOptions>? = nil,
@@ -188,6 +192,7 @@ public struct ServerCapabilities: Codable, Hashable {
     self.typeHierarchyProvider = typeHierarchyProvider
     self.semanticTokensProvider = semanticTokensProvider
     self.inlayHintProvider = inlayHintProvider
+    self.diagnosticProvider = diagnosticProvider
     self.selectionRangeProvider = selectionRangeProvider
     self.linkedEditingRangeProvider = linkedEditingRangeProvider
     self.experimental = experimental

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -515,6 +515,10 @@ extension ClangLanguageServerShim {
     forwardRequestToClangdOnQueue(req)
   }
 
+  func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) {
+    forwardRequestToClangdOnQueue(req)
+  }
+
   func foldingRange(_ req: Request<FoldingRangeRequest>) {
     queue.async {
       if self.capabilities?.foldingRangeProvider?.isSupported == true {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -202,6 +202,8 @@ public final class SourceKitServer: LanguageServer {
     registerToolchainTextDocumentRequest(SourceKitServer.colorPresentation, [])
     registerToolchainTextDocumentRequest(SourceKitServer.codeAction, nil)
     registerToolchainTextDocumentRequest(SourceKitServer.inlayHint, [])
+    registerToolchainTextDocumentRequest(SourceKitServer.documentDiagnostic,
+                                         .full(.init(items: [])))
   }
 
   /// Register a `TextDocumentRequest` that requires a valid `Workspace`, `ToolchainLanguageServer`,
@@ -709,6 +711,11 @@ extension SourceKitServer {
         self.dynamicallyRegisterCapability($0, registry)
       }
     }
+    if let diagnosticOptions = server.diagnosticProvider {
+      registry.registerDiagnosticIfNeeded(options: diagnosticOptions, for: languages) {
+        self.dynamicallyRegisterCapability($0, registry)
+      }
+    }
     if let commandOptions = server.executeCommandProvider {
       registry.registerExecuteCommandIfNeeded(commands: commandOptions.commands) {
         self.dynamicallyRegisterCapability($0, registry)
@@ -1207,6 +1214,14 @@ extension SourceKitServer {
     languageService: ToolchainLanguageServer
   ) {
     languageService.inlayHint(req)
+  }
+
+  func documentDiagnostic(
+    _ req: Request<DocumentDiagnosticsRequest>,
+    workspace: Workspace,
+    languageService: ToolchainLanguageServer
+  ) {
+    languageService.documentDiagnostic(req)
   }
 
   /// Converts a location from the symbol index to an LSP location.

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1326,6 +1326,11 @@ extension SwiftLanguageServer {
       }
     }
   }
+  
+  public func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) {
+    // TODO: Return provider object in initializeSync and implement pull-model document diagnostics here.
+    req.reply(.failure(.unknown("Pull-model diagnostics not implemented yet.")))
+  }
 
   public func executeCommand(_ req: Request<ExecuteCommandRequest>) {
     let params = req.params

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -97,6 +97,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func colorPresentation(_ req: Request<ColorPresentationRequest>)
   func codeAction(_ req: Request<CodeActionRequest>)
   func inlayHint(_ req: Request<InlayHintRequest>)
+  func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>)
 
   // MARK: - Other
 


### PR DESCRIPTION
Adds the capabilities, options and registration structs for pull-model diagnostics. Does not report support for them yet so this code currently has no impact. This PR is also to get guidance on how to implement the document diagnostic request in `SwiftLanguageServer`. Any pointers are welcome.

# How tested
- Locally added the snippet to report support for pull request diagnostics in `SwiftLanguageServer.initializeSync`, then built, ran locally in VS Code and confirmed that I could get a dummy diagnostic shown in VS Code.
- Then removed the feature reporting snippet (the state of the code in this PR), rebuilt, reran in VS Code, and confirmed that `publishDiagnostics` still work.