### PR TITLE
Rename some `SyntaxClassification`

### DIFF
--- a/Sources/SourceKitLSP/DocumentTokens.swift
+++ b/Sources/SourceKitLSP/DocumentTokens.swift
@@ -89,23 +89,19 @@ extension SyntaxClassification {
       return nil
     case .editorPlaceholder:
       return nil
-    case .stringInterpolationAnchor:
-      return nil
     case .keyword:
       return (.keyword, [])
-    case .identifier, .typeIdentifier, .dollarIdentifier:
+    case .identifier, .type, .dollarIdentifier:
       return (.identifier, [])
-    case .operatorIdentifier:
+    case .operator:
       return (.operator, [])
-    case .integerLiteral, .floatingLiteral:
+    case .integerLiteral, .floatLiteral:
       return (.number, [])
     case .stringLiteral:
       return (.string, [])
     case .regexLiteral:
       return (.regexp, [])
-    case .poundDirective:
-      return (.macro, [])
-    case .buildConfigId:
+    case .ifConfigDirective:
       return (.macro, [])
     case .attribute:
       return (.modifier, [])


### PR DESCRIPTION
To sync changes in https://github.com/apple/swift-syntax/pull/1998