### PR TITLE
[5.9] Don’t update Package.resolved from sourcekit-lsp

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -177,6 +177,7 @@ extension SwiftPMWorkspace {
 
     let packageGraph = try self.workspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [packageRoot]),
+      forceResolvedVersions: true,
       observabilityScope: observabilitySystem.topScope
     )
 


### PR DESCRIPTION
* **Explanation**: There was a race condition when running `swift package update` while sourcekit-lsp was running that could cause `Package.resolved` to not get updated. Fix the issue by not writing an updated Package.resolved from sourcekit-lsp
* **Risk**: Low
* **Testing**: Verified locally that Package.resolved does not get updated with this change
* **Issue**: rdar://105173375 / https://github.com/apple/sourcekit-lsp/issues/707
* **Reviewer**:  @bnbarham 
