### PR TITLE
Fully decode InitializeRequest

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
@@ -110,6 +110,7 @@ public struct InitializeRequest: RequestType, Hashable {
 extension InitializeRequest: Codable {
   private enum CodingKeys: String, CodingKey {
     case processId
+    case clientInfo
     case rootPath
     case rootURI = "rootUri"
     case initializationOptions

--- a/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
@@ -111,6 +111,7 @@ extension InitializeRequest: Codable {
   private enum CodingKeys: String, CodingKey {
     case processId
     case clientInfo
+    case locale
     case rootPath
     case rootURI = "rootUri"
     case initializationOptions

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -18,7 +18,7 @@ import XCTest
 final class CodingTests: XCTestCase {
 
   func testMessageCoding() {
-    checkMessageCoding(InitializeRequest(processId: 1, rootPath: "/foo", rootURI: nil, initializationOptions: nil, capabilities: ClientCapabilities(workspace: nil, textDocument: nil), trace: .off, workspaceFolders: nil), id: .number(2), json: """
+    checkMessageCoding(InitializeRequest(processId: 1, clientInfo: InitializeRequest.ClientInfo(name: "dummy-client", version: "1.0"), rootPath: "/foo", rootURI: nil, initializationOptions: nil, capabilities: ClientCapabilities(workspace: nil, textDocument: nil), trace: .off, workspaceFolders: nil), id: .number(2), json: """
     {
       "id" : 2,
       "jsonrpc" : "2.0",
@@ -26,6 +26,10 @@ final class CodingTests: XCTestCase {
       "params" : {
         "capabilities" : {
 
+        },
+        "clientInfo" : {
+          "name" : "dummy-client",
+          "version" : "1.0"
         },
         "processId" : 1,
         "rootPath" : "\\/foo",

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -18,7 +18,7 @@ import XCTest
 final class CodingTests: XCTestCase {
 
   func testMessageCoding() {
-    checkMessageCoding(InitializeRequest(processId: 1, clientInfo: InitializeRequest.ClientInfo(name: "dummy-client", version: "1.0"), rootPath: "/foo", rootURI: nil, initializationOptions: nil, capabilities: ClientCapabilities(workspace: nil, textDocument: nil), trace: .off, workspaceFolders: nil), id: .number(2), json: """
+    checkMessageCoding(InitializeRequest(processId: 1, clientInfo: InitializeRequest.ClientInfo(name: "dummy-client", version: "1.0"), locale: "en-US", rootPath: "/foo", rootURI: nil, initializationOptions: nil, capabilities: ClientCapabilities(workspace: nil, textDocument: nil), trace: .off, workspaceFolders: nil), id: .number(2), json: """
     {
       "id" : 2,
       "jsonrpc" : "2.0",
@@ -31,6 +31,7 @@ final class CodingTests: XCTestCase {
           "name" : "dummy-client",
           "version" : "1.0"
         },
+        "locale" : "en-US",
         "processId" : 1,
         "rootPath" : "\\/foo",
         "trace" : "off"


### PR DESCRIPTION
I found out that `clientInfo` is not decoded. This fixes this issue and modifies a test to ensure deserialization works. It has no impact on sourcekit-lsp, but as I use your LSPBindings product I want to have access to `clientInfo` 