### PR TITLE
Don’t update Package.resolved from sourcekit-lsp

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -182,6 +182,7 @@ extension SwiftPMWorkspace {
 
     let packageGraph = try self.workspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [AbsolutePath(packageRoot)]),
+      forceResolvedVersions: true,
       observabilityScope: observabilitySystem.topScope
     )
 


### PR DESCRIPTION
`SwiftPMWorkspace.reloadPackage` called `loadPackageGraph`, which causes package resolution and could thus update `Package.resolved`. This caused race conditions when `swift package update` was run from terminal while sourcekit-lsp is running since sourcekit-lsp was notified about the file changes and thus reloaded the pacakge to get build settings for the modified files.

Set `forceResolvedVersions` to only resolve packages based on the versions in `Package.resolved`, eliminating this problem.

Fixes https://github.com/apple/sourcekit-lsp/issues/707 rdar://105173375