### PR TITLE
Implement pull-model documentDiagnostics

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -171,12 +171,7 @@ public struct DiagnosticRegistrationOptions: RegistrationOptions, TextDocumentRe
 
   public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
     textDocumentRegistrationOptions.encodeIntoLSPAny(dict: &dict)
-
-    dict["interFileDependencies"] = .bool(diagnosticOptions.interFileDependencies)
-    dict["workspaceDiagnostics"] = .bool(diagnosticOptions.workspaceDiagnostics)
-    if let workDoneProgress = diagnosticOptions.workDoneProgress {
-      dict["workDoneProgress"] = .bool(workDoneProgress)
-    }
+    diagnosticOptions.encodeIntoLSPAny(dict: &dict)
   }
 }
 

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -868,9 +868,6 @@ public struct DiagnosticOptions: WorkDoneProgressOptions, Codable, Hashable {
   /// The server provides support for workspace diagnostics as well.
   public var workspaceDiagnostics: Bool
 
-  /// A document selector to identify the scope of the registration. If set to null the document selector provided on the client side will be used.
-  public var documentSelector: DocumentSelector?
-
   /// The id used to register the request. The id can be used to deregister the request again. See also Registration#id
   public var id: String?
 
@@ -880,16 +877,28 @@ public struct DiagnosticOptions: WorkDoneProgressOptions, Codable, Hashable {
     identifier: String? = nil,
     interFileDependencies: Bool,
     workspaceDiagnostics: Bool,
-    documentSelector: DocumentSelector? = nil,
     id: String? = nil,
     workDoneProgress: Bool? = nil
   ) {
     self.identifier = identifier
     self.interFileDependencies = interFileDependencies
     self.workspaceDiagnostics = workspaceDiagnostics
-    self.documentSelector = documentSelector
     self.id = id
     self.workDoneProgress = workDoneProgress
+  }
+
+  public func encodeIntoLSPAny(dict: inout [String: LSPAny]) {
+    if let identifier = identifier {
+      dict["identifier"] = .string(identifier)
+    }
+    dict["interFileDependencies"] = .bool(interFileDependencies)
+    dict["workspaceDiagnostics"] = .bool(workspaceDiagnostics)
+    if let id = id {
+      dict["id"] = .string(id)
+    }
+    if let workDoneProgress = workDoneProgress {
+      dict["workDoneProgress"] = .bool(workDoneProgress)
+    }
   }
 }
 

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -177,6 +177,7 @@ public struct sourcekitd_requests {
   public let codecomplete_update: sourcekitd_uid_t
   public let codecomplete_close: sourcekitd_uid_t
   public let cursorinfo: sourcekitd_uid_t
+  public let diagnostics: sourcekitd_uid_t
   public let expression_type: sourcekitd_uid_t
   public let find_usr: sourcekitd_uid_t
   public let variable_type: sourcekitd_uid_t
@@ -194,6 +195,7 @@ public struct sourcekitd_requests {
     codecomplete_update = api.uid_get_from_cstr("source.request.codecomplete.update")!
     codecomplete_close = api.uid_get_from_cstr("source.request.codecomplete.close")!
     cursorinfo = api.uid_get_from_cstr("source.request.cursorinfo")!
+    diagnostics = api.uid_get_from_cstr("source.request.diagnostics")!
     expression_type = api.uid_get_from_cstr("source.request.expression.type")!
     find_usr = api.uid_get_from_cstr("source.request.editor.find_usr")!
     variable_type = api.uid_get_from_cstr("source.request.variable.type")!

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -75,6 +75,14 @@ public final class CapabilityRegistry {
     clientCapabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration == true
   }
 
+  public var clientHasSemanticTokenRefreshSupport: Bool {
+    clientCapabilities.workspace?.semanticTokens?.refreshSupport == true
+  }
+
+  public var clientHasDiagnosticsCodeDescriptionSupport: Bool {
+    clientCapabilities.textDocument?.publishDiagnostics?.codeDescriptionSupport == true
+  }
+
   /// Dynamically register completion capabilities if the client supports it and
   /// we haven't yet registered any completion capabilities for the given
   /// languages.
@@ -266,13 +274,26 @@ public final class CapabilityRegistry {
     if registration.method == CompletionRequest.method {
       completion.removeValue(forKey: registration)
     }
+    if registration.method == FoldingRangeRegistrationOptions.method {
+      foldingRange.removeValue(forKey: registration)
+    }
     if registration.method == SemanticTokensRegistrationOptions.method {
       semanticTokens.removeValue(forKey: registration)
     }
+    if registration.method == InlayHintRegistrationOptions.method {
+      inlayHint.removeValue(forKey: registration)
+    }
+    if registration.method == DiagnosticRegistrationOptions.method {
+      pullDiagnostics.removeValue(forKey: registration)
+    }
   }
 
-  private func documentSelector(for langauges: [Language]) -> DocumentSelector {
-    return DocumentSelector(langauges.map { DocumentFilter(language: $0.rawValue) })
+  public func pullDiagnosticsRegistration(for language: Language) -> DiagnosticRegistrationOptions? {
+    registration(for: language, in: pullDiagnostics)
+  }
+
+  private func documentSelector(for languages: [Language]) -> DocumentSelector {
+    return DocumentSelector(languages.map { DocumentFilter(language: $0.rawValue) })
   }
 
   private func encode<T: RegistrationOptions>(_ options: T) -> LSPAny {

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -274,22 +274,22 @@ public final class CapabilityRegistry {
     if registration.method == CompletionRequest.method {
       completion.removeValue(forKey: registration)
     }
-    if registration.method == FoldingRangeRegistrationOptions.method {
+    if registration.method == FoldingRangeRequest.method {
       foldingRange.removeValue(forKey: registration)
     }
     if registration.method == SemanticTokensRegistrationOptions.method {
       semanticTokens.removeValue(forKey: registration)
     }
-    if registration.method == InlayHintRegistrationOptions.method {
+    if registration.method == InlayHintRequest.method {
       inlayHint.removeValue(forKey: registration)
     }
-    if registration.method == DiagnosticRegistrationOptions.method {
+    if registration.method == DocumentDiagnosticsRequest.method {
       pullDiagnostics.removeValue(forKey: registration)
     }
   }
 
   public func pullDiagnosticsRegistration(for language: Language) -> DiagnosticRegistrationOptions? {
-    registration(for: language, in: pullDiagnostics)
+    registration(for: [language], in: pullDiagnostics)
   }
 
   private func documentSelector(for languages: [Language]) -> DocumentSelector {

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -63,7 +63,7 @@ public final class CapabilityRegistry {
     clientCapabilities.textDocument?.inlayHint?.dynamicRegistration == true
   }
 
-  public var clientHasDocumentDiagnosticsRegistration: Bool {
+  public var clientHasDynamicDocumentDiagnosticsRegistration: Bool {
     clientCapabilities.textDocument?.diagnostic?.dynamicRegistration == true
   }
   
@@ -224,7 +224,7 @@ public final class CapabilityRegistry {
     for languages: [Language],
     registerOnClient: ClientRegistrationHandler
   ) {
-    guard clientHasDocumentDiagnosticsRegistration else { return }
+    guard clientHasDynamicDocumentDiagnosticsRegistration else { return }
     if let registration = registration(for: languages, in: pullDiagnostics) {
       if options != registration.diagnosticOptions {
         log("Unable to register new pull diagnostics options \(options) for " +

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -103,7 +103,6 @@ final class ClangLanguageServerShim: LanguageServer, ToolchainLanguageServer {
   public init?(
     client: LocalConnection,
     toolchain: Toolchain,
-    clientCapabilities: ClientCapabilities?,
     options: SourceKitServer.Options,
     workspace: Workspace,
     reopenDocuments: @escaping (ToolchainLanguageServer) -> Void

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -674,7 +674,10 @@ extension SourceKitServer {
         changeNotifications: .bool(true)
       )),
       callHierarchyProvider: .bool(true),
-      typeHierarchyProvider: .bool(true)
+      typeHierarchyProvider: .bool(true),
+      diagnosticProvider: DiagnosticOptions(
+        interFileDependencies: true,
+        workspaceDiagnostics: false)
     )
   }
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -674,10 +674,7 @@ extension SourceKitServer {
         changeNotifications: .bool(true)
       )),
       callHierarchyProvider: .bool(true),
-      typeHierarchyProvider: .bool(true),
-      diagnosticProvider: DiagnosticOptions(
-        interFileDependencies: true,
-        workspaceDiagnostics: false)
+      typeHierarchyProvider: .bool(true)
     )
   }
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1769,7 +1769,6 @@ func languageService(
   let server = try languageServerType.serverType.init(
     client: connectionToClient,
     toolchain: toolchain,
-    clientCapabilities: workspace.capabilityRegistry.clientCapabilities,
     options: options,
     workspace: workspace,
     reopenDocuments: reopenDocuments

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -139,8 +139,8 @@ extension SwiftLanguageServer {
       let typeName: String? = value[self.keys.typename]
       let docBrief: String? = value[self.keys.doc_brief]
 
-      let clientCompletionCapabilities = self.clientCapabilities.textDocument?.completion
-      let clientSupportsSnippets = clientCompletionCapabilities?.completionItem?.snippetSupport == true
+      let completionCapabilities = self.capabilityRegistry.clientCapabilities.textDocument?.completion
+      let clientSupportsSnippets = completionCapabilities?.completionItem?.snippetSupport == true
       let text = insertText.map {
         rewriteSourceKitPlaceholders(inString: $0, clientSupportsSnippets: clientSupportsSnippets)
       }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1377,7 +1377,6 @@ extension SwiftLanguageServer {
       var diagnostics: [Diagnostic] = []
       dict[keys.diagnostics]?.forEach { _, diag in
         if var diagnostic = Diagnostic(diag, in: snapshot, useEducationalNoteAsCode: supportsCodeDescription) {
-          diagnostic.source = "pulldiag"
           diagnostics.append(diagnostic)
         }
         return true

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -32,7 +32,6 @@ public protocol ToolchainLanguageServer: AnyObject {
   init?(
     client: LocalConnection,
     toolchain: Toolchain,
-    clientCapabilities: ClientCapabilities?,
     options: SourceKitServer.Options,
     workspace: Workspace,
     reopenDocuments: @escaping (ToolchainLanguageServer) -> Void

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -15,7 +15,7 @@ import LSPTestSupport
 import SKTestSupport
 import XCTest
 
-final class DiagnosticsTests: XCTestCase {
+final class PublishDiagnosticsTests: XCTestCase {
   /// Connection and lifetime management for the service.
   var connection: TestSourceKitServer! = nil
 
@@ -28,7 +28,7 @@ final class DiagnosticsTests: XCTestCase {
 
   override func setUp() {
     version = 0
-    uri = DocumentURI(URL(fileURLWithPath: "/DiagnosticsTests/\(UUID()).swift"))
+    uri = DocumentURI(URL(fileURLWithPath: "/PublishDiagnosticsTests/\(UUID()).swift"))
     connection = TestSourceKitServer()
     sk = connection.client
     let documentCapabilities = TextDocumentClientCapabilities()

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import LSPTestSupport
+import SKTestSupport
+import XCTest
+
+final class PullDiagnosticsTests: XCTestCase {
+  /// Connection and lifetime management for the service.
+  var connection: TestSourceKitServer! = nil
+
+  /// The primary interface to make requests to the SourceKitServer.
+  var sk: TestClient! = nil
+
+  override func setUp() {
+    connection = TestSourceKitServer()
+    sk = connection.client
+    _ = try! sk.sendSync(InitializeRequest(
+      processId: nil,
+      rootPath: nil,
+      rootURI: nil,
+      initializationOptions: nil,
+      capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+      trace: .off,
+      workspaceFolders: nil
+    ))
+  }
+
+  override func tearDown() {
+    sk = nil
+    connection = nil
+  }
+
+  func performDiagnosticRequest(text: String) throws -> [Diagnostic] {
+    let url = URL(fileURLWithPath: "/PullDiagnostics/\(UUID()).swift")
+
+    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
+      uri: DocumentURI(url),
+      language: .swift,
+      version: 17,
+      text: text
+    )))
+
+    let request = DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(url))
+
+    let report: DocumentDiagnosticReport
+    do {
+      report = try sk.sendSync(request)
+    } catch let error as ResponseError where error.message.contains("unknown request: source.request.diagnostics") {
+      throw XCTSkip("toolchain does not support source.request.diagnostics request")
+    }
+
+    guard case .full(let fullReport) = report else {
+        XCTFail("Unexpected diagnostics report type: \(report)")
+    }
+
+    return fullReport.diagnostics
+  }
+
+  func testUnknownIdentifierDiagnostic() {
+    let diagnostics = performDiagnosticRequest(text: """
+    func foo() {
+      invalid
+    }
+    """)
+    XCTAssertEqual(diagnostics.count, 1)
+    XCTAssertEqual(diagnostics[0].range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+  }
+}

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -61,7 +61,7 @@ final class PullDiagnosticsTests: XCTestCase {
     }
 
     guard case .full(let fullReport) = report else {
-        XCTFail("Unexpected diagnostics report type: \(report)")
+      XCTFail("Unexpected diagnostics report type: \(report)")
     }
 
     return fullReport.items

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -62,6 +62,7 @@ final class PullDiagnosticsTests: XCTestCase {
 
     guard case .full(let fullReport) = report else {
       XCTFail("Unexpected diagnostics report type: \(report)")
+      return
     }
 
     return fullReport.items

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -16,6 +16,10 @@ import SKTestSupport
 import XCTest
 
 final class PullDiagnosticsTests: XCTestCase {
+  enum Error: Swift.Error {
+    case unexpectedDiagnosticReport
+  }
+
   /// Connection and lifetime management for the service.
   var connection: TestSourceKitServer! = nil
 
@@ -61,8 +65,7 @@ final class PullDiagnosticsTests: XCTestCase {
     }
 
     guard case .full(let fullReport) = report else {
-      XCTFail("Unexpected diagnostics report type: \(report)")
-      return
+      throw Error.unexpectedDiagnosticReport
     }
 
     return fullReport.items

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -64,11 +64,11 @@ final class PullDiagnosticsTests: XCTestCase {
         XCTFail("Unexpected diagnostics report type: \(report)")
     }
 
-    return fullReport.diagnostics
+    return fullReport.items
   }
 
-  func testUnknownIdentifierDiagnostic() {
-    let diagnostics = performDiagnosticRequest(text: """
+  func testUnknownIdentifierDiagnostic() throws {
+    let diagnostics = try performDiagnosticRequest(text: """
     func foo() {
       invalid
     }


### PR DESCRIPTION
Implements LSP 3.17.0's pull-model documentDiagnostics request, which fix stale squiggly issues after fixing an error due to the relationship between code in two files. When using pull-model documentDiagnostics, we disable the push-model publishDiagnostics to avoid reporting them twice.

![PullDiagsDemo](https://github.com/apple/sourcekit-lsp/assets/2314287/ddf7b96c-dd29-4491-af1f-0b1a20ddcbc3)
(this gif was using a temporary "pulldiag" source name to verify that it wasn't publish diagnostics in action)

Fixes #500