### PR TITLE
Public initializer for DidSaveTextDocumentNotification

### DIFF
--- a/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
+++ b/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
@@ -138,6 +138,11 @@ public struct DidSaveTextDocumentNotification: TextDocumentNotification, Hashabl
   ///
   /// Only provided if the server specified `includeText == true`.
   public var text: String?
+
+  public init(textDocument: TextDocumentIdentifier, text: String? = nil) {
+    self.textDocument = textDocument
+    self.text = text
+  }
 }
 
 /// The open notification is sent from the client to the server when a notebook document is opened. It is only sent by a client if the server requested the synchronization mode `notebook` in its `notebookDocumentSync` capability.

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -761,7 +761,9 @@ public struct DocumentLinkOptions: WorkDoneProgressOptions, Codable, Hashable {
 public struct SemanticTokensOptions: WorkDoneProgressOptions, Codable, Hashable {
 
   public struct SemanticTokensRangeOptions: Equatable, Hashable, Codable {
-    // Empty in the LSP 3.16 spec.
+    public init() {
+      // Empty in the LSP 3.16 spec.
+    }
   }
 
   public struct SemanticTokensFullOptions: Equatable, Hashable, Codable {


### PR DESCRIPTION
The public initializer for `DidSaveTextDocumentNotification` and `SemanticTokensRangeOptions`

not used anywhere here, however I found need to use it and cried it's not possible.