### PR TITLE
Adjustment for rename `SyntaxClassification.floatingLiteral` -> `floatLiteral` in SwiftSyntax

### DIFF
--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -97,7 +97,7 @@ extension SyntaxClassification {
       return (.identifier, [])
     case .operatorIdentifier:
       return (.operator, [])
-    case .integerLiteral, .floatingLiteral:
+    case .integerLiteral, .floatLiteral:
       return (.number, [])
     case .stringLiteral:
       return (.string, [])


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1983