### PR TITLE
Make targets automatic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,10 @@ let package = Package(
       ),
       .library(
         name: "_SourceKitLSP",
-        type: .dynamic,
         targets: ["SourceKitLSP"]
       ),
       .library(
         name: "LSPBindings",
-        type: .static,
         targets: [
           "LanguageServerProtocol",
           "LanguageServerProtocolJSONRPC",

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -238,11 +238,7 @@ def handle_invocation(swift_exec: str, args: argparse.Namespace) -> None:
     Depending on the action in 'args', build the package, installs the package or run tests.
     """
     if args.action == 'build':
-        # These products are listed in dependency order. Lower-level targets are listed first.
-        products = ["LSPBindings", "_SourceKitLSP", "sourcekit-lsp"]
-        # Build in reverse dependency order so we can build lower-level targets in parallel.
-        for product in reversed(products):
-            build_single_product(product, swift_exec, args)
+        build_single_product("sourcekit-lsp", swift_exec, args)
     elif args.action == 'test':
         run_tests(swift_exec, args)
     elif args.action == 'install':


### PR DESCRIPTION
There’s no reason why we should specify them as static or dynamic.

Fixes #822
rdar://115633096