### PR TITLE
Add support for Musl libc with `canImport(Musl)` checks

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
@@ -13,13 +13,15 @@
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
-#if os(Linux) || os(Android)
+#if canImport(Glibc) || canImport(Musl)
 // This is a lazily initialised global variable that when read for the first time, will ignore SIGPIPE.
 private let globallyIgnoredSIGPIPE: Bool = {
     /* no F_SETNOSIGPIPE on Linux :( */
-    _ = Glibc.signal(SIGPIPE, SIG_IGN)
+    _ = signal(SIGPIPE, SIG_IGN)
     return true
 }()
 

--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -15,8 +15,10 @@ import CRT
 import WinSDK
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 public final class DLHandle {

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #endif

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #endif

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #endif

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #endif

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -13,6 +13,8 @@
 import Csourcekitd
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(CRT)
 import CRT
 #endif


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.

Musl is a low footprint libc that's used in Linux distributions such as Alpine Linux, which allows producing fairly small container images. Additionally, unlike Glibc, musl allows full static linking, meaning apps can be easily distributed to an arbitrary Linux distribution that may have a version of Glibc incompatible with the one that Swift is usually built with or no Glibc installed at all.