### PR TITLE
Fix typo in `reloadPackage` token name

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -158,7 +158,7 @@ public final class SourceKitServer: LanguageServer {
 
   private let documentManager = DocumentManager()
 
-  private var packageLoadingWorkDoneProgress = WorkDoneProgressState("SourceKitLSP.SoruceKitServer.reloadPackage", title: "Reloading Package")
+  private var packageLoadingWorkDoneProgress = WorkDoneProgressState("SourceKitLSP.SourceKitServer.reloadPackage", title: "Reloading Package")
 
   /// **Public for testing**
   public var _documentManager: DocumentManager {


### PR DESCRIPTION
I noticed that #791 introduced a misspelling of `SourceKit` in the `WorkDoneProgressState` token for `reloadPackage` so I corrected it.

This value did not seem to be explicitly covered in tests and given the statelessness (between server restarts) of the protocol I believe this doesn't have further ramifications.