### PR TITLE
Get compiler arguments for files in the Plugins folder

### DIFF
--- a/Sources/SKSwiftPMWorkspace/CMakeLists.txt
+++ b/Sources/SKSwiftPMWorkspace/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(SKSwiftPMWorkspace PRIVATE
   SKCore
   TSCBasic)
 target_link_libraries(SKSwiftPMWorkspace PUBLIC
-  Build)
+  Build
+  SourceKitLSPAPI)

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -22,6 +22,7 @@ import PackageModel
 import SKCore
 import SKSupport
 import SourceControl
+import SourceKitLSPAPI
 import Workspace
 
 import struct Basics.AbsolutePath
@@ -42,6 +43,12 @@ public enum ReloadPackageStatus {
   case start
   case end
 }
+
+/// A build target in SwiftPM
+public typealias SwiftBuildTarget = SourceKitLSPAPI.BuildTarget
+
+/// A build target in `BuildServerProtocol`
+public typealias BuildServerTarget = BuildServerProtocol.BuildTarget
 
 /// Same as `toolchainRegistry.default`.
 ///
@@ -83,8 +90,8 @@ public actor SwiftPMWorkspace {
   public let buildParameters: BuildParameters
   let fileSystem: FileSystem
 
-  var fileToTarget: [AbsolutePath: TargetBuildDescription] = [:]
-  var sourceDirToTarget: [AbsolutePath: TargetBuildDescription] = [:]
+  var fileToTarget: [AbsolutePath: SwiftBuildTarget] = [:]
+  var sourceDirToTarget: [AbsolutePath: SwiftBuildTarget] = [:]
 
   /// The URIs for which the delegate has registered for change notifications,
   /// mapped to the language the delegate specified when registering for change notifications.
@@ -215,19 +222,20 @@ extension SwiftPMWorkspace {
       fileSystem: fileSystem,
       observabilityScope: observabilitySystem.topScope
     )
+    let buildDescription = BuildDescription(buildPlan: plan)
 
     /// Make sure to execute any throwing statements before setting any
     /// properties because otherwise we might end up in an inconsistent state
     /// with only some properties modified.
     self.packageGraph = packageGraph
 
-    self.fileToTarget = [AbsolutePath: TargetBuildDescription](
+    self.fileToTarget = [AbsolutePath: SwiftBuildTarget](
       packageGraph.allTargets.flatMap { target in
         return target.sources.paths.compactMap {
-          guard let td = plan.targetMap[target.id] else {
+          guard let buildTarget = buildDescription.getBuildTarget(for: target) else {
             return nil
           }
-          return (key: $0, value: td)
+          return (key: $0, value: buildTarget)
         }
       },
       uniquingKeysWith: { td, _ in
@@ -236,12 +244,12 @@ extension SwiftPMWorkspace {
       }
     )
 
-    self.sourceDirToTarget = [AbsolutePath: TargetBuildDescription](
-      packageGraph.allTargets.compactMap { target in
-        guard let td = plan.targetMap[target.id] else {
+    self.sourceDirToTarget = [AbsolutePath: SwiftBuildTarget](
+      packageGraph.allTargets.compactMap { (target) -> (AbsolutePath, SwiftBuildTarget)? in
+        guard let buildTarget = buildDescription.getBuildTarget(for: target) else {
           return nil
         }
-        return (key: target.sources.root, value: td)
+        return (key: target.sources.root, value: buildTarget)
       },
       uniquingKeysWith: { td, _ in
         // FIXME: is there  a preferred target?
@@ -284,8 +292,11 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
       return nil
     }
 
-    if let td = try targetDescription(for: path) {
-      return try settings(for: path, language, td)
+    if let buildTarget = try buildTarget(for: path) {
+      return FileBuildSettings(
+        compilerArguments: try buildTarget.compileArguments(for: path.asURL),
+        workingDirectory: workspacePath.pathString
+      )
     }
 
     if path.basename == "Package.swift" {
@@ -310,7 +321,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
   }
 
   /// Returns the resolved target description for the given file, if one is known.
-  private func targetDescription(for file: AbsolutePath) throws -> TargetBuildDescription? {
+  private func buildTarget(for file: AbsolutePath) throws -> SwiftBuildTarget? {
     if let td = fileToTarget[file] {
       return td
     }
@@ -359,7 +370,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
     guard let fileUrl = uri.fileURL else {
       return .unhandled
     }
-    if (try? targetDescription(for: AbsolutePath(validating: fileUrl.path))) != nil {
+    if (try? buildTarget(for: AbsolutePath(validating: fileUrl.path))) != nil {
       return .handled
     } else {
       return .unhandled
@@ -370,24 +381,6 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 extension SwiftPMWorkspace {
 
   // MARK: Implementation details
-
-  /// Retrieve settings for the given file, which is part of a known target build description.
-  public func settings(
-    for path: AbsolutePath,
-    _ language: Language,
-    _ td: TargetBuildDescription
-  ) throws -> FileBuildSettings? {
-    switch (td, language) {
-    case (.swift(let td), .swift):
-      return try settings(forSwiftFile: path, td)
-    case (.clang, .swift):
-      return nil
-    case (.clang(let td), _):
-      return try settings(forClangFile: path, language, td)
-    default:
-      return nil
-    }
-  }
 
   /// Retrieve settings for a package manifest (Package.swift).
   private func settings(forPackageManifest path: AbsolutePath) throws -> FileBuildSettings? {
@@ -408,12 +401,24 @@ extension SwiftPMWorkspace {
   }
 
   /// Retrieve settings for a given header file.
+  ///
+  /// This finds the target the header belongs to based on its location in the file system, retrieves the build settings
+  /// for any file within that target and generates compiler arguments by replacing that picked file with the header
+  /// file.
+  /// This is safe because all files within one target have the same build settings except for reference to the file
+  /// itself, which we are replacing.
   private func settings(forHeader path: AbsolutePath, _ language: Language) throws -> FileBuildSettings? {
     func impl(_ path: AbsolutePath) throws -> FileBuildSettings? {
       var dir = path.parentDirectory
       while !dir.isRoot {
-        if let td = sourceDirToTarget[dir] {
-          return try settings(for: path, language, td)
+        if let buildTarget = sourceDirToTarget[dir] {
+          if let sourceFile = buildTarget.sources.first {
+            return FileBuildSettings(
+              compilerArguments: try buildTarget.compileArguments(for: sourceFile),
+              workingDirectory: workspacePath.pathString
+            ).patching(newFile: path.pathString, originalFile: sourceFile.absoluteString)
+          }
+          return nil
         }
         dir = dir.parentDirectory
       }
@@ -426,103 +431,6 @@ extension SwiftPMWorkspace {
 
     let canonicalPath = try resolveSymlinks(path)
     return try canonicalPath == path ? nil : impl(canonicalPath)
-  }
-
-  /// Retrieve settings for the given swift file, which is part of a known target build description.
-  public func settings(
-    forSwiftFile path: AbsolutePath,
-    _ td: SwiftTargetBuildDescription
-  ) throws -> FileBuildSettings {
-    // FIXME: this is re-implementing llbuild's constructCommandLineArgs.
-    var args: [String] = [
-      "-module-name",
-      td.target.c99name,
-      "-incremental",
-      "-emit-dependencies",
-      "-emit-module",
-      "-emit-module-path",
-      buildPath.appending(component: "\(td.target.c99name).swiftmodule").pathString,
-      // -output-file-map <path>
-    ]
-    if td.target.type == .library || td.target.type == .test {
-      args += ["-parse-as-library"]
-    }
-    args += ["-c"]
-    args += td.sources.map { $0.pathString }
-    args += ["-I", td.moduleOutputPath.parentDirectory.pathString]
-    args += try td.compileArguments()
-
-    return FileBuildSettings(
-      compilerArguments: args,
-      workingDirectory: workspacePath.pathString
-    )
-  }
-
-  /// Retrieve settings for the given C-family language file, which is part of a known target build
-  /// description.
-  ///
-  /// - Note: language must be a C-family language.
-  public func settings(
-    forClangFile path: AbsolutePath,
-    _ language: Language,
-    _ td: ClangTargetBuildDescription
-  ) throws -> FileBuildSettings {
-    // FIXME: this is re-implementing things from swiftpm's createClangCompileTarget
-
-    var args = try td.basicArguments()
-
-    let nativePath: AbsolutePath =
-      try URL(fileURLWithPath: path.pathString).withUnsafeFileSystemRepresentation {
-        try AbsolutePath(validating: String(cString: $0!))
-      }
-    let compilePath = try td.compilePaths().first(where: { $0.source == nativePath })
-    if let compilePath = compilePath {
-      args += [
-        "-MD",
-        "-MT",
-        "dependencies",
-        "-MF",
-        compilePath.deps.pathString,
-      ]
-    }
-
-    switch language {
-    case .c:
-      if let std = td.clangTarget.cLanguageStandard {
-        args += ["-std=\(std)"]
-      }
-    case .cpp:
-      if let std = td.clangTarget.cxxLanguageStandard {
-        args += ["-std=\(std)"]
-      }
-    default:
-      break
-    }
-
-    if let compilePath = compilePath {
-      args += [
-        "-c",
-        compilePath.source.pathString,
-        "-o",
-        compilePath.object.pathString,
-      ]
-    } else if path.extension == "h" {
-      args += ["-c"]
-      if let xflag = language.xflagHeader {
-        args += ["-x", xflag]
-      }
-      args += [path.pathString]
-    } else {
-      args += [
-        "-c",
-        path.pathString,
-      ]
-    }
-
-    return FileBuildSettings(
-      compilerArguments: args,
-      workingDirectory: workspacePath.pathString
-    )
   }
 }
 

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -275,14 +275,6 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 
   public var indexPrefixMappings: [PathPrefixMapping] { return [] }
 
-  /// **Public for testing only**
-  public func _settings(
-    for uri: DocumentURI,
-    _ language: Language
-  ) throws -> FileBuildSettings? {
-    try self.buildSettings(for: uri, language: language)
-  }
-
   public func buildSettings(for uri: DocumentURI, language: Language) throws -> FileBuildSettings? {
     guard let url = uri.fileURL else {
       // We can't determine build settings for non-file URIs.

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -13,6 +13,7 @@
 import LSPTestSupport
 @_spi(Testing) import SKCore
 import SKSupport
+import SKTestSupport
 import TSCBasic
 import XCTest
 
@@ -341,7 +342,7 @@ final class ToolchainRegistryTests: XCTestCase {
   func testFromDirectory() async throws {
     // This test uses the real file system because the in-memory system doesn't support marking files executable.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       let path = tempDir.appending(components: "A.xctoolchain", "usr")
       try makeToolchain(
         binPath: path.appending(component: "bin"),

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -31,7 +31,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
   func testNoPackage() async throws {
     let fs = InMemoryFileSystem()
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -53,7 +53,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
   func testUnparsablePackage() async throws {
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -80,7 +80,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
   func testNoToolchain() async throws {
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -108,7 +108,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testBasicSwiftArgs() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -168,7 +168,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testBuildSetup() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -214,7 +214,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testManifestArgs() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -247,7 +247,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testMultiFileSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -285,7 +285,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testMultiTargetSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -351,7 +351,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testUnknownFile() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -387,7 +387,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testBasicCXXArgs() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -481,7 +481,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testDeploymentTargetSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -524,7 +524,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testSymlinkInWorkspaceSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -579,7 +579,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testSymlinkInWorkspaceCXX() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -629,7 +629,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   func testSwiftDerivedSources() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [
@@ -670,7 +670,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
   func testNestedInvalidPackageSwift() async throws {
     let fs = InMemoryFileSystem()
-    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTestScratchDir { tempDir in
       try fs.createFiles(
         root: tempDir,
         files: [

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -136,7 +136,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       assertEqual(await ws.buildPath, build)
       assertNotNil(await ws.indexStorePath)
-      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
 
       check(
         "-module-name",
@@ -203,7 +203,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let build = buildPath(root: packageRoot, config: config, platform: hostTriple.platformBuildPathComponent)
 
       assertEqual(await ws.buildPath, build)
-      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
 
       check("-typecheck", arguments: arguments)
       check("-Xcc", "-m32", arguments: arguments)
@@ -237,7 +237,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
-      let arguments = try await ws._settings(for: source.asURI, .swift)!.compilerArguments
+      let arguments = try await ws.buildSettings(for: source.asURI, language: .swift)!.compilerArguments
 
       check("-swift-version", "4.2", arguments: arguments)
       check(source.pathString, arguments: arguments)
@@ -273,10 +273,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
 
-      let argumentsA = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let argumentsA = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       check(aswift.pathString, arguments: argumentsA)
       check(bswift.pathString, arguments: argumentsA)
-      let argumentsB = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let argumentsB = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       check(aswift.pathString, arguments: argumentsB)
       check(bswift.pathString, arguments: argumentsB)
     }
@@ -316,7 +316,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       checkNot(bswift.pathString, arguments: arguments)
       // Temporary conditional to work around revlock between SourceKit-LSP and SwiftPM
@@ -337,7 +337,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         )
       }
 
-      let argumentsB = try await ws._settings(for: bswift.asURI, .swift)!.compilerArguments
+      let argumentsB = try await ws.buildSettings(for: bswift.asURI, language: .swift)!.compilerArguments
       check(bswift.pathString, arguments: argumentsB)
       checkNot(aswift.pathString, arguments: argumentsB)
       checkNot(
@@ -378,9 +378,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      assertNotNil(try await ws._settings(for: aswift.asURI, .swift))
-      assertNil(try await ws._settings(for: bswift.asURI, .swift))
-      assertNil(try await ws._settings(for: DocumentURI(URL(string: "https://www.apple.com")!), .swift))
+      assertNotNil(try await ws.buildSettings(for: aswift.asURI, language: .swift))
+      assertNil(try await ws.buildSettings(for: bswift.asURI, language: .swift))
+      assertNil(try await ws.buildSettings(for: DocumentURI(URL(string: "https://www.apple.com")!), language: .swift))
     }
   }
 
@@ -447,7 +447,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         checkNot(bcxx.pathString, arguments: arguments)
       }
 
-      let args = try await ws._settings(for: acxx.asURI, .cpp)!.compilerArguments
+      let args = try await ws.buildSettings(for: acxx.asURI, language: .cpp)!.compilerArguments
       checkArgsCommon(args)
 
       URL(fileURLWithPath: build.appending(components: "lib.build", "a.cpp.d").pathString)
@@ -465,7 +465,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         }
 
       let header = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
-      let headerArgs = try await ws._settings(for: header.asURI, .cpp)!.compilerArguments
+      let headerArgs = try await ws.buildSettings(for: header.asURI, language: .cpp)!.compilerArguments
       checkArgsCommon(headerArgs)
 
       check(
@@ -505,7 +505,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       check("-target", arguments: arguments)  // Only one!
       let hostTriple = await ws.buildParameters.targetTriple
 
@@ -559,8 +559,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         .appending(components: "Sources", "lib", "a.swift")
       let manifest = packageRoot.appending(components: "Package.swift")
 
-      let arguments1 = try await ws._settings(for: aswift1.asURI, .swift)?.compilerArguments
-      let arguments2 = try await ws._settings(for: aswift2.asURI, .swift)?.compilerArguments
+      let arguments1 = try await ws.buildSettings(for: aswift1.asURI, language: .swift)?.compilerArguments
+      let arguments2 = try await ws.buildSettings(for: aswift2.asURI, language: .swift)?.compilerArguments
       XCTAssertNotNil(arguments1)
       XCTAssertNotNil(arguments2)
       XCTAssertEqual(arguments1, arguments2)
@@ -568,7 +568,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       checkNot(aswift1.pathString, arguments: arguments1 ?? [])
       check(try resolveSymlinks(aswift1).pathString, arguments: arguments1 ?? [])
 
-      let argsManifest = try await ws._settings(for: manifest.asURI, .swift)?.compilerArguments
+      let argsManifest = try await ws.buildSettings(for: manifest.asURI, language: .swift)?.compilerArguments
       XCTAssertNotNil(argsManifest)
 
       checkNot(manifest.pathString, arguments: argsManifest ?? [])
@@ -614,12 +614,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let ah = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
 
-      let argsCxx = try await ws._settings(for: acxx.asURI, .cpp)?.compilerArguments
+      let argsCxx = try await ws.buildSettings(for: acxx.asURI, language: .cpp)?.compilerArguments
       XCTAssertNotNil(argsCxx)
       check(acxx.pathString, arguments: argsCxx ?? [])
       checkNot(try resolveSymlinks(acxx).pathString, arguments: argsCxx ?? [])
 
-      let argsH = try await ws._settings(for: ah.asURI, .cpp)?.compilerArguments
+      let argsH = try await ws.buildSettings(for: ah.asURI, language: .cpp)?.compilerArguments
       XCTAssertNotNil(argsH)
       checkNot(ah.pathString, arguments: argsH ?? [])
       check(try resolveSymlinks(ah).pathString, arguments: argsH ?? [])
@@ -657,7 +657,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       XCTAssertNotNil(
         arguments.firstIndex(where: {

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -106,7 +106,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testBasicSwiftArgs() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -166,7 +165,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testBuildSetup() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -212,7 +210,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testManifestArgs() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -245,7 +242,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testMultiFileSwift() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -283,7 +279,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testMultiTargetSwift() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -349,7 +344,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testUnknownFile() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -385,7 +379,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testBasicCXXArgs() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -479,7 +472,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testDeploymentTargetSwift() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -522,7 +514,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testSymlinkInWorkspaceSwift() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -577,7 +568,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testSymlinkInWorkspaceCXX() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(
@@ -627,7 +617,6 @@ final class SwiftPMWorkspaceTests: XCTestCase {
   }
 
   func testSwiftDerivedSources() async throws {
-    // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
     try await withTestScratchDir { tempDir in
       try fs.createFiles(


### PR DESCRIPTION
Preceded by some preliminary clean-up commits that don’t change functionality.

---

This uses the new API in SwiftPM introduced by https://github.com/apple/swift-package-manager/pull/6763 to get compiler arguments for a target instead of stitching them together in sourcekit-lsp.

Fixes https://github.com/apple/sourcekit-lsp/issues/664
rdar://102213837