### PR TITLE
Remove `SyntaxClassification.objectLiteral`

### DIFF
--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -105,7 +105,7 @@ extension SyntaxClassification {
       return (.regexp, [])
     case .poundDirective:
       return (.macro, [])
-    case .buildConfigId, .objectLiteral:
+    case .buildConfigId:
       return (.macro, [])
     case .attribute:
       return (.modifier, [])


### PR DESCRIPTION
To sync changes in https://github.com/apple/swift-syntax/pull/1953