### PR TITLE
Reduce usages of `try!` in tests

### DIFF
--- a/Sources/LSPTestSupport/AssertNoThrow.swift
+++ b/Sources/LSPTestSupport/AssertNoThrow.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+/// Same as `XCTAssertThrows` but executes the trailing closure.
+public func assertNoThrow<T>(_ expression: () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+  XCTAssertNoThrow(try expression(), message(), file: file, line: line)
+}

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -46,7 +46,9 @@ class ConnectionTests: XCTestCase {
     let expectation = self.expectation(description: "response received")
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.get(), "hello!")
+      assertNoThrow {
+        XCTAssertEqual(try resp.get(), "hello!")
+      }
       expectation.fulfill()
     }
 
@@ -100,8 +102,12 @@ class ConnectionTests: XCTestCase {
     let expectation = self.expectation(description: "response received 1")
     let expectation2 = self.expectation(description: "response received 2")
 
-    _ = client.send(EchoError(code: nil)) { resp in
-      XCTAssertEqual(try! resp.get(), VoidResponse())
+    _ = client.send(EchoError(code: nil)) { (resp) -> Void in
+      do {
+        assertNoThrow {
+          XCTAssertEqual(try resp.get(), VoidResponse())
+        }
+      }
       expectation.fulfill()
     }
 
@@ -157,7 +163,9 @@ class ConnectionTests: XCTestCase {
     // Nothing bad should happen; check that the next request works.
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.get(), "hello!")
+      assertNoThrow {
+        XCTAssertEqual(try resp.get(), "hello!")
+      }
       expectation.fulfill()
     }
 
@@ -174,7 +182,9 @@ class ConnectionTests: XCTestCase {
     // Nothing bad should happen; check that the next request works.
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.get(), "hello!")
+      assertNoThrow {
+        XCTAssertEqual(try resp.get(), "hello!")
+      }
       expectation.fulfill()
     }
 

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -35,7 +35,9 @@ class ConnectionTests: XCTestCase {
     let expectation = self.expectation(description: "response received")
 
     _ = client.send(EchoRequest(string: "hello!")) { resp in
-      XCTAssertEqual(try! resp.get(), "hello!")
+      assertNoThrow {
+        XCTAssertEqual(try resp.get(), "hello!")
+      }
       expectation.fulfill()
     }
 
@@ -48,7 +50,9 @@ class ConnectionTests: XCTestCase {
     let expectation2 = self.expectation(description: "response received 2")
 
     _ = client.send(EchoError(code: nil)) { resp in
-      XCTAssertEqual(try! resp.get(), VoidResponse())
+      assertNoThrow {
+        XCTAssertEqual(try resp.get(), VoidResponse())
+      }
       expectation.fulfill()
     }
 

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -187,16 +187,16 @@ final class CompilationDatabaseTests: XCTestCase {
 
   func testFixedCompilationDatabase() throws {
     let fs = InMemoryFileSystem()
-    try fs.createDirectory(try! AbsolutePath(validating: "/a"))
-    XCTAssertNil(tryLoadCompilationDatabase(directory: try! AbsolutePath(validating: "/a"), fs))
+    try fs.createDirectory(try AbsolutePath(validating: "/a"))
+    XCTAssertNil(tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs))
 
-    try fs.writeFileContents(try! AbsolutePath(validating: "/a/compile_flags.txt"), bytes: """
+    try fs.writeFileContents(try AbsolutePath(validating: "/a/compile_flags.txt"), bytes: """
       -xc++
       -I
       libwidget/include/
       """)
 
-    let db = tryLoadCompilationDatabase(directory: try! AbsolutePath(validating: "/a"), fs)
+    let db = tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs)
     XCTAssertNotNil(db)
 
     XCTAssertEqual(db![URL(fileURLWithPath: "/a/b")], [
@@ -325,10 +325,10 @@ final class CompilationDatabaseTests: XCTestCase {
   }
 }
 
-private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, file: StaticString = #filePath, line: UInt = #line, block: (CompilationDatabaseBuildSystem) throws -> ()) throws {
+private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, block: (CompilationDatabaseBuildSystem) throws -> ()) throws {
   let fs = InMemoryFileSystem()
-  XCTAssertNoThrow(try fs.createDirectory(AbsolutePath(validating: "/a")), file: file, line: line)
-  XCTAssertNoThrow(try fs.writeFileContents(AbsolutePath(validating: "/a/compile_commands.json"), bytes: compdb), file: file, line: line)
+  try fs.createDirectory(AbsolutePath(validating: "/a"))
+  try fs.writeFileContents(AbsolutePath(validating: "/a/compile_commands.json"), bytes: compdb)
   let buildSystem = CompilationDatabaseBuildSystem(projectRoot: try AbsolutePath(validating: "/a"), fileSystem: fs)
   try block(buildSystem)
 }

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -58,7 +58,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
     let fs = InMemoryFileSystem()
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fs, sourcekitdInProc: true)
+    try makeToolchain(binPath: binPath, fs, sourcekitdInProc: true)
 
     guard let t = Toolchain(binPath, fs) else {
       XCTFail("could not find any tools")
@@ -77,7 +77,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let xcodeDeveloper = ToolchainRegistry.currentXcodeDeveloperPath!
     let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
       opensource: false,
       toolchains.appending(component: "XcodeDefault.xctoolchain"), fs,
@@ -105,12 +105,12 @@ final class ToolchainRegistryTests: XCTestCase {
 
     XCTAssert(tr.toolchains.first === defaultToolchain)
 
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
       toolchains.appending(component: "A.xctoolchain"), fs,
       sourcekitd: true)
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "com.apple.fake.B",
       opensource: false,
       toolchains.appending(component: "B.xctoolchain"), fs,
@@ -119,12 +119,12 @@ final class ToolchainRegistryTests: XCTestCase {
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 3)
 
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "com.apple.fake.C",
       opensource: false,
       toolchains.appending(component: "C.wrong_extension"), fs,
       sourcekitd: true)
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "com.apple.fake.D",
       opensource: false,
       toolchains.appending(component: "D_no_extension"), fs,
@@ -133,7 +133,7 @@ final class ToolchainRegistryTests: XCTestCase {
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 3)
 
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
       toolchains.appending(component: "E.xctoolchain"), fs,
@@ -142,12 +142,12 @@ final class ToolchainRegistryTests: XCTestCase {
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 3)
 
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "org.fake.global.A",
       opensource: true,
       try AbsolutePath(validating: "/Library/Developer/Toolchains/A.xctoolchain"), fs,
       sourcekitd: true)
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "org.fake.global.B",
       opensource: true,
       try AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"), fs,
@@ -157,7 +157,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertEqual(tr.toolchains.count, 5)
 
     let path = toolchains.appending(component: "Explicit.xctoolchain")
-    makeXCToolchain(
+    try makeXCToolchain(
       identifier: "org.fake.explicit",
       opensource: false,
       toolchains.appending(component: "Explicit.xctoolchain"), fs,
@@ -194,7 +194,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = InMemoryFileSystem()
     let tr = ToolchainRegistry(fs)
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fs, sourcekitd: true)
+    try makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
@@ -225,7 +225,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
     let binPath2 = try AbsolutePath(validating: "/other/my_toolchain/bin")
     try ProcessEnv.setVar("SOME_TEST_ENV_PATH", value: ["/bogus", binPath2.pathString, "bogus2"].joined(separator: separator))
-    makeToolchain(binPath: binPath2, fs, sourcekitd: true)
+    try makeToolchain(binPath: binPath2, fs, sourcekitd: true)
     tr.scanForToolchains(pathVariables: ["NOPE", "SOME_TEST_ENV_PATH", "MORE_NOPE"], fs)
 
     guard let tc2 = tr.toolchains.first(where: { tc in tc.path == binPath2 }) else {
@@ -242,7 +242,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = InMemoryFileSystem()
     let tr = ToolchainRegistry(fs)
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fs, sourcekitd: true)
+    try makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
@@ -269,7 +269,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = InMemoryFileSystem()
     let tr = ToolchainRegistry(fs)
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fs, sourcekitd: true)
+    try makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
@@ -299,7 +299,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = localFileSystem
     try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       let path = tempDir.appending(components: "A.xctoolchain", "usr")
-      makeToolchain(
+      try makeToolchain(
         binPath: path.appending(component: "bin"), fs,
         clang: true,
         clangd: true,
@@ -353,7 +353,7 @@ final class ToolchainRegistryTests: XCTestCase {
   func testDylibNames() throws {
     let fs = InMemoryFileSystem()
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    makeToolchain(binPath: binPath, fs, sourcekitdInProc: true, libIndexStore: true)
+    try makeToolchain(binPath: binPath, fs, sourcekitdInProc: true, libIndexStore: true)
     guard let t = Toolchain(binPath, fs) else {
       XCTFail("could not find any tools")
       return
@@ -364,8 +364,8 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testSubDirs() throws {
     let fs = InMemoryFileSystem()
-    makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
-    makeToolchain(binPath: try AbsolutePath(validating: "/t2/usr/bin"), fs, sourcekitd: true)
+    try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
+    try makeToolchain(binPath: try AbsolutePath(validating: "/t2/usr/bin"), fs, sourcekitd: true)
 
     XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t1"), fs))
     XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t1/bin"), fs))
@@ -375,14 +375,14 @@ final class ToolchainRegistryTests: XCTestCase {
     try fs.createDirectory(try AbsolutePath(validating: "/t3/bin"), recursive: true)
     try fs.createDirectory(try AbsolutePath(validating: "/t3/lib/sourcekitd.framework"), recursive: true)
     XCTAssertNil(Toolchain(try AbsolutePath(validating: "/t3"), fs))
-    makeToolchain(binPath: try AbsolutePath(validating: "/t3/bin"), fs, sourcekitd: true)
+    try makeToolchain(binPath: try AbsolutePath(validating: "/t3/bin"), fs, sourcekitd: true)
     XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t3"), fs))
   }
 
-  func testDuplicateError() {
+  func testDuplicateError() throws {
     let tr = ToolchainRegistry()
     let toolchain = Toolchain(identifier: "a", displayName: "a", path: nil)
-    XCTAssertNoThrow(try tr.registerToolchain(toolchain), "Error registering toolchain")
+    try tr.registerToolchain(toolchain)
     XCTAssertThrowsError(try tr.registerToolchain(toolchain),
                          "Expected error registering toolchain twice") { e in
       guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainIdentifier else {
@@ -397,7 +397,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let path = try AbsolutePath(validating: "/foo/bar")
     let first = Toolchain(identifier: "a", displayName: "a", path: path)
     let second = Toolchain(identifier: "b", displayName: "b", path: path)
-    XCTAssertNoThrow(try tr.registerToolchain(first), "Error registering toolchain")
+    try tr.registerToolchain(first)
     XCTAssertThrowsError(try tr.registerToolchain(second),
                          "Expected error registering toolchain twice") { e in
       guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainPath else {
@@ -412,7 +412,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let xcodeToolchain = Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
                                    displayName: "a",
                                    path: try AbsolutePath(validating: "/versionA"))
-    XCTAssertNoThrow(try tr.registerToolchain(xcodeToolchain), "Error registering toolchain")
+    try tr.registerToolchain(xcodeToolchain)
     XCTAssertThrowsError(try tr.registerToolchain(xcodeToolchain),
                          "Expected error registering toolchain twice") { e in
       guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainPath else {
@@ -432,8 +432,8 @@ final class ToolchainRegistryTests: XCTestCase {
     let xcodeB = Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
                            displayName: "b",
                            path: pathB)
-    XCTAssertNoThrow(try tr.registerToolchain(xcodeA))
-    XCTAssertNoThrow(try tr.registerToolchain(xcodeB))
+    try tr.registerToolchain(xcodeA)
+    try tr.registerToolchain(xcodeB)
     XCTAssert(tr.toolchain(path: pathA) === xcodeA)
     XCTAssert(tr.toolchain(path: pathB) === xcodeB)
 
@@ -445,7 +445,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testInstallPath() throws {
     let fs = InMemoryFileSystem()
-    makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
+    try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
 
     let trEmpty = ToolchainRegistry(installPath: nil, fs)
     XCTAssertNil(trEmpty.default)
@@ -460,8 +460,8 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testInstallPathVsEnv() throws {
     let fs = InMemoryFileSystem()
-    makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
-    makeToolchain(binPath: try AbsolutePath(validating: "/t2/bin"), fs, sourcekitd: true)
+    try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
+    try makeToolchain(binPath: try AbsolutePath(validating: "/t2/bin"), fs, sourcekitd: true)
 
     try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: "/t2/bin")
 
@@ -487,16 +487,16 @@ private func makeXCToolchain(
   sourcekitd: Bool = false,
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
-) {
-  try! fs.createDirectory(path, recursive: true)
+) throws {
+  try fs.createDirectory(path, recursive: true)
   let infoPlistPath = path.appending(component: opensource ? "Info.plist" : "ToolchainInfo.plist")
-  let infoPlist = try! PropertyListEncoder().encode(
+  let infoPlist = try PropertyListEncoder().encode(
     XCToolchainPlist(identifier: identifier, displayName: "name-\(identifier)"))
-  try! fs.writeFileContents(infoPlistPath, body: { stream in
+  try fs.writeFileContents(infoPlistPath, body: { stream in
     stream.write(infoPlist)
   })
 
-  makeToolchain(
+  try makeToolchain(
     binPath: path.appending(components: "usr", "bin"),
     fs,
     clang: clang,
@@ -519,7 +519,7 @@ private func makeToolchain(
   sourcekitd: Bool = false,
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
-) {
+) throws {
   precondition(!clang && !swiftc && !clangd || !shouldChmod,
     "Cannot make toolchain binaries exectuable with InMemoryFileSystem")
 
@@ -537,11 +537,11 @@ private func makeToolchain(
   ]
 
   let libPath = binPath.parentDirectory.appending(component: "lib")
-  try! fs.createDirectory(binPath, recursive: true)
-  try! fs.createDirectory(libPath)
+  try fs.createDirectory(binPath, recursive: true)
+  try fs.createDirectory(libPath)
 
   let makeExec = { (path: AbsolutePath) in
-    try! fs.writeFileContents(path, bytes: ByteString(contents))
+    try fs.writeFileContents(path, bytes: ByteString(contents))
 #if !os(Windows)
     if shouldChmod {
       XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
@@ -552,34 +552,34 @@ private func makeToolchain(
   let execExt = Platform.current?.executableExtension ?? ""
 
   if clang {
-    makeExec(binPath.appending(component: "clang\(execExt)"))
+    try makeExec(binPath.appending(component: "clang\(execExt)"))
   }
   if clangd {
-    makeExec(binPath.appending(component: "clangd\(execExt)"))
+    try makeExec(binPath.appending(component: "clangd\(execExt)"))
   }
   if swiftc {
-    makeExec(binPath.appending(component: "swiftc\(execExt)"))
+    try makeExec(binPath.appending(component: "swiftc\(execExt)"))
   }
 
   let dylibSuffix = Platform.current?.dynamicLibraryExtension ?? ".so"
 
   if sourcekitd {
-    try! fs.createDirectory(libPath.appending(component: "sourcekitd.framework"))
-    try! fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd") , bytes: "")
+    try fs.createDirectory(libPath.appending(component: "sourcekitd.framework"))
+    try fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd") , bytes: "")
   }
   if sourcekitdInProc {
 #if os(Windows)
-    try! fs.writeFileContents(binPath.appending(component: "sourcekitdInProc\(dylibSuffix)") , bytes: "")
+    try fs.writeFileContents(binPath.appending(component: "sourcekitdInProc\(dylibSuffix)") , bytes: "")
 #else
-    try! fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibSuffix)") , bytes: "")
+    try fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibSuffix)") , bytes: "")
 #endif
   }
   if libIndexStore {
 #if os(Windows)
     // Windows has a prefix of `lib` on this particular library ...
-    try! fs.writeFileContents(binPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
+    try fs.writeFileContents(binPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
 #else
-    try! fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
+    try fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
 #endif
   }
 }

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -26,10 +26,10 @@ import struct PackageModel.BuildFlags
 
 final class SwiftPMWorkspaceTests: XCTestCase {
 
-  func testNoPackage() {
+  func testNoPackage() throws {
     let fs = InMemoryFileSystem()
-    try! withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
-      try! fs.createFiles(root: tempDir, files: [
+    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+      try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
       ])
       let packageRoot = tempDir.appending(component: "pkg")

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -33,9 +33,9 @@ final class SourceKitDTests: XCTestCase {
     sdkpath = try? Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx").trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
-  func testMultipleNotificationHandlers() {
-    let ws = try! mutableTibsTestWorkspace(name: "proj1")!
-    let sourcekitd = try! SourceKitDImpl.getOrCreate(dylibPath: SourceKitDTests.sourcekitdPath)
+  func testMultipleNotificationHandlers() throws {
+    let ws = try mutableTibsTestWorkspace(name: "proj1")!
+    let sourcekitd = try SourceKitDImpl.getOrCreate(dylibPath: SourceKitDTests.sourcekitdPath)
     let keys = sourcekitd.keys
     let path: String = ws.testLoc("c").url.path
 
@@ -86,14 +86,14 @@ final class SourceKitDTests: XCTestCase {
     args.append(path)
     req[keys.compilerargs] = args
 
-    _ = try! sourcekitd.sendSync(req)
+    _ = try sourcekitd.sendSync(req)
 
     waitForExpectations(timeout: defaultTimeout)
 
     let close = SKDRequestDictionary(sourcekitd: sourcekitd)
     close[keys.request] = sourcekitd.requests.editor_close
     close[keys.name] = path
-    _ = try! sourcekitd.sendSync(close)
+    _ = try sourcekitd.sendSync(close)
   }
 }
 

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -61,7 +61,7 @@ final class LocalClangTests: XCTestCase {
 
   // MARK: Tests
 
-  func testSymbolInfo() {
+  func testSymbolInfo() throws {
     guard haveClangd else { return }
 #if os(Windows)
     let url = URL(fileURLWithPath: "C:/a.cpp")
@@ -82,7 +82,7 @@ final class LocalClangTests: XCTestCase {
       """)))
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 0, utf16index: 7)))
 
@@ -95,7 +95,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 1, utf16index: 7)))
 
@@ -108,7 +108,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 2, utf16index: 8)))
 
@@ -121,7 +121,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 3, utf16index: 0)))
 
@@ -129,7 +129,7 @@ final class LocalClangTests: XCTestCase {
     }
   }
 
-  func testFoldingRange() {
+  func testFoldingRange() throws {
     guard haveClangd else { return }
 #if os(Windows)
     let url = URL(fileURLWithPath: "C:/a.cpp")
@@ -149,7 +149,7 @@ final class LocalClangTests: XCTestCase {
       };
       """)))
 
-    let resp = try! sk.sendSync(FoldingRangeRequest(textDocument: TextDocumentIdentifier(url)))
+    let resp = try sk.sendSync(FoldingRangeRequest(textDocument: TextDocumentIdentifier(url)))
     if let resp = resp {
       XCTAssertEqual(resp, [
         FoldingRange(startLine: 0, startUTF16Index: 10, endLine: 4, kind: .region),
@@ -178,7 +178,7 @@ final class LocalClangTests: XCTestCase {
       };
       """)))
 
-    guard let resp = try! sk.sendSync(DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))) else {
+    guard let resp = try sk.sendSync(DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))) else {
       XCTFail("Invalid document symbol response")
       return
     }
@@ -279,8 +279,8 @@ final class LocalClangTests: XCTestCase {
     }
   }
 
-  func testClangModules() {
-    guard let ws = try! staticSourceKitTibsWorkspace(name: "ClangModules") else { return }
+  func testClangModules() throws {
+    guard let ws = try staticSourceKitTibsWorkspace(name: "ClangModules") else { return }
     if ToolchainRegistry.shared.default?.clangd == nil { return }
 
     let loc = ws.testLoc("main_file")
@@ -292,7 +292,7 @@ final class LocalClangTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try! ws.openDocument(loc.url, language: .objective_c)
+    try ws.openDocument(loc.url, language: .objective_c)
 
     withExtendedLifetime(ws) {
       waitForExpectations(timeout: defaultTimeout)
@@ -329,7 +329,7 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testDocumentDependenciesUpdated() throws {
-    let ws = try! mutableSourceKitTibsTestWorkspace(name: "BasicCXX")!
+    let ws = try mutableSourceKitTibsTestWorkspace(name: "BasicCXX")!
 
     let cFileLoc = ws.testLoc("Object:ref:main")
 
@@ -340,14 +340,14 @@ final class LocalClangTests: XCTestCase {
       documentOpened.fulfill()
     })
 
-    try! ws.openDocument(cFileLoc.url, language: .cpp)
+    try ws.openDocument(cFileLoc.url, language: .cpp)
 
     self.wait(for: [documentOpened], timeout: 5)
 
     // We rename Object to MyObject in the header.
     _ = try ws.sources.edit { builder in
       let headerFilePath = ws.sources.rootDirectory.appendingPathComponent("Object.h")
-      var headerFile = try! String(contentsOf: headerFilePath, encoding: .utf8)
+      var headerFile = try String(contentsOf: headerFilePath, encoding: .utf8)
       let targetMarkerRange = headerFile.range(of: "/*Object*/")!
       headerFile.replaceSubrange(targetMarkerRange, with: "My")
       builder.write(headerFile, to: headerFilePath)

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -799,7 +799,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testXMLToMarkdownDeclaration() {
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Declaration>func foo(_ bar: <Type usr="fake">Baz</Type>)</Declaration>
       """), """
       ```swift
@@ -809,7 +809,7 @@ final class LocalSwiftTests: XCTestCase {
       ---
 
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Declaration>func foo() -&gt; <Type>Bar</Type></Declaration>
       """), """
       ```swift
@@ -819,17 +819,17 @@ final class LocalSwiftTests: XCTestCase {
       ---
 
       """)
-	  XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+	  XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Link href="https://example.com">My Link</Link>
       """), """
       [My Link](https://example.com)
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Link>My Invalid Link</Link>
       """), """
       My Invalid Link
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Declaration>func replacingOccurrences&lt;Target, Replacement&gt;(of target: Target, with replacement: Replacement, options: <Type usr="s:SS">String</Type>.<Type usr="s:SS10FoundationE14CompareOptionsa">CompareOptions</Type> = default, range searchRange: <Type usr="s:Sn">Range</Type>&lt;<Type usr="s:SS">String</Type>.<Type usr="s:SS5IndexV">Index</Type>&gt;? = default) -&gt; <Type usr="s:SS">String</Type> where Target : <Type usr="s:Sy">StringProtocol</Type>, Replacement : <Type usr="s:Sy">StringProtocol</Type></Declaration>
       """), """
       ```swift
@@ -842,7 +842,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testXMLToMarkdownComment() {
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><Declaration>var foo</Declaration></Class>
       """), """
       ```swift
@@ -853,7 +853,7 @@ final class LocalSwiftTests: XCTestCase {
 
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><Name>foo</Name><Declaration>var foo</Declaration></Class>
       """), """
       ```swift
@@ -863,7 +863,7 @@ final class LocalSwiftTests: XCTestCase {
       ---
 
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><USR>asdf</USR><Declaration>var foo</Declaration><Name>foo</Name></Class>
       """), """
       ```swift
@@ -874,12 +874,12 @@ final class LocalSwiftTests: XCTestCase {
 
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><Abstract>FOO</Abstract></Class>
       """), """
       FOO
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><Abstract>FOO</Abstract><Declaration>var foo</Declaration></Class>
       """), """
       FOO
@@ -892,7 +892,7 @@ final class LocalSwiftTests: XCTestCase {
 
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><Abstract>FOO</Abstract><Discussion>BAR</Discussion></Class>
       """), """
       FOO
@@ -902,7 +902,7 @@ final class LocalSwiftTests: XCTestCase {
       BAR
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><Para>A</Para><Para>B</Para><Para>C</Para></Class>
       """), """
       A
@@ -912,7 +912,7 @@ final class LocalSwiftTests: XCTestCase {
       C
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <CodeListing>a</CodeListing>
       """), """
       ```
@@ -922,7 +922,7 @@ final class LocalSwiftTests: XCTestCase {
 
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered></CodeListing>
       """), """
       ```
@@ -931,7 +931,7 @@ final class LocalSwiftTests: XCTestCase {
 
 
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing>
       """), """
       ```
@@ -941,7 +941,7 @@ final class LocalSwiftTests: XCTestCase {
 
       
       """)
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Class><CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing><CodeListing><zCodeLineNumbered>c</zCodeLineNumbered><zCodeLineNumbered>d</zCodeLineNumbered></CodeListing></Class>
       """), """
       ```
@@ -957,25 +957,25 @@ final class LocalSwiftTests: XCTestCase {
 
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Para>a b c <codeVoice>d e f</codeVoice> g h i</Para>
       """), """
       a b c `d e f` g h i
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Para>a b c <emphasis>d e f</emphasis> g h i</Para>
       """), """
       a b c *d e f* g h i
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Para>a b c <bold>d e f</bold> g h i</Para>
       """), """
       a b c **d e f** g h i
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Para>a b c<h1>d e f</h1>g h i</Para>
       """), """
       a b c
@@ -985,7 +985,7 @@ final class LocalSwiftTests: XCTestCase {
       g h i
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <Para>a b c<h3>d e f</h3>g h i</Para>
       """), """
       a b c
@@ -995,7 +995,7 @@ final class LocalSwiftTests: XCTestCase {
       g h i
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown(
+    XCTAssertEqual(try xmlDocumentationToMarkdown(
       "<Class>" +
         "<Name>String</Name>" +
         "<USR>s:SS</USR>" +
@@ -1051,7 +1051,7 @@ final class LocalSwiftTests: XCTestCase {
 
       """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown(
+    XCTAssertEqual(try xmlDocumentationToMarkdown(
       "<Function file=\"DocumentManager.swift\" line=\"92\" column=\"15\">" +
         "<CommentParts>" +
           "<Abstract><Para>Applies the given edits to the document.</Para></Abstract>" +
@@ -1076,7 +1076,7 @@ final class LocalSwiftTests: XCTestCase {
         - before: The document contents *before* the edit is applied.
     """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <ResultDiscussion><Para>The contents of the file after all the edits are applied.</Para></ResultDiscussion>
       """), """
     ### Returns
@@ -1084,7 +1084,7 @@ final class LocalSwiftTests: XCTestCase {
     The contents of the file after all the edits are applied.
     """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown("""
+    XCTAssertEqual(try xmlDocumentationToMarkdown("""
       <ThrowsDiscussion><Para>Error.missingDocument if the document is not open.</Para></ThrowsDiscussion>
       """), """
     ### Throws
@@ -1092,7 +1092,7 @@ final class LocalSwiftTests: XCTestCase {
     Error.missingDocument if the document is not open.
     """)
 
-    XCTAssertEqual(try! xmlDocumentationToMarkdown(
+    XCTAssertEqual(try xmlDocumentationToMarkdown(
       "<Class>" +
         "<Name>S</Name>" +
         "<USR>s:1a1SV</USR>" +
@@ -1132,7 +1132,7 @@ final class LocalSwiftTests: XCTestCase {
     """)
   }
 
-  func testSymbolInfo() {
+  func testSymbolInfo() throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1150,7 +1150,7 @@ final class LocalSwiftTests: XCTestCase {
       """)))
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 0, utf16index: 7)))
 
@@ -1167,7 +1167,7 @@ final class LocalSwiftTests: XCTestCase {
     }
     
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 1, utf16index: 7)))
 
@@ -1183,7 +1183,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 2, utf16index: 7)))
 
@@ -1199,7 +1199,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 3, utf16index: 8)))
 
@@ -1215,7 +1215,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(SymbolInfoRequest(
+      let resp = try sk.sendSync(SymbolInfoRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 3, utf16index: 0)))
 
@@ -1223,7 +1223,7 @@ final class LocalSwiftTests: XCTestCase {
     }
   }
 
-  func testHover() {
+  func testHover() throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1239,7 +1239,7 @@ final class LocalSwiftTests: XCTestCase {
       """)))
 
     do {
-      let resp = try! sk.sendSync(HoverRequest(
+      let resp = try sk.sendSync(HoverRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 3, utf16index: 7)))
 
@@ -1268,7 +1268,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(HoverRequest(
+      let resp = try sk.sendSync(HoverRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 0, utf16index: 7)))
 
@@ -1276,7 +1276,7 @@ final class LocalSwiftTests: XCTestCase {
     }
   }
 
-  func testHoverNameEscaping() {
+  func testHoverNameEscaping() throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
     sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
@@ -1291,7 +1291,7 @@ final class LocalSwiftTests: XCTestCase {
       """)))
 
     do {
-      let resp = try! sk.sendSync(HoverRequest(
+      let resp = try sk.sendSync(HoverRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 1, utf16index: 7)))
 
@@ -1316,7 +1316,7 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try! sk.sendSync(HoverRequest(
+      let resp = try sk.sendSync(HoverRequest(
         textDocument: TextDocumentIdentifier(url),
         position: Position(line: 3, utf16index: 7)))
 

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -21,7 +21,7 @@ import XCTest
 final class MainFilesProviderTests: XCTestCase {
 
   func testMainFilesChanged() throws {
-    let ws = try! mutableSourceKitTibsTestWorkspace(name: "MainFiles")!
+    let ws = try mutableSourceKitTibsTestWorkspace(name: "MainFiles")!
     let indexDelegate = SourceKitIndexDelegate()
     ws.tibsWorkspace.delegate = indexDelegate
 

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -22,13 +22,13 @@ public typealias URL = Foundation.URL
 
 final class SKTests: XCTestCase {
 
-    func testInitLocal() {
+    func testInitLocal() throws {
       let c = TestSourceKitServer()
       defer { withExtendedLifetime(c) {} } // Keep connection alive for callbacks.
 
       let sk = c.client
 
-      let initResult = try! sk.sendSync(InitializeRequest(
+      let initResult = try sk.sendSync(InitializeRequest(
         processId: nil,
         rootPath: nil,
         rootURI: nil,
@@ -45,13 +45,13 @@ final class SKTests: XCTestCase {
       XCTAssertNotNil(initResult.capabilities.completionProvider)
     }
 
-    func testInitJSON() {
+    func testInitJSON() throws {
       let c = TestSourceKitServer(connectionKind: .jsonrpc)
       defer { withExtendedLifetime(c) {} } // Keep connection alive for callbacks.
 
       let sk = c.client
 
-      let initResult = try! sk.sendSync(InitializeRequest(
+      let initResult = try sk.sendSync(InitializeRequest(
         processId: nil,
         rootPath: nil,
         rootURI: nil,
@@ -377,7 +377,7 @@ final class SKTests: XCTestCase {
 
     let goToInclude = DeclarationRequest(
       textDocument: mainLoc.docIdentifier, position: includePosition)
-    let resp = try! ws.sk.sendSync(goToInclude)
+    let resp = try ws.sk.sendSync(goToInclude)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-declaration")
     switch locationsOrLinks {

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -51,7 +51,7 @@ final class SwiftCompletionTests: XCTestCase {
     connection = nil
   }
 
-  func initializeServer(options: SKCompletionOptions = .init(), capabilities: CompletionCapabilities? = nil) {
+  func initializeServer(options: SKCompletionOptions = .init(), capabilities: CompletionCapabilities? = nil) throws {
     connection = TestSourceKitServer()
     sk = connection.client
     var documentCapabilities: TextDocumentClientCapabilities?
@@ -61,7 +61,7 @@ final class SwiftCompletionTests: XCTestCase {
     } else {
       documentCapabilities = nil
     }
-    _ = try! sk.sendSync(
+    _ = try sk.sendSync(
       InitializeRequest(
         processId: nil,
         rootPath: nil,
@@ -98,7 +98,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionBasic(options: SKCompletionOptions) throws {
-    initializeServer(options: options)
+    try initializeServer(options: options)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(url: url)
 
@@ -149,7 +149,7 @@ final class SwiftCompletionTests: XCTestCase {
     var capabilities = CompletionCapabilities()
     capabilities.completionItem = CompletionCapabilities.CompletionItem(snippetSupport: true)
 
-    initializeServer(capabilities: capabilities)
+    try initializeServer(capabilities: capabilities)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(url: url)
 
@@ -192,7 +192,7 @@ final class SwiftCompletionTests: XCTestCase {
 
     shutdownServer()
     capabilities.completionItem?.snippetSupport = false
-    initializeServer(capabilities: capabilities)
+    try initializeServer(capabilities: capabilities)
     openDocument(url: url)
 
     test = try getTestMethodACompletion()
@@ -228,7 +228,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionPosition(options: SKCompletionOptions) throws {
-    initializeServer(options: options)
+    try initializeServer(options: options)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: "foo", url: url)
 
@@ -252,7 +252,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionOptional() throws {
-    initializeServer()
+    try initializeServer()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
     struct Foo {
@@ -278,7 +278,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionOverride() throws {
-    initializeServer()
+    try initializeServer()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
     class Base {
@@ -303,7 +303,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionOverrideInNewLine() throws {
-    initializeServer()
+    try initializeServer()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
     class Base {
@@ -329,7 +329,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testMaxResults() throws {
-    initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
+    try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: """
       struct S {
@@ -412,7 +412,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testRefilterAfterIncompleteResults() throws {
-    initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: 20))
+    try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: 20))
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: """
       struct S {
@@ -473,7 +473,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testRefilterAfterIncompleteResultsWithEdits() throws {
-    initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
+    try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: """
       struct S {
@@ -554,7 +554,7 @@ final class SwiftCompletionTests: XCTestCase {
   /// Regression test for https://bugs.swift.org/browse/SR-13561 to make sure the a session
   /// close waits for its respective open to finish to prevent a session geting stuck open.
   func testSessionCloseWaitsforOpen() throws {
-    initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
+    try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(UUID())/file.swift")
     openDocument(text: """
       struct S {

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -161,7 +161,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     _ = try ws.sources.edit { builder in
       let packageManifest = ws.sources.rootDirectory
         .appendingPathComponent("Package.swift")
-      var packageManifestContents = try! String(contentsOf: packageManifest, encoding: .utf8)
+      var packageManifestContents = try String(contentsOf: packageManifest, encoding: .utf8)
       let targetMarkerRange = packageManifestContents.range(of: "/*Package.swift:targets*/")!
       packageManifestContents.replaceSubrange(targetMarkerRange, with: """
       .target(

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -154,7 +154,7 @@ final class WorkspaceTests: XCTestCase {
     _ = try ws.sources.edit { builder in
       let packageManifest = ws.sources.rootDirectory
         .appendingPathComponent("Package.swift")
-      var packageManifestContents = try! String(contentsOf: packageManifest, encoding: .utf8)
+      var packageManifestContents = try String(contentsOf: packageManifest, encoding: .utf8)
       let targetMarkerRange = packageManifestContents.range(of: "/*Package.swift:targets*/")!
       packageManifestContents.replaceSubrange(targetMarkerRange, with: """
         .target(


### PR DESCRIPTION
The usage of `try!` was still a relict of when `XCTest` didn’t allow throwing test method.