### PR TITLE
Add VSCode launch configuration for attaching to executable.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
             "program": "${workspaceFolder:sourcekit-lsp}/.build/debug/sourcekit-lsp",
             "args": [],
             "cwd": "${workspaceFolder:sourcekit-lsp}",
-            "preLaunchTask": "swift: Build Debug sourcekit-lsp"
+            "preLaunchTask": "swift: Build Debug sourcekit-lsp",
+            "sourceLanguages": ["swift"]
         },
         {
             "type": "lldb",
@@ -16,7 +17,16 @@
             "program": "${workspaceFolder:sourcekit-lsp}/.build/release/sourcekit-lsp",
             "args": [],
             "cwd": "${workspaceFolder:sourcekit-lsp}",
-            "preLaunchTask": "swift: Build Release sourcekit-lsp"
+            "preLaunchTask": "swift: Build Release sourcekit-lsp",
+            "sourceLanguages": ["swift"]
+        },
+        {
+            "type": "lldb",
+            "request": "attach",
+            "name": "Attach sourcekit-lsp",
+            "program": "${workspaceFolder:sourcekit-lsp}/.build/debug/sourcekit-lsp",
+            "sourceLanguages": ["swift"],
+            "waitFor": true
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
         {
             "type": "lldb",
             "request": "attach",
-            "name": "Attach sourcekit-lsp",
+            "name": "Attach sourcekit-lsp (debug)",
             "program": "${workspaceFolder:sourcekit-lsp}/.build/debug/sourcekit-lsp",
             "sourceLanguages": ["swift"],
             "waitFor": true


### PR DESCRIPTION
Useful for attaching to already running sourcekit-lsp executable. 

Example of usage.
1) Build debug version of sourcekit-lsp in VSCode.
2) Open a SwiftPM project in a second "target" version of VSCode.
3) Go to settings in "target" VSCode, click to edit workspace settings and set `Sourcekit-lsp: server path` to the path to your debug version of sourcekit-lsp: `<Fullpath>/sourcekit-lsp/.build/debug/sourcekit-lsp`.
4) Restart LSP server as requested.
5) Go to original VSCode and run debug target `Attach sourcekit-lsp`.

You are now debugging the sourcekit-lsp server running in the "target" VSCode.