### PR TITLE
Make long test execution opt-out instead of opt-in

### DIFF
--- a/Sources/SKTestSupport/LongTestsEnabled.swift
+++ b/Sources/SKTestSupport/LongTestsEnabled.swift
@@ -12,8 +12,8 @@
 
 import Foundation
 
-public var longTestsEnabled: Bool {
-  if let value = ProcessInfo.processInfo.environment["SOURCEKIT_LSP_ENABLE_LONG_TESTS"] {
+public var longTestsDisabled: Bool {
+  if let value = ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] {
     return value == "1" || value == "YES"
   }
   return false

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -46,7 +46,7 @@ fileprivate extension HoverResponse {
 final class CrashRecoveryTests: XCTestCase {
   func testSourcekitdCrashRecovery() throws {
     try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
-    try XCTSkipUnless(longTestsEnabled)
+    try XCTSkipIf(longTestsDisabled)
 
     let ws = try staticSourceKitTibsWorkspace(name: "sourcekitdCrashRecovery")!
     let loc = ws.testLoc("loc")
@@ -156,7 +156,7 @@ final class CrashRecoveryTests: XCTestCase {
   }
 
   func testClangdCrashRecovery() throws {
-    try XCTSkipUnless(longTestsEnabled)
+    try XCTSkipIf(longTestsDisabled)
 
     let ws = try staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!
     let loc = ws.testLoc("loc")
@@ -193,7 +193,7 @@ final class CrashRecoveryTests: XCTestCase {
   }
     
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() throws {
-    try XCTSkipUnless(longTestsEnabled)
+    try XCTSkipIf(longTestsDisabled)
 
     let ws = try staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings")!
     let loc = ws.testLoc("loc")
@@ -226,7 +226,7 @@ final class CrashRecoveryTests: XCTestCase {
   }
   
   func testPreventClangdCrashLoop() throws {
-    try XCTSkipUnless(longTestsEnabled)
+    try XCTSkipIf(longTestsDisabled)
 
     let ws = try staticSourceKitTibsWorkspace(name: "ClangCrashRecovery")!
     let loc = ws.testLoc("loc")

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -178,8 +178,8 @@ def get_swiftpm_environment_variables(swift_exec: str, args: argparse.Namespace)
     if args.sanitize and 'thread' in args.sanitize:
         env['TSAN_OPTIONS'] = 'halt_on_error=true'
 
-    if args.action == 'test' and not args.skip_long_tests:
-        env['SOURCEKIT_LSP_ENABLE_LONG_TESTS'] = '1'
+    if args.action == 'test' and args.skip_long_tests:
+        env['SKIP_LONG_TESTS'] = '1'
 
     return env
 


### PR DESCRIPTION
This matches what swift-syntax is doing and ensures that new contributors run all tests by default.