### PR TITLE
[NFC] Use `SwiftSDK` instead of deprecated `Destination`

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -119,8 +119,8 @@ public final class SwiftPMWorkspace {
         throw Error.cannotDetermineHostToolchain
     }
 
-    let destination = try Destination.hostDestination(AbsolutePath(destinationToolchainBinDir))
-    let toolchain = try UserToolchain(destination: destination)
+    let swiftSDK = try SwiftSDK.hostSwiftSDK(AbsolutePath(destinationToolchainBinDir))
+    let toolchain = try UserToolchain(swiftSDK: swiftSDK)
 
     var location = try Workspace.Location(
         forRootPackage: AbsolutePath(packageRoot),
@@ -139,8 +139,6 @@ public final class SwiftPMWorkspace {
         configuration: configuration,
         customHostToolchain: toolchain)
 
-    let triple = toolchain.triple
-
     let buildConfiguration: PackageModel.BuildConfiguration
     switch buildSetup.configuration {
     case .debug:
@@ -150,7 +148,7 @@ public final class SwiftPMWorkspace {
     }
 
     self.buildParameters = try BuildParameters(
-        dataPath: location.scratchDirectory.appending(component: triple.platformBuildPathComponent()),
+        dataPath: location.scratchDirectory.appending(component: toolchain.targetTriple.platformBuildPathComponent()),
         configuration: buildConfiguration,
         toolchain: toolchain,
         flags: buildSetup.flags


### PR DESCRIPTION
Code utilizing libSwiftPM should use `SwiftSDK` instead, with a few other properties renamed for clarity on related types. In this PR specifically we should use new `targetTriple` instead of the deprecated `triple` on the `Toolchain` type.

Depends on https://github.com/apple/swift-package-manager/pull/6707.