### PR TITLE
Run tests sequentially in CI

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -210,7 +210,6 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
 
     cmd = [
         swift_exec, 'test',
-        '--parallel',
         '--disable-testable-imports',
         '--test-product', 'SourceKitLSPPackageTests'
     ] + swiftpm_args


### PR DESCRIPTION
The parallel test logs are just so hard to read that they don’t really provide any value. Locally, running the tests in serial only increases test times by 1 minute, which I think is a tradeoff worth making to actually be able to tell what’s going wrong in CI.