### PR TITLE
Introduce a `relatedDependenciesBranch` variable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -247,13 +247,15 @@ let package = Package(
 // for building the swift toolchain, such as `update-checkout`, or cross-repo PR tests.
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+  let relatedDependenciesBranch = "main"
+
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/indexstore-db.git", branch: "main"),
-    .package(url: "https://github.com/apple/swift-package-manager.git", branch: "main"),
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "main"),
+    .package(url: "https://github.com/apple/indexstore-db.git", branch: relatedDependenciesBranch),
+    .package(url: "https://github.com/apple/swift-package-manager.git", branch: relatedDependenciesBranch),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: relatedDependenciesBranch),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
-    .package(url: "https://github.com/apple/swift-syntax.git", branch: "main"),
+    .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
This way we only need to update one value when branching for a new release of Swift.