### PR TITLE
Don’t offer text edits from inlay hints if they are syntactically invalid

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1320,13 +1320,17 @@ extension SwiftLanguageServer {
           .map { info -> InlayHint in
             let position = info.range.upperBound
             let label = ": \(info.printedType)"
+            let textEdits: [TextEdit]?
+            if info.canBeFollowedByTypeAnnotation {
+              textEdits = [TextEdit(range: position..<position, newText: label)]
+            } else {
+              textEdits = nil
+            }
             return InlayHint(
               position: position,
               label: .string(label),
               kind: .type,
-              textEdits: [
-                TextEdit(range: position..<position, newText: label)
-              ]
+              textEdits: textEdits
             )
           }
 

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -61,14 +61,18 @@ final class InlayHintTests: XCTestCase {
     }
   }
 
-  private func makeInlayHint(position: Position, kind: InlayHintKind, label: String) -> InlayHint {
-    InlayHint(
+  private func makeInlayHint(position: Position, kind: InlayHintKind, label: String, hasEdit: Bool = true) -> InlayHint {
+    let textEdits: [TextEdit]?
+    if hasEdit {
+      textEdits = [TextEdit(range: position..<position, newText: label)]
+    } else {
+      textEdits = nil
+    }
+    return InlayHint(
       position: position,
       label: .string(label),
       kind: kind,
-      textEdits: [
-        TextEdit(range: position..<position, newText: label)
-      ]
+      textEdits: textEdits
     )
   }
 
@@ -205,7 +209,8 @@ final class InlayHintTests: XCTestCase {
       makeInlayHint(
         position: Position(line: 3, utf16index: 31),
         kind: .type,
-        label: ": String"
+        label: ": String",
+        hasEdit: false
       ),
       makeInlayHint(
         position: Position(line: 4, utf16index: 40),


### PR DESCRIPTION
Don’t offer any text edits for inlay hints displayed in closure paramters or enum case items.

Fixes #759
rdar://111559715