### PR TITLE
Improve folding of line comments

### DIFF
--- a/Sources/SKTestSupport/INPUTS/FoldingRange/FoldingRangeMultilineDocLineComment.swift
+++ b/Sources/SKTestSupport/INPUTS/FoldingRange/FoldingRangeMultilineDocLineComment.swift
@@ -1,0 +1,14 @@
+/// Do some fancy stuff
+///
+/// This does very fancy stuff. Use it when building a great app.
+func doStuff() {
+  
+}
+
+// Some comment
+// And some more test
+
+// And another comment separated by newlines
+func foo() {}
+
+/*fr:multilineDocLineComment*/

--- a/Sources/SKTestSupport/INPUTS/FoldingRange/project.json
+++ b/Sources/SKTestSupport/INPUTS/FoldingRange/project.json
@@ -1,1 +1,8 @@
-{ "sources": ["FoldingRangeBase.swift", "FoldingRangeEmptyFile.swift"] }
+{
+  "sources": [
+    "FoldingRangeBase.swift",
+    "FoldingRangeEmptyFile.swift",
+    "FoldingRangeMultilineDocLineComment.swift",
+    "FoldingRangeDuplicateRanges.swift"
+  ]
+}

--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -38,11 +38,11 @@ final class FoldingRangeTests: XCTestCase {
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
 
-    XCTAssertEqual(ranges, [
+    let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 1, endUTF16Index: 18, kind: .comment),
       FoldingRange(startLine: 3, startUTF16Index: 0, endLine: 13, endUTF16Index: 2, kind: .comment),
       FoldingRange(startLine: 14, startUTF16Index: 10, endLine: 27, endUTF16Index: 0, kind: nil),
-      FoldingRange(startLine: 15, startUTF16Index: 2, endLine: 17, endUTF16Index: 2, kind: .comment),
+      FoldingRange(startLine: 15, startUTF16Index: 2, endLine: 16, endUTF16Index: 6, kind: .comment),
       FoldingRange(startLine: 17, startUTF16Index: 2, endLine: 19, endUTF16Index: 4, kind: .comment),
       FoldingRange(startLine: 22, startUTF16Index: 21, endLine: 25, endUTF16Index: 2, kind: nil),
       FoldingRange(startLine: 23, startUTF16Index: 23, endLine: 23, endUTF16Index: 30, kind: nil),
@@ -51,7 +51,9 @@ final class FoldingRangeTests: XCTestCase {
       FoldingRange(startLine: 33, startUTF16Index: 0, endLine: 35, endUTF16Index: 2, kind: .comment),
       FoldingRange(startLine: 37, startUTF16Index: 0, endLine: 37, endUTF16Index: 32, kind: .comment),
       FoldingRange(startLine: 39, startUTF16Index: 0, endLine: 39, endUTF16Index: 11, kind: .comment),
-    ])
+    ]
+
+    XCTAssertEqual(ranges, expected)
   }
 
   func testLineFoldingOnly() throws {
@@ -63,16 +65,18 @@ final class FoldingRangeTests: XCTestCase {
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
 
-    XCTAssertEqual(ranges, [
+    let expected = [
       FoldingRange(startLine: 0, endLine: 1, kind: .comment),
       FoldingRange(startLine: 3, endLine: 13, kind: .comment),
       FoldingRange(startLine: 14, endLine: 27, kind: nil),
-      FoldingRange(startLine: 15, endLine: 17, kind: .comment),
+      FoldingRange(startLine: 15, endLine: 16, kind: .comment),
       FoldingRange(startLine: 17, endLine: 19, kind: .comment),
       FoldingRange(startLine: 22, endLine: 25, kind: nil),
       FoldingRange(startLine: 29, endLine: 31, kind: .comment),
       FoldingRange(startLine: 33, endLine: 35, kind: .comment),
-    ])
+    ]
+
+    XCTAssertEqual(ranges, expected)
   }
 
   func testRangeLimit() throws {
@@ -103,6 +107,28 @@ final class FoldingRangeTests: XCTestCase {
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
 
     XCTAssertEqual(ranges?.count, 0)
+  }
+
+  func testMultilineDocLineComment() throws {
+    // In this file the range of the call to `print` and the range of the argument "/*fr:duplicateRanges*/" are the same.
+    // Test that we only report the folding range once.
+    let capabilities = FoldingRangeCapabilities()
+
+    guard let (ws, url) = try initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:multilineDocLineComment") else { return }
+
+    let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
+    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+
+    let expected = [
+      FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 2, endUTF16Index: 65, kind: .comment),
+      FoldingRange(startLine: 3, startUTF16Index: 16, endLine: 5, endUTF16Index: 0),
+      FoldingRange(startLine: 7, startUTF16Index: 0, endLine: 8, endUTF16Index: 21, kind: .comment),
+      FoldingRange(startLine: 10, startUTF16Index: 0, endLine: 10, endUTF16Index: 44, kind: .comment),
+      FoldingRange(startLine: 11, startUTF16Index: 12, endLine: 11, endUTF16Index: 12),
+      FoldingRange(startLine: 13, startUTF16Index: 0, endLine: 13, endUTF16Index: 30, kind: .comment)
+    ]
+
+    XCTAssertEqual(ranges, expected)
   }
 
   func testDontReportDuplicateRangesRanges() throws {


### PR DESCRIPTION
Previously, the folding range of a block of line comments was ended after the newline of the last line comment, which would usually be the line of the function’s start. That caused VS Code to not show a folding range for the function body itself since it started on the same line that the line comment folding range ended.

Rewrite the trivia folding logic so that the folding range of those line comments ends on the line of the last line comment.

Fixes #803
rdar://114428202