### PR TITLE
Show a progress indicator in the editor if SourceKit-LSP is reloading packages

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -137,6 +137,13 @@ public final class TestClient: MessageHandler {
   }
 
   public func handle<R: RequestType>(_ params: R, id: RequestID, from clientID: ObjectIdentifier, reply: @escaping (LSPResult<R.Response>) -> Void) {
+    if R.self == CreateWorkDoneProgressRequest.self {
+      // We don’t want to require tests to specify request handlers for work done progress.
+      // Simply ignore requests to create WorkDoneProgress for now.
+      reply(.failure(.unknown("WorkDone not supported in TestClient")))
+      return
+    }
+
     let cancellationToken = CancellationToken()
 
     let request = Request(params, id: id, clientID: clientID, cancellation: cancellationToken, reply: reply)

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -35,6 +35,14 @@ import func TSCBasic.resolveSymlinks
 import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem
 
+/// Parameter of `reloadPackageStatusCallback` in ``SwiftPMWorkspace``.
+///
+/// Informs the callback about whether `reloadPackage` started or finished executing.
+public enum ReloadPackageStatus {
+  case start
+  case end
+}
+
 /// Swift Package Manager build system and workspace support.
 ///
 /// This class implements the `BuildSystem` interface to provide the build settings for a Swift
@@ -78,18 +86,25 @@ public final class SwiftPMWorkspace {
   /// - `sourceDirToTarget`
   let queue: DispatchQueue = .init(label: "SwiftPMWorkspace.queue", qos: .utility)
 
+  /// This callback is informed when `reloadPackage` starts and ends executing.
+  var reloadPackageStatusCallback: (ReloadPackageStatus) -> Void
+
+
   /// Creates a build system using the Swift Package Manager, if this workspace is a package.
   ///
   /// - Parameters:
   ///   - workspace: The workspace root path.
   ///   - toolchainRegistry: The toolchain registry to use to provide the Swift compiler used for
   ///     manifest parsing and runtime support.
+  ///   - reloadPackageStatusCallback: Will be informed when `reloadPackage` starts and ends executing.
   /// - Throws: If there is an error loading the package, or no manifest is found.
   public init(
     workspacePath: TSCAbsolutePath,
     toolchainRegistry: ToolchainRegistry,
     fileSystem: FileSystem = localFileSystem,
-    buildSetup: BuildSetup) throws
+    buildSetup: BuildSetup,
+    reloadPackageStatusCallback: @escaping (ReloadPackageStatus) -> Void = { _ in }
+  ) throws
   {
     self.workspacePath = workspacePath
     self.fileSystem = fileSystem
@@ -142,23 +157,31 @@ public final class SwiftPMWorkspace {
     )
 
     self.packageGraph = try PackageGraph(rootPackages: [], dependencies: [], binaryArtifacts: [:])
+    self.reloadPackageStatusCallback = reloadPackageStatusCallback
 
     try reloadPackage()
   }
 
   /// Creates a build system using the Swift Package Manager, if this workspace is a package.
-  ///
+  /// 
+  /// - Parameters:
+  ///   - reloadPackageStatusCallback: Will be informed when `reloadPackage` starts and ends executing.
   /// - Returns: nil if `workspacePath` is not part of a package or there is an error.
-  public convenience init?(url: URL,
-                           toolchainRegistry: ToolchainRegistry,
-                           buildSetup: BuildSetup)
+  public convenience init?(
+    url: URL,
+    toolchainRegistry: ToolchainRegistry,
+    buildSetup: BuildSetup,
+    reloadPackageStatusCallback: @escaping (ReloadPackageStatus) -> Void
+  )
   {
     do {
       try self.init(
         workspacePath: try TSCAbsolutePath(validating: url.path),
         toolchainRegistry: toolchainRegistry,
         fileSystem: localFileSystem,
-        buildSetup: buildSetup)
+        buildSetup: buildSetup,
+        reloadPackageStatusCallback: reloadPackageStatusCallback
+      )
     } catch Error.noManifest(let path) {
       log("could not find manifest, or not a SwiftPM package: \(path)", level: .warning)
       return nil
@@ -175,6 +198,11 @@ extension SwiftPMWorkspace {
   /// dependencies.
   /// Must only be called on `queue` or from the initializer.
   func reloadPackage() throws {
+    reloadPackageStatusCallback(.start)
+    defer {
+      reloadPackageStatusCallback(.end)
+    }
+
 
     let observabilitySystem = ObservabilitySystem({ scope, diagnostic in
         log(diagnostic.description, level: diagnostic.severity.asLogLevel)

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -84,15 +84,19 @@ public final class Workspace {
     capabilityRegistry: CapabilityRegistry,
     toolchainRegistry: ToolchainRegistry,
     buildSetup: BuildSetup,
-    indexOptions: IndexOptions = IndexOptions()
+    indexOptions: IndexOptions = IndexOptions(),
+    reloadPackageStatusCallback: @escaping (ReloadPackageStatus) -> Void
   ) throws {
     var buildSystem: BuildSystem? = nil
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
       if let buildServer = BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
         buildSystem = buildServer
-      } else if let swiftpm = SwiftPMWorkspace(url: rootUrl,
-                                          toolchainRegistry: toolchainRegistry,
-                                          buildSetup: buildSetup) {
+      } else if let swiftpm = SwiftPMWorkspace(
+        url: rootUrl,
+        toolchainRegistry: toolchainRegistry,
+        buildSetup: buildSetup,
+        reloadPackageStatusCallback: reloadPackageStatusCallback
+      ) {
         buildSystem = swiftpm
       } else {
         buildSystem = CompilationDatabaseBuildSystem(projectRoot: rootPath)


### PR DESCRIPTION
I noticed that the initial package loading can take ~5s. It’s good behavior to inform the client that sourcekit-lsp is busy reloading the package, showing the user that semantic functionality might not be ready yet.

https://github.com/apple/sourcekit-lsp/issues/620
rdar://111917300