### PR TITLE
Update diagnostic in PullDiagnosticsTests to be imperative

### DIFF
--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -118,6 +118,6 @@ final class PullDiagnosticsTests: XCTestCase {
 
     XCTAssertEqual(actions.count, 1)
     let action = try XCTUnwrap(actions.first)
-    XCTAssertEqual(action.title, "do you want to add protocol stubs?")
+    XCTAssertEqual(action.title, "add stubs for conformance")
   }
 }


### PR DESCRIPTION
This commit corresponds to changes introduced in https://github.com/apple/swift/pull/67909.

The merge should be timed accordingly to go hand-in-hand with https://github.com/apple/swift/pull/67909.