### PR TITLE
Highlight references to actors like references to classes

### DIFF
--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -267,7 +267,9 @@ public struct sourcekitd_values {
   public let ref_var_local: sourcekitd_uid_t
   public let decl_var_parameter: sourcekitd_uid_t
   public let decl_module: sourcekitd_uid_t
+  public let decl_actor: sourcekitd_uid_t
   public let decl_class: sourcekitd_uid_t
+  public let ref_actor: sourcekitd_uid_t
   public let ref_class: sourcekitd_uid_t
   public let decl_struct: sourcekitd_uid_t
   public let ref_struct: sourcekitd_uid_t
@@ -371,6 +373,8 @@ public struct sourcekitd_values {
     ref_var_local = api.uid_get_from_cstr("source.lang.swift.ref.var.local")!
     decl_var_parameter = api.uid_get_from_cstr("source.lang.swift.decl.var.parameter")!
     decl_module = api.uid_get_from_cstr("source.lang.swift.decl.module")!
+    decl_actor = api.uid_get_from_cstr("source.lang.swift.decl.actor")!
+    ref_actor = api.uid_get_from_cstr("source.lang.swift.ref.actor")!
     decl_class = api.uid_get_from_cstr("source.lang.swift.decl.class")!
     ref_class = api.uid_get_from_cstr("source.lang.swift.ref.class")!
     decl_struct = api.uid_get_from_cstr("source.lang.swift.decl.struct")!

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
@@ -62,6 +62,7 @@ public struct SyntaxHighlightingToken: Hashable {
   public enum Kind: UInt32, CaseIterable, Hashable {
     case namespace = 0
     case type
+    case actor
     case `class`
     case `enum`
     case interface
@@ -91,6 +92,7 @@ public struct SyntaxHighlightingToken: Hashable {
       switch self {
       case .namespace: return "namespace"
       case .type: return "type"
+      case .actor: return "class" // LSP doesn’t know about actors. Display actors as classes.
       case .class: return "class"
       case .enum: return "enum"
       case .interface: return "interface"

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
@@ -83,6 +83,10 @@ struct SyntaxHighlightingTokenParser {
       return (.class, [.declaration])
     case values.ref_class:
       return (.class, [])
+    case values.decl_actor:
+      return (.actor, [.declaration])
+    case values.ref_actor:
+      return (.actor, [])
     case values.decl_struct:
       return (.struct, [.declaration])
     case values.ref_struct:

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -743,8 +743,33 @@ final class SemanticTokensTests: XCTestCase {
       Token(line: 1, utf16index: 8, length: 7, kind: .variable),
     ])
   }
-
   
+  func testActor() {
+    let text = """
+    actor MyActor {}
+
+    struct MyStruct {}
+
+    func t(
+        x: MyActor,
+        y: MyStruct
+    ) {}
+    """
+
+    let tokens = openAndPerformSemanticTokensRequest(text: text)
+    XCTAssertEqual(tokens, [
+      Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
+      Token(line: 0, utf16index: 6, length: 7, kind: .identifier),
+      Token(line: 2, utf16index: 0, length: 6, kind: .keyword),
+      Token(line: 2, utf16index: 7, length: 8, kind: .identifier),
+      Token(line: 4, utf16index: 0, length: 4, kind: .keyword),
+      Token(line: 4, utf16index: 5, length: 1, kind: .identifier),
+      Token(line: 5, utf16index: 4, length: 1, kind: .identifier),
+      Token(line: 5, utf16index: 7, length: 7, kind: .actor),
+      Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
+      Token(line: 6, utf16index: 7, length: 8, kind: .struct)
+    ])
+  }
 }
 
 extension Token {


### PR DESCRIPTION
We weren’t semantically highlighting references to actors because we missed the `ref_actor` case from the sourcekitd `annotations` response.

Fixes #694
rdar://104573568