### PR TITLE
Swiftinterface symbol lookup

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
@@ -22,9 +22,13 @@ public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
   /// The module to generate an index for.
   public var name: String
 
-  public init(textDocument: TextDocumentIdentifier, name: String) {
+  /// The symbol to search for in the generated module interface.
+  public var symbol: String?
+
+  public init(textDocument: TextDocumentIdentifier, name: String, symbol: String?) {
     self.textDocument = textDocument
     self.name = name
+    self.symbol = symbol
   }
 }
 
@@ -32,8 +36,10 @@ public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
 public struct InterfaceDetails: ResponseType, Hashable {
 
   public var uri: DocumentURI
+  public var position: Position?
 
-  public init(uri: DocumentURI) {
+  public init(uri: DocumentURI, position: Position?) {
     self.uri = uri
+    self.position = position
   }
 }

--- a/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
@@ -20,15 +20,35 @@ public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
   public var textDocument: TextDocumentIdentifier
 
   /// The module to generate an index for.
-  public var name: String
+  public var moduleName: String
+
+  /// The module group name.
+  public var groupNames: [String]
 
   /// The symbol to search for in the generated module interface.
   public var symbol: String?
 
   public init(textDocument: TextDocumentIdentifier, name: String, symbol: String?) {
     self.textDocument = textDocument
-    self.name = name
     self.symbol = symbol
+    // Stdlib Swift modules are all in the "Swift" module, but their symbols return a module name `Swift.***`.
+    let splitName = name.split(separator: ".")
+    if splitName.count == 1 {
+      self.moduleName = name
+      self.groupNames = []
+    } else {
+      self.moduleName = String(splitName[0])
+      self.groupNames = [String.SubSequence](splitName.dropFirst()).map { String($0)}
+    }
+  }
+
+  /// Name of interface module name with group names appended
+  public var name: String {
+    if groupNames.count > 0 {
+      return "\(self.moduleName).\(self.groupNames.joined(separator: "."))"
+    } else {
+      return self.moduleName
+    }
   }
 }
 

--- a/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
@@ -25,21 +25,16 @@ public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
   /// The module group name.
   public var groupNames: [String]
 
-  /// The symbol to search for in the generated module interface.
-  public var symbol: String?
+  /// The symbol USR to search for in the generated module interface.
+  public var symbolUSR: String?
 
-  public init(textDocument: TextDocumentIdentifier, name: String, symbol: String?) {
+  public init(textDocument: TextDocumentIdentifier, name: String, symbolUSR: String?) {
     self.textDocument = textDocument
-    self.symbol = symbol
+    self.symbolUSR = symbolUSR
     // Stdlib Swift modules are all in the "Swift" module, but their symbols return a module name `Swift.***`.
     let splitName = name.split(separator: ".")
-    if splitName.count == 1 {
-      self.moduleName = name
-      self.groupNames = []
-    } else {
-      self.moduleName = String(splitName[0])
-      self.groupNames = [String.SubSequence](splitName.dropFirst()).map { String($0)}
-    }
+    self.moduleName = String(splitName[0])
+    self.groupNames = [String.SubSequence](splitName.dropFirst()).map(String.init)
   }
 
   /// Name of interface module name with group names appended

--- a/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
+++ b/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
@@ -1,11 +1,7 @@
 public struct Lib {
-  let a: /*Lib.a.string*/String
-
   public func /*Lib.foo:def*/foo() {}
 
-  public init() {
-    self.a = "lib"
-  }
+  public init() {}
 }
 
 func topLevelFunction() {

--- a/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
+++ b/Sources/SKTestSupport/INPUTS/SwiftPMPackage/Sources/lib/lib.swift
@@ -1,7 +1,11 @@
 public struct Lib {
+  let a: /*Lib.a.string*/String
+
   public func /*Lib.foo:def*/foo() {}
 
-  public init() {}
+  public init() {
+    self.a = "lib"
+  }
 }
 
 func topLevelFunction() {

--- a/Sources/SKTestSupport/INPUTS/SystemSwiftInterface/Package.swift
+++ b/Sources/SKTestSupport/INPUTS/SystemSwiftInterface/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+  name: "SystemSwiftInterface",
+  platforms: [.macOS(.v10_15)],
+  products: [],
+  dependencies: [],
+  targets: [
+    .target(
+      name: "lib",
+      dependencies: []),
+    /*Package.swift:targets*/
+  ]
+)

--- a/Sources/SKTestSupport/INPUTS/SystemSwiftInterface/Sources/lib/lib.swift
+++ b/Sources/SKTestSupport/INPUTS/SystemSwiftInterface/Sources/lib/lib.swift
@@ -1,0 +1,10 @@
+public func libFunc() async {
+  let a: /*lib.string*/String = "test"
+  let i: /*lib.integer*/Int = 2
+  await /*lib.withTaskGroup*/withTaskGroup(of: Void.self) { group in
+    group.addTask {
+      print(a)
+      print(i)
+    }
+  }
+}

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -125,6 +125,11 @@ extension SKSwiftPMTestWorkspace {
     index.pollForUnitChangesAndWait()
   }
 
+  public func buildAndIndexWithSystemSymbols() throws {
+    try buildWithSystemSymbols()
+    index.pollForUnitChangesAndWait()
+  }
+
   func build() throws {
     try TSCBasic.Process.checkNonZeroExit(arguments: [
       toolchain.swift!.pathString,
@@ -133,6 +138,15 @@ extension SKSwiftPMTestWorkspace {
       "--scratch-path", buildDir.path,
       "-Xswiftc", "-index-ignore-system-modules",
       "-Xcc", "-index-ignore-system-symbols",
+    ])
+  }
+
+  func buildWithSystemSymbols() throws {
+    try TSCBasic.Process.checkNonZeroExit(arguments: [
+      toolchain.swift!.pathString,
+      "build",
+      "--package-path", sources.rootDirectory.path,
+      "--scratch-path", buildDir.path,
     ])
   }
 }

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -120,34 +120,25 @@ extension SKSwiftPMTestWorkspace {
 
   public func testLoc(_ name: String) -> TestLocation { sources.locations[name]! }
 
-  public func buildAndIndex() throws {
-    try build()
+  public func buildAndIndex(withSystemSymbols: Bool = false) throws {
+    try build(withSystemSymbols: withSystemSymbols)
     index.pollForUnitChangesAndWait()
   }
 
-  public func buildAndIndexWithSystemSymbols() throws {
-    try buildWithSystemSymbols()
-    index.pollForUnitChangesAndWait()
-  }
-
-  func build() throws {
-    try TSCBasic.Process.checkNonZeroExit(arguments: [
+  func build(withSystemSymbols: Bool = false) throws {
+    var arguments = [
       toolchain.swift!.pathString,
       "build",
       "--package-path", sources.rootDirectory.path,
       "--scratch-path", buildDir.path,
-      "-Xswiftc", "-index-ignore-system-modules",
-      "-Xcc", "-index-ignore-system-symbols",
-    ])
-  }
-
-  func buildWithSystemSymbols() throws {
-    try TSCBasic.Process.checkNonZeroExit(arguments: [
-      toolchain.swift!.pathString,
-      "build",
-      "--package-path", sources.rootDirectory.path,
-      "--scratch-path", buildDir.path,
-    ])
+    ]
+    if !withSystemSymbols {
+      arguments.append(contentsOf: [
+        "-Xswiftc", "-index-ignore-system-modules",
+        "-Xcc", "-index-ignore-system-symbols",
+      ])
+    }
+    try TSCBasic.Process.checkNonZeroExit(arguments: arguments)
   }
 }
 

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -40,6 +40,7 @@ public struct sourcekitd_keys {
   public let expression_type_list: sourcekitd_uid_t
   public let filepath: sourcekitd_uid_t
   public let fixits: sourcekitd_uid_t
+  public let groupname: sourcekitd_uid_t
   public let id: sourcekitd_uid_t
   public let is_system: sourcekitd_uid_t
   public let kind: sourcekitd_uid_t
@@ -115,6 +116,7 @@ public struct sourcekitd_keys {
     expression_type_list = api.uid_get_from_cstr("key.expression_type_list")!
     filepath = api.uid_get_from_cstr("key.filepath")!
     fixits = api.uid_get_from_cstr("key.fixits")!
+    groupname = api.uid_get_from_cstr("key.groupname")!
     id = api.uid_get_from_cstr("key.id")!
     is_system = api.uid_get_from_cstr("key.is_system")!
     kind = api.uid_get_from_cstr("key.kind")!

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -176,6 +176,7 @@ public struct sourcekitd_requests {
   public let codecomplete_close: sourcekitd_uid_t
   public let cursorinfo: sourcekitd_uid_t
   public let expression_type: sourcekitd_uid_t
+  public let find_usr: sourcekitd_uid_t
   public let variable_type: sourcekitd_uid_t
   public let relatedidents: sourcekitd_uid_t
   public let semantic_refactoring: sourcekitd_uid_t
@@ -192,6 +193,7 @@ public struct sourcekitd_requests {
     codecomplete_close = api.uid_get_from_cstr("source.request.codecomplete.close")!
     cursorinfo = api.uid_get_from_cstr("source.request.cursorinfo")!
     expression_type = api.uid_get_from_cstr("source.request.expression.type")!
+    find_usr = api.uid_get_from_cstr("source.request.editor.find_usr")!
     variable_type = api.uid_get_from_cstr("source.request.variable.type")!
     relatedidents = api.uid_get_from_cstr("source.request.relatedidents")!
     semantic_refactoring = api.uid_get_from_cstr("source.request.semantic.refactoring")!

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1307,7 +1307,7 @@ extension SourceKitServer {
 
       // If this symbol is a module then generate a textual interface
       if case .success(let symbols) = result, let symbol = symbols.first, symbol.kind == .module, let name = symbol.name {
-        self.respondWithInterface(req, moduleName: name, symbol: nil, languageService: languageService)
+        self.respondWithInterface(req, moduleName: name, symbolUSR: nil, languageService: languageService)
         return
       }
 
@@ -1330,7 +1330,7 @@ extension SourceKitServer {
           self.respondWithInterface(
             req, 
             moduleName: moduleName, 
-            symbol: firstResolved.occurrence?.symbol.usr,
+            symbolUSR: firstResolved.occurrence?.symbol.usr,
             languageService: languageService
           )
           return
@@ -1357,10 +1357,10 @@ extension SourceKitServer {
   func respondWithInterface(
     _ req: Request<DefinitionRequest>,
     moduleName: String,
-    symbol: String?,
+    symbolUSR: String?,
     languageService: ToolchainLanguageServer
   ) {
-      let openInterface = OpenInterfaceRequest(textDocument: req.params.textDocument, name: moduleName, symbol: symbol)
+      let openInterface = OpenInterfaceRequest(textDocument: req.params.textDocument, name: moduleName, symbolUSR: symbolUSR)
       let request = Request(openInterface, id: req.id, clientID: ObjectIdentifier(self),
                             cancellation: req.cancellationToken, reply: { (result: Result<OpenInterfaceRequest.Response, ResponseError>) in
         switch result {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1360,11 +1360,6 @@ extension SourceKitServer {
     symbol: String?,
     languageService: ToolchainLanguageServer
   ) {
-      var moduleName = moduleName
-      // Stdlib Swift modules are all in the "Swift" module, but their symbols return a module name `Swift.***`.
-      if moduleName.hasPrefix("Swift.") {
-        moduleName = "Swift"
-      }            
       let openInterface = OpenInterfaceRequest(textDocument: req.params.textDocument, name: moduleName, symbol: symbol)
       let request = Request(openInterface, id: req.id, clientID: ObjectIdentifier(self),
                             cancellation: req.cancellationToken, reply: { (result: Result<OpenInterfaceRequest.Response, ResponseError>) in

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1307,20 +1307,7 @@ extension SourceKitServer {
 
       // If this symbol is a module then generate a textual interface
       if case .success(let symbols) = result, let symbol = symbols.first, symbol.kind == .module, let name = symbol.name {
-        let openInterface = OpenInterfaceRequest(textDocument: req.params.textDocument, name: name)
-        let request = Request(openInterface, id: req.id, clientID: ObjectIdentifier(self),
-                              cancellation: req.cancellationToken, reply: { (result: Result<OpenInterfaceRequest.Response, ResponseError>) in
-          switch result {
-          case .success(let interfaceDetails?):
-            let loc = Location(uri: interfaceDetails.uri, range: Range(Position(line: 0, utf16index: 0)))
-            req.reply(.locations([loc]))
-          case .success(nil):
-            req.reply(.failure(.unknown("Could not generate Swift Interface for \(name)")))
-          case .failure(let error):
-            req.reply(.failure(error))
-          }
-        })
-        languageService.openInterface(request)
+        self.respondWithInterface(req, moduleName: name, languageService: languageService)
         return
       }
 
@@ -1335,6 +1322,14 @@ extension SourceKitServer {
 
       switch extractedResult {
       case .success(let resolved):
+        // if first resolved location is in `.swiftinterface` file. Use moduleName to return 
+        // textual interface 
+        if let firstResolved = resolved.first, 
+           let moduleName = firstResolved.occurrence?.location.moduleName, 
+           firstResolved.location.uri.fileURL?.pathExtension == "swiftinterface" {
+          self.respondWithInterface(req, moduleName: moduleName, languageService: languageService)
+          return
+        }
         let locs = resolved.map(\.location)
         // If we're unable to handle the definition request using our index, see if the
         // language service can handle it (e.g. clangd can provide AST based definitions).
@@ -1352,6 +1347,32 @@ extension SourceKitServer {
     let request = Request(symbolInfo, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
     languageService.symbolInfo(request)
+  }
+
+  func respondWithInterface(
+    _ req: Request<DefinitionRequest>,
+    moduleName: String,
+    languageService: ToolchainLanguageServer
+  ) {
+      var moduleName = moduleName
+      // Stdlib Swift modules are all in the "Swift" module, but their symbols return a module name `Swift.***`.
+      if moduleName.hasPrefix("Swift.") {
+        moduleName = "Swift"
+      }            
+      let openInterface = OpenInterfaceRequest(textDocument: req.params.textDocument, name: moduleName)
+      let request = Request(openInterface, id: req.id, clientID: ObjectIdentifier(self),
+                            cancellation: req.cancellationToken, reply: { (result: Result<OpenInterfaceRequest.Response, ResponseError>) in
+        switch result {
+        case .success(let interfaceDetails?):
+          let loc = Location(uri: interfaceDetails.uri, range: Range(Position(line: 0, utf16index: 0)))
+          req.reply(.locations([loc]))
+        case .success(nil):
+          req.reply(.failure(.unknown("Could not generate Swift Interface for \(moduleName)")))
+        case .failure(let error):
+          req.reply(.failure(error))
+        }
+      })
+      languageService.openInterface(request)
   }
 
   func implementation(

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -14,30 +14,59 @@ import Foundation
 import SourceKitD
 import LanguageServerProtocol
 import LSPLogging
+import SKSupport
 
 struct InterfaceInfo {
   var contents: String
+}
+
+struct FindUSRInfo {
+  let position: Position?
 }
 
 extension SwiftLanguageServer {
   public func openInterface(_ request: LanguageServerProtocol.Request<LanguageServerProtocol.OpenInterfaceRequest>) {
     let uri = request.params.textDocument.uri
     let moduleName = request.params.name
+    let symbol = request.params.symbol
     self.queue.async {
       let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(moduleName).swiftinterface")
       let interfaceDocURI = DocumentURI(interfaceFilePath)
-      self._openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI) { result in
-        switch result {
-        case .success(let interfaceInfo):
-          do {
-            try interfaceInfo.contents.write(to: interfaceFilePath, atomically: true, encoding: String.Encoding.utf8)
-            request.reply(.success(InterfaceDetails(uri: interfaceDocURI)))
-          } catch {
-            request.reply(.failure(ResponseError.unknown(error.localizedDescription)))
+      // has interface already been generated
+      if let snapshot = self.documentManager.latestSnapshot(interfaceDocURI) {
+        self._findUSR(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol) { result in
+          switch result {
+            case .success(let info):
+              request.reply(.success(InterfaceDetails(uri: interfaceDocURI, position: info.position)))
+            case .failure:
+              request.reply(.success(InterfaceDetails(uri: interfaceDocURI, position: nil)))
           }
-        case .failure(let error):
-          log("open interface failed: \(error)", level: .warning)
-          request.reply(.failure(ResponseError(error)))
+        }
+      } else {
+        // generate interface
+        self._openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI) { result in
+          switch result {
+          case .success(let interfaceInfo):
+            do {
+              // write to file
+              try interfaceInfo.contents.write(to: interfaceFilePath, atomically: true, encoding: String.Encoding.utf8)
+              // store snapshot
+              let snapshot = try self.documentManager.open(interfaceDocURI, language: .swift, version: 0, text: interfaceInfo.contents)
+              self._findUSR(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol) { result in
+                switch result {
+                  case .success(let info):
+                    request.reply(.success(InterfaceDetails(uri: interfaceDocURI, position: info.position)))
+                  case .failure(let error):
+                    request.reply(.success(InterfaceDetails(uri: interfaceDocURI, position: nil)))
+                }
+              }
+            } catch {
+              request.reply(.failure(ResponseError.unknown(error.localizedDescription)))
+            }
+          case .failure(let error):
+            log("open interface failed: \(error)", level: .warning)
+            request.reply(.failure(ResponseError(error)))
+          }
         }
       }
     }
@@ -70,6 +99,48 @@ extension SwiftLanguageServer {
       switch result {
       case .success(let dict):
         return completion(.success(InterfaceInfo(contents: dict[keys.sourcetext] ?? "")))
+      case .failure(let error):
+        return completion(.failure(error))
+      }
+    }
+    
+    if let handle = handle {
+      request.cancellationToken.addCancellationHandler { [weak self] in
+        self?.sourcekitd.cancel(handle)
+      }
+    }
+  }
+
+  private func _findUSR(
+    request: LanguageServerProtocol.Request<LanguageServerProtocol.OpenInterfaceRequest>, 
+    uri: DocumentURI, 
+    snapshot: DocumentSnapshot,
+    symbol: String?,
+    completion: @escaping (Swift.Result<FindUSRInfo, SKDError>) -> Void
+  ) {
+    guard let symbol = symbol else {
+      return completion(.success(FindUSRInfo(position: nil)))
+    }
+    let keys = self.keys
+    let skreq = SKDRequestDictionary(sourcekitd: sourcekitd)
+
+    skreq[keys.request] = requests.find_usr
+    skreq[keys.sourcefile] = uri.pseudoPath
+    skreq[keys.usr] = symbol
+
+    if let compileCommand = self.commandsByFile[uri] {
+      skreq[keys.compilerargs] = compileCommand.compilerArgs
+    }
+    
+    let handle = self.sourcekitd.send(skreq, self.queue) { result in
+      switch result {
+      case .success(let dict):
+          if let offset: Int = dict[keys.offset],
+            let position = snapshot.positionOf(utf8Offset: offset) {
+              return completion(.success(FindUSRInfo(position: position)))
+          } else {
+            return completion(.success(FindUSRInfo(position: nil)))
+          } 
       case .failure(let error):
         return completion(.failure(error))
       }

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -56,7 +56,7 @@ extension SwiftLanguageServer {
                 switch result {
                   case .success(let info):
                     request.reply(.success(InterfaceDetails(uri: interfaceDocURI, position: info.position)))
-                  case .failure(let error):
+                  case .failure:
                     request.reply(.success(InterfaceDetails(uri: interfaceDocURI, position: nil)))
                 }
               }

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -29,7 +29,7 @@ extension SwiftLanguageServer {
     let uri = request.params.textDocument.uri
     let moduleName = request.params.moduleName
     let name = request.params.name
-    let symbol = request.params.symbol
+    let symbol = request.params.symbolUSR
     self.queue.async {
       let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(name).swiftinterface")
       let interfaceDocURI = DocumentURI(interfaceFilePath)

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -27,10 +27,11 @@ struct FindUSRInfo {
 extension SwiftLanguageServer {
   public func openInterface(_ request: LanguageServerProtocol.Request<LanguageServerProtocol.OpenInterfaceRequest>) {
     let uri = request.params.textDocument.uri
-    let moduleName = request.params.name
+    let moduleName = request.params.moduleName
+    let name = request.params.name
     let symbol = request.params.symbol
     self.queue.async {
-      let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(moduleName).swiftinterface")
+      let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(name).swiftinterface")
       let interfaceDocURI = DocumentURI(interfaceFilePath)
       // has interface already been generated
       if let snapshot = self.documentManager.latestSnapshot(interfaceDocURI) {
@@ -75,6 +76,9 @@ extension SwiftLanguageServer {
     let skreq = SKDRequestDictionary(sourcekitd: sourcekitd)
     skreq[keys.request] = requests.editor_open_interface
     skreq[keys.modulename] = name
+    if request.params.groupNames.count > 0 {
+      skreq[keys.groupname] = request.params.groupNames
+    }
     skreq[keys.name] = interfaceURI.pseudoPath
     skreq[keys.synthesizedextensions] = 1
     if let compileCommand = self.commandsByFile[uri] {

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -99,7 +99,7 @@ final class SwiftInterfaceTests: XCTestCase {
     try ws.buildAndIndex()
     let importedModule = ws.testLoc("lib:import")
     try ws.openDocument(importedModule.url, language: .swift)
-    let openInterface = OpenInterfaceRequest(textDocument: importedModule.docIdentifier, name: "lib", symbol: nil)
+    let openInterface = OpenInterfaceRequest(textDocument: importedModule.docIdentifier, name: "lib", symbolUSR: nil)
     let interfaceDetails = try XCTUnwrap(ws.sk.sendSync(openInterface))
     XCTAssertTrue(interfaceDetails.uri.pseudoPath.hasSuffix("/lib.swiftinterface"))
     let fileContents = try XCTUnwrap(interfaceDetails.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -116,7 +116,7 @@ final class SwiftInterfaceTests: XCTestCase {
   
   func testDefinitionInSystemModuleInterface() throws {
     guard let ws = try staticSourceKitSwiftPMWorkspace(name: "SwiftPMPackage") else { return }
-    try ws.buildAndIndexWithSystemSymbols()
+    try ws.buildAndIndex(withSystemSymbols: true)
     let stringRef = ws.testLoc("Lib.a.string")
     try ws.openDocument(stringRef.url, language: .swift)
     let definition = try ws.sk.sendSync(DefinitionRequest(

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -99,7 +99,7 @@ final class SwiftInterfaceTests: XCTestCase {
     try ws.buildAndIndex()
     let importedModule = ws.testLoc("lib:import")
     try ws.openDocument(importedModule.url, language: .swift)
-    let openInterface = OpenInterfaceRequest(textDocument: importedModule.docIdentifier, name: "lib")
+    let openInterface = OpenInterfaceRequest(textDocument: importedModule.docIdentifier, name: "lib", symbol: nil)
     let interfaceDetails = try XCTUnwrap(ws.sk.sendSync(openInterface))
     XCTAssertTrue(interfaceDetails.uri.pseudoPath.hasSuffix("/lib.swiftinterface"))
     let fileContents = try XCTUnwrap(interfaceDetails.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))


### PR DESCRIPTION
 On calling `definition` if a symbol returns it is in a file with a `.swiftinterface` extension it will use OpenInterface to create the generated interface file. It will then call sourcekitd `source.request.editor.find_usr` to find the location of the symbol in the generated file.

- `OpenInterfaceRequest` has been extended to include an optional symbol name.
- Broke out openInterface code in `SourceKitServer.definition` into a separate function: `respondWithInterface`, as it is called from multiple sites now
- If first occurrence of symbol definition occurs inside a `swiftInterface` file then use `respondWithInterface` to build generated interface and then find symbol location in generated interface.
- Use DocumentManager to store instances of generated interface files, to avoid generating them on every call to `openInterface` and also cache the line table.
- Added `_findUSR` function that calls `source.request.editor.find_usr`
