### PR TITLE
Migrate `SwiftLanguageServer` and `ClangLanguageServerShim` to be actors

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -62,6 +62,22 @@ public func orLog<R>(
   }
 }
 
+/// Like `try?`, but logs the error on failure.
+public func orLog<R>(
+  _ prefix: String = "",
+  level: LogLevel = .default,
+  logger: Logger = Logger.shared,
+  _ block: () async throws -> R?) async -> R?
+{
+  do {
+    return try await block()
+  } catch {
+    logger.log("\(prefix)\(prefix.isEmpty ? "" : " ")\(error)", level: level)
+    return nil
+  }
+}
+
+
 /// Logs the time that the given block takes to execute in milliseconds.
 public func logExecutionTime<R>(
   _ prefix: String = #function,

--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public typealias CodeActionProviderCompletion = (LSPResult<[CodeAction]>) -> Void
-public typealias CodeActionProvider = (CodeActionRequest, @escaping CodeActionProviderCompletion) -> Void
+public typealias CodeActionProvider = (CodeActionRequest, @escaping CodeActionProviderCompletion) async -> Void
 
 /// Request for returning all possible code actions for a given text document and range.
 ///

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -65,6 +65,9 @@ public final class BuildServerBuildSystem: MessageHandler {
   /// Delegate to handle any build system events.
   public weak var delegate: BuildSystemDelegate?
 
+  /// The build settings that have been received from the build server.
+  private var buildSettings: [DocumentURI: FileBuildSettings] = [:]
+
   public init(projectRoot: AbsolutePath, buildFolder: AbsolutePath?, fileSystem: FileSystem = localFileSystem) throws {
     let configPath = projectRoot.appending(component: "buildServer.json")
     let config = try loadBuildServerConfig(path: configPath, fileSystem: fileSystem)
@@ -195,7 +198,18 @@ public final class BuildServerBuildSystem: MessageHandler {
     let result = notification.params.updatedOptions
     let settings = FileBuildSettings(
         compilerArguments: result.options, workingDirectory: result.workingDirectory)
-    self.delegate?.fileBuildSettingsChanged([notification.params.uri: .modified(settings)])
+    self.buildSettingsChanged(for: notification.params.uri, settings: settings)
+  }
+
+  /// Record the new build settings for the given document and inform the delegate
+  /// about the changed build settings.
+  private func buildSettingsChanged(for document: DocumentURI, settings: FileBuildSettings?) {
+    buildSettings[document] = settings
+    if let settings {
+      self.delegate?.fileBuildSettingsChanged([document: .modified(settings)])
+    } else {
+      self.delegate?.fileBuildSettingsChanged([document: .removedOrUnavailable])
+    }
   }
 }
 
@@ -208,19 +222,14 @@ private func readReponseDataKey(data: LSPAny?, key: String) -> String? {
   return nil
 }
 
-extension BuildServerBuildSystem {
-  /// Exposed for *testing*.
-  public func _settings(for uri: DocumentURI) -> FileBuildSettings? {
-    if let response = try? self.buildServer?.sendSync(SourceKitOptions(uri: uri)) {
-      return FileBuildSettings(
-        compilerArguments: response.options,
-        workingDirectory: response.workingDirectory)
-    }
-    return nil
-  }
-}
-
 extension BuildServerBuildSystem: BuildSystem {
+  /// The build settings for the given file.
+  ///
+  /// Returns `nil` if no build settings have been received from the build
+  /// server yet or if no build settings are available for this file.
+  public func buildSettings(for document: DocumentURI, language: Language) async throws -> FileBuildSettings? {
+    return buildSettings[document]
+  }
 
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     let request = RegisterForChanges(uri: uri, action: .register)
@@ -230,7 +239,7 @@ extension BuildServerBuildSystem: BuildSystem {
 
         // BuildServer registration failed, so tell our delegate that no build
         // settings are available.
-        self.delegate?.fileBuildSettingsChanged([uri: .removedOrUnavailable])
+        self.buildSettingsChanged(for: uri, settings: nil)
       }
     })
   }

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -51,6 +51,13 @@ public protocol BuildSystem: AnyObject {
   /// initial reports as well as changes.
   var delegate: BuildSystemDelegate? { get set }
 
+  /// Retrieve build settings for the given document with the given source
+  /// language.
+  ///
+  /// Returns `nil` if the build system can't provide build settings for this
+  /// file or if it hasn't computed build settings for the file yet.
+  func buildSettings(for document: DocumentURI, language: Language) async throws -> FileBuildSettings?
+
   /// Register the given file for build-system level change notifications, such
   /// as command line flag changes, dependency changes, etc.
   ///

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -149,7 +149,7 @@ extension BuildSystemManager {
   /// Get the build settings for the given document, assuming it has the given
   /// language.
   ///
-  /// Returns `nil` if no build settings are availabe in the build system and
+  /// Returns `nil` if no build settings are available in the build system and
   /// no fallback build settings can be computed.
   ///
   /// `isFallback` is `true` if the build settings couldn't be computed and
@@ -172,7 +172,7 @@ extension BuildSystemManager {
       log("Getting build settings failed: \(error)")
     }
     if let settings = fallbackBuildSystem?.buildSettings(for: document, language: language) {
-      // If there is no build system and we onlyl have the fallback build system,
+      // If there is no build system and we only have the fallback build system,
       // we will never get real build settings. Consider the build settings
       // non-fallback.
       return (buildSettings: settings, isFallback: buildSystem != nil)
@@ -270,7 +270,7 @@ extension BuildSystemManager {
   }
 
   /// *Must be called on queue*. Update and notify our delegate for the given
-  /// main file changes if they are convertable into `FileBuildSettingsChange`.
+  /// main file changes if they are convertible into `FileBuildSettingsChange`.
   func updateAndNotifyStatuses(changes: [DocumentURI: MainFileStatus]) {
     var changedWatchedFiles = [DocumentURI: FileBuildSettingsChange]()
     for (mainFile, status) in changes {
@@ -314,7 +314,7 @@ extension BuildSystemManager {
     _ fallback: FallbackBuildSystem
   ) {
     // There won't be a current status if it's unreferenced by any watched file.
-    // Simiarly, if the status isn't `waiting` then there's nothing to do.
+    // Similarly, if the status isn't `waiting` then there's nothing to do.
     guard let status = self.mainFileStatuses[mainFile], status == .waiting else {
       return
     }
@@ -371,7 +371,7 @@ extension BuildSystemManager: BuildSystemDelegate {
           newStatus = settingsChange.isFallback ? .fallback(newSettings) : .primary(newSettings)
         } else if let fallback = self.fallbackBuildSystem {
           // FIXME: we need to stop threading the language everywhere, or we need the build system
-          // itself to pass it in here. Or alteratively cache the fallback settings/language earlier?
+          // itself to pass it in here. Or alternatively cache the fallback settings/language earlier?
           let language = firstWatch.value.language
           if let settings = fallback.buildSettings(for: mainFile, language: language) {
             newStatus = .fallback(settings)

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -93,6 +93,15 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
 
   public var indexPrefixMappings: [PathPrefixMapping] { return [] }
 
+  public func buildSettings(for document: DocumentURI, language: Language) async throws -> FileBuildSettings? {
+    // FIXME: (async) Convert this to an async function once `CompilationDatabaseBuildSystem` is an actor.
+    return await withCheckedContinuation { continuation in
+      self.queue.async {
+        continuation.resume(returning: self.settings(for: document))
+      }
+    }
+  }
+
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     queue.async {
       self.watchedFiles[uri] = language

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -44,7 +44,7 @@ public final class FallbackBuildSystem: BuildSystem {
 
   public var indexPrefixMappings: [PathPrefixMapping] { return [] }
 
-  public func settings(for uri: DocumentURI, _ language: Language) -> FileBuildSettings? {
+  public func buildSettings(for uri: DocumentURI, language: Language) -> FileBuildSettings? {
     switch language {
     case .swift:
       return settingsSwift(uri.pseudoPath)
@@ -58,7 +58,7 @@ public final class FallbackBuildSystem: BuildSystem {
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     guard let delegate = self.delegate else { return }
 
-    let settings = self.settings(for: uri, language)
+    let settings = self.buildSettings(for: uri, language: language)
     DispatchQueue.global().async {
       delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
     }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -290,6 +290,18 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
     }
   }
 
+  public func buildSettings(for document: DocumentURI, language: Language) async throws -> FileBuildSettings? {
+    return try await withCheckedThrowingContinuation { continuation in
+      queue.async {
+        do {
+          continuation.resume(returning: try self.settings(for: document, language))
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
   /// Must only be called on `queue`.
   private func settings(
     for uri: DocumentURI,

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -385,14 +385,16 @@ extension ClangLanguageServerShim {
     forwardNotificationToClangdOnQueue(initialized)
   }
 
-  public func shutdown(callback: @escaping () -> Void) {
-    queue.async {
-      _ = self.clangd.send(ShutdownRequest(), queue: self.queue) { [weak self] _ in
-        self?.clangd.send(ExitNotification())
-        if let localConnection = self?.client as? LocalConnection {
-          localConnection.close()
+  public func shutdown() async {
+    await withCheckedContinuation { continuation in
+      queue.async {
+        _ = self.clangd.send(ShutdownRequest(), queue: self.queue) { [weak self] _ in
+          self?.clangd.send(ExitNotification())
+          if let localConnection = self?.client as? LocalConnection {
+            localConnection.close()
+          }
+          continuation.resume()
         }
-        callback()
       }
     }
   }

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -64,12 +64,6 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   
   let clangdOptions: [String]
 
-  /// Resolved build settings by file. Must be accessed with the `lock`.
-  private var buildSettingsByFile: [DocumentURI: ClangBuildSettings] = [:]
-
-  /// Lock protecting `buildSettingsByFile`.
-  private var lock: NSLock = NSLock()
-
   /// The current state of the `clangd` language server.
   /// Changing the property automatically notified the state change handlers.
   private var state: LanguageServerState {
@@ -102,6 +96,10 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// A callback with which `ClangLanguageServer` can request its owner to reopen all documents in case it has crashed.
   private let reopenDocuments: (ToolchainLanguageServer) -> Void
 
+  /// The documents that have been opened and which language they have been
+  /// opened with.
+  private var openDocuments: [DocumentURI: Language] = [:]
+
   /// While `clangd` is running, its PID.
 #if os(Windows)
   private var hClangd: HANDLE = INVALID_HANDLE_VALUE
@@ -132,6 +130,16 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     try startClangdProcesss()
   }
 
+  private func buildSettings(for document: DocumentURI) async -> ClangBuildSettings? {
+    guard let workspace = workspace.value, let language = openDocuments[document] else {
+      return nil
+    }
+    guard let settings = await workspace.buildSystemManager.buildSettings(for: document, language: language) else {
+      return nil
+    }
+    return ClangBuildSettings(settings.buildSettings, clangPath: clangdPath, isFallback: settings.isFallback)
+  }
+
   nonisolated func canHandle(workspace: Workspace) -> Bool {
     // We launch different clangd instance for each workspace because clangd doesn't have multi-root workspace support.
     return workspace === self.workspace.value
@@ -160,8 +168,8 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
 
   /// Start the `clangd` process, either on creation of the `ClangLanguageServerShim` or after `clangd` has crashed.
   private func startClangdProcesss() throws {
-    // Since we are starting a new clangd process, reset the build settings we have transmitted to clangd
-    buildSettingsByFile = [:]
+    // Since we are starting a new clangd process, reset the list of open document
+    openDocuments = [:]
 
     let usToClangd: Pipe = Pipe()
     let clangdToUs: Pipe = Pipe()
@@ -249,9 +257,9 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// sending a notification that's intended for the editor.
   ///
   /// We should either handle it ourselves or forward it to the client.
-  func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) {
+  func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) async {
     if let publishDiags = params as? PublishDiagnosticsNotification {
-      self.publishDiagnostics(Notification(publishDiags, clientID: clientID))
+      await self.publishDiagnostics(Notification(publishDiags, clientID: clientID))
     } else if clientID == ObjectIdentifier(self.clangd) {
       self.client.send(params)
     }
@@ -332,19 +340,27 @@ extension ClangLanguageServerShim {
 
   /// Intercept clangd's `PublishDiagnosticsNotification` to withold it if we're using fallback
   /// build settings.
-  func publishDiagnostics(_ note: Notification<PublishDiagnosticsNotification>) {
+  func publishDiagnostics(_ note: Notification<PublishDiagnosticsNotification>) async {
     let params = note.params
-    let buildSettings = self.lock.withLock {
-      return self.buildSettingsByFile[params.uri]
-    }
-    let isFallback = buildSettings?.isFallback ?? true
-    guard isFallback else {
+    // Technically, the publish diagnostics notification could still originate
+    // from when we opened the file with fallback build settings and we could
+    // have received real build settings since, which haven't been acknowledged
+    // by clangd yet.
+    //
+    // Since there is no way to tell which build settings clangd used to generate
+    // the diagnostics, there's no good way to resolve this race. For now, this
+    // should be good enough since the time in which the race may occur is pretty
+    // short and we expect clangd to send us new diagnostics with the updated
+    // non-fallback settings very shortly after, which will override the
+    // incorrect result, making it very temporary.
+    let buildSettings = await self.buildSettings(for: params.uri)
+    if buildSettings?.isFallback ?? true {
+      // Fallback: send empty publish notification instead.
+      client.send(PublishDiagnosticsNotification(
+        uri: params.uri, version: params.version, diagnostics: []))
+    } else {
       client.send(note.params)
-      return
     }
-    // Fallback: send empty publish notification instead.
-    client.send(PublishDiagnosticsNotification(
-      uri: params.uri, version: params.version, diagnostics: []))
   }
 
 }
@@ -383,16 +399,18 @@ extension ClangLanguageServerShim {
 
   // MARK: - Text synchronization
 
-  public func openDocument(_ note: DidOpenTextDocumentNotification) {
+  public func openDocument(_ note: DidOpenTextDocumentNotification) async {
+    openDocuments[note.textDocument.uri] = note.textDocument.language
+    // Send clangd the build settings for the new file. We need to do this before
+    // sending the open notification, so that the initial diagnostics already
+    // have build settings.
+    await documentUpdatedBuildSettings(note.textDocument.uri, change: .removedOrUnavailable)
     clangd.send(note)
   }
 
   public func closeDocument(_ note: DidCloseTextDocumentNotification) {
+    openDocuments[note.textDocument.uri] = nil
     clangd.send(note)
-
-    // Don't clear cached build settings since we've already informed clangd of the settings for the
-    // file; if we clear the build settings here we should give clangd dummy build settings to make
-    // sure we're in sync.
   }
 
   public func changeDocument(_ note: DidChangeTextDocumentNotification) {
@@ -409,25 +427,17 @@ extension ClangLanguageServerShim {
 
   // MARK: - Build System Integration
 
-  public func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) {
+  public func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) async {
     guard let url = uri.fileURL else {
       // FIXME: The clang workspace can probably be reworked to support non-file URIs.
       log("Received updated build settings for non-file URI '\(uri)'. Ignoring the update.")
       return
     }
-    let clangBuildSettings = ClangBuildSettings(change: change, clangPath: self.clangPath)
+    let clangBuildSettings = await self.buildSettings(for: uri)
     logAsync(level: clangBuildSettings == nil ? .warning : .debug) { _ in
       let settingsStr = clangBuildSettings == nil ? "nil" : clangBuildSettings!.compilerArgs.description
       return "settings for \(uri): \(settingsStr)"
     }
-
-    let changed = lock.withLock { () -> Bool in
-      let prevBuildSettings = self.buildSettingsByFile[uri]
-      guard clangBuildSettings != prevBuildSettings else { return false }
-      self.buildSettingsByFile[uri] = clangBuildSettings
-      return true
-    }
-    guard changed else { return }
 
     // The compile command changed, send over the new one.
     // FIXME: what should we do if we no longer have valid build settings?

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -118,7 +118,8 @@ final class ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     toolchain: Toolchain,
     options: SourceKitServer.Options,
     workspace: Workspace,
-    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void
+    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+    workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
   ) throws {
     guard let clangdPath = toolchain.clangd else {
       return nil

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -94,7 +94,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   private let workspace: WeakWorkspace
 
   /// A callback with which `ClangLanguageServer` can request its owner to reopen all documents in case it has crashed.
-  private let reopenDocuments: (ToolchainLanguageServer) -> Void
+  private let reopenDocuments: (ToolchainLanguageServer) async -> Void
 
   /// The documents that have been opened and which language they have been
   /// opened with.
@@ -114,7 +114,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     toolchain: Toolchain,
     options: SourceKitServer.Options,
     workspace: Workspace,
-    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+    reopenDocuments: @escaping (ToolchainLanguageServer) async -> Void,
     workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
   ) async throws {
     guard let clangdPath = toolchain.clangd else {
@@ -245,7 +245,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
         // But since SourceKitServer more or less ignores them right now anyway, this should be fine for now.
         _ = try self.initializeSync(initializeRequest)
         self.clientInitialized(InitializedNotification())
-        self.reopenDocuments(self)
+        await self.reopenDocuments(self)
         self.state = .connected
       } catch {
         log("Failed to restart clangd after a crash.", level: .error)

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -27,10 +27,6 @@ import var TSCBasic.localFileSystem
 
 public typealias URL = Foundation.URL
 
-private struct WeakWorkspace {
-  weak var value: Workspace?
-}
-
 /// Exhaustive enumeration of all toolchain language servers known to SourceKit-LSP.
 enum LanguageServerType: Hashable {
   case clangd
@@ -232,7 +228,7 @@ public actor SourceKitServer {
         bestWorkspace = (workspace, fileHandlingCapability)
       }
     }
-    uriToWorkspaceCache[uri] = WeakWorkspace(value: bestWorkspace.workspace)
+    uriToWorkspaceCache[uri] = WeakWorkspace(bestWorkspace.workspace)
     return bestWorkspace.workspace
   }
 
@@ -403,7 +399,7 @@ public actor SourceKitServer {
 
     // Start a new service.
     return await orLog("failed to start language service", level: .error) {
-      let service = try SourceKitLSP.languageService(
+      let service = try await SourceKitLSP.languageService(
         for: toolchain,
         serverType,
         options: options,
@@ -2014,10 +2010,10 @@ func languageService(
   in workspace: Workspace,
   reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
   workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
-) throws -> ToolchainLanguageServer? {
+) async throws -> ToolchainLanguageServer? {
   let connectionToClient = LocalConnection()
 
-  let server = try languageServerType.serverType.init(
+  let server = try await languageServerType.serverType.init(
     client: connectionToClient,
     toolchain: toolchain,
     options: options,

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -414,6 +414,10 @@ public actor SourceKitServer {
           Task {
             await self.reopenDocuments(for: toolchainLanguageServer)
           }
+        },
+        workspaceForDocument: { [weak self] document in
+          guard let self else { return nil }
+          return await self.workspaceForDocument(uri: document)
         }
       )
 
@@ -2008,7 +2012,8 @@ func languageService(
   options: SourceKitServer.Options,
   client: MessageHandler,
   in workspace: Workspace,
-  reopenDocuments: @escaping (ToolchainLanguageServer) -> Void
+  reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+  workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
 ) throws -> ToolchainLanguageServer? {
   let connectionToClient = LocalConnection()
 
@@ -2017,7 +2022,8 @@ func languageService(
     toolchain: toolchain,
     options: options,
     workspace: workspace,
-    reopenDocuments: reopenDocuments
+    reopenDocuments: reopenDocuments,
+    workspaceForDocument: workspaceForDocument
   )
   connectionToClient.start(handler: client)
   return server

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -406,10 +406,7 @@ public actor SourceKitServer {
         client: self,
         in: workspace,
         reopenDocuments: { [weak self] toolchainLanguageServer in
-          guard let self else { return }
-          Task {
-            await self.reopenDocuments(for: toolchainLanguageServer)
-          }
+          await self?.reopenDocuments(for: toolchainLanguageServer)
         },
         workspaceForDocument: { [weak self] document in
           guard let self else { return nil }
@@ -2008,7 +2005,7 @@ func languageService(
   options: SourceKitServer.Options,
   client: MessageHandler,
   in workspace: Workspace,
-  reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+  reopenDocuments: @escaping (ToolchainLanguageServer) async -> Void,
   workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
 ) async throws -> ToolchainLanguageServer? {
   let connectionToClient = LocalConnection()

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -241,8 +241,8 @@ public actor SourceKitServer {
   /// incomplete or fallback settings.
   private func withReadyDocument<NotificationType: TextDocumentNotification>(
     for notification: Notification<NotificationType>,
-    notificationHandler: @escaping (Notification<NotificationType>, ToolchainLanguageServer) -> Void
-  ) {
+    notificationHandler: @escaping (Notification<NotificationType>, ToolchainLanguageServer) async -> Void
+  ) async {
     let doc = notification.params.textDocument.uri
     guard let workspace = self.workspaceForDocument(uri: doc) else {
       return
@@ -256,13 +256,13 @@ public actor SourceKitServer {
 
     // If the document is ready, we can handle it right now.
     guard !self.documentsReady.contains(doc) else {
-      notificationHandler(notification, languageService)
+      await notificationHandler(notification, languageService)
       return
     }
 
     // Not ready to handle it, we'll queue it and handle it later.
     self.documentToPendingQueue[doc, default: DocumentNotificationRequestQueue()].add(operation: {
-      notificationHandler(notification, languageService)
+      await notificationHandler(notification, languageService)
     })
   }
 
@@ -271,9 +271,9 @@ public actor SourceKitServer {
   /// incomplete or fallback settings.
   private func withReadyDocument<RequestType: TextDocumentRequest>(
     for request: Request<RequestType>,
-    requestHandler: @escaping (Request<RequestType>, Workspace, ToolchainLanguageServer) -> Void,
+    requestHandler: @escaping (Request<RequestType>, Workspace, ToolchainLanguageServer) async -> Void,
     fallback: RequestType.Response
-  ) {
+  ) async {
     let doc = request.params.textDocument.uri
     guard let workspace = self.workspaceForDocument(uri: doc) else {
       return request.reply(.failure(.workspaceNotOpen(doc)))
@@ -287,13 +287,13 @@ public actor SourceKitServer {
 
     // If the document is ready, we can handle it right now.
     guard !self.documentsReady.contains(doc) else {
-      requestHandler(request, workspace, languageService)
+      await requestHandler(request, workspace, languageService)
       return
     }
 
     // Not ready to handle it, we'll queue it and handle it later.
     self.documentToPendingQueue[doc, default: DocumentNotificationRequestQueue()].add(operation: {
-      requestHandler(request, workspace, languageService)
+      await requestHandler(request, workspace, languageService)
     }, cancellationHandler: {
       request.reply(fallback)
     })
@@ -352,7 +352,7 @@ public actor SourceKitServer {
   }
   
   /// After the language service has crashed, send `DidOpenTextDocumentNotification`s to a newly instantiated language service for previously open documents.
-  func reopenDocuments(for languageService: ToolchainLanguageServer) {
+  func reopenDocuments(for languageService: ToolchainLanguageServer) async {
     for documentUri in self.documentManager.openDocuments {
       guard let workspace = self.workspaceForDocument(uri: documentUri) else {
         continue
@@ -367,34 +367,42 @@ public actor SourceKitServer {
 
       // Close the document properly in the document manager and build system manager to start with a clean sheet when re-opening it.
       let closeNotification = DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(documentUri))
-      self.closeDocument(closeNotification, workspace: workspace)
+      await self.closeDocument(closeNotification, workspace: workspace)
 
       let textDocument = TextDocumentItem(uri: documentUri,
                                           language: snapshot.document.language,
                                           version: snapshot.version,
                                           text: snapshot.text)
-      self.openDocument(DidOpenTextDocumentNotification(textDocument: textDocument), workspace: workspace)
-
+      await self.openDocument(DidOpenTextDocumentNotification(textDocument: textDocument), workspace: workspace)
     }
+  }
+
+  /// If a language service of type `serverType` that can handle `workspace` has
+  /// already been started, return it, otherwise return `nil`.
+  private func existingLanguageService(_ serverType: LanguageServerType, workspace: Workspace) -> ToolchainLanguageServer? {
+    for languageService in languageServices[serverType, default: []] {
+      if languageService.canHandle(workspace: workspace) {
+        return languageService
+      }
+    }
+    return nil
   }
 
   func languageService(
     for toolchain: Toolchain,
     _ language: Language,
     in workspace: Workspace
-  ) -> ToolchainLanguageServer? {
+  ) async -> ToolchainLanguageServer? {
     guard let serverType = LanguageServerType(language: language) else {
       return nil
     }
     // Pick the first language service that can handle this workspace.
-    for languageService in languageServices[serverType, default: []] {
-      if languageService.canHandle(workspace: workspace) {
-        return languageService
-      }
+    if let languageService = existingLanguageService(serverType, workspace: workspace) {
+      return languageService
     }
 
     // Start a new service.
-    return orLog("failed to start language service", level: .error) {
+    return await orLog("failed to start language service", level: .error) {
       let service = try SourceKitLSP.languageService(
         for: toolchain,
         serverType,
@@ -414,7 +422,7 @@ public actor SourceKitServer {
       }
 
       let pid = Int(ProcessInfo.processInfo.processIdentifier)
-      let resp = try service.initializeSync(InitializeRequest(
+      let resp = try await service.initializeSync(InitializeRequest(
         processId: pid,
         rootPath: nil,
         rootURI: workspace.rootUri,
@@ -440,7 +448,17 @@ public actor SourceKitServer {
         fatalError("non-incremental update not implemented")
       }
 
-      service.clientInitialized(InitializedNotification())
+      await service.clientInitialized(InitializedNotification())
+
+      if let concurrentlyInitializedService = existingLanguageService(serverType, workspace: workspace) {
+        // Since we 'await' above, another call to languageService might have
+        // happened concurrently, passed the `existingLanguageService` check at
+        // the top and started initializing another language service.
+        // If this race happened, just shut down our server and return the
+        // other one.
+        await service.shutdown()
+        return concurrentlyInitializedService
+      }
 
       languageServices[serverType, default: []].append(service)
       return service
@@ -448,23 +466,30 @@ public actor SourceKitServer {
   }
 
   /// **Public for testing purposes only**
-  public func _languageService(for uri: DocumentURI, _ language: Language, in workspace: Workspace) -> ToolchainLanguageServer? {
-    return languageService(for: uri, language, in: workspace)
+  public func _languageService(for uri: DocumentURI, _ language: Language, in workspace: Workspace) async -> ToolchainLanguageServer? {
+    return await languageService(for: uri, language, in: workspace)
   }
 
-  func languageService(for uri: DocumentURI, _ language: Language, in workspace: Workspace) -> ToolchainLanguageServer? {
+  func languageService(for uri: DocumentURI, _ language: Language, in workspace: Workspace) async -> ToolchainLanguageServer? {
     if let service = workspace.documentService[uri] {
       return service
     }
 
     guard let toolchain = toolchain(for: uri, language),
-          let service = languageService(for: toolchain, language, in: workspace)
+          let service = await languageService(for: toolchain, language, in: workspace)
     else {
       return nil
     }
 
     log("Using toolchain \(toolchain.displayName) (\(toolchain.identifier)) for \(uri)")
 
+    if let concurrentlySetService = workspace.documentService[uri] {
+      // Since we await the consutrction of `service`, another call to this
+      // function might have happened and raced us, setting
+      // `workspace.documentServices[uri]`. If this is the case, return the
+      // exising value and discard the service that we just retrieved.
+      return concurrentlySetService
+    }
     workspace.documentService[uri] = service
     return service
   }
@@ -473,7 +498,7 @@ public actor SourceKitServer {
 // MARK: - MessageHandler
 
 extension SourceKitServer: MessageHandler {
-  public func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) {
+  public func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) async {
     let notification = Notification(params, clientID: clientID)
     self._logNotification(notification)
 
@@ -485,25 +510,25 @@ extension SourceKitServer: MessageHandler {
     case let notification as Notification<ExitNotification>:
       self.exit(notification)
     case let notification as Notification<DidOpenTextDocumentNotification>:
-      self.openDocument(notification)
+      await self.openDocument(notification)
     case let notification as Notification<DidCloseTextDocumentNotification>:
-      self.closeDocument(notification)
+      await self.closeDocument(notification)
     case let notification as Notification<DidChangeTextDocumentNotification>:
-      self.changeDocument(notification)
+      await self.changeDocument(notification)
     case let notification as Notification<DidChangeWorkspaceFoldersNotification>:
-      self.didChangeWorkspaceFolders(notification)
+      await self.didChangeWorkspaceFolders(notification)
     case let notification as Notification<DidChangeWatchedFilesNotification>:
       self.didChangeWatchedFiles(notification)
     case let notification as Notification<WillSaveTextDocumentNotification>:
-      self.withReadyDocument(for: notification, notificationHandler: self.willSaveDocument)
+      await self.withReadyDocument(for: notification, notificationHandler: self.willSaveDocument)
     case let notification as Notification<DidSaveTextDocumentNotification>:
-      self.withReadyDocument(for: notification, notificationHandler: self.didSaveDocument)
+      await self.withReadyDocument(for: notification, notificationHandler: self.didSaveDocument)
     default:
       self._handleUnknown(notification)
     }
   }
 
-  public func handle<R: RequestType>(_ params: R, id: RequestID, from clientID: ObjectIdentifier, reply: @escaping (LSPResult<R.Response >) -> Void) {
+  public func handle<R: RequestType>(_ params: R, id: RequestID, from clientID: ObjectIdentifier, reply: @escaping (LSPResult<R.Response >) -> Void) async {
     let cancellationToken = CancellationToken()
     let key = RequestCancelKey(client: clientID, request: id)
 
@@ -529,13 +554,13 @@ extension SourceKitServer: MessageHandler {
     case let request as Request<InitializeRequest>:
       self.initialize(request)
     case let request as Request<ShutdownRequest>:
-      self.shutdown(request)
+      await self.shutdown(request)
     case let request as Request<WorkspaceSymbolsRequest>:
       self.workspaceSymbols(request)
     case let request as Request<PollIndexRequest>:
       self.pollIndex(request)
     case let request as Request<ExecuteCommandRequest>:
-      self.executeCommand(request)
+      await self.executeCommand(request)
     case let request as Request<CallHierarchyIncomingCallsRequest>:
       self.incomingCalls(request)
     case let request as Request<CallHierarchyOutgoingCallsRequest>:
@@ -545,47 +570,47 @@ extension SourceKitServer: MessageHandler {
     case let request as Request<TypeHierarchySubtypesRequest>:
       self.subtypes(request)
     case let request as Request<CompletionRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
+      await self.withReadyDocument(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
     case let request as Request<HoverRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.hover, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.hover, fallback: nil)
     case let request as Request<OpenInterfaceRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.openInterface, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.openInterface, fallback: nil)
     case let request as Request<DeclarationRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.declaration, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.declaration, fallback: nil)
     case let request as Request<DefinitionRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.definition, fallback: .locations([]))
+      await self.withReadyDocument(for: request, requestHandler: self.definition, fallback: .locations([]))
     case let request as Request<ReferencesRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.references, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.references, fallback: [])
     case let request as Request<ImplementationRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.implementation, fallback: .locations([]))
+      await self.withReadyDocument(for: request, requestHandler: self.implementation, fallback: .locations([]))
     case let request as Request<CallHierarchyPrepareRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.prepareCallHierarchy, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.prepareCallHierarchy, fallback: [])
     case let request as Request<TypeHierarchyPrepareRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.prepareTypeHierarchy, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.prepareTypeHierarchy, fallback: [])
     case let request as Request<SymbolInfoRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.symbolInfo, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.symbolInfo, fallback: [])
     case let request as Request<DocumentHighlightRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentSymbolHighlight, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.documentSymbolHighlight, fallback: nil)
     case let request as Request<FoldingRangeRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.foldingRange, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.foldingRange, fallback: nil)
     case let request as Request<DocumentSymbolRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentSymbol, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.documentSymbol, fallback: nil)
     case let request as Request<DocumentColorRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentColor, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.documentColor, fallback: [])
     case let request as Request<DocumentSemanticTokensRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokens, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokens, fallback: nil)
     case let request as Request<DocumentSemanticTokensDeltaRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokensDelta, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokensDelta, fallback: nil)
     case let request as Request<DocumentSemanticTokensRangeRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokensRange, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokensRange, fallback: nil)
     case let request as Request<ColorPresentationRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.colorPresentation, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.colorPresentation, fallback: [])
     case let request as Request<CodeActionRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.codeAction, fallback: nil)
+      await self.withReadyDocument(for: request, requestHandler: self.codeAction, fallback: nil)
     case let request as Request<InlayHintRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.inlayHint, fallback: [])
+      await self.withReadyDocument(for: request, requestHandler: self.inlayHint, fallback: [])
     case let request as Request<DocumentDiagnosticsRequest>:
-      self.withReadyDocument(for: request, requestHandler: self.documentDiagnostic, fallback: .full(.init(items: [])))
+      await self.withReadyDocument(for: request, requestHandler: self.documentDiagnostic, fallback: .full(.init(items: [])))
     default:
       self._handleUnknown(request)
     }
@@ -656,7 +681,7 @@ extension SourceKitServer: BuildSystemDelegate {
   /// - Changed settings for an already open file
   public func fileBuildSettingsChangedImpl(
     _ changedFiles: [DocumentURI: FileBuildSettingsChange]
-  ) {
+  ) async {
     for (uri, change) in changedFiles {
       // Non-ready documents should be considered open even though we haven't
       // opened it with the language service yet.
@@ -682,10 +707,19 @@ extension SourceKitServer: BuildSystemDelegate {
         }
 
         // Notify the language server so it can apply the proper arguments.
-        service.documentUpdatedBuildSettings(uri, change: change)
+        await service.documentUpdatedBuildSettings(uri, change: change)
 
         // Catch up on any queued notifications and requests.
-        self.documentToPendingQueue[uri]?.handleAll()
+        while !(documentToPendingQueue[uri]?.queue.isEmpty ?? true) {
+          // We need to run this loop until converence since new closures can
+          // get added to `documentToPendingQueue` while we are awaiting the
+          // result of a `task.operation()`.
+          let pendingQueue = documentToPendingQueue[uri]?.queue ?? []
+          documentToPendingQueue[uri]?.queue = []
+          for task in pendingQueue {
+            await task.operation()
+          }
+        }
         self.documentToPendingQueue[uri] = nil
         self.documentsReady.insert(uri)
         continue
@@ -694,7 +728,7 @@ extension SourceKitServer: BuildSystemDelegate {
       // Case 2: changed settings for an already open file.
       log("Build settings changed for opened file \(uri)")
       if let service = workspace.documentService[uri] {
-        service.documentUpdatedBuildSettings(uri, change: change)
+        await service.documentUpdatedBuildSettings(uri, change: change)
       }
     }
   }
@@ -709,7 +743,7 @@ extension SourceKitServer: BuildSystemDelegate {
   /// Handle a dependencies updated notification from the `BuildSystem`.
   /// We inform the respective language services as long as the given file is open
   /// (not queued for opening).
-  public func filesDependenciesUpdatedImpl(_ changedFiles: Set<DocumentURI>) {
+  public func filesDependenciesUpdatedImpl(_ changedFiles: Set<DocumentURI>) async {
     // Split the changedFiles into the workspaces they belong to.
     // Then invoke affectedOpenDocumentsForChangeSet for each workspace with its affected files.
     let changedFilesAndWorkspace = changedFiles.map({
@@ -728,7 +762,7 @@ extension SourceKitServer: BuildSystemDelegate {
         }
         log("Dependencies updated for opened file \(uri)")
         if let service = workspace.documentService[uri] {
-          service.documentDependenciesUpdated(uri)
+          await service.documentDependenciesUpdated(uri)
         }
       }
     }
@@ -1002,23 +1036,28 @@ extension SourceKitServer {
   }
 
 
-  func shutdown(_ request: Request<ShutdownRequest>) {
+  func shutdown(_ request: Request<ShutdownRequest>) async {
     prepareForExit()
-    let shutdownGroup = DispatchGroup()
-    for service in languageServices.values.flatMap({ $0 }) {
-      shutdownGroup.enter()
-      service.shutdown() {
-        shutdownGroup.leave()
+
+    await withTaskGroup(of: Void.self) { taskGroup in
+      for service in languageServices.values.flatMap({ $0 }) {
+        taskGroup.addTask {
+          await service.shutdown()
+        }
       }
     }
+
+    // We have a semantic guarantee that no request or notification should be
+    // sent to an LSP server after the shutdown request. Thus, there's no chance
+    // that a new language service has been started during the above 'await'
+    // call.
     languageServices = [:]
+
     // Wait for all services to shut down before sending the shutdown response.
     // Otherwise we might terminate sourcekit-lsp while it still has open
     // connections to the toolchain servers, which could send messages to
     // sourcekit-lsp while it is being deallocated, causing crashes.
-    shutdownGroup.notify(queue: clientCommunicationQueue) {
-      request.reply(VoidResponse())
-    }
+    request.reply(VoidResponse())
   }
 
   func exit(_ notification: Notification<ExitNotification>) {
@@ -1035,16 +1074,16 @@ extension SourceKitServer {
 
   // MARK: - Text synchronization
 
-  func openDocument(_ note: Notification<DidOpenTextDocumentNotification>) {
+  func openDocument(_ note: Notification<DidOpenTextDocumentNotification>) async {
     let uri = note.params.textDocument.uri
     guard let workspace = workspaceForDocument(uri: uri) else {
       log("received open notification for file '\(uri)' without a corresponding workspace, ignoring...", level: .error)
       return
     }
-    openDocument(note.params, workspace: workspace)
+    await openDocument(note.params, workspace: workspace)
   }
 
-  private func openDocument(_ note: DidOpenTextDocumentNotification, workspace: Workspace) {
+  private func openDocument(_ note: DidOpenTextDocumentNotification, workspace: Workspace) async {
     // Immediately open the document even if the build system isn't ready. This is important since
     // we check that the document is open when we receive messages from the build system.
     documentManager.open(note)
@@ -1054,7 +1093,7 @@ extension SourceKitServer {
     let language = textDocument.language
 
     // If we can't create a service, this document is unsupported and we can bail here.
-    guard let service = languageService(for: uri, language, in: workspace) else {
+    guard let service = await languageService(for: uri, language, in: workspace) else {
       return
     }
 
@@ -1062,26 +1101,26 @@ extension SourceKitServer {
 
     // If the document is ready, we can immediately send the notification.
     guard !documentsReady.contains(uri) else {
-      service.openDocument(note)
+      await service.openDocument(note)
       return
     }
 
     // Need to queue the open call so we can handle it when ready.
     self.documentToPendingQueue[uri, default: DocumentNotificationRequestQueue()].add(operation: {
-      service.openDocument(note)
+      await service.openDocument(note)
     })
   }
 
-  func closeDocument(_ note: Notification<DidCloseTextDocumentNotification>) {
+  func closeDocument(_ note: Notification<DidCloseTextDocumentNotification>) async {
     let uri = note.params.textDocument.uri
     guard let workspace = workspaceForDocument(uri: uri) else {
       log("received close notification for file '\(uri)' without a corresponding workspace, ignoring...", level: .error)
       return
     }
-    self.closeDocument(note.params, workspace: workspace)
+    await self.closeDocument(note.params, workspace: workspace)
   }
 
-  func closeDocument(_ note: DidCloseTextDocumentNotification, workspace: Workspace) {
+  func closeDocument(_ note: DidCloseTextDocumentNotification, workspace: Workspace) async {
     // Immediately close the document. We need to be sure to clear our pending work queue in case
     // the build system still isn't ready.
     documentManager.close(note)
@@ -1093,7 +1132,7 @@ extension SourceKitServer {
     // If the document is ready, we can close it now.
     guard !documentsReady.contains(uri) else {
       self.documentsReady.remove(uri)
-      workspace.documentService[uri]?.closeDocument(note)
+      await workspace.documentService[uri]?.closeDocument(note)
       return
     }
 
@@ -1103,7 +1142,7 @@ extension SourceKitServer {
     self.documentToPendingQueue[uri] = nil
   }
 
-  func changeDocument(_ note: Notification<DidChangeTextDocumentNotification>) {
+  func changeDocument(_ note: Notification<DidChangeTextDocumentNotification>) async {
     let uri = note.params.textDocument.uri
 
     guard let workspace = workspaceForDocument(uri: uri) else {
@@ -1114,32 +1153,32 @@ extension SourceKitServer {
     // If the document is ready, we can handle the change right now.
     guard !documentsReady.contains(uri) else {
       documentManager.edit(note.params)
-      workspace.documentService[uri]?.changeDocument(note.params)
+      await workspace.documentService[uri]?.changeDocument(note.params)
       return
     }
 
     // Need to queue the change call so we can handle it when ready.
     self.documentToPendingQueue[uri, default: DocumentNotificationRequestQueue()].add(operation: {
       self.documentManager.edit(note.params)
-      workspace.documentService[uri]?.changeDocument(note.params)
+      await workspace.documentService[uri]?.changeDocument(note.params)
     })
   }
 
   func willSaveDocument(
     _ note: Notification<WillSaveTextDocumentNotification>,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.willSaveDocument(note.params)
+  ) async {
+    await languageService.willSaveDocument(note.params)
   }
 
   func didSaveDocument(
     _ note: Notification<DidSaveTextDocumentNotification>,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.didSaveDocument(note.params)
+  ) async {
+    await languageService.didSaveDocument(note.params)
   }
 
-  func didChangeWorkspaceFolders(_ note: Notification<DidChangeWorkspaceFoldersNotification>) {
+  func didChangeWorkspaceFolders(_ note: Notification<DidChangeWorkspaceFoldersNotification>) async {
     var preChangeWorkspaces: [DocumentURI: Workspace] = [:]
     for docUri in self.documentManager.openDocuments {
       preChangeWorkspaces[docUri] = self.workspaceForDocument(uri: docUri)
@@ -1169,12 +1208,12 @@ extension SourceKitServer {
           continue
         }
         if let oldWorkspace = oldWorkspace {
-          self.closeDocument(DidCloseTextDocumentNotification(
+          await self.closeDocument(DidCloseTextDocumentNotification(
             textDocument: TextDocumentIdentifier(docUri)
           ), workspace: oldWorkspace)
         }
         if let newWorkspace = newWorkspace {
-          self.openDocument(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
+          await self.openDocument(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
             uri: docUri,
             language: snapshot.document.language,
             version: snapshot.version,
@@ -1202,24 +1241,24 @@ extension SourceKitServer {
     _ req: Request<CompletionRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.completion(req)
+  ) async {
+    await languageService.completion(req)
   }
 
   func hover(
     _ req: Request<HoverRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.hover(req)
+  ) async {
+    await languageService.hover(req)
   }
   
   func openInterface(
     _ req: Request<OpenInterfaceRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.openInterface(req)
+  ) async {
+    await languageService.openInterface(req)
   }
 
   /// Find all symbols in the workspace that include a string in their name.
@@ -1287,74 +1326,74 @@ extension SourceKitServer {
     _ req: Request<SymbolInfoRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.symbolInfo(req)
+  ) async {
+    await languageService.symbolInfo(req)
   }
 
   func documentSymbolHighlight(
     _ req: Request<DocumentHighlightRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentSymbolHighlight(req)
+  ) async {
+    await languageService.documentSymbolHighlight(req)
   }
 
   func foldingRange(
     _ req: Request<FoldingRangeRequest>,
     workspace: Workspace,
-    languageService: ToolchainLanguageServer) {
-    languageService.foldingRange(req)
+    languageService: ToolchainLanguageServer) async {
+    await languageService.foldingRange(req)
   }
 
   func documentSymbol(
     _ req: Request<DocumentSymbolRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentSymbol(req)
+  ) async {
+    await languageService.documentSymbol(req)
   }
 
   func documentColor(
     _ req: Request<DocumentColorRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentColor(req)
+  ) async {
+    await languageService.documentColor(req)
   }
 
   func documentSemanticTokens(
     _ req: Request<DocumentSemanticTokensRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentSemanticTokens(req)
+  ) async {
+    await languageService.documentSemanticTokens(req)
   }
 
   func documentSemanticTokensDelta(
     _ req: Request<DocumentSemanticTokensDeltaRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentSemanticTokensDelta(req)
+  ) async {
+    await languageService.documentSemanticTokensDelta(req)
   }
 
   func documentSemanticTokensRange(
     _ req: Request<DocumentSemanticTokensRangeRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentSemanticTokensRange(req)
+  ) async {
+    await languageService.documentSemanticTokensRange(req)
   }
 
   func colorPresentation(
     _ req: Request<ColorPresentationRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.colorPresentation(req)
+  ) async {
+    await languageService.colorPresentation(req)
   }
 
-  func executeCommand(_ req: Request<ExecuteCommandRequest>) {
+  func executeCommand(_ req: Request<ExecuteCommandRequest>) async {
     guard let uri = req.params.textDocument?.uri else {
       log("attempted to perform executeCommand request without an url!", level: .error)
       req.reply(nil)
@@ -1390,13 +1429,13 @@ extension SourceKitServer {
       return
     }
 
-    self.fowardExecuteCommand(req, languageService: languageService)
+    await self.fowardExecuteCommand(req, languageService: languageService)
   }
 
   func fowardExecuteCommand(
     _ req: Request<ExecuteCommandRequest>,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let params = req.params
     let executeCommand = ExecuteCommandRequest(command: params.command,
                                                arguments: params.argumentsWithoutSourceKitMetadata)
@@ -1405,14 +1444,14 @@ extension SourceKitServer {
     }
     let request = Request(executeCommand, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.executeCommand(request)
+    await languageService.executeCommand(request)
   }
 
   func codeAction(
     _ req: Request<CodeActionRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let codeAction = CodeActionRequest(range: req.params.range, context: req.params.context,
                                        textDocument: req.params.textDocument)
     let callback = { (result: Result<CodeActionRequest.Response, ResponseError>) in
@@ -1425,23 +1464,23 @@ extension SourceKitServer {
     }
     let request = Request(codeAction, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.codeAction(request)
+    await languageService.codeAction(request)
   }
 
   func inlayHint(
     _ req: Request<InlayHintRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.inlayHint(req)
+  ) async {
+    await languageService.inlayHint(req)
   }
 
   func documentDiagnostic(
     _ req: Request<DocumentDiagnosticsRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    languageService.documentDiagnostic(req)
+  ) async {
+    await languageService.documentDiagnostic(req)
   }
 
   /// Converts a location from the symbol index to an LSP location.
@@ -1510,8 +1549,8 @@ extension SourceKitServer {
     _ req: Request<DeclarationRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
-    guard languageService.declaration(req) else {
+  ) async {
+    guard await languageService.declaration(req) else {
       return req.reply(.locations([]))
     }
   }
@@ -1520,58 +1559,59 @@ extension SourceKitServer {
     _ req: Request<DefinitionRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let symbolInfo = SymbolInfoRequest(textDocument: req.params.textDocument, position: req.params.position)
     let index = self.workspaceForDocument(uri: req.params.textDocument.uri)?.index
-    let callback = { (result: LSPResult<SymbolInfoRequest.Response>) in
-
-      // If this symbol is a module then generate a textual interface
-      if case .success(let symbols) = result, let symbol = symbols.first, symbol.kind == .module, let name = symbol.name {
-        self.respondWithInterface(req, moduleName: name, symbolUSR: nil, languageService: languageService)
-        return
-      }
-
-      let extractedResult = self.extractIndexedOccurrences(result: result, index: index, useLocalFallback: true) { (usr, index) in
-        log("performing indexed jump-to-def with usr \(usr)")
-        var occurs = index.occurrences(ofUSR: usr, roles: [.definition])
-        if occurs.isEmpty {
-          occurs = index.occurrences(ofUSR: usr, roles: [.declaration])
-        }
-        return occurs
-      }
-
-      switch extractedResult {
-      case .success(let resolved):
-        // if first resolved location is in `.swiftinterface` file. Use moduleName to return 
-        // textual interface 
-        if let firstResolved = resolved.first, 
-           let moduleName = firstResolved.occurrence?.location.moduleName, 
-           firstResolved.location.uri.fileURL?.pathExtension == "swiftinterface" {
-          self.respondWithInterface(
-            req, 
-            moduleName: moduleName, 
-            symbolUSR: firstResolved.occurrence?.symbol.usr,
-            languageService: languageService
-          )
+    let callback = { (result: LSPResult<SymbolInfoRequest.Response>) -> Void in
+      Task {
+        // If this symbol is a module then generate a textual interface
+        if case .success(let symbols) = result, let symbol = symbols.first, symbol.kind == .module, let name = symbol.name {
+          await self.respondWithInterface(req, moduleName: name, symbolUSR: nil, languageService: languageService)
           return
         }
-        let locs = resolved.map(\.location)
-        // If we're unable to handle the definition request using our index, see if the
-        // language service can handle it (e.g. clangd can provide AST based definitions).
-        guard locs.isEmpty else {
-          req.reply(.locations(locs))
-          return
+
+        let extractedResult = self.extractIndexedOccurrences(result: result, index: index, useLocalFallback: true) { (usr, index) in
+          log("performing indexed jump-to-def with usr \(usr)")
+          var occurs = index.occurrences(ofUSR: usr, roles: [.definition])
+          if occurs.isEmpty {
+            occurs = index.occurrences(ofUSR: usr, roles: [.declaration])
+          }
+          return occurs
         }
-        let handled = languageService.definition(req)
-        guard !handled else { return }
-        req.reply(.locations([]))
-      case .failure(let error):
-        req.reply(.failure(error))
+
+        switch extractedResult {
+        case .success(let resolved):
+          // if first resolved location is in `.swiftinterface` file. Use moduleName to return
+          // textual interface
+          if let firstResolved = resolved.first,
+             let moduleName = firstResolved.occurrence?.location.moduleName,
+             firstResolved.location.uri.fileURL?.pathExtension == "swiftinterface" {
+            await self.respondWithInterface(
+              req,
+              moduleName: moduleName,
+              symbolUSR: firstResolved.occurrence?.symbol.usr,
+              languageService: languageService
+            )
+            return
+          }
+          let locs = resolved.map(\.location)
+          // If we're unable to handle the definition request using our index, see if the
+          // language service can handle it (e.g. clangd can provide AST based definitions).
+          guard locs.isEmpty else {
+            req.reply(.locations(locs))
+            return
+          }
+          let handled = await languageService.definition(req)
+          guard !handled else { return }
+          req.reply(.locations([]))
+        case .failure(let error):
+          req.reply(.failure(error))
+        }
       }
     }
     let request = Request(symbolInfo, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.symbolInfo(request)
+    await languageService.symbolInfo(request)
   }
 
   func respondWithInterface(
@@ -1579,7 +1619,7 @@ extension SourceKitServer {
     moduleName: String,
     symbolUSR: String?,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
       let openInterface = OpenInterfaceRequest(textDocument: req.params.textDocument, name: moduleName, symbolUSR: symbolUSR)
       let request = Request(openInterface, id: req.id, clientID: ObjectIdentifier(self),
                             cancellation: req.cancellationToken, reply: { (result: Result<OpenInterfaceRequest.Response, ResponseError>) in
@@ -1594,14 +1634,14 @@ extension SourceKitServer {
           req.reply(.failure(error))
         }
       })
-      languageService.openInterface(request)
+      await languageService.openInterface(request)
   }
 
   func implementation(
     _ req: Request<ImplementationRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let symbolInfo = SymbolInfoRequest(textDocument: req.params.textDocument, position: req.params.position)
     let index = self.workspaceForDocument(uri: req.params.textDocument.uri)?.index
     let callback = { (result: LSPResult<SymbolInfoRequest.Response>) in
@@ -1617,14 +1657,14 @@ extension SourceKitServer {
     }
     let request = Request(symbolInfo, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.symbolInfo(request)
+    await languageService.symbolInfo(request)
   }
 
   func references(
     _ req: Request<ReferencesRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let symbolInfo = SymbolInfoRequest(textDocument: req.params.textDocument, position: req.params.position)
     let index = self.workspaceForDocument(uri: req.params.textDocument.uri)?.index
     let callback = { (result: LSPResult<SymbolInfoRequest.Response>) in
@@ -1641,7 +1681,7 @@ extension SourceKitServer {
     }
     let request = Request(symbolInfo, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.symbolInfo(request)
+    await languageService.symbolInfo(request)
   }
 
   private func indexToLSPCallHierarchyItem(
@@ -1669,7 +1709,7 @@ extension SourceKitServer {
     _ req: Request<CallHierarchyPrepareRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let symbolInfo = SymbolInfoRequest(textDocument: req.params.textDocument, position: req.params.position)
     let index = self.workspaceForDocument(uri: req.params.textDocument.uri)?.index
     let callback = { (result: LSPResult<SymbolInfoRequest.Response>) in
@@ -1694,7 +1734,7 @@ extension SourceKitServer {
     }
     let request = Request(symbolInfo, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.symbolInfo(request)
+    await languageService.symbolInfo(request)
   }
 
   /// Extracts our implementation-specific data about a call hierarchy
@@ -1827,7 +1867,7 @@ extension SourceKitServer {
     _ req: Request<TypeHierarchyPrepareRequest>,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) {
+  ) async {
     let symbolInfo = SymbolInfoRequest(textDocument: req.params.textDocument, position: req.params.position)
     guard let index = self.workspaceForDocument(uri: req.params.textDocument.uri)?.index else {
       req.reply([])
@@ -1856,7 +1896,7 @@ extension SourceKitServer {
     }
     let request = Request(symbolInfo, id: req.id, clientID: ObjectIdentifier(self),
                           cancellation: req.cancellationToken, reply: callback)
-    languageService.symbolInfo(request)
+    await languageService.symbolInfo(request)
   }
 
   /// Extracts our implementation-specific data about a type hierarchy
@@ -2043,8 +2083,8 @@ extension SymbolOccurrence {
 
 /// Simple struct for pending notifications/requests, including a cancellation handler.
 /// For convenience the notifications/request handlers are type erased via wrapping.
-private struct NotificationRequestOperation {
-  let operation: () -> Void
+fileprivate struct NotificationRequestOperation {
+  let operation: () async -> Void
   let cancellationHandler: (() -> Void)?
 }
 
@@ -2052,20 +2092,12 @@ private struct NotificationRequestOperation {
 /// on `BuildSystem` operations such as fetching build settings.
 ///
 /// Note: This is not thread safe. Must be called from the `SourceKitServer.queue`.
-private struct DocumentNotificationRequestQueue {
-  private var queue = [NotificationRequestOperation]()
+fileprivate struct DocumentNotificationRequestQueue {
+  fileprivate var queue = [NotificationRequestOperation]()
 
   /// Add an operation to the end of the queue.
-  mutating func add(operation: @escaping () -> Void, cancellationHandler: (() -> Void)? = nil) {
+  mutating func add(operation: @escaping () async -> Void, cancellationHandler: (() -> Void)? = nil) {
     queue.append(NotificationRequestOperation(operation: operation, cancellationHandler: cancellationHandler))
-  }
-
-  /// Invoke all operations in the queue.
-  mutating func handleAll() {
-    for task in queue {
-      task.operation()
-    }
-    queue = []
   }
 
   /// Cancel all operations in the queue. No-op for operations without a cancellation

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -59,7 +59,7 @@ final actor WorkDoneProgressState {
   private enum State {
     /// No `WorkDoneProgress` has been created.
     case noProgress
-    /// We have sent the request to create a `WorkDoneProgress` but haven’t received a respose yet.
+    /// We have sent the request to create a `WorkDoneProgress` but haven’t received a response yet.
     case creating
     /// A `WorkDoneProgress` has been created.
     case created
@@ -481,10 +481,10 @@ public actor SourceKitServer {
     log("Using toolchain \(toolchain.displayName) (\(toolchain.identifier)) for \(uri)")
 
     if let concurrentlySetService = workspace.documentService[uri] {
-      // Since we await the consutrction of `service`, another call to this
+      // Since we await the construction of `service`, another call to this
       // function might have happened and raced us, setting
       // `workspace.documentServices[uri]`. If this is the case, return the
-      // exising value and discard the service that we just retrieved.
+      // existing value and discard the service that we just retrieved.
       return concurrentlySetService
     }
     workspace.documentService[uri] = service
@@ -708,7 +708,7 @@ extension SourceKitServer: BuildSystemDelegate {
 
         // Catch up on any queued notifications and requests.
         while !(documentToPendingQueue[uri]?.queue.isEmpty ?? true) {
-          // We need to run this loop until converence since new closures can
+          // We need to run this loop until convergence since new closures can
           // get added to `documentToPendingQueue` while we are awaiting the
           // result of a `task.operation()`.
           let pendingQueue = documentToPendingQueue[uri]?.queue ?? []

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -17,7 +17,7 @@ import Foundation
 
 extension SwiftLanguageServer {
 
-  public func completion(_ req: Request<CompletionRequest>) {
+  public func completion(_ req: Request<CompletionRequest>) async {
     guard let snapshot = documentManager.latestSnapshot(req.params.textDocument.uri) else {
       log("failed to find snapshot for url \(req.params.textDocument.uri)")
       req.reply(CompletionList(isIncomplete: true, items: []))
@@ -39,14 +39,13 @@ extension SwiftLanguageServer {
     let options = req.params.sourcekitlspOptions ?? serverOptions.completionOptions
 
     if options.serverSideFiltering {
-      _completionWithServerFiltering(offset: offset, completionPos: completionPos, snapshot: snapshot, request: req, options: options)
+      await _completionWithServerFiltering(offset: offset, completionPos: completionPos, snapshot: snapshot, request: req, options: options)
     } else {
-      _completionWithClientFiltering(offset: offset, completionPos: completionPos, snapshot: snapshot, request: req, options: options)
+      await _completionWithClientFiltering(offset: offset, completionPos: completionPos, snapshot: snapshot, request: req, options: options)
     }
   }
 
-  /// Must be called on `queue`.
-  func _completionWithServerFiltering(offset: Int, completionPos: Position, snapshot: DocumentSnapshot, request req: Request<CompletionRequest>, options: SKCompletionOptions) {
+  func _completionWithServerFiltering(offset: Int, completionPos: Position, snapshot: DocumentSnapshot, request req: Request<CompletionRequest>, options: SKCompletionOptions) async {
     guard let start = snapshot.indexOf(utf8Offset: offset),
           let end = snapshot.index(of: req.params.position) else {
       log("invalid completion position \(req.params.position)")
@@ -74,7 +73,7 @@ extension SwiftLanguageServer {
         snapshot: snapshot,
         utf8Offset: offset,
         position: completionPos,
-        compileCommand: commandsByFile[snapshot.document.uri])
+        compileCommand: await buildSettings(for: snapshot.document.uri))
 
       currentCompletionSession?.close()
       currentCompletionSession = session
@@ -83,8 +82,7 @@ extension SwiftLanguageServer {
     session.update(filterText: filterText, position: req.params.position, in: snapshot, options: options, completion: req.reply)
   }
 
-  /// Must be called on `queue`.
-  func _completionWithClientFiltering(offset: Int, completionPos: Position, snapshot: DocumentSnapshot, request req: Request<CompletionRequest>, options: SKCompletionOptions) {
+  func _completionWithClientFiltering(offset: Int, completionPos: Position, snapshot: DocumentSnapshot, request req: Request<CompletionRequest>, options: SKCompletionOptions) async {
     let skreq = SKDRequestDictionary(sourcekitd: sourcekitd)
     skreq[keys.request] = requests.codecomplete
     skreq[keys.offset] = offset
@@ -96,7 +94,7 @@ extension SwiftLanguageServer {
     skreq[keys.codecomplete_options] = skreqOptions
 
     // FIXME: SourceKit should probably cache this for us.
-    if let compileCommand = commandsByFile[snapshot.document.uri] {
+    if let compileCommand = await buildSettings(for: snapshot.document.uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
 

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -17,8 +17,7 @@ import Foundation
 
 extension SwiftLanguageServer {
 
-  /// Must be called on `queue`.
-  func _completion(_ req: Request<CompletionRequest>) {
+  public func completion(_ req: Request<CompletionRequest>) {
     guard let snapshot = documentManager.latestSnapshot(req.params.textDocument.uri) else {
       log("failed to find snapshot for url \(req.params.textDocument.uri)")
       req.reply(CompletionList(isIncomplete: true, items: []))
@@ -120,7 +119,7 @@ extension SwiftLanguageServer {
     _ = handle
   }
 
-  func completionsFromSKDResponse(
+  nonisolated func completionsFromSKDResponse(
     _ completions: SKDResponseArray,
     in snapshot: DocumentSnapshot,
     completionPos: Position,
@@ -220,7 +219,7 @@ extension SwiftLanguageServer {
     return Position(line: pos.line, utf16index: adjustedOffset)
   }
 
-  private func computeCompletionTextEdit(completionPos: Position, requestPosition: Position, utf8CodeUnitsToErase: Int, newText: String, snapshot: DocumentSnapshot) -> TextEdit {
+  private nonisolated func computeCompletionTextEdit(completionPos: Position, requestPosition: Position, utf8CodeUnitsToErase: Int, newText: String, snapshot: DocumentSnapshot) -> TextEdit {
     let textEditRangeStart: Position
 
     // Compute the TextEdit

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -71,8 +71,16 @@ extension CursorInfoError: CustomStringConvertible {
 
 extension SwiftLanguageServer {
 
-  /// Must be called on self.queue.
-  func _cursorInfo(
+  /// Provides detailed information about a symbol under the cursor, if any.
+  ///
+  /// Wraps the information returned by sourcekitd's `cursor_info` request, such as symbol name,
+  /// USR, and declaration location. This request does minimal processing of the result.
+  ///
+  /// - Parameters:
+  ///   - url: Document URL in which to perform the request. Must be an open document.
+  ///   - range: The position range within the document to lookup the symbol at.
+  ///   - completion: Completion block to asynchronously receive the CursorInfo, or error.
+  func cursorInfo(
     _ uri: DocumentURI,
     _ range: Range<Position>,
     additionalParameters appendAdditionalParameters: ((SKDRequestDictionary) -> Void)? = nil,
@@ -146,26 +154,5 @@ extension SwiftLanguageServer {
 
     // FIXME: cancellation
     _ = handle
-  }
-
-  /// Provides detailed information about a symbol under the cursor, if any.
-  ///
-  /// Wraps the information returned by sourcekitd's `cursor_info` request, such as symbol name,
-  /// USR, and declaration location. This request does minimal processing of the result.
-  ///
-  /// - Parameters:
-  ///   - url: Document URL in which to perform the request. Must be an open document.
-  ///   - range: The position range within the document to lookup the symbol at.
-  ///   - completion: Completion block to asynchronously receive the CursorInfo, or error.
-  func cursorInfo(
-    _ uri: DocumentURI,
-    _ range: Range<Position>,
-    additionalParameters appendAdditionalParameters: ((SKDRequestDictionary) -> Void)? = nil,
-    _ completion: @escaping (Swift.Result<CursorInfo?, CursorInfoError>) -> Void)
-  {
-    self.queue.async {
-      self._cursorInfo(uri, range,
-                       additionalParameters: appendAdditionalParameters, completion)
-    }
   }
 }

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -84,7 +84,7 @@ extension SwiftLanguageServer {
     _ uri: DocumentURI,
     _ range: Range<Position>,
     additionalParameters appendAdditionalParameters: ((SKDRequestDictionary) -> Void)? = nil,
-    _ completion: @escaping (Swift.Result<CursorInfo?, CursorInfoError>) -> Void)
+    _ completion: @escaping (Swift.Result<CursorInfo?, CursorInfoError>) -> Void) async
   {
     guard let snapshot = documentManager.latestSnapshot(uri) else {
        return completion(.failure(.unknownDocument(uri)))
@@ -105,7 +105,7 @@ extension SwiftLanguageServer {
     skreq[keys.sourcefile] = snapshot.document.uri.pseudoPath
 
     // FIXME: SourceKit should probably cache this for us.
-    if let compileCommand = self.commandsByFile[uri] {
+    if let compileCommand = await self.buildSettings(for: uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
 

--- a/Sources/SourceKitLSP/Swift/ExpressionTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/ExpressionTypeInfo.swift
@@ -57,7 +57,7 @@ extension SwiftLanguageServer {
   func expressionTypeInfos(
     _ uri: DocumentURI,
     _ completion: @escaping (Swift.Result<[ExpressionTypeInfo], ExpressionTypeInfoError>) -> Void
-  ) {
+  ) async {
     guard let snapshot = documentManager.latestSnapshot(uri) else {
       return completion(.failure(.unknownDocument(uri)))
     }
@@ -69,7 +69,7 @@ extension SwiftLanguageServer {
     skreq[keys.sourcefile] = snapshot.document.uri.pseudoPath
 
     // FIXME: SourceKit should probably cache this for us.
-    if let compileCommand = self.commandsByFile[uri] {
+    if let compileCommand = await self.buildSettings(for: uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
 

--- a/Sources/SourceKitLSP/Swift/ExpressionTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/ExpressionTypeInfo.swift
@@ -49,13 +49,15 @@ enum ExpressionTypeInfoError: Error, Equatable {
 }
 
 extension SwiftLanguageServer {
-  /// Must be called on self.queue.
-  private func _expressionTypeInfos(
+  /// Provides typed expressions in a document.
+  ///
+  /// - Parameters:
+  ///   - url: Document URL in which to perform the request. Must be an open document.
+  ///   - completion: Completion block to asynchronously receive the ExpressionTypeInfos, or error.
+  func expressionTypeInfos(
     _ uri: DocumentURI,
     _ completion: @escaping (Swift.Result<[ExpressionTypeInfo], ExpressionTypeInfoError>) -> Void
   ) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     guard let snapshot = documentManager.latestSnapshot(uri) else {
       return completion(.failure(.unknownDocument(uri)))
     }
@@ -97,19 +99,5 @@ extension SwiftLanguageServer {
 
     // FIXME: cancellation
     _ = handle
-  }
-
-  /// Provides typed expressions in a document.
-  ///
-  /// - Parameters:
-  ///   - url: Document URL in which to perform the request. Must be an open document.
-  ///   - completion: Completion block to asynchronously receive the ExpressionTypeInfos, or error.
-  func expressionTypeInfos(
-    _ uri: DocumentURI,
-    _ completion: @escaping (Swift.Result<[ExpressionTypeInfo], ExpressionTypeInfoError>) -> Void
-  ) {
-    queue.async {
-      self._expressionTypeInfos(uri, completion)
-    }
   }
 }

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -30,30 +30,28 @@ extension SwiftLanguageServer {
     let moduleName = request.params.moduleName
     let name = request.params.name
     let symbol = request.params.symbolUSR
-    self.queue.async {
-      let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(name).swiftinterface")
-      let interfaceDocURI = DocumentURI(interfaceFilePath)
-      // has interface already been generated
-      if let snapshot = self.documentManager.latestSnapshot(interfaceDocURI) {
-        self._findUSRAndRespond(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
-      } else {
-        // generate interface
-        self._openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI) { result in
-          switch result {
-          case .success(let interfaceInfo):
-            do {
-              // write to file
-              try interfaceInfo.contents.write(to: interfaceFilePath, atomically: true, encoding: String.Encoding.utf8)
-              // store snapshot
-              let snapshot = try self.documentManager.open(interfaceDocURI, language: .swift, version: 0, text: interfaceInfo.contents)
-              self._findUSRAndRespond(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
-            } catch {
-              request.reply(.failure(ResponseError.unknown(error.localizedDescription)))
-            }
-          case .failure(let error):
-            log("open interface failed: \(error)", level: .warning)
-            request.reply(.failure(ResponseError(error)))
+    let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(name).swiftinterface")
+    let interfaceDocURI = DocumentURI(interfaceFilePath)
+    // has interface already been generated
+    if let snapshot = self.documentManager.latestSnapshot(interfaceDocURI) {
+      self._findUSRAndRespond(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
+    } else {
+      // generate interface
+      self._openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI) { result in
+        switch result {
+        case .success(let interfaceInfo):
+          do {
+            // write to file
+            try interfaceInfo.contents.write(to: interfaceFilePath, atomically: true, encoding: String.Encoding.utf8)
+            // store snapshot
+            let snapshot = try self.documentManager.open(interfaceDocURI, language: .swift, version: 0, text: interfaceInfo.contents)
+            self._findUSRAndRespond(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
+          } catch {
+            request.reply(.failure(ResponseError.unknown(error.localizedDescription)))
           }
+        case .failure(let error):
+          log("open interface failed: \(error)", level: .warning)
+          request.reply(.failure(ResponseError(error)))
         }
       }
     }

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -25,7 +25,7 @@ struct FindUSRInfo {
 }
 
 extension SwiftLanguageServer {
-  public func openInterface(_ request: LanguageServerProtocol.Request<LanguageServerProtocol.OpenInterfaceRequest>) {
+  public func openInterface(_ request: LanguageServerProtocol.Request<LanguageServerProtocol.OpenInterfaceRequest>) async {
     let uri = request.params.textDocument.uri
     let moduleName = request.params.moduleName
     let name = request.params.name
@@ -37,7 +37,7 @@ extension SwiftLanguageServer {
       self._findUSRAndRespond(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
     } else {
       // generate interface
-      self._openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI) { result in
+      await self._openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI) { result in
         switch result {
         case .success(let interfaceInfo):
           do {
@@ -69,7 +69,7 @@ extension SwiftLanguageServer {
                               uri: DocumentURI,
                               name: String,
                               interfaceURI: DocumentURI,
-                              completion: @escaping (Swift.Result<InterfaceInfo, SKDError>) -> Void) {
+                              completion: @escaping (Swift.Result<InterfaceInfo, SKDError>) -> Void) async {
     let keys = self.keys
     let skreq = SKDRequestDictionary(sourcekitd: sourcekitd)
     skreq[keys.request] = requests.editor_open_interface
@@ -79,7 +79,7 @@ extension SwiftLanguageServer {
     }
     skreq[keys.name] = interfaceURI.pseudoPath
     skreq[keys.synthesizedextensions] = 1
-    if let compileCommand = self.commandsByFile[uri] {
+    if let compileCommand = await self.buildSettings(for: uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
     

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -130,50 +130,48 @@ extension SwiftLanguageServer {
   {
     let keys = self.keys
 
-    queue.async {
-      let uri = refactorCommand.textDocument.uri
-      guard let snapshot = self.documentManager.latestSnapshot(uri) else {
-        return completion(.failure(.unknownDocument(uri)))
-      }
-      guard let offsetRange = snapshot.utf8OffsetRange(of: refactorCommand.positionRange) else {
-        return completion(.failure(.failedToRetrieveOffset(refactorCommand.positionRange)))
-      }
-      let line = refactorCommand.positionRange.lowerBound.line
-      let utf16Column = refactorCommand.positionRange.lowerBound.utf16index
-      guard let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column) else {
-        return completion(.failure(.invalidRange(refactorCommand.positionRange)))
-      }
-
-      let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-      skreq[keys.request] = self.requests.semantic_refactoring
-      // Preferred name for e.g. an extracted variable.
-      // Empty string means sourcekitd chooses a name automatically.
-      skreq[keys.name] = ""
-      skreq[keys.sourcefile] = uri.pseudoPath
-      // LSP is zero based, but this request is 1 based.
-      skreq[keys.line] = line + 1
-      skreq[keys.column] = utf8Column + 1
-      skreq[keys.length] = offsetRange.count
-      skreq[keys.actionuid] = self.sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!
-
-      // FIXME: SourceKit should probably cache this for us.
-      if let compileCommand = self.commandsByFile[snapshot.document.uri] {
-        skreq[keys.compilerargs] = compileCommand.compilerArgs
-      }
-
-      let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
-        guard let self = self else { return }
-        guard let dict = result.success else {
-          return completion(.failure(.responseError(ResponseError(result.failure!))))
-        }
-        guard let refactor = SemanticRefactoring(refactorCommand.title, dict, snapshot, self.keys) else {
-          return completion(.failure(.noEditsNeeded(uri)))
-        }
-        completion(.success(refactor))
-      }
-
-      // FIXME: cancellation
-      _ = handle
+    let uri = refactorCommand.textDocument.uri
+    guard let snapshot = self.documentManager.latestSnapshot(uri) else {
+      return completion(.failure(.unknownDocument(uri)))
     }
+    guard let offsetRange = snapshot.utf8OffsetRange(of: refactorCommand.positionRange) else {
+      return completion(.failure(.failedToRetrieveOffset(refactorCommand.positionRange)))
+    }
+    let line = refactorCommand.positionRange.lowerBound.line
+    let utf16Column = refactorCommand.positionRange.lowerBound.utf16index
+    guard let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column) else {
+      return completion(.failure(.invalidRange(refactorCommand.positionRange)))
+    }
+
+    let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+    skreq[keys.request] = self.requests.semantic_refactoring
+    // Preferred name for e.g. an extracted variable.
+    // Empty string means sourcekitd chooses a name automatically.
+    skreq[keys.name] = ""
+    skreq[keys.sourcefile] = uri.pseudoPath
+    // LSP is zero based, but this request is 1 based.
+    skreq[keys.line] = line + 1
+    skreq[keys.column] = utf8Column + 1
+    skreq[keys.length] = offsetRange.count
+    skreq[keys.actionuid] = self.sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!
+
+    // FIXME: SourceKit should probably cache this for us.
+    if let compileCommand = self.commandsByFile[snapshot.document.uri] {
+      skreq[keys.compilerargs] = compileCommand.compilerArgs
+    }
+
+    let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
+      guard let self = self else { return }
+      guard let dict = result.success else {
+        return completion(.failure(.responseError(ResponseError(result.failure!))))
+      }
+      guard let refactor = SemanticRefactoring(refactorCommand.title, dict, snapshot, self.keys) else {
+        return completion(.failure(.noEditsNeeded(uri)))
+      }
+      completion(.success(refactor))
+    }
+
+    // FIXME: cancellation
+    _ = handle
   }
 }

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -126,7 +126,7 @@ extension SwiftLanguageServer {
   ///   - completion: Completion block to asynchronously receive the SemanticRefactoring data, or error.
   func semanticRefactoring(
     _ refactorCommand: SemanticRefactorCommand,
-    _ completion: @escaping (Result<SemanticRefactoring, SemanticRefactoringError>) -> Void)
+    _ completion: @escaping (Result<SemanticRefactoring, SemanticRefactoringError>) -> Void) async
   {
     let keys = self.keys
 
@@ -156,7 +156,7 @@ extension SwiftLanguageServer {
     skreq[keys.actionuid] = self.sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!
 
     // FIXME: SourceKit should probably cache this for us.
-    if let compileCommand = self.commandsByFile[snapshot.document.uri] {
+    if let compileCommand = await self.buildSettings(for: snapshot.document.uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -427,15 +427,17 @@ extension SwiftLanguageServer {
     // Nothing to do.
   }
 
-  public func shutdown(callback: @escaping () -> Void) {
-    queue.async {
-      if let session = self.currentCompletionSession {
-        session.close()
-        self.currentCompletionSession = nil
+  public func shutdown() async {
+    await withCheckedContinuation { continuation in
+      queue.async {
+        if let session = self.currentCompletionSession {
+          session.close()
+          self.currentCompletionSession = nil
+        }
+        self.sourcekitd.removeNotificationHandler(self)
+        self.client.close()
+        continuation.resume(returning: ())
       }
-      self.sourcekitd.removeNotificationHandler(self)
-      self.client.close()
-      callback()
     }
   }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -94,9 +94,16 @@ public struct SwiftCompileCommand: Equatable {
   }
 }
 
-public final class SwiftLanguageServer: ToolchainLanguageServer {
+public actor SwiftLanguageServer: ToolchainLanguageServer {
 
-  /// The server's request queue, used to serialize requests and responses to `sourcekitd`.
+  // FIXME: (async) We can delete this after
+  // - CodeCompletionSession is an actor
+  // - sourcekitd.send is async
+  // - client.send is async
+  /// The queue on which we want to be called back. This includes
+  /// - Completion callback from sourcekitd
+  /// - Sending requests to the editor
+  /// - Guarding the state of `CodeCompletionSession`
   public let queue: DispatchQueue = DispatchQueue(label: "swift-language-server-queue", qos: .userInitiated)
 
   let client: LocalConnection
@@ -122,9 +129,9 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
   /// *For Testing*
   public var reusedNodeCallback: ReusedNodeCallback?
 
-  var keys: sourcekitd_keys { return sourcekitd.keys }
-  var requests: sourcekitd_requests { return sourcekitd.requests }
-  var values: sourcekitd_values { return sourcekitd.values }
+  nonisolated var keys: sourcekitd_keys { return sourcekitd.keys }
+  nonisolated var requests: sourcekitd_requests { return sourcekitd.requests }
+  nonisolated var values: sourcekitd_values { return sourcekitd.values }
 
   var enablePublishDiagnostics: Bool {
     // Since LSP 3.17.0, diagnostics can be reported through pull-based requests,
@@ -136,8 +143,6 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
   
   private var state: LanguageServerState {
     didSet {
-      // `state` must only be set from `queue`.
-      dispatchPrecondition(condition: .onQueue(queue))
       for handler in stateChangeHandlers {
         handler(oldValue, state)
       }
@@ -171,24 +176,19 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
     try FileManager.default.createDirectory(at: generatedInterfacesPath, withIntermediateDirectories: true)
   }
 
-  public func canHandle(workspace: Workspace) -> Bool {
+  public nonisolated func canHandle(workspace: Workspace) -> Bool {
     // We have a single sourcekitd instance for all workspaces.
     return true
   }
 
   public func addStateChangeHandler(handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void) {
-    queue.async {
-      self.stateChangeHandlers.append(handler)
-    }
+    self.stateChangeHandlers.append(handler)
   }
 
   /// Updates the lexical tokens for the given `snapshot`.
-  /// Must be called on `self.queue`.
   private func updateSyntacticTokens(
     for snapshot: DocumentSnapshot
   ) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     let uri = snapshot.document.uri
     let docTokens = updateSyntaxTree(for: snapshot)
 
@@ -227,13 +227,10 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
   }
 
   /// Updates the semantic tokens for the given `snapshot`.
-  /// Must be called on `self.queue`.
   private func updateSemanticTokens(
     response: SKDResponseDictionary,
     for snapshot: DocumentSnapshot
   ) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     let uri = snapshot.document.uri
     let docTokens = updatedSemanticTokens(response: response, for: snapshot)
 
@@ -320,8 +317,6 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
 
   /// Publish diagnostics for the given `snapshot`. We withhold semantic diagnostics if we are using
   /// fallback arguments.
-  ///
-  /// Should be called on self.queue.
   func publishDiagnostics(
     response: SKDResponseDictionary,
     for snapshot: DocumentSnapshot,
@@ -351,9 +346,7 @@ public final class SwiftLanguageServer: ToolchainLanguageServer {
     )
   }
 
-  /// Should be called on self.queue.
   func handleDocumentUpdate(uri: DocumentURI) {
-    dispatchPrecondition(condition: .onQueue(queue))
     guard let snapshot = documentManager.latestSnapshot(uri) else {
       return
     }
@@ -428,17 +421,12 @@ extension SwiftLanguageServer {
   }
 
   public func shutdown() async {
-    await withCheckedContinuation { continuation in
-      queue.async {
-        if let session = self.currentCompletionSession {
-          session.close()
-          self.currentCompletionSession = nil
-        }
-        self.sourcekitd.removeNotificationHandler(self)
-        self.client.close()
-        continuation.resume(returning: ())
-      }
+    if let session = self.currentCompletionSession {
+      session.close()
+      self.currentCompletionSession = nil
     }
+    self.sourcekitd.removeNotificationHandler(self)
+    self.client.close()
   }
 
   /// Tell sourcekitd to crash itself. For testing purposes only.
@@ -450,7 +438,6 @@ extension SwiftLanguageServer {
   
   // MARK: - Build System Integration
 
-  /// Should be called on self.queue.
   private func reopenDocument(_ snapshot: DocumentSnapshot, _ compileCmd: SwiftCompileCommand?) {
     let keys = self.keys
     let uri = snapshot.document.uri
@@ -479,37 +466,33 @@ extension SwiftLanguageServer {
   }
 
   public func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) {
-    self.queue.async {
-      let compileCommand = SwiftCompileCommand(change: change)
-      // Confirm that the compile commands actually changed, otherwise we don't need to do anything.
-      // This includes when the compiler arguments are the same but the command is no longer
-      // considered to be fallback.
-      guard self.commandsByFile[uri] != compileCommand else {
-        return
-      }
-      self.commandsByFile[uri] = compileCommand
-
-      // We may not have a snapshot if this is called just before `openDocument`.
-      guard let snapshot = self.documentManager.latestSnapshot(uri) else {
-        return
-      }
-
-      // Close and re-open the document internally to inform sourcekitd to update the compile
-      // command. At the moment there's no better way to do this.
-      self.reopenDocument(snapshot, compileCommand)
+    let compileCommand = SwiftCompileCommand(change: change)
+    // Confirm that the compile commands actually changed, otherwise we don't need to do anything.
+    // This includes when the compiler arguments are the same but the command is no longer
+    // considered to be fallback.
+    guard self.commandsByFile[uri] != compileCommand else {
+      return
     }
+    self.commandsByFile[uri] = compileCommand
+
+    // We may not have a snapshot if this is called just before `openDocument`.
+    guard let snapshot = self.documentManager.latestSnapshot(uri) else {
+      return
+    }
+
+    // Close and re-open the document internally to inform sourcekitd to update the compile
+    // command. At the moment there's no better way to do this.
+    self.reopenDocument(snapshot, compileCommand)
   }
 
   public func documentDependenciesUpdated(_ uri: DocumentURI) {
-    self.queue.async {
-      guard let snapshot = self.documentManager.latestSnapshot(uri) else {
-        return
-      }
-
-      // Forcefully reopen the document since the `BuildSystem` has informed us
-      // that the dependencies have changed and the AST needs to be reloaded.
-      self.reopenDocument(snapshot, self.commandsByFile[uri])
+    guard let snapshot = self.documentManager.latestSnapshot(uri) else {
+      return
     }
+
+    // Forcefully reopen the document since the `BuildSystem` has informed us
+    // that the dependencies have changed and the AST needs to be reloaded.
+    self.reopenDocument(snapshot, self.commandsByFile[uri])
   }
 
   // MARK: - Text synchronization
@@ -517,103 +500,97 @@ extension SwiftLanguageServer {
   public func openDocument(_ note: DidOpenTextDocumentNotification) {
     let keys = self.keys
 
-    self.queue.async {
-      guard let snapshot = self.documentManager.open(note) else {
-        // Already logged failure.
-        return
-      }
-
-      let uri = snapshot.document.uri
-      let req = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-      req[keys.request] = self.requests.editor_open
-      req[keys.name] = note.textDocument.uri.pseudoPath
-      req[keys.sourcetext] = snapshot.text
-
-      let compileCommand = self.commandsByFile[uri]
-
-      if let compilerArgs = compileCommand?.compilerArgs {
-        req[keys.compilerargs] = compilerArgs
-      }
-
-      guard let dict = try? self.sourcekitd.sendSync(req) else {
-        // Already logged failure.
-        return
-      }
-      self.publishDiagnostics(response: dict, for: snapshot, compileCommand: compileCommand)
-      self.updateSyntacticTokens(for: snapshot)
+    guard let snapshot = self.documentManager.open(note) else {
+      // Already logged failure.
+      return
     }
+
+    let uri = snapshot.document.uri
+    let req = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+    req[keys.request] = self.requests.editor_open
+    req[keys.name] = note.textDocument.uri.pseudoPath
+    req[keys.sourcetext] = snapshot.text
+
+    let compileCommand = self.commandsByFile[uri]
+
+    if let compilerArgs = compileCommand?.compilerArgs {
+      req[keys.compilerargs] = compilerArgs
+    }
+
+    guard let dict = try? self.sourcekitd.sendSync(req) else {
+      // Already logged failure.
+      return
+    }
+    self.publishDiagnostics(response: dict, for: snapshot, compileCommand: compileCommand)
+    self.updateSyntacticTokens(for: snapshot)
   }
 
   public func closeDocument(_ note: DidCloseTextDocumentNotification) {
     let keys = self.keys
 
-    self.queue.async {
-      self.documentManager.close(note)
+    self.documentManager.close(note)
 
-      let uri = note.textDocument.uri
+    let uri = note.textDocument.uri
 
-      let req = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-      req[keys.request] = self.requests.editor_close
-      req[keys.name] = uri.pseudoPath
+    let req = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+    req[keys.request] = self.requests.editor_close
+    req[keys.name] = uri.pseudoPath
 
-      // Clear settings that should not be cached for closed documents.
-      self.commandsByFile[uri] = nil
-      self.currentDiagnostics[uri] = nil
+    // Clear settings that should not be cached for closed documents.
+    self.commandsByFile[uri] = nil
+    self.currentDiagnostics[uri] = nil
 
-      _ = try? self.sourcekitd.sendSync(req)
-    }
+    _ = try? self.sourcekitd.sendSync(req)
   }
 
   public func changeDocument(_ note: DidChangeTextDocumentNotification) {
     let keys = self.keys
     var edits: [IncrementalEdit] = []
 
-    self.queue.async {
-      var lastResponse: SKDResponseDictionary? = nil
+    var lastResponse: SKDResponseDictionary? = nil
 
-      let snapshot = self.documentManager.edit(note) {
-        (before: DocumentSnapshot, edit: TextDocumentContentChangeEvent) in
-        let req = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-        req[keys.request] = self.requests.editor_replacetext
-        req[keys.name] = note.textDocument.uri.pseudoPath
+    let snapshot = self.documentManager.edit(note) {
+      (before: DocumentSnapshot, edit: TextDocumentContentChangeEvent) in
+      let req = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+      req[keys.request] = self.requests.editor_replacetext
+      req[keys.name] = note.textDocument.uri.pseudoPath
 
-        if let range = edit.range {
-          guard let offset = before.utf8Offset(of: range.lowerBound),
-            let end = before.utf8Offset(of: range.upperBound)
-          else {
-            fatalError("invalid edit \(range)")
-          }
-
-          let length = end - offset
-          req[keys.offset] = offset
-          req[keys.length] = length
-
-          edits.append(IncrementalEdit(offset: offset, length: length, replacementLength: edit.text.utf8.count))
-        } else {
-          // Full text
-          let length = before.text.utf8.count
-          req[keys.offset] = 0
-          req[keys.length] = length
-
-          edits.append(IncrementalEdit(offset: 0, length: length, replacementLength: edit.text.utf8.count))
+      if let range = edit.range {
+        guard let offset = before.utf8Offset(of: range.lowerBound),
+          let end = before.utf8Offset(of: range.upperBound)
+        else {
+          fatalError("invalid edit \(range)")
         }
 
-        req[keys.sourcetext] = edit.text
-        lastResponse = try? self.sourcekitd.sendSync(req)
+        let length = end - offset
+        req[keys.offset] = offset
+        req[keys.length] = length
 
-        self.adjustDiagnosticRanges(of: note.textDocument.uri, for: edit)
-      } updateDocumentTokens: { (after: DocumentSnapshot) in
-        if lastResponse != nil {
-          return self.updateSyntaxTree(for: after, with: ConcurrentEdits(fromSequential: edits))
-        } else {
-          return DocumentTokens()
-        }
+        edits.append(IncrementalEdit(offset: offset, length: length, replacementLength: edit.text.utf8.count))
+      } else {
+        // Full text
+        let length = before.text.utf8.count
+        req[keys.offset] = 0
+        req[keys.length] = length
+
+        edits.append(IncrementalEdit(offset: 0, length: length, replacementLength: edit.text.utf8.count))
       }
 
-      if let dict = lastResponse, let snapshot = snapshot {
-        let compileCommand = self.commandsByFile[note.textDocument.uri]
-        self.publishDiagnostics(response: dict, for: snapshot, compileCommand: compileCommand)
+      req[keys.sourcetext] = edit.text
+      lastResponse = try? self.sourcekitd.sendSync(req)
+
+      self.adjustDiagnosticRanges(of: note.textDocument.uri, for: edit)
+    } updateDocumentTokens: { (after: DocumentSnapshot) in
+      if lastResponse != nil {
+        return self.updateSyntaxTree(for: after, with: ConcurrentEdits(fromSequential: edits))
+      } else {
+        return DocumentTokens()
       }
+    }
+
+    if let dict = lastResponse, let snapshot = snapshot {
+      let compileCommand = self.commandsByFile[note.textDocument.uri]
+      self.publishDiagnostics(response: dict, for: snapshot, compileCommand: compileCommand)
     }
   }
 
@@ -636,12 +613,6 @@ extension SwiftLanguageServer {
   public func declaration(_ request: Request<DeclarationRequest>) -> Bool {
     // We don't handle it.
     return false
-  }
-
-  public func completion(_ req: Request<CompletionRequest>) {
-    queue.async {
-      self._completion(req)
-    }
   }
 
   public func hover(_ req: Request<HoverRequest>) {
@@ -699,13 +670,10 @@ extension SwiftLanguageServer {
     }
   }
 
-  // Must be called on self.queue
-  private func _documentSymbols(
+  public func documentSymbols(
     _ uri: DocumentURI,
     _ completion: @escaping (Result<[DocumentSymbol], ResponseError>) -> Void
   ) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     guard let snapshot = self.documentManager.latestSnapshot(uri) else {
       let msg = "failed to find snapshot for url \(uri)"
       log(msg)
@@ -793,15 +761,6 @@ extension SwiftLanguageServer {
     _ = handle
   }
 
-  public func documentSymbols(
-    _ uri: DocumentURI,
-    _ completion: @escaping (Result<[DocumentSymbol], ResponseError>) -> Void
-  ) {
-    queue.async {
-      self._documentSymbols(uri, completion)
-    }
-  }
-
   public func documentSymbol(_ req: Request<DocumentSymbolRequest>) {
     documentSymbols(req.params.textDocument.uri) { result in
       req.reply(result.map { .documentSymbols($0) })
@@ -811,122 +770,118 @@ extension SwiftLanguageServer {
   public func documentColor(_ req: Request<DocumentColorRequest>) {
     let keys = self.keys
 
-    queue.async {
-      guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
-        log("failed to find snapshot for url \(req.params.textDocument.uri)")
-        req.reply([])
+    guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
+      log("failed to find snapshot for url \(req.params.textDocument.uri)")
+      req.reply([])
+      return
+    }
+
+    let helperDocumentName = "DocumentColor:" + snapshot.document.uri.pseudoPath
+    let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+    skreq[keys.request] = self.requests.editor_open
+    skreq[keys.name] = helperDocumentName
+    skreq[keys.sourcetext] = snapshot.text
+    skreq[keys.syntactic_only] = 1
+
+    let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
+      guard let self = self else { return }
+
+      defer {
+        let closeHelperReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+        closeHelperReq[keys.request] = self.requests.editor_close
+        closeHelperReq[keys.name] = helperDocumentName
+        _ = self.sourcekitd.send(closeHelperReq, .global(qos: .utility), reply: { _ in })
+      }
+
+      guard let dict = result.success else {
+        req.reply(.failure(ResponseError(result.failure!)))
         return
       }
 
-      let helperDocumentName = "DocumentColor:" + snapshot.document.uri.pseudoPath
-      let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-      skreq[keys.request] = self.requests.editor_open
-      skreq[keys.name] = helperDocumentName
-      skreq[keys.sourcetext] = snapshot.text
-      skreq[keys.syntactic_only] = 1
-
-      let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
-        guard let self = self else { return }
-
-        defer {
-          let closeHelperReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-          closeHelperReq[keys.request] = self.requests.editor_close
-          closeHelperReq[keys.name] = helperDocumentName
-          _ = self.sourcekitd.send(closeHelperReq, .global(qos: .utility), reply: { _ in })
-        }
-
-        guard let dict = result.success else {
-          req.reply(.failure(ResponseError(result.failure!)))
-          return
-        }
-
-        guard let results: SKDResponseArray = dict[self.keys.substructure] else {
-          return req.reply([])
-        }
-
-        func colorInformation(dict: SKDResponseDictionary) -> ColorInformation? {
-          guard let kind: sourcekitd_uid_t = dict[self.keys.kind],
-                kind == self.values.expr_object_literal,
-                let name: String = dict[self.keys.name],
-                name == "colorLiteral",
-                let offset: Int = dict[self.keys.offset],
-                let start: Position = snapshot.positionOf(utf8Offset: offset),
-                let length: Int = dict[self.keys.length],
-                let end: Position = snapshot.positionOf(utf8Offset: offset + length),
-                let substructure: SKDResponseArray = dict[self.keys.substructure] else {
-            return nil
-          }
-          var red, green, blue, alpha: Double?
-          substructure.forEach{ (i: Int, value: SKDResponseDictionary) in
-            guard let name: String = value[self.keys.name],
-                  let bodyoffset: Int = value[self.keys.bodyoffset],
-                  let bodylength: Int = value[self.keys.bodylength] else {
-              return true
-            }
-            let view = snapshot.text.utf8
-            let bodyStart = view.index(view.startIndex, offsetBy: bodyoffset)
-            let bodyEnd = view.index(view.startIndex, offsetBy: bodyoffset+bodylength)
-            let value = String(view[bodyStart..<bodyEnd]).flatMap(Double.init)
-            switch name {
-              case "red":
-                red = value
-              case "green":
-                green = value
-              case "blue":
-                blue = value
-              case "alpha":
-                alpha = value
-              default:
-                break
-            }
-            return true
-          }
-          if let red = red,
-             let green = green,
-             let blue = blue,
-             let alpha = alpha {
-            let color = Color(red: red, green: green, blue: blue, alpha: alpha)
-            return ColorInformation(range: start..<end, color: color)
-          } else {
-            return nil
-          }
-        }
-
-        func colorInformation(array: SKDResponseArray) -> [ColorInformation] {
-          var result: [ColorInformation] = []
-          array.forEach { (i: Int, value: SKDResponseDictionary) in
-            if let documentSymbol = colorInformation(dict: value) {
-              result.append(documentSymbol)
-            } else if let substructure: SKDResponseArray = value[self.keys.substructure] {
-              result += colorInformation(array: substructure)
-            }
-            return true
-          }
-          return result
-        }
-
-        req.reply(colorInformation(array: results))
+      guard let results: SKDResponseArray = dict[self.keys.substructure] else {
+        return req.reply([])
       }
-      // FIXME: cancellation
-      _ = handle
+
+      func colorInformation(dict: SKDResponseDictionary) -> ColorInformation? {
+        guard let kind: sourcekitd_uid_t = dict[self.keys.kind],
+              kind == self.values.expr_object_literal,
+              let name: String = dict[self.keys.name],
+              name == "colorLiteral",
+              let offset: Int = dict[self.keys.offset],
+              let start: Position = snapshot.positionOf(utf8Offset: offset),
+              let length: Int = dict[self.keys.length],
+              let end: Position = snapshot.positionOf(utf8Offset: offset + length),
+              let substructure: SKDResponseArray = dict[self.keys.substructure] else {
+          return nil
+        }
+        var red, green, blue, alpha: Double?
+        substructure.forEach{ (i: Int, value: SKDResponseDictionary) in
+          guard let name: String = value[self.keys.name],
+                let bodyoffset: Int = value[self.keys.bodyoffset],
+                let bodylength: Int = value[self.keys.bodylength] else {
+            return true
+          }
+          let view = snapshot.text.utf8
+          let bodyStart = view.index(view.startIndex, offsetBy: bodyoffset)
+          let bodyEnd = view.index(view.startIndex, offsetBy: bodyoffset+bodylength)
+          let value = String(view[bodyStart..<bodyEnd]).flatMap(Double.init)
+          switch name {
+            case "red":
+              red = value
+            case "green":
+              green = value
+            case "blue":
+              blue = value
+            case "alpha":
+              alpha = value
+            default:
+              break
+          }
+          return true
+        }
+        if let red = red,
+           let green = green,
+           let blue = blue,
+           let alpha = alpha {
+          let color = Color(red: red, green: green, blue: blue, alpha: alpha)
+          return ColorInformation(range: start..<end, color: color)
+        } else {
+          return nil
+        }
+      }
+
+      func colorInformation(array: SKDResponseArray) -> [ColorInformation] {
+        var result: [ColorInformation] = []
+        array.forEach { (i: Int, value: SKDResponseDictionary) in
+          if let documentSymbol = colorInformation(dict: value) {
+            result.append(documentSymbol)
+          } else if let substructure: SKDResponseArray = value[self.keys.substructure] {
+            result += colorInformation(array: substructure)
+          }
+          return true
+        }
+        return result
+      }
+
+      req.reply(colorInformation(array: results))
     }
+    // FIXME: cancellation
+    _ = handle
   }
 
   public func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) {
     let uri = req.params.textDocument.uri
 
-    queue.async {
-      guard let snapshot = self.documentManager.latestSnapshot(uri) else {
-        log("failed to find snapshot for uri \(uri)")
-        req.reply(DocumentSemanticTokensResponse(data: []))
-        return
-      }
-
-      let tokens = snapshot.mergedAndSortedTokens()
-      let encodedTokens = tokens.lspEncoded
-
-      req.reply(DocumentSemanticTokensResponse(data: encodedTokens))
+    guard let snapshot = self.documentManager.latestSnapshot(uri) else {
+      log("failed to find snapshot for uri \(uri)")
+      req.reply(DocumentSemanticTokensResponse(data: []))
+      return
     }
+
+    let tokens = snapshot.mergedAndSortedTokens()
+    let encodedTokens = tokens.lspEncoded
+
+    req.reply(DocumentSemanticTokensResponse(data: encodedTokens))
   }
 
   public func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) {
@@ -938,18 +893,16 @@ extension SwiftLanguageServer {
     let uri = req.params.textDocument.uri
     let range = req.params.range
 
-    queue.async {
-      guard let snapshot = self.documentManager.latestSnapshot(uri) else {
-        log("failed to find snapshot for uri \(uri)")
-        req.reply(DocumentSemanticTokensResponse(data: []))
-        return
-      }
-
-      let tokens = snapshot.mergedAndSortedTokens(in: range)
-      let encodedTokens = tokens.lspEncoded
-
-      req.reply(DocumentSemanticTokensResponse(data: encodedTokens))
+    guard let snapshot = self.documentManager.latestSnapshot(uri) else {
+      log("failed to find snapshot for uri \(uri)")
+      req.reply(DocumentSemanticTokensResponse(data: []))
+      return
     }
+
+    let tokens = snapshot.mergedAndSortedTokens(in: range)
+    let encodedTokens = tokens.lspEncoded
+
+    req.reply(DocumentSemanticTokensResponse(data: encodedTokens))
   }
 
   public func colorPresentation(_ req: Request<ColorPresentationRequest>) {
@@ -965,290 +918,286 @@ extension SwiftLanguageServer {
   public func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>) {
     let keys = self.keys
 
-    queue.async {
-      guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
-        log("failed to find snapshot for url \(req.params.textDocument.uri)")
-        req.reply(nil)
-        return
-      }
-
-      guard let offset = snapshot.utf8Offset(of: req.params.position) else {
-        log("invalid position \(req.params.position)")
-        req.reply(nil)
-        return
-      }
-
-      let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
-      skreq[keys.request] = self.requests.relatedidents
-      skreq[keys.offset] = offset
-      skreq[keys.sourcefile] = snapshot.document.uri.pseudoPath
-
-      // FIXME: SourceKit should probably cache this for us.
-      if let compileCommand = self.commandsByFile[snapshot.document.uri] {
-        skreq[keys.compilerargs] = compileCommand.compilerArgs
-      }
-
-      let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
-        guard let self = self else { return }
-        guard let dict = result.success else {
-          req.reply(.failure(ResponseError(result.failure!)))
-          return
-        }
-
-        guard let results: SKDResponseArray = dict[self.keys.results] else {
-          return req.reply([])
-        }
-
-        var highlights: [DocumentHighlight] = []
-
-        results.forEach { _, value in
-          if let offset: Int = value[self.keys.offset],
-             let start: Position = snapshot.positionOf(utf8Offset: offset),
-             let length: Int = value[self.keys.length],
-             let end: Position = snapshot.positionOf(utf8Offset: offset + length)
-          {
-            highlights.append(DocumentHighlight(
-              range: start..<end,
-              kind: .read // unknown
-            ))
-          }
-          return true
-        }
-
-        req.reply(highlights)
-      }
-
-      // FIXME: cancellation
-      _ = handle
+    guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
+      log("failed to find snapshot for url \(req.params.textDocument.uri)")
+      req.reply(nil)
+      return
     }
+
+    guard let offset = snapshot.utf8Offset(of: req.params.position) else {
+      log("invalid position \(req.params.position)")
+      req.reply(nil)
+      return
+    }
+
+    let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
+    skreq[keys.request] = self.requests.relatedidents
+    skreq[keys.offset] = offset
+    skreq[keys.sourcefile] = snapshot.document.uri.pseudoPath
+
+    // FIXME: SourceKit should probably cache this for us.
+    if let compileCommand = self.commandsByFile[snapshot.document.uri] {
+      skreq[keys.compilerargs] = compileCommand.compilerArgs
+    }
+
+    let handle = self.sourcekitd.send(skreq, self.queue) { [weak self] result in
+      guard let self = self else { return }
+      guard let dict = result.success else {
+        req.reply(.failure(ResponseError(result.failure!)))
+        return
+      }
+
+      guard let results: SKDResponseArray = dict[self.keys.results] else {
+        return req.reply([])
+      }
+
+      var highlights: [DocumentHighlight] = []
+
+      results.forEach { _, value in
+        if let offset: Int = value[self.keys.offset],
+           let start: Position = snapshot.positionOf(utf8Offset: offset),
+           let length: Int = value[self.keys.length],
+           let end: Position = snapshot.positionOf(utf8Offset: offset + length)
+        {
+          highlights.append(DocumentHighlight(
+            range: start..<end,
+            kind: .read // unknown
+          ))
+        }
+        return true
+      }
+
+      req.reply(highlights)
+    }
+
+    // FIXME: cancellation
+    _ = handle
   }
 
   public func foldingRange(_ req: Request<FoldingRangeRequest>) {
     let foldingRangeCapabilities = capabilityRegistry.clientCapabilities.textDocument?.foldingRange
-    queue.async {
-      guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
-        log("failed to find snapshot for url \(req.params.textDocument.uri)")
-        req.reply(nil)
-        return
+    guard let snapshot = self.documentManager.latestSnapshot(req.params.textDocument.uri) else {
+      log("failed to find snapshot for url \(req.params.textDocument.uri)")
+      req.reply(nil)
+      return
+    }
+
+    guard let sourceFile = snapshot.tokens.syntaxTree else {
+      log("no lexical structure available for url \(req.params.textDocument.uri)")
+      req.reply(nil)
+      return
+    }
+
+    final class FoldingRangeFinder: SyntaxVisitor {
+      private let snapshot: DocumentSnapshot
+      /// Some ranges might occur multiple times.
+      /// E.g. for `print("hi")`, `"hi"` is both the range of all call arguments and the range the first argument in the call.
+      /// It doesn't make sense to report them multiple times, so use a `Set` here.
+      private var ranges: Set<FoldingRange>
+      /// The client-imposed limit on the number of folding ranges it would
+      /// prefer to recieve from the LSP server. If the value is `nil`, there
+      /// is no preset limit.
+      private var rangeLimit: Int?
+      /// If `true`, the client is only capable of folding entire lines. If
+      /// `false` the client can handle folding ranges.
+      private var lineFoldingOnly: Bool
+
+      init(snapshot: DocumentSnapshot, rangeLimit: Int?, lineFoldingOnly: Bool) {
+        self.snapshot = snapshot
+        self.ranges = []
+        self.rangeLimit = rangeLimit
+        self.lineFoldingOnly = lineFoldingOnly
+        super.init(viewMode: .sourceAccurate)
       }
 
-      guard let sourceFile = snapshot.tokens.syntaxTree else {
-        log("no lexical structure available for url \(req.params.textDocument.uri)")
-        req.reply(nil)
-        return
+      override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+        // Index comments, so we need to see at least '/*', or '//'.
+        if node.leadingTriviaLength.utf8Length > 2 {
+          self.addTrivia(from: node, node.leadingTrivia)
+        }
+
+        if node.trailingTriviaLength.utf8Length > 2 {
+          self.addTrivia(from: node, node.trailingTrivia)
+        }
+
+        return .visitChildren
       }
 
-      final class FoldingRangeFinder: SyntaxVisitor {
-        private let snapshot: DocumentSnapshot
-        /// Some ranges might occur multiple times.
-        /// E.g. for `print("hi")`, `"hi"` is both the range of all call arguments and the range the first argument in the call.
-        /// It doesn't make sense to report them multiple times, so use a `Set` here.
-        private var ranges: Set<FoldingRange>
-        /// The client-imposed limit on the number of folding ranges it would
-        /// prefer to recieve from the LSP server. If the value is `nil`, there
-        /// is no preset limit.
-        private var rangeLimit: Int?
-        /// If `true`, the client is only capable of folding entire lines. If
-        /// `false` the client can handle folding ranges.
-        private var lineFoldingOnly: Bool
+      private func addTrivia(from node: TokenSyntax, _ trivia: Trivia) {
+        let pieces = trivia.pieces
+        var start = node.position.utf8Offset
+        /// The index of the trivia piece we are currently inspecting.
+        var index = 0
 
-        init(snapshot: DocumentSnapshot, rangeLimit: Int?, lineFoldingOnly: Bool) {
-          self.snapshot = snapshot
-          self.ranges = []
-          self.rangeLimit = rangeLimit
-          self.lineFoldingOnly = lineFoldingOnly
-          super.init(viewMode: .sourceAccurate)
-        }
-
-        override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
-          // Index comments, so we need to see at least '/*', or '//'.
-          if node.leadingTriviaLength.utf8Length > 2 {
-            self.addTrivia(from: node, node.leadingTrivia)
+        while index < pieces.count {
+          let piece = pieces[index]
+          defer {
+            start += pieces[index].sourceLength.utf8Length
+            index += 1
           }
+          switch piece {
+          case .blockComment:
+            _ = self.addFoldingRange(
+              start: start,
+              end: start + piece.sourceLength.utf8Length,
+              kind: .comment
+            )
+          case .docBlockComment:
+            _ = self.addFoldingRange(
+              start: start,
+              end: start + piece.sourceLength.utf8Length,
+              kind: .comment
+            )
+          case .lineComment, .docLineComment:
+            let lineCommentBlockStart = start
 
-          if node.trailingTriviaLength.utf8Length > 2 {
-            self.addTrivia(from: node, node.trailingTrivia)
-          }
-
-          return .visitChildren
-        }
-
-        private func addTrivia(from node: TokenSyntax, _ trivia: Trivia) {
-          let pieces = trivia.pieces
-          var start = node.position.utf8Offset
-          /// The index of the trivia piece we are currently inspecting.
-          var index = 0
-
-          while index < pieces.count {
-            let piece = pieces[index]
-            defer {
-              start += pieces[index].sourceLength.utf8Length
-              index += 1
-            }
-            switch piece {
-            case .blockComment:
-              _ = self.addFoldingRange(
-                start: start,
-                end: start + piece.sourceLength.utf8Length,
-                kind: .comment
-              )
-            case .docBlockComment:
-              _ = self.addFoldingRange(
-                start: start,
-                end: start + piece.sourceLength.utf8Length,
-                kind: .comment
-              )
-            case .lineComment, .docLineComment:
-              let lineCommentBlockStart = start
-
-              // Keep scanning the upcoming trivia pieces to find the end of the
-              // block of line comments.
-              // As we find a new end of the block comment, we set `index` and
-              // `start` to `lookaheadIndex` and `lookaheadStart` resp. to
-              // commit the newly found end.
-              var lookaheadIndex = index
-              var lookaheadStart = start
-              var hasSeenNewline = false
-              LOOP: while lookaheadIndex < pieces.count {
-                let piece = pieces[lookaheadIndex]
-                defer {
-                  lookaheadIndex += 1
-                  lookaheadStart += piece.sourceLength.utf8Length
-                }
-                switch piece {
-                case .newlines(let count), .carriageReturns(let count), .carriageReturnLineFeeds(let count):
-                  if count > 1 || hasSeenNewline {
-                    // More than one newline is separating the two line comment blocks.
-                    // We have reached the end of this block of line comments.
-                    break LOOP
-                  }
-                  hasSeenNewline = true
-                case .spaces, .tabs:
-                  // We allow spaces and tabs because the comments might be indented
-                  continue
-                case .lineComment, .docLineComment:
-                  // We have found a new line comment in this block. Commit it.
-                  index = lookaheadIndex
-                  start = lookaheadStart
-                  hasSeenNewline = false
-                default:
-                  // We assume that any other trivia piece terminates the block
-                  // of line comments.
+            // Keep scanning the upcoming trivia pieces to find the end of the
+            // block of line comments.
+            // As we find a new end of the block comment, we set `index` and
+            // `start` to `lookaheadIndex` and `lookaheadStart` resp. to
+            // commit the newly found end.
+            var lookaheadIndex = index
+            var lookaheadStart = start
+            var hasSeenNewline = false
+            LOOP: while lookaheadIndex < pieces.count {
+              let piece = pieces[lookaheadIndex]
+              defer {
+                lookaheadIndex += 1
+                lookaheadStart += piece.sourceLength.utf8Length
+              }
+              switch piece {
+              case .newlines(let count), .carriageReturns(let count), .carriageReturnLineFeeds(let count):
+                if count > 1 || hasSeenNewline {
+                  // More than one newline is separating the two line comment blocks.
+                  // We have reached the end of this block of line comments.
                   break LOOP
                 }
+                hasSeenNewline = true
+              case .spaces, .tabs:
+                // We allow spaces and tabs because the comments might be indented
+                continue
+              case .lineComment, .docLineComment:
+                // We have found a new line comment in this block. Commit it.
+                index = lookaheadIndex
+                start = lookaheadStart
+                hasSeenNewline = false
+              default:
+                // We assume that any other trivia piece terminates the block
+                // of line comments.
+                break LOOP
               }
-              _ = self.addFoldingRange(
-                start: lineCommentBlockStart,
-                end: start + pieces[index].sourceLength.utf8Length,
-                kind: .comment
-              )
-            default:
-              break
             }
+            _ = self.addFoldingRange(
+              start: lineCommentBlockStart,
+              end: start + pieces[index].sourceLength.utf8Length,
+              kind: .comment
+            )
+          default:
+            break
           }
         }
+      }
 
-        override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.statements.position.utf8Offset,
-            end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
+      override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.statements.position.utf8Offset,
+          end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
+      }
+
+      override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.members.position.utf8Offset,
+          end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
+      }
+
+      override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.statements.position.utf8Offset,
+          end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
+      }
+
+      override func visit(_ node: AccessorBlockSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.accessors.position.utf8Offset,
+          end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
+      }
+
+      override func visit(_ node: SwitchExprSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.cases.position.utf8Offset,
+          end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
+      }
+
+      override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.arguments.position.utf8Offset,
+          end: node.arguments.endPosition.utf8Offset)
+      }
+
+      override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
+        return self.addFoldingRange(
+          start: node.arguments.position.utf8Offset,
+          end: node.arguments.endPosition.utf8Offset)
+      }
+
+      __consuming func finalize() -> Set<FoldingRange> {
+        return self.ranges
+      }
+
+      private func addFoldingRange(start: Int, end: Int, kind: FoldingRangeKind? = nil) -> SyntaxVisitorContinueKind {
+        if let limit = self.rangeLimit, self.ranges.count >= limit {
+          return .skipChildren
         }
 
-        override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.members.position.utf8Offset,
-            end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
-        }
-
-        override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.statements.position.utf8Offset,
-            end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
-        }
-
-        override func visit(_ node: AccessorBlockSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.accessors.position.utf8Offset,
-            end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
-        }
-
-        override func visit(_ node: SwitchExprSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.cases.position.utf8Offset,
-            end: node.rightBrace.positionAfterSkippingLeadingTrivia.utf8Offset)
-        }
-
-        override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.arguments.position.utf8Offset,
-            end: node.arguments.endPosition.utf8Offset)
-        }
-
-        override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
-          return self.addFoldingRange(
-            start: node.arguments.position.utf8Offset,
-            end: node.arguments.endPosition.utf8Offset)
-        }
-
-        __consuming func finalize() -> Set<FoldingRange> {
-          return self.ranges
-        }
-
-        private func addFoldingRange(start: Int, end: Int, kind: FoldingRangeKind? = nil) -> SyntaxVisitorContinueKind {
-          if let limit = self.rangeLimit, self.ranges.count >= limit {
-            return .skipChildren
-          }
-
-          guard let start: Position = snapshot.positionOf(utf8Offset: start),
-                let end: Position = snapshot.positionOf(utf8Offset: end) else {
-            log("folding range failed to retrieve position of \(snapshot.document.uri): \(start)-\(end)", level: .warning)
-            return .visitChildren
-          }
-          let range: FoldingRange
-          if lineFoldingOnly {
-            // Since the client cannot fold less than a single line, if the
-            // fold would span 1 line there's no point in reporting it.
-            guard end.line > start.line else {
-              return .visitChildren
-            }
-
-            // If the client only supports folding full lines, don't report
-            // the end of the range since there's nothing they could do with it.
-            range = FoldingRange(startLine: start.line,
-                                 startUTF16Index: nil,
-                                 endLine: end.line,
-                                 endUTF16Index: nil,
-                                 kind: kind)
-          } else {
-            range = FoldingRange(startLine: start.line,
-                                 startUTF16Index: start.utf16index,
-                                 endLine: end.line,
-                                 endUTF16Index: end.utf16index,
-                                 kind: kind)
-          }
-          ranges.insert(range)
+        guard let start: Position = snapshot.positionOf(utf8Offset: start),
+              let end: Position = snapshot.positionOf(utf8Offset: end) else {
+          log("folding range failed to retrieve position of \(snapshot.document.uri): \(start)-\(end)", level: .warning)
           return .visitChildren
         }
+        let range: FoldingRange
+        if lineFoldingOnly {
+          // Since the client cannot fold less than a single line, if the
+          // fold would span 1 line there's no point in reporting it.
+          guard end.line > start.line else {
+            return .visitChildren
+          }
+
+          // If the client only supports folding full lines, don't report
+          // the end of the range since there's nothing they could do with it.
+          range = FoldingRange(startLine: start.line,
+                               startUTF16Index: nil,
+                               endLine: end.line,
+                               endUTF16Index: nil,
+                               kind: kind)
+        } else {
+          range = FoldingRange(startLine: start.line,
+                               startUTF16Index: start.utf16index,
+                               endLine: end.line,
+                               endUTF16Index: end.utf16index,
+                               kind: kind)
+        }
+        ranges.insert(range)
+        return .visitChildren
       }
-
-      // If the limit is less than one, do nothing.
-      if let limit = foldingRangeCapabilities?.rangeLimit, limit <= 0 {
-        req.reply([])
-        return
-      }
-
-      let rangeFinder = FoldingRangeFinder(
-        snapshot: snapshot,
-        rangeLimit: foldingRangeCapabilities?.rangeLimit,
-        lineFoldingOnly: foldingRangeCapabilities?.lineFoldingOnly ?? false)
-      rangeFinder.walk(sourceFile)
-      let ranges = rangeFinder.finalize()
-
-      req.reply(ranges.sorted())
     }
+
+    // If the limit is less than one, do nothing.
+    if let limit = foldingRangeCapabilities?.rangeLimit, limit <= 0 {
+      req.reply([])
+      return
+    }
+
+    let rangeFinder = FoldingRangeFinder(
+      snapshot: snapshot,
+      rangeLimit: foldingRangeCapabilities?.rangeLimit,
+      lineFoldingOnly: foldingRangeCapabilities?.lineFoldingOnly ?? false)
+    rangeFinder.walk(sourceFile)
+    let ranges = rangeFinder.finalize()
+
+    req.reply(ranges.sorted())
   }
 
-  public func codeAction(_ req: Request<CodeActionRequest>) {
+  public func codeAction(_ req: Request<CodeActionRequest>) async {
     let providersAndKinds: [(provider: CodeActionProvider, kind: CodeActionKind)] = [
       (retrieveRefactorCodeActions, .refactor),
       (retrieveQuickFixCodeActions, .quickFix)
@@ -1256,7 +1205,7 @@ extension SwiftLanguageServer {
     let wantedActionKinds = req.params.context.only
     let providers = providersAndKinds.filter { wantedActionKinds?.contains($0.1) != false }
     let codeActionCapabilities = capabilityRegistry.clientCapabilities.textDocument?.codeAction
-    retrieveCodeActions(req, providers: providers.map { $0.provider }) { result in
+    await retrieveCodeActions(req, providers: providers.map { $0.provider }) { result in
       switch result {
       case .success(let codeActions):
         let response = CodeActionRequestResponse(codeActions: codeActions,
@@ -1268,28 +1217,35 @@ extension SwiftLanguageServer {
     }
   }
 
-  func retrieveCodeActions(_ req: Request<CodeActionRequest>, providers: [CodeActionProvider], completion: @escaping CodeActionProviderCompletion) {
+  func retrieveCodeActions(_ req: Request<CodeActionRequest>, providers: [CodeActionProvider], completion: @escaping CodeActionProviderCompletion) async {
     guard providers.isEmpty == false else {
       completion(.success([]))
       return
     }
-    var codeActions = [CodeAction]()
-    let dispatchGroup = DispatchGroup()
-    (0..<providers.count).forEach { _ in dispatchGroup.enter() }
-    dispatchGroup.notify(queue: queue) {
-      completion(.success(codeActions))
-    }
-    for i in 0..<providers.count {
-      self.queue.async {
-        providers[i](req.params) { result in
-          defer { dispatchGroup.leave() }
-          guard case .success(let actions) = result else {
-            return
+    let codeActions = await withTaskGroup(of: [CodeAction].self) { taskGroup in
+      for provider in providers {
+        taskGroup.addTask {
+          // FIXME: (async) Migrate `CodeActionProvider` to be async so that we
+          // don't need to do the `withCheckedContinuation` dance here.
+          await withCheckedContinuation { continuation in
+            provider(req.params) {
+              switch $0 {
+              case .success(let actions):
+                continuation.resume(returning: actions)
+              case .failure:
+                continuation.resume(returning: [])
+              }
+            }
           }
-          codeActions += actions
         }
       }
+      var results: [CodeAction] = []
+      for await taskResults in taskGroup {
+        results += taskResults
+      }
+      return results
     }
+    completion(.success(codeActions))
   }
 
   func retrieveRefactorCodeActions(_ params: CodeActionRequest, completion: @escaping CodeActionProviderCompletion) {
@@ -1297,7 +1253,7 @@ extension SwiftLanguageServer {
       skreq[self.keys.retrieve_refactor_actions] = 1
     }
 
-    _cursorInfo(
+    cursorInfo(
       params.textDocument.uri,
       params.range,
       additionalParameters: additionalCursorInfoParameters)
@@ -1419,13 +1375,10 @@ extension SwiftLanguageServer {
     }
   }
 
-  // Must be called on self.queue
-  public func _documentDiagnostic(
+  public func documentDiagnostic(
     _ uri: DocumentURI,
     _ completion: @escaping (Result<[Diagnostic], ResponseError>) -> Void
   ) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     guard let snapshot = documentManager.latestSnapshot(uri) else {
       let msg = "failed to find snapshot for url \(uri)"
       log(msg)
@@ -1459,15 +1412,6 @@ extension SwiftLanguageServer {
 
     // FIXME: cancellation
     _ = handle
-  }
-  
-  public func documentDiagnostic(
-    _ uri: DocumentURI,
-    _ completion: @escaping (Result<[Diagnostic], ResponseError>) -> Void
-  ) {
-    self.queue.async {
-      self._documentDiagnostic(uri, completion)
-    }
   }
 
   public func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) {
@@ -1540,32 +1484,34 @@ extension SwiftLanguageServer {
 }
 
 extension SwiftLanguageServer: SKDNotificationHandler {
-  public func notification(_ notification: SKDResponse) {
+  // FIXME: (async) Make this method isolated once `SKDNotificationHandler` has ben asyncified
+  public nonisolated func notification(_ notification: SKDResponse) {
+    Task {
+      await notificationImpl(notification)
+    }
+  }
+
+  public func notificationImpl(_ notification: SKDResponse) {
     // Check if we need to update our `state` based on the contents of the notification.
-    // Execute the entire code block on `queue` because we need to switch to `queue` anyway to
-    // check `state` in the second `if`. Moving `queue.async` up ensures we only need to switch
-    // queues once and makes the code inside easier to read.
-    self.queue.async {
-      if notification.value?[self.keys.notification] == self.values.notification_sema_enabled {
-        self.state = .connected
-      }
+    if notification.value?[self.keys.notification] == self.values.notification_sema_enabled {
+      self.state = .connected
+    }
 
-      if self.state == .connectionInterrupted {
-        // If we get a notification while we are restoring the connection, it means that the server has restarted.
-        // We still need to wait for semantic functionality to come back up.
-        self.state = .semanticFunctionalityDisabled
+    if self.state == .connectionInterrupted {
+      // If we get a notification while we are restoring the connection, it means that the server has restarted.
+      // We still need to wait for semantic functionality to come back up.
+      self.state = .semanticFunctionalityDisabled
 
-        // Ask our parent to re-open all of our documents.
-        self.reopenDocuments(self)
-      }
+      // Ask our parent to re-open all of our documents.
+      self.reopenDocuments(self)
+    }
 
-      if case .connectionInterrupted = notification.error {
-        self.state = .connectionInterrupted
+    if case .connectionInterrupted = notification.error {
+      self.state = .connectionInterrupted
 
-        // We don't have any open documents anymore after sourcekitd crashed.
-        // Reset the document manager to reflect that.
-        self.documentManager = DocumentManager()
-      }
+      // We don't have any open documents anymore after sourcekitd crashed.
+      // Reset the document manager to reflect that.
+      self.documentManager = DocumentManager()
     }
     
     guard let dict = notification.value else {
@@ -1579,33 +1525,31 @@ extension SwiftLanguageServer: SKDNotificationHandler {
        kind == self.values.notification_documentupdate,
        let name: String = dict[self.keys.name] {
 
-      self.queue.async {
-        let uri: DocumentURI
+      let uri: DocumentURI
 
-        // Paths are expected to be absolute; on Windows, this means that the
-        // path is either drive letter prefixed (and thus `PathGetDriveNumberW`
-        // will provide the driver number OR it is a UNC path and `PathIsUNCW`
-        // will return `true`.  On Unix platforms, the path will start with `/`
-        // which takes care of both a regular absolute path and a POSIX
-        // alternate root path.
+      // Paths are expected to be absolute; on Windows, this means that the
+      // path is either drive letter prefixed (and thus `PathGetDriveNumberW`
+      // will provide the driver number OR it is a UNC path and `PathIsUNCW`
+      // will return `true`.  On Unix platforms, the path will start with `/`
+      // which takes care of both a regular absolute path and a POSIX
+      // alternate root path.
 
-        // TODO: this is not completely portable, e.g. MacOS 9 HFS paths are
-        // unhandled.
+      // TODO: this is not completely portable, e.g. MacOS 9 HFS paths are
+      // unhandled.
 #if os(Windows)
-        let isPath: Bool = name.withCString(encodedAs: UTF16.self) {
-          !PathIsURLW($0)
-        }
-#else
-        let isPath: Bool = name.starts(with: "/")
-#endif
-        if isPath {
-          // If sourcekitd returns us a path, translate it back into a URL
-          uri = DocumentURI(URL(fileURLWithPath: name))
-        } else {
-          uri = DocumentURI(string: name)
-        }
-        self.handleDocumentUpdate(uri: uri)
+      let isPath: Bool = name.withCString(encodedAs: UTF16.self) {
+        !PathIsURLW($0)
       }
+#else
+      let isPath: Bool = name.starts(with: "/")
+#endif
+      if isPath {
+        // If sourcekitd returns us a path, translate it back into a URL
+        uri = DocumentURI(URL(fileURLWithPath: name))
+      } else {
+        uri = DocumentURI(string: name)
+      }
+      self.handleDocumentUpdate(uri: uri)
     }
   }
 }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -150,7 +150,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
   private var stateChangeHandlers: [(_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void] = []
   
   /// A callback with which `SwiftLanguageServer` can request its owner to reopen all documents in case it has crashed.
-  private let reopenDocuments: (ToolchainLanguageServer) -> Void
+  private let reopenDocuments: (ToolchainLanguageServer) async -> Void
 
   /// Get the workspace that the document with the given URI belongs to.
   ///
@@ -166,7 +166,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
     toolchain: Toolchain,
     options: SourceKitServer.Options,
     workspace: Workspace,
-    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+    reopenDocuments: @escaping (ToolchainLanguageServer) async -> Void,
     workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
   ) throws {
     guard let sourcekitd = toolchain.sourcekitd else { return nil }
@@ -1523,7 +1523,7 @@ extension SwiftLanguageServer: SKDNotificationHandler {
       self.state = .semanticFunctionalityDisabled
 
       // Ask our parent to re-open all of our documents.
-      self.reopenDocuments(self)
+      await self.reopenDocuments(self)
     }
 
     if case .connectionInterrupted = notification.error {

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -93,7 +93,7 @@ extension SwiftLanguageServer {
     _ uri: DocumentURI,
     _ range: Range<Position>? = nil,
     _ completion: @escaping (Swift.Result<[VariableTypeInfo], VariableTypeInfoError>) -> Void
-  ) {
+  ) async {
     guard let snapshot = documentManager.latestSnapshot(uri) else {
       return completion(.failure(.unknownDocument(uri)))
     }
@@ -112,7 +112,7 @@ extension SwiftLanguageServer {
     }
 
     // FIXME: SourceKit should probably cache this for us
-    if let compileCommand = self.commandsByFile[uri] {
+    if let compileCommand = await self.buildSettings(for: uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
 

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -84,14 +84,16 @@ enum VariableTypeInfoError: Error, Equatable {
 }
 
 extension SwiftLanguageServer {
-  /// Must be called on self.queue.
-  private func _variableTypeInfos(
+  /// Provides typed variable declarations in a document.
+  ///
+  /// - Parameters:
+  ///   - url: Document URL in which to perform the request. Must be an open document.
+  ///   - completion: Completion block to asynchronously receive the VariableTypeInfos, or error.
+  func variableTypeInfos(
     _ uri: DocumentURI,
     _ range: Range<Position>? = nil,
     _ completion: @escaping (Swift.Result<[VariableTypeInfo], VariableTypeInfoError>) -> Void
   ) {
-    dispatchPrecondition(condition: .onQueue(queue))
-
     guard let snapshot = documentManager.latestSnapshot(uri) else {
       return completion(.failure(.unknownDocument(uri)))
     }
@@ -140,20 +142,5 @@ extension SwiftLanguageServer {
 
     // FIXME: cancellation
     _ = handle
-  }
-
-  /// Provides typed variable declarations in a document.
-  ///
-  /// - Parameters:
-  ///   - url: Document URL in which to perform the request. Must be an open document.
-  ///   - completion: Completion block to asynchronously receive the VariableTypeInfos, or error.
-  func variableTypeInfos(
-    _ uri: DocumentURI,
-    _ range: Range<Position>? = nil,
-    _ completion: @escaping (Swift.Result<[VariableTypeInfo], VariableTypeInfoError>) -> Void
-  ) {
-    queue.async {
-      self._variableTypeInfos(uri, range, completion)
-    }
   }
 }

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -34,7 +34,8 @@ public protocol ToolchainLanguageServer: AnyObject {
     toolchain: Toolchain,
     options: SourceKitServer.Options,
     workspace: Workspace,
-    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void
+    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+    workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
   ) throws
 
   /// Returns `true` if this instance of the language server can handle opening documents in `workspace`.

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -38,70 +38,72 @@ public protocol ToolchainLanguageServer: AnyObject {
   ) throws
 
   /// Returns `true` if this instance of the language server can handle opening documents in `workspace`.
+  ///
   /// If this returns `false`, a new language server will be started for `workspace`.
   func canHandle(workspace: Workspace) -> Bool
 
   // MARK: - Lifetime
 
-  func initializeSync(_ initialize: InitializeRequest) throws -> InitializeResult
-  func clientInitialized(_ initialized: InitializedNotification)
-  /// `callback` will be called when the server has finished shutting down.
-  func shutdown(callback: @escaping () -> Void)
+  func initializeSync(_ initialize: InitializeRequest) async throws -> InitializeResult
+  func clientInitialized(_ initialized: InitializedNotification) async
+  
+  /// Shut the server down and return once the server has finished shutting down
+  func shutdown() async
 
   /// Add a handler that is called whenever the state of the language server changes.
-  func addStateChangeHandler(handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void)
+  func addStateChangeHandler(handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void) async
 
   // MARK: - Text synchronization
 
   /// Sent to open up a document on the Language Server.
   /// This may be called before or after a corresponding
   /// `documentUpdatedBuildSettings` call for the same document.
-  func openDocument(_ note: DidOpenTextDocumentNotification)
+  func openDocument(_ note: DidOpenTextDocumentNotification) async
 
   /// Sent to close a document on the Language Server.
-  func closeDocument(_ note: DidCloseTextDocumentNotification)
-  func changeDocument(_ note: DidChangeTextDocumentNotification)
-  func willSaveDocument(_ note: WillSaveTextDocumentNotification)
-  func didSaveDocument(_ note: DidSaveTextDocumentNotification)
+  func closeDocument(_ note: DidCloseTextDocumentNotification) async
+  func changeDocument(_ note: DidChangeTextDocumentNotification) async
+  func willSaveDocument(_ note: WillSaveTextDocumentNotification) async
+  func didSaveDocument(_ note: DidSaveTextDocumentNotification) async
 
   // MARK: - Build System Integration
 
   /// Sent when the `BuildSystem` has resolved build settings, such as for the intial build settings
   /// or when the settings have changed (e.g. modified build system files). This may be sent before
   /// the respective `DocumentURI` has been opened.
-  func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange)
+  func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) async
 
   /// Sent when the `BuildSystem` has detected that dependencies of the given file have changed
   /// (e.g. header files, swiftmodule files, other compiler input files).
-  func documentDependenciesUpdated(_ uri: DocumentURI)
+  func documentDependenciesUpdated(_ uri: DocumentURI) async
 
   // MARK: - Text Document
 
-  func completion(_ req: Request<CompletionRequest>)
-  func hover(_ req: Request<HoverRequest>)
-  func symbolInfo(_ request: Request<SymbolInfoRequest>)
-  func openInterface(_ request: Request<OpenInterfaceRequest>)
+  func completion(_ req: Request<CompletionRequest>) async
+  func hover(_ req: Request<HoverRequest>) async
+  func symbolInfo(_ request: Request<SymbolInfoRequest>) async
+  func openInterface(_ request: Request<OpenInterfaceRequest>) async
 
   /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
-  func definition(_ request: Request<DefinitionRequest>) -> Bool
-  func declaration(_ request: Request<DeclarationRequest>) -> Bool
+  func definition(_ request: Request<DefinitionRequest>) async -> Bool
+  func declaration(_ request: Request<DeclarationRequest>) async -> Bool
 
-  func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>)
-  func foldingRange(_ req: Request<FoldingRangeRequest>)
-  func documentSymbol(_ req: Request<DocumentSymbolRequest>)
-  func documentColor(_ req: Request<DocumentColorRequest>)
-  func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>)
-  func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>)
-  func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>)
-  func colorPresentation(_ req: Request<ColorPresentationRequest>)
-  func codeAction(_ req: Request<CodeActionRequest>)
-  func inlayHint(_ req: Request<InlayHintRequest>)
-  func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>)
+  func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>) async
+  func foldingRange(_ req: Request<FoldingRangeRequest>) async
+  func documentSymbol(_ req: Request<DocumentSymbolRequest>) async
+  func documentColor(_ req: Request<DocumentColorRequest>) async
+  func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) async
+  func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) async
+  func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>) async
+  func colorPresentation(_ req: Request<ColorPresentationRequest>) async
+  func codeAction(_ req: Request<CodeActionRequest>) async
+  func inlayHint(_ req: Request<InlayHintRequest>) async
+  func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) async
 
   // MARK: - Other
 
-  func executeCommand(_ req: Request<ExecuteCommandRequest>)
+  func executeCommand(_ req: Request<ExecuteCommandRequest>) async
 
   /// Crash the language server. Should be used for crash recovery testing only.
-  func _crash()
+  func _crash() async
 }

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -36,7 +36,7 @@ public protocol ToolchainLanguageServer: AnyObject {
     workspace: Workspace,
     reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
     workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
-  ) throws
+  ) async throws
 
   /// Returns `true` if this instance of the language server can handle opening documents in `workspace`.
   ///

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -34,7 +34,7 @@ public protocol ToolchainLanguageServer: AnyObject {
     toolchain: Toolchain,
     options: SourceKitServer.Options,
     workspace: Workspace,
-    reopenDocuments: @escaping (ToolchainLanguageServer) -> Void,
+    reopenDocuments: @escaping (ToolchainLanguageServer) async -> Void,
     workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
   ) async throws
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -143,6 +143,15 @@ public final class Workspace {
   }
 }
 
+/// Wrapper around a workspace that isn't being retained.
+struct WeakWorkspace {
+  weak var value: Workspace?
+
+  init(_ value: Workspace? = nil) {
+    self.value = value
+  }
+}
+
 public struct IndexOptions {
 
   /// Override the index-store-path provided by the build system.

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -40,24 +40,6 @@ final class BuildServerBuildSystemTests: XCTestCase {
     )
   }
 
-  func testSettings() throws {
-#if os(Windows)
-    try XCTSkipIf(true, "hang")
-#endif
-    let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
-
-    // test settings with a response
-    let fileURL = URL(fileURLWithPath: "/path/to/some/file.swift")
-    let settings = buildSystem._settings(for: DocumentURI(fileURL))
-    XCTAssertNotNil(settings)
-    XCTAssertEqual(settings?.compilerArguments, ["-a", "-b"])
-    XCTAssertEqual(settings?.workingDirectory, fileURL.deletingLastPathComponent().path)
-
-    // test error
-    let missingFileURL = URL(fileURLWithPath: "/path/to/some/missingfile.missing")
-    XCTAssertNil(buildSystem._settings(for: DocumentURI(missingFileURL)))
-  }
-
   func testFileRegistration() throws {
     let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -149,7 +149,7 @@ final class BuildSystemManagerTests: XCTestCase {
       mainFilesProvider: mainFiles)
     defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
     let del = BSMDelegate(bsm)
-    let fallbackSettings = fallback.settings(for: a, .swift)
+    let fallbackSettings = fallback.buildSettings(for: a, language: .swift)
     let initial = expectation(description: "initial fallback settings")
     del.expected = [(a, fallbackSettings, initial, #file, #line)]
     bsm.registerForChangeNotifications(for: a, language: .swift)
@@ -475,12 +475,12 @@ class ManualBuildSystem: BuildSystem {
 
   var delegate: BuildSystemDelegate? = nil
 
-  func settings(for uri: DocumentURI, _ language: Language) -> FileBuildSettings? {
+  func buildSettings(for uri: DocumentURI, language: Language) -> FileBuildSettings? {
     return map[uri]
   }
 
   func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
-    let settings = self.settings(for: uri, language)
+    let settings = self.buildSettings(for: uri, language: language)
     self.delegate?.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
   }
 

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -29,7 +29,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     XCTAssertNil(bs.indexStorePath)
     XCTAssertNil(bs.indexDatabasePath)
 
-    let settings = bs.settings(for: source.asURI, .swift)!
+    let settings = bs.buildSettings(for: source.asURI, language: .swift)!
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
@@ -41,7 +41,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .swift)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments, [
       source.pathString,
     ])
   }
@@ -57,7 +57,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    let args = bs.settings(for: source.asURI, .swift)?.compilerArguments
+    let args = bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments
     XCTAssertEqual(args, [
       "-Xfrontend",
       "-debug-constraints",
@@ -68,7 +68,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .swift)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments, [
       "-Xfrontend",
       "-debug-constraints",
       source.pathString,
@@ -88,7 +88,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .swift)!.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments, [
       "-sdk",
       "/some/custom/sdk",
       "-Xfrontend",
@@ -98,7 +98,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .swift)!.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments, [
       "-sdk",
       "/some/custom/sdk",
       "-Xfrontend",
@@ -114,7 +114,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = sdk
 
-    let settings = bs.settings(for: source.asURI, .cpp)!
+    let settings = bs.buildSettings(for: source.asURI, language: .cpp)!
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
@@ -126,7 +126,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .cpp)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
       source.pathString,
     ])
   }
@@ -141,7 +141,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .cpp)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
       "-v",
       "-isysroot",
       sdk.pathString,
@@ -150,7 +150,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .cpp)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
       "-v",
       source.pathString,
     ])
@@ -168,7 +168,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .cpp)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
       "-isysroot",
       "/my/custom/sdk",
       "-v",
@@ -177,7 +177,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.settings(for: source.asURI, .cpp)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
       "-isysroot",
       "/my/custom/sdk",
       "-v",
@@ -189,7 +189,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let source = try AbsolutePath(validating: "/my/source.c")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.settings(for: source.asURI, .c)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments, [
       source.pathString,
     ])
   }
@@ -202,7 +202,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     ]))
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.settings(for: source.asURI, .c)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments, [
       "-v",
       source.pathString,
     ])
@@ -212,7 +212,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let source = try AbsolutePath(validating: "/my/source.m")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.settings(for: source.asURI, .objective_c)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .objective_c)?.compilerArguments, [
       source.pathString,
     ])
   }
@@ -221,7 +221,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.settings(for: source.asURI, .objective_cpp)?.compilerArguments, [
+    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .objective_cpp)?.compilerArguments, [
       source.pathString,
     ])
   }
@@ -229,6 +229,6 @@ final class FallbackBuildSystemTests: XCTestCase {
   func testUnknown() throws {
     let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
-    XCTAssertNil(bs.settings(for: source.asURI, Language(rawValue: "unknown")))
+    XCTAssertNil(bs.buildSettings(for: source.asURI, language: Language(rawValue: "unknown")))
   }
 }

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -94,7 +94,7 @@ final class CrashRecoveryTests: XCTestCase {
     let sourcekitdRestarted = expectation(description: "sourcekitd has been restarted (syntactic only)")
     let semanticFunctionalityRestored = expectation(description: "sourcekitd has restored semantic language functionality")
 
-    sourcekitdServer.addStateChangeHandler { (oldState, newState) in
+    await sourcekitdServer.addStateChangeHandler { (oldState, newState) in
       switch newState {
       case .connectionInterrupted:
         sourcekitdCrashed.fulfill()
@@ -105,7 +105,7 @@ final class CrashRecoveryTests: XCTestCase {
       }
     }
 
-    sourcekitdServer._crash()
+    await sourcekitdServer._crash()
 
     try await fulfillmentOfOrThrow([sourcekitdCrashed], timeout: 5)
     try await fulfillmentOfOrThrow([sourcekitdRestarted], timeout: 30)

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -138,7 +138,7 @@ final class CrashRecoveryTests: XCTestCase {
     let clangdCrashed = self.expectation(description: "clangd crashed")
     let clangdRestarted = self.expectation(description: "clangd restarted")
 
-    clangdServer.addStateChangeHandler { (oldState, newState) in
+    await clangdServer.addStateChangeHandler { (oldState, newState) in
       switch newState {
       case .connectionInterrupted:
         clangdCrashed.fulfill()
@@ -149,7 +149,7 @@ final class CrashRecoveryTests: XCTestCase {
       }
     }
 
-    clangdServer._crash()
+    await clangdServer._crash()
 
     try await fulfillmentOfOrThrow([clangdCrashed])
     try await fulfillmentOfOrThrow([clangdRestarted])
@@ -250,7 +250,7 @@ final class CrashRecoveryTests: XCTestCase {
 
     var clangdHasRestartedFirstTime = false
 
-    clangdServer.addStateChangeHandler { (oldState, newState) in
+    await clangdServer.addStateChangeHandler { (oldState, newState) in
       switch newState {
       case .connectionInterrupted:
         clangdCrashed.fulfill()
@@ -266,7 +266,7 @@ final class CrashRecoveryTests: XCTestCase {
       }
     }
 
-    clangdServer._crash()
+    await clangdServer._crash()
 
     try await fulfillmentOfOrThrow([clangdCrashed], timeout: 5)
     try await fulfillmentOfOrThrow([clangdRestartedFirstTime], timeout: 30)
@@ -274,7 +274,7 @@ final class CrashRecoveryTests: XCTestCase {
     let firstRestartDate = Date()
 
     // Crash clangd again. This time, it should only restart after a delay.
-    clangdServer._crash()
+    await clangdServer._crash()
 
     try await fulfillmentOfOrThrow([clangdRestartedSecondTime], timeout: 30)
     XCTAssert(Date().timeIntervalSince(firstRestartDate) > 5, "Clangd restarted too quickly after crashing twice in a row. We are not preventing crash loops.")

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -43,6 +43,10 @@ final class TestBuildSystem: BuildSystem {
   /// Files currently being watched by our delegate.
   var watchedFiles: Set<DocumentURI> = []
 
+  func buildSettings(for document: DocumentURI, language: Language) async throws -> FileBuildSettings? {
+    return buildSettingsByFile[document]
+  }
+
   func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     watchedFiles.insert(uri)
 
@@ -196,7 +200,7 @@ final class BuildSystemTests: XCTestCase {
   func testSwiftDocumentUpdatedBuildSettings() async throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let doc = DocumentURI(url)
-    let args = FallbackBuildSystem(buildSetup: .default).settings(for: doc, .swift)!.compilerArguments
+    let args = FallbackBuildSystem(buildSetup: .default).buildSettings(for: doc, language: .swift)!.compilerArguments
 
     buildSystem.buildSettingsByFile[doc] = FileBuildSettings(compilerArguments: args)
 
@@ -306,7 +310,7 @@ final class BuildSystemTests: XCTestCase {
     let doc = DocumentURI(url)
 
     // Primary settings must be different than the fallback settings.
-    var primarySettings = FallbackBuildSystem(buildSetup: .default).settings(for: doc, .swift)!
+    var primarySettings = FallbackBuildSystem(buildSetup: .default).buildSettings(for: doc, language: .swift)!
     primarySettings.compilerArguments.append("-DPRIMARY")
 
     let text = """

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -352,7 +352,7 @@ final class LocalClangTests: XCTestCase {
 
     let clangdServer = await ws.testServer.server!._languageService(for: cFileLoc.docUri, .cpp, in: ws.testServer.server!.workspaceForDocument(uri: cFileLoc.docUri)!)!
 
-    clangdServer.documentDependenciesUpdated(cFileLoc.docUri)
+    await clangdServer.documentDependenciesUpdated(cFileLoc.docUri)
 
     try await fulfillmentOfOrThrow([updatedNotificationsReceived], timeout: 5)
   }

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -17,9 +17,16 @@ import SKTestSupport
 import SourceKitLSP
 import XCTest
 import SwiftSyntax
+import SwiftParser
 
 // Workaround ambiguity with Foundation.
 typealias Notification = LanguageServerProtocol.Notification
+
+extension SwiftLanguageServer {
+  func setReusedNodeCallback(_ callback: ReusedNodeCallback?) {
+    self.reusedNodeCallback = callback
+  }
+}
 
 final class LocalSwiftTests: XCTestCase {
 
@@ -1484,7 +1491,7 @@ final class LocalSwiftTests: XCTestCase {
 
     var reusedNodes: [Syntax] = []
     let swiftLanguageServer = await connection.server!._languageService(for: uri, .swift, in: connection.server!.workspaceForDocument(uri: uri)!) as! SwiftLanguageServer
-    swiftLanguageServer.reusedNodeCallback = { reusedNodes.append($0) }
+    await swiftLanguageServer.setReusedNodeCallback({ reusedNodes.append($0) })
     sk.allowUnexpectedNotification = false
     
     sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(


### PR DESCRIPTION
The next step to making sourcekit-lsp use Swift concurrency. 

I think the best way to review this, is commit by commit, ignoring whitespace-only changes because I changed the indentation of quite a few lines if e.g. `queue.async` becomes unnecessary since the function is now `async` itself.

After this change, there are a few low-probability race conditions in the code as well as things to clean up. Those are marked with `FIXME: (async)`. I will fix all of them in follow-up PRs. I’m splitting them to keep the reviews manageable.

For reference, my full stack of asyncifying commits is in https://github.com/ahoppen/sourcekit-lsp/tree/ahoppen/swift-concurrency-4. 