### PR TITLE
[5.9] Update tests to allow multiple -F options

### DIFF
--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -123,7 +123,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let versionString = PackageModel.Platform.macOS.oldestSupportedVersion.versionString
       check("-target", hostTriple.tripleString(forPlatformVersion: versionString), arguments: arguments)
       check("-sdk", arguments: arguments)
-      check("-F", arguments: arguments)
+      check("-F", arguments: arguments, allowMultiple: true)
   #else
       check("-target", hostTriple.tripleString, arguments: arguments)
   #endif
@@ -365,7 +365,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         check("-target",
           hostTriple.tripleString(forPlatformVersion: versionString), arguments: arguments)
         check("-isysroot", arguments: arguments)
-        check("-F", arguments: arguments)
+        check("-F", arguments: arguments, allowMultiple: true)
     #else
         check("-target", hostTriple.tripleString, arguments: arguments)
     #endif
@@ -609,6 +609,7 @@ private func checkNot(
 private func check(
   _ pattern: String...,
   arguments: [String],
+  allowMultiple: Bool = false,
   file: StaticString = #filePath,
   line: UInt = #line)
 {
@@ -617,7 +618,7 @@ private func check(
     return
   }
 
-  if let index2 = arguments[(index+1)...].firstIndex(of: pattern) {
+  if !allowMultiple, let index2 = arguments[(index+1)...].firstIndex(of: pattern) {
     XCTFail(
       "pattern \(pattern) found twice (\(index), \(index2)) in \(arguments)",
       file: file, line: line)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/sourcekit-lsp/pull/742 required to unblock https://github.com/apple/swift-package-manager/pull/6709.

Updates tests to allow compile arguments with multiple `-F` options such as `-F <foo> -Xcc -F -Xcc <foo>`. This change is required to support SwiftPM changes which forward C compiler flags to the Swift compiler in more cases.