### PR TITLE
[SwiftSyntax] Remove `Keyword` suffix from Pound*

### DIFF
--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -103,7 +103,7 @@ extension SyntaxClassification {
       return (.string, [])
     case .regexLiteral:
       return (.regexp, [])
-    case .poundDirectiveKeyword:
+    case .poundDirective:
       return (.macro, [])
     case .buildConfigId, .objectLiteral:
       return (.macro, [])


### PR DESCRIPTION
Companion to https://github.com/apple/swift-syntax/pull/1862