### PR TITLE
Don’t crash when unregistering for change notifications of a file that isn’t watched

### DIFF
--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -299,7 +299,10 @@ extension BuildSystemManager: BuildSystem {
 
   public func unregisterForChangeNotifications(for uri: DocumentURI) {
     queue.async {
-      let mainFile = self.watchedFiles[uri]!.mainFile
+      guard let mainFile = self.watchedFiles[uri]?.mainFile else {
+        log("Unbalanced calls for registerForChangeNotifications and unregisterForChangeNotifications", level: .warning)
+        return
+      }
       self.watchedFiles[uri] = nil
       self.checkUnreferencedMainFile(mainFile)
     }


### PR DESCRIPTION
I believe this should fix the crash reported in https://forums.swift.org/t/vscode-with-5-9-stopping-server-failed/67397.

I am still investigating where the unbalanced open / close calls might be coming from, but in either case, we shouldn’t crash.