### PR TITLE
Migrate `BuildSystemManager` and all the build systems to be actors

### DIFF
--- a/Sources/LSPTestSupport/Assertions.swift
+++ b/Sources/LSPTestSupport/Assertions.swift
@@ -22,6 +22,27 @@ public func assertNoThrow<T>(
   XCTAssertNoThrow(try expression(), message(), file: file, line: line)
 }
 
+/// Same as `XCTAssertThrows` but executes the trailing closure.
+public func assertThrowsError<T>(
+  _ expression: @autoclosure () async throws -> T,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line,
+  _ errorHandler: (_ error: Error) -> Void = { _ in }
+) async {
+  let didThrow: Bool
+  do {
+    _ = try await expression()
+    didThrow = false
+  } catch {
+    errorHandler(error)
+    didThrow = true
+  }
+  if !didThrow {
+    XCTFail("Expression was expected to throw but did not throw", file: file, line: line)
+  }
+}
+
 /// Same as `XCTAssertEqual` but doesn't take autoclosures and thus `expression1`
 /// and `expression2` can contain `await`.
 public func assertEqual<T: Equatable>(
@@ -32,6 +53,28 @@ public func assertEqual<T: Equatable>(
   line: UInt = #line
 ) {
   XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
+}
+
+/// Same as `XCTAssertNil` but doesn't take autoclosures and thus `expression`
+/// can contain `await`.
+public func assertNil<T: Equatable>(
+  _ expression: T?,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssertNil(expression, message(), file: file, line: line)
+}
+
+/// Same as `XCTAssertNotNil` but doesn't take autoclosures and thus `expression`
+/// can contain `await`.
+public func assertNotNil<T: Equatable>(
+  _ expression: T?,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssertNotNil(expression, message(), file: file, line: line)
 }
 
 extension XCTestCase {

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -65,6 +65,11 @@ public final class BuildServerBuildSystem: MessageHandler {
   /// Delegate to handle any build system events.
   public weak var delegate: BuildSystemDelegate?
 
+  /// - Note: Needed to set the delegate from a different actor isolation context
+  public func setDelegate(_ delegate: BuildSystemDelegate?) async {
+    self.delegate = delegate
+  }
+
   /// The build settings that have been received from the build server.
   private var buildSettings: [DocumentURI: FileBuildSettings] = [:]
 

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -39,17 +39,23 @@ public enum FileHandlingCapability: Comparable {
 public protocol BuildSystem: AnyObject {
 
   /// The path to the raw index store data, if any.
-  var indexStorePath: AbsolutePath? { get }
+  var indexStorePath: AbsolutePath? { get async }
 
   /// The path to put the index database, if any.
-  var indexDatabasePath: AbsolutePath? { get }
+  var indexDatabasePath: AbsolutePath? { get async }
 
   /// Path remappings for remapping index data for local use.
-  var indexPrefixMappings: [PathPrefixMapping] { get }
+  var indexPrefixMappings: [PathPrefixMapping] { get async }
 
   /// Delegate to handle any build system events such as file build settings
   /// initial reports as well as changes.
-  var delegate: BuildSystemDelegate? { get set }
+  var delegate: BuildSystemDelegate? { get async }
+
+  /// Set the build system's delegate.
+  ///
+  /// - Note: Needed so we can set the delegate from a different actor isolation
+  ///   context.
+  func setDelegate(_ delegate: BuildSystemDelegate?) async
 
   /// Retrieve build settings for the given document with the given source
   /// language.
@@ -64,16 +70,16 @@ public protocol BuildSystem: AnyObject {
   /// IMPORTANT: When first receiving a register request, the `BuildSystem` MUST asynchronously
   /// inform its delegate of any initial settings for the given file via the
   /// `fileBuildSettingsChanged` method, even if unavailable.
-  func registerForChangeNotifications(for: DocumentURI, language: Language)
+  func registerForChangeNotifications(for: DocumentURI, language: Language) async
 
   /// Unregister the given file for build-system level change notifications,
   /// such as command line flag changes, dependency changes, etc.
-  func unregisterForChangeNotifications(for: DocumentURI)
+  func unregisterForChangeNotifications(for: DocumentURI) async
 
   /// Called when files in the project change.
-  func filesDidChange(_ events: [FileEvent])
+  func filesDidChange(_ events: [FileEvent]) async
 
-  func fileHandlingCapability(for uri: DocumentURI) -> FileHandlingCapability
+  func fileHandlingCapability(for uri: DocumentURI) async -> FileHandlingCapability
 }
 
 public let buildTargetsNotSupported =

--- a/Sources/SKCore/BuildSystemDelegate.swift
+++ b/Sources/SKCore/BuildSystemDelegate.swift
@@ -18,14 +18,14 @@ public protocol BuildSystemDelegate: AnyObject {
   ///
   /// The callee should request new sources and outputs for the build targets of
   /// interest.
-  func buildTargetsChanged(_ changes: [BuildTargetEvent])
+  func buildTargetsChanged(_ changes: [BuildTargetEvent]) async
 
   /// Notify the delegate that the given files' build settings have changed.
   ///
   /// The delegate should cache the new build settings for any of the given
   /// files that they are interested in.
   func fileBuildSettingsChanged(
-    _ changedFiles: [DocumentURI: FileBuildSettingsChange])
+    _ changedFiles: [DocumentURI: FileBuildSettingsChange]) async
 
   /// Notify the delegate that the dependencies of the given files have changed
   /// and that ASTs may need to be refreshed. If the given set is empty, assume
@@ -33,10 +33,10 @@ public protocol BuildSystemDelegate: AnyObject {
   ///
   /// The callee should refresh ASTs unless it is able to determine that a
   /// refresh is not necessary.
-  func filesDependenciesUpdated(_ changedFiles: Set<DocumentURI>)
+  func filesDependenciesUpdated(_ changedFiles: Set<DocumentURI>) async
 
   /// Notify the delegate that the file handling capability of this build system
   /// for some file has changed. The delegate should discard any cached file
   /// handling capability.
-  func fileHandlingCapabilityChanged()
+  func fileHandlingCapabilityChanged() async
 }

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -200,7 +200,7 @@ extension BuildSystemManager {
     if let mainChange = newStatus.buildSettingsChange,
        let delegate = self._delegate {
       let change = self.convert(change: mainChange, ofMainFile: mainFile, to: uri)
-      delegate.fileBuildSettingsChanged([uri: change])
+      await delegate.fileBuildSettingsChanged([uri: change])
     }
   }
 
@@ -242,7 +242,7 @@ extension BuildSystemManager {
       if let fallback = self.fallbackBuildSystem {
         Task {
           try await Task.sleep(nanoseconds: UInt64(self.fallbackSettingsTimeout.nanoseconds()!))
-          self.handleFallbackTimer(for: mainFile, language: language, fallback)
+          await self.handleFallbackTimer(for: mainFile, language: language, fallback)
         }
       }
 
@@ -280,7 +280,7 @@ extension BuildSystemManager {
 
   /// Update and notify our delegate for the given main file changes if they are
   /// convertible into `FileBuildSettingsChange`.
-  func updateAndNotifyStatuses(changes: [DocumentURI: MainFileStatus]) {
+  func updateAndNotifyStatuses(changes: [DocumentURI: MainFileStatus]) async {
     var changedWatchedFiles = [DocumentURI: FileBuildSettingsChange]()
     for (mainFile, status) in changes {
       let watches = self.watchedFiles.filter { $1.mainFile == mainFile }
@@ -307,7 +307,7 @@ extension BuildSystemManager {
     }
 
     if !changedWatchedFiles.isEmpty, let delegate = self._delegate {
-      delegate.fileBuildSettingsChanged(changedWatchedFiles)
+      await delegate.fileBuildSettingsChanged(changedWatchedFiles)
     }
   }
 
@@ -319,14 +319,14 @@ extension BuildSystemManager {
     for mainFile: DocumentURI,
     language: Language,
     _ fallback: FallbackBuildSystem
-  ) {
+  ) async {
     // There won't be a current status if it's unreferenced by any watched file.
     // Similarly, if the status isn't `waiting` then there's nothing to do.
     guard let status = self.mainFileStatuses[mainFile], status == .waiting else {
       return
     }
     if let settings = fallback.buildSettings(for: mainFile, language: language) {
-      self.updateAndNotifyStatuses(changes: [mainFile: .waitingUsingFallback(settings)])
+      await self.updateAndNotifyStatuses(changes: [mainFile: .waitingUsingFallback(settings)])
     } else {
       // Keep the status as waiting.
     }
@@ -367,7 +367,7 @@ extension BuildSystemManager: BuildSystemDelegate {
     }
   }
 
-  public func fileBuildSettingsChangedImpl(_ changes: [DocumentURI: FileBuildSettingsChange]) {
+  public func fileBuildSettingsChangedImpl(_ changes: [DocumentURI: FileBuildSettingsChange]) async {
     let statusChanges: [DocumentURI: MainFileStatus] =
         changes.reduce(into: [:]) { (result, entry) in
       let mainFile = entry.key
@@ -395,7 +395,7 @@ extension BuildSystemManager: BuildSystemDelegate {
       }
       result[mainFile] = newStatus
     }
-    self.updateAndNotifyStatuses(changes: statusChanges)
+    await self.updateAndNotifyStatuses(changes: statusChanges)
   }
 
   // FIXME: (async) Make this method isolated once `BuildSystemDelegate` has ben asyncified
@@ -405,11 +405,11 @@ extension BuildSystemManager: BuildSystemDelegate {
     }
   }
 
-  public func filesDependenciesUpdatedImpl(_ changedFiles: Set<DocumentURI>) {
+  public func filesDependenciesUpdatedImpl(_ changedFiles: Set<DocumentURI>) async {
     // Empty changes --> assume everything has changed.
     guard !changedFiles.isEmpty else {
       if let delegate = self._delegate {
-        delegate.filesDependenciesUpdated(changedFiles)
+        await delegate.filesDependenciesUpdated(changedFiles)
       }
       return
     }
@@ -418,7 +418,7 @@ extension BuildSystemManager: BuildSystemDelegate {
     let changedWatchedFiles = self.watchedFiles.filter { changedFiles.contains($1.mainFile) }
     let newChangedFiles = Set(changedWatchedFiles.map { $0.key })
     if let delegate = self._delegate, !newChangedFiles.isEmpty {
-      delegate.filesDependenciesUpdated(newChangedFiles)
+      await delegate.filesDependenciesUpdated(newChangedFiles)
     }
   }
 
@@ -429,9 +429,9 @@ extension BuildSystemManager: BuildSystemDelegate {
     }
   }
 
-  public func buildTargetsChangedImpl(_ changes: [BuildTargetEvent]) {
+  public func buildTargetsChangedImpl(_ changes: [BuildTargetEvent]) async {
     if let delegate = self._delegate {
-      delegate.buildTargetsChanged(changes)
+      await delegate.buildTargetsChanged(changes)
     }
   }
 
@@ -442,9 +442,9 @@ extension BuildSystemManager: BuildSystemDelegate {
     }
   }
 
-  public func fileHandlingCapabilityChangedImpl() {
+  public func fileHandlingCapabilityChangedImpl() async {
     if let delegate = self._delegate {
-      delegate.fileHandlingCapabilityChanged()
+      await delegate.fileHandlingCapabilityChanged()
     }
   }
 }
@@ -484,7 +484,7 @@ extension BuildSystemManager: MainFilesDelegate {
     }
 
     if let delegate = self._delegate, !buildSettingsChanges.isEmpty {
-      delegate.fileBuildSettingsChanged(buildSettingsChanges)
+      await delegate.fileBuildSettingsChanged(buildSettingsChanges)
     }
   }
 }

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -46,6 +46,10 @@ public final class CompilationDatabaseBuildSystem {
   /// Delegate to handle any build system events.
   public weak var delegate: BuildSystemDelegate? = nil
 
+  public func setDelegate(_ delegate: BuildSystemDelegate?) async {
+    self.delegate = delegate
+  }
+
   let projectRoot: AbsolutePath?
 
   let fileSystem: FileSystem

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -91,13 +91,13 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     return self.settings(for: document)
   }
 
-  public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
+  public func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {
     self.watchedFiles[uri] = language
 
     guard let delegate = self.delegate else { return }
 
     let settings = self.settings(for: uri)
-    delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
+    await delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
   }
 
   /// We don't support change watching.
@@ -142,7 +142,7 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
 
   /// The compilation database has been changed on disk.
   /// Reload it and notify the delegate about build setting changes.
-  private func reloadCompilationDatabase() {
+  private func reloadCompilationDatabase() async {
     guard let projectRoot = self.projectRoot else { return }
 
     self.compdb = tryLoadCompilationDatabase(directory: projectRoot, self.fileSystem)
@@ -156,13 +156,13 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
           changedFiles[uri] = .removedOrUnavailable
         }
       }
-      delegate.fileBuildSettingsChanged(changedFiles)
+      await delegate.fileBuildSettingsChanged(changedFiles)
     }
   }
 
-  public func filesDidChange(_ events: [FileEvent]) {
+  public func filesDidChange(_ events: [FileEvent]) async {
     if events.contains(where: { self.fileEventShouldTriggerCompilationDatabaseReload(event: $0) }) {
-      self.reloadCompilationDatabase()
+      await self.reloadCompilationDatabase()
     }
   }
 

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -38,6 +38,10 @@ public final class FallbackBuildSystem: BuildSystem {
   /// Delegate to handle any build system events.
   public weak var delegate: BuildSystemDelegate? = nil
 
+  public func setDelegate(_ delegate: BuildSystemDelegate?) async {
+    self.delegate = delegate
+  }
+
   public var indexStorePath: AbsolutePath? { return nil }
 
   public var indexDatabasePath: AbsolutePath? { return nil }

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -63,8 +63,8 @@ public final class FallbackBuildSystem: BuildSystem {
     guard let delegate = self.delegate else { return }
 
     let settings = self.buildSettings(for: uri, language: language)
-    DispatchQueue.global().async {
-      delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
+    Task {
+      await delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
     }
   }
 

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -62,6 +62,10 @@ public final class SwiftPMWorkspace {
   /// Delegate to handle any build system events.
   public weak var delegate: SKCore.BuildSystemDelegate? = nil
 
+  public func setDelegate(_ delegate: SKCore.BuildSystemDelegate?) async {
+    self.delegate = delegate
+  }
+
   let workspacePath: TSCAbsolutePath
   let packageRoot: TSCAbsolutePath
   /// *Public for testing*

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -85,19 +85,19 @@ public final class SKSwiftPMTestWorkspace {
     let buildPath = try AbsolutePath(validating: buildDir.path)
     let buildSetup = BuildSetup(configuration: .debug, path: buildPath, flags: BuildFlags())
 
-    let swiftpm = try SwiftPMWorkspace(
+    let swiftpm = try await SwiftPMWorkspace(
       workspacePath: sourcePath,
       toolchainRegistry: ToolchainRegistry.shared,
       buildSetup: buildSetup)
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore!.pathString)
 
-    try fm.createDirectory(atPath: swiftpm.indexStorePath!.pathString, withIntermediateDirectories: true)
+    try fm.createDirectory(atPath: await swiftpm.indexStorePath!.pathString, withIntermediateDirectories: true)
 
     let indexDelegate = SourceKitIndexDelegate()
 
     self.index = try IndexStoreDB(
-      storePath: swiftpm.indexStorePath!.pathString,
+      storePath: await swiftpm.indexStorePath!.pathString,
       databasePath: tmpDir.path,
       library: libIndexStore,
       delegate: indexDelegate,

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -113,7 +113,7 @@ public final class SKSwiftPMTestWorkspace {
       underlyingBuildSystem: swiftpm,
       index: index,
       indexDelegate: indexDelegate)
-    workspace.buildSystemManager.delegate = server
+    await workspace.buildSystemManager.setDelegate(server)
     await server.addWorkspace(workspace)
   }
 

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -104,7 +104,7 @@ public final class SKSwiftPMTestWorkspace {
       listenToUnitEvents: false)
 
     let server = self.testServer.server!
-    let workspace = Workspace(
+    let workspace = await Workspace(
       documentManager: DocumentManager(),
       rootUri: DocumentURI(sources.rootDirectory),
       capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -87,7 +87,7 @@ public final class SKTibsTestWorkspace {
     let indexDelegate = SourceKitIndexDelegate()
     tibsWorkspace.delegate = indexDelegate
 
-    let workspace = Workspace(
+    let workspace = await Workspace(
       documentManager: DocumentManager(),
       rootUri: DocumentURI(sources.rootDirectory),
       capabilityRegistry: CapabilityRegistry(clientCapabilities: clientCapabilities),

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -97,7 +97,7 @@ public final class SKTibsTestWorkspace {
       index: index,
       indexDelegate: indexDelegate)
 
-    workspace.buildSystemManager.delegate = testServer.server!
+    await workspace.buildSystemManager.setDelegate(testServer.server!)
     await testServer.server!.setWorkspaces([workspace])
   }
 }

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(SourceKitLSP STATIC
   DocumentTokens.swift
   IndexStoreDB+MainFilesProvider.swift
   RangeAdjuster.swift
+  Sequence+AsyncMap.swift
   SourceKitIndexDelegate.swift
   SourceKitLSPCommandMetadata.swift
   SourceKitServer+Options.swift

--- a/Sources/SourceKitLSP/Sequence+AsyncMap.swift
+++ b/Sources/SourceKitLSP/Sequence+AsyncMap.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Just like `Sequence.map` but allows an `async` transform function.
+  func asyncMap<T>(
+    _ transform: (Element) async throws -> T
+  ) async rethrows -> [T] {
+    var result: [T] = []
+    result.reserveCapacity(self.underestimatedCount)
+
+    for element in self {
+      try await result.append(transform(element))
+    }
+
+    return result
+  }
+
+  /// Just like `Sequence.compactMap` but allows an `async` transform function.
+  func asyncCompactMap<T>(
+    _ transform: (Element) async throws -> T?
+  ) async rethrows -> [T] {
+    var result: [T] = []
+
+    for element in self {
+      if let transformed = try await transform(element) {
+        result.append(transformed)
+      }
+    }
+
+    return result
+  }
+}
+

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -97,7 +97,7 @@ public final class Workspace {
   ) async throws {
     var buildSystem: BuildSystem? = nil
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
-      if let buildServer = BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
+      if let buildServer = await BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
         buildSystem = buildServer
       } else if let swiftpm = await SwiftPMWorkspace(
         url: rootUrl,

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -99,7 +99,7 @@ public final class Workspace {
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
       if let buildServer = BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
         buildSystem = buildServer
-      } else if let swiftpm = SwiftPMWorkspace(
+      } else if let swiftpm = await SwiftPMWorkspace(
         url: rootUrl,
         toolchainRegistry: toolchainRegistry,
         buildSetup: buildSetup,

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -27,21 +27,21 @@ final class BuildServerBuildSystemTests: XCTestCase {
   } 
   let buildFolder = try! AbsolutePath(validating: NSTemporaryDirectory())
 
-  func testServerInitialize() throws {
-    let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
+  func testServerInitialize() async throws {
+    let buildSystem = try await BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
-    XCTAssertEqual(
-      buildSystem.indexDatabasePath,
+    assertEqual(
+      await buildSystem.indexDatabasePath,
       try AbsolutePath(validating: "some/index/db/path", relativeTo: root)
     )
-    XCTAssertEqual(
-      buildSystem.indexStorePath, 
+    assertEqual(
+      await buildSystem.indexStorePath,
       try AbsolutePath(validating: "some/index/store/path", relativeTo: root)
     )
   }
 
-  func testFileRegistration() throws {
-    let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
+  func testFileRegistration() async throws {
+    let buildSystem = try await BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "\(fileUrl) settings updated")
@@ -50,14 +50,14 @@ final class BuildServerBuildSystemTests: XCTestCase {
       // BuildSystemManager has a weak reference to delegate. Keep it alive.
       _fixLifetime(buildSystemDelegate)
     }
-    buildSystem.delegate = buildSystemDelegate
-    buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
+    await buildSystem.setDelegate(buildSystemDelegate)
+    await buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: defaultTimeout), .completed)
   }
 
-  func testBuildTargetsChanged() throws {
-    let buildSystem = try BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
+  func testBuildTargetsChanged() async throws {
+    let buildSystem = try await BuildServerBuildSystem(projectRoot: root, buildFolder: buildFolder)
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "target changed")
@@ -71,14 +71,10 @@ final class BuildServerBuildSystemTests: XCTestCase {
       // BuildSystemManager has a weak reference to delegate. Keep it alive.
       _fixLifetime(buildSystemDelegate)
     }
-    buildSystem.delegate = buildSystemDelegate
-    buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
+    await buildSystem.setDelegate(buildSystemDelegate)
+    await buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl), language: .swift)
 
-    let result = XCTWaiter.wait(for: [expectation], timeout: defaultTimeout)
-    guard result == .completed else {
-      XCTFail("error \(result) waiting for targets changed notification")
-      return
-    }
+    try await fulfillmentOfOrThrow([expectation])
   }
 }
 

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -33,7 +33,7 @@ final class BuildSystemManagerTests: XCTestCase {
       d: Set([d]),
     ]
 
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: FallbackBuildSystem(buildSetup: .default),
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -94,7 +94,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider()
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -119,7 +119,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider()
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -143,7 +143,7 @@ final class BuildSystemManagerTests: XCTestCase {
     mainFiles.mainFiles = [a: Set([a])]
     let bs = ManualBuildSystem()
     let fallback = FallbackBuildSystem(buildSetup: .default)
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: fallback,
       mainFilesProvider: mainFiles)
@@ -174,7 +174,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider()
     mainFiles.mainFiles = [a: Set([a]), b: Set([b])]
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -221,7 +221,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider()
     mainFiles.mainFiles = [a: Set([a]), b: Set([b])]
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -263,7 +263,7 @@ final class BuildSystemManagerTests: XCTestCase {
     ]
 
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -318,7 +318,7 @@ final class BuildSystemManagerTests: XCTestCase {
     ]
 
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -366,7 +366,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider()
     mainFiles.mainFiles = [a: Set([a]), b: Set([b]), c: Set([c])]
     let bs = ManualBuildSystem()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -425,7 +425,7 @@ final class BuildSystemManagerTests: XCTestCase {
     }
 
     let bs = DepUpdateDuringRegistrationBS()
-    let bsm = BuildSystemManager(
+    let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles)
@@ -474,6 +474,10 @@ class ManualBuildSystem: BuildSystem {
   var map: [DocumentURI: FileBuildSettings] = [:]
 
   var delegate: BuildSystemDelegate? = nil
+
+  func setDelegate(_ delegate: SKCore.BuildSystemDelegate?) async {
+    self.delegate = delegate
+  }
 
   func buildSettings(for uri: DocumentURI, language: Language) -> FileBuildSettings? {
     return map[uri]

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -418,9 +418,9 @@ final class BuildSystemManagerTests: XCTestCase {
     mainFiles.mainFiles = [a: Set([a])]
 
     class DepUpdateDuringRegistrationBS: ManualBuildSystem {
-        override func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
-          delegate?.filesDependenciesUpdated([uri])
-          super.registerForChangeNotifications(for: uri, language: language)
+        override func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {
+          await delegate?.filesDependenciesUpdated([uri])
+          await super.registerForChangeNotifications(for: uri, language: language)
         }
     }
 
@@ -483,9 +483,9 @@ class ManualBuildSystem: BuildSystem {
     return map[uri]
   }
 
-  func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
+  func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {
     let settings = self.buildSettings(for: uri, language: language)
-    self.delegate?.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
+    await self.delegate?.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
   }
 
   func unregisterForChangeNotifications(for: DocumentURI) {

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -103,13 +103,13 @@ final class BuildSystemManagerTests: XCTestCase {
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let initial = expectation(description: "initial settings")
-    del.expected = [(a, bs.map[a]!, initial, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
 
     bs.map[a] = nil
     let changed = expectation(description: "changed settings")
-    del.expected = [(a, nil, changed, #file, #line)]
+    await del.setExpected([(a, nil, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .removedOrUnavailable])
     try await fulfillmentOfOrThrow([changed])
   }
@@ -126,13 +126,13 @@ final class BuildSystemManagerTests: XCTestCase {
     defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
     let initial = expectation(description: "initial settings")
-    del.expected = [(a, nil, initial, #file, #line)]
+    await del.setExpected([(a, nil, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let changed = expectation(description: "changed settings")
-    del.expected = [(a, bs.map[a]!, changed, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
     try await fulfillmentOfOrThrow([changed])
   }
@@ -151,19 +151,19 @@ final class BuildSystemManagerTests: XCTestCase {
     let del = await BSMDelegate(bsm)
     let fallbackSettings = fallback.buildSettings(for: a, language: .swift)
     let initial = expectation(description: "initial fallback settings")
-    del.expected = [(a, fallbackSettings, initial, #file, #line)]
+    await del.setExpected([(a, fallbackSettings, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["non-fallback", "args"])
     let changed = expectation(description: "changed settings")
-    del.expected = [(a, bs.map[a]!, changed, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
     try await fulfillmentOfOrThrow([changed])
 
     bs.map[a] = nil
     let revert = expectation(description: "revert to fallback settings")
-    del.expected = [(a, fallbackSettings, revert, #file, #line)]
+    await del.setExpected([(a, fallbackSettings, revert, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .removedOrUnavailable])
     try await fulfillmentOfOrThrow([revert])
   }
@@ -184,18 +184,18 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     bs.map[b] = FileBuildSettings(compilerArguments: ["y"])
     let initial = expectation(description: "initial settings")
-    del.expected = [(a, bs.map[a]!, initial, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
     let initialB = expectation(description: "initial settings")
-    del.expected = [(b, bs.map[b]!, initialB, #file, #line)]
+    await del.setExpected([(b, bs.map[b]!, initialB, #file, #line)])
     await bsm.registerForChangeNotifications(for: b, language: .swift)
     try await fulfillmentOfOrThrow([initialB])
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["xx"])
     bs.map[b] = FileBuildSettings(compilerArguments: ["yy"])
     let changed = expectation(description: "changed settings")
-    del.expected = [(a, bs.map[a]!, changed, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
     try await fulfillmentOfOrThrow([changed])
 
@@ -204,10 +204,10 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[b] = FileBuildSettings(compilerArguments: ["yyy"])
     let changedBothA = expectation(description: "changed setting a")
     let changedBothB = expectation(description: "changed setting b")
-    del.expected = [
+    await del.setExpected([
       (a, bs.map[a]!, changedBothA, #file, #line),
       (b, bs.map[b]!, changedBothB, #file, #line),
-    ]
+    ])
     bsm.fileBuildSettingsChanged([
       a:. modified(bs.map[a]!),
       b: .modified(bs.map[b]!)
@@ -232,19 +232,19 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[b] = FileBuildSettings(compilerArguments: ["b"])
 
     let initialA = expectation(description: "initial settings a")
-    del.expected = [(a, bs.map[a]!, initialA, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, initialA, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initialA])
 
     let initialB = expectation(description: "initial settings b")
-    del.expected = [(b, bs.map[b]!, initialB, #file, #line)]
+    await del.setExpected([(b, bs.map[b]!, initialB, #file, #line)])
     await bsm.registerForChangeNotifications(for: b, language: .swift)
     try await fulfillmentOfOrThrow([initialB])
 
     bs.map[a] = nil
     bs.map[b] = nil
     let changed = expectation(description: "changed settings")
-    del.expected = [(b, nil, changed, #file, #line)]
+    await del.setExpected([(b, nil, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([
       b: .removedOrUnavailable
     ])
@@ -274,20 +274,20 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[cpp2] = FileBuildSettings(compilerArguments: ["C++ 2"])
 
     let initial = expectation(description: "initial settings via cpp1")
-    del.expected = [(h, bs.map[cpp1]!, initial, #file, #line)]
+    await del.setExpected([(h, bs.map[cpp1]!, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: h, language: .c)
     try await fulfillmentOfOrThrow([initial])
 
     mainFiles.mainFiles[h] = Set([cpp2])
 
     let changed = expectation(description: "changed settings to cpp2")
-    del.expected = [(h, bs.map[cpp2]!, changed, #file, #line)]
+    await del.setExpected([(h, bs.map[cpp2]!, changed, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed])
 
     let changed2 = expectation(description: "still cpp2, no update")
     changed2.isInverted = true
-    del.expected = [(h, nil, changed2, #file, #line)]
+    await del.setExpected([(h, nil, changed2, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed2], timeout: 1)
 
@@ -295,14 +295,14 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let changed3 = expectation(description: "added main file, no update")
     changed3.isInverted = true
-    del.expected = [(h, nil, changed3, #file, #line)]
+    await del.setExpected([(h, nil, changed3, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed3], timeout: 1)
 
     mainFiles.mainFiles[h] = Set([])
 
     let changed4 = expectation(description: "changed settings to []")
-    del.expected = [(h, nil, changed4, #file, #line)]
+    await del.setExpected([(h, nil, changed4, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed4])
   }
@@ -332,10 +332,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let initial2 = expectation(description: "initial settings h2 via cpp")
     let expectedArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h1.pseudoPath])
     let expectedArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h2.pseudoPath])
-    del.expected = [
+    await del.setExpected([
       (h1, expectedArgsH1, initial1, #file, #line),
       (h2, expectedArgsH2, initial2, #file, #line),
-    ]
+    ])
 
     await bsm.registerForChangeNotifications(for: h1, language: .c)
     await bsm.registerForChangeNotifications(for: h2, language: .c)
@@ -350,10 +350,10 @@ final class BuildSystemManagerTests: XCTestCase {
     let changed2 = expectation(description: "initial settings h2 via cpp")
     let newArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", newCppArg, h1.pseudoPath])
     let newArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", newCppArg, h2.pseudoPath])
-    del.expected = [
+    await del.setExpected([
       (h1, newArgsH1, changed1, #file, #line),
       (h2, newArgsH2, changed2, #file, #line),
-    ]
+    ])
     bsm.fileBuildSettingsChanged([cpp: .modified(bs.map[cpp]!)])
 
     try await fulfillmentOfOrThrow([changed1, changed2])
@@ -380,11 +380,11 @@ final class BuildSystemManagerTests: XCTestCase {
     let initialA = expectation(description: "initial settings a")
     let initialB = expectation(description: "initial settings b")
     let initialC = expectation(description: "initial settings c")
-    del.expected = [
+    await del.setExpected([
       (a, bs.map[a]!, initialA, #file, #line),
       (b, bs.map[b]!, initialB, #file, #line),
       (c, bs.map[c]!, initialC, #file, #line),
-    ]
+    ])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     await bsm.registerForChangeNotifications(for: b, language: .swift)
     await bsm.registerForChangeNotifications(for: c, language: .swift)
@@ -395,9 +395,9 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[c] = FileBuildSettings(compilerArguments: ["new-c"])
 
     let changedB = expectation(description: "changed settings b")
-    del.expected = [
+    await del.setExpected([
       (b, bs.map[b]!, changedB, #file, #line),
-    ]
+    ])
 
     await bsm.unregisterForChangeNotifications(for: a)
     await bsm.unregisterForChangeNotifications(for: c)
@@ -434,16 +434,16 @@ final class BuildSystemManagerTests: XCTestCase {
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let initial = expectation(description: "initial settings")
-    del.expected = [(a, bs.map[a]!, initial, #file, #line)]
+    await del.setExpected([(a, bs.map[a]!, initial, #file, #line)])
 
     let depUpdate1 = expectation(description: "dependencies update during registration")
-    del.expectedDependenciesUpdate = [(a, depUpdate1, #file, #line)]
+    await del.setExpectedDependenciesUpdate([(a, depUpdate1, #file, #line)])
 
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial, depUpdate1])
 
     let depUpdate2 = expectation(description: "dependencies update 2")
-    del.expectedDependenciesUpdate = [(a, depUpdate2, #file, #line)]
+    await del.setExpectedDependenciesUpdate([(a, depUpdate2, #file, #line)])
 
     bsm.filesDependenciesUpdated([a])
     try await fulfillmentOfOrThrow([depUpdate2])
@@ -507,45 +507,59 @@ class ManualBuildSystem: BuildSystem {
 }
 
 /// A `BuildSystemDelegate` setup for testing.
-private final class BSMDelegate: BuildSystemDelegate {
+private actor BSMDelegate: BuildSystemDelegate {
+  fileprivate typealias ExpectedBuildSettingChangedCall = (uri: DocumentURI, settings: FileBuildSettings?, expectation: XCTestExpectation, file: StaticString, line: UInt)
+  fileprivate typealias ExpectedDependenciesUpdatedCall = (uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt)
+
   let queue: DispatchQueue = DispatchQueue(label: "\(BSMDelegate.self)")
   unowned let bsm: BuildSystemManager
-  var expected: [(uri: DocumentURI, settings: FileBuildSettings?, expectation: XCTestExpectation, file: StaticString, line: UInt)] = []
+  var expected: [ExpectedBuildSettingChangedCall] = []
+
+  /// - Note: Needed to set `expected` outside of the actor's isolation context.
+  func setExpected(_ expected: [ExpectedBuildSettingChangedCall]) {
+    self.expected = expected
+  }
+
   var expectedDependenciesUpdate: [(uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt)] = []
+
+  /// - Note: Needed to set `expected` outside of the actor's isolation context.
+  func setExpectedDependenciesUpdate(_ expectedDependenciesUpdated: [ExpectedDependenciesUpdatedCall]) {
+    self.expectedDependenciesUpdate = expectedDependenciesUpdated
+  }
 
   init(_ bsm: BuildSystemManager) async {
     self.bsm = bsm
-    await bsm.setDelegate(self)
+    // Actor initializers can't directly leave their executor. Moving the call
+    // of `bsm.setDelegate` into a closure works around that limitation. rdar://116221716
+    await {
+      await bsm.setDelegate(self)
+    }()
   }
 
   func fileBuildSettingsChanged(_ changes: [DocumentURI: FileBuildSettingsChange]) {
-    queue.sync {
-      for (uri, change) in changes {
-        guard let expected = expected.first(where: { $0.uri == uri }) else {
-          XCTFail("unexpected settings change for \(uri)")
-          continue
-        }
-
-        XCTAssertEqual(uri, expected.uri, file: expected.file, line: expected.line)
-        let settings = change.newSettings
-        XCTAssertEqual(settings, expected.settings, file: expected.file, line: expected.line)
-        expected.expectation.fulfill()
+    for (uri, change) in changes {
+      guard let expected = expected.first(where: { $0.uri == uri }) else {
+        XCTFail("unexpected settings change for \(uri)")
+        continue
       }
+
+      XCTAssertEqual(uri, expected.uri, file: expected.file, line: expected.line)
+      let settings = change.newSettings
+      XCTAssertEqual(settings, expected.settings, file: expected.file, line: expected.line)
+      expected.expectation.fulfill()
     }
   }
 
   func buildTargetsChanged(_ changes: [BuildTargetEvent]) {}
   func filesDependenciesUpdated(_ changedFiles: Set<DocumentURI>) {
-    queue.sync {
-      for uri in changedFiles {
-        guard let expected = expectedDependenciesUpdate.first(where: { $0.uri == uri }) else {
-          XCTFail("unexpected filesDependenciesUpdated for \(uri)")
-          continue
-        }
-
-        XCTAssertEqual(uri, expected.uri, file: expected.file, line: expected.line)
-        expected.expectation.fulfill()
+    for uri in changedFiles {
+      guard let expected = expectedDependenciesUpdate.first(where: { $0.uri == uri }) else {
+        XCTFail("unexpected filesDependenciesUpdated for \(uri)")
+        continue
       }
+
+      XCTAssertEqual(uri, expected.uri, file: expected.file, line: expected.line)
+      expected.expectation.fulfill()
     }
   }
   

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -207,8 +207,8 @@ final class CompilationDatabaseTests: XCTestCase {
     ])
   }
 
-  func testCompilationDatabaseBuildSystem() throws {
-    try checkCompilationDatabaseBuildSystem("""
+  func testCompilationDatabaseBuildSystem() async throws {
+    try await checkCompilationDatabaseBuildSystem("""
     [
       {
         "file": "/a/a.swift",
@@ -217,23 +217,23 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      let settings = buildSystem._settings(for: DocumentURI(URL(fileURLWithPath: "/a/a.swift")))
+      let settings = await buildSystem._settings(for: DocumentURI(URL(fileURLWithPath: "/a/a.swift")))
       XCTAssertNotNil(settings)
       XCTAssertEqual(settings?.workingDirectory, "/a")
       XCTAssertEqual(settings?.compilerArguments, ["-swift-version", "4", "/a/a.swift"])
-      XCTAssertNil(buildSystem.indexStorePath)
-      XCTAssertNil(buildSystem.indexDatabasePath)
+      assertNil(await buildSystem.indexStorePath)
+      assertNil(await buildSystem.indexDatabasePath)
     }
   }
 
-  func testCompilationDatabaseBuildSystemIndexStoreSwift0() throws {
-    try checkCompilationDatabaseBuildSystem("[]") { buildSystem in
-      XCTAssertNil(buildSystem.indexStorePath)
+  func testCompilationDatabaseBuildSystemIndexStoreSwift0() async throws {
+    try await checkCompilationDatabaseBuildSystem("[]") { buildSystem in
+      assertNil(await buildSystem.indexStorePath)
     }
   }
 
-  func testCompilationDatabaseBuildSystemIndexStoreSwift1() throws {
-    try checkCompilationDatabaseBuildSystem("""
+  func testCompilationDatabaseBuildSystemIndexStoreSwift1() async throws {
+    try await checkCompilationDatabaseBuildSystem("""
     [
       {
         "file": "/a/a.swift",
@@ -242,13 +242,13 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexStorePath?.pathString ?? "").path, "/b")
-      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
+      assertEqual(URL(fileURLWithPath: await buildSystem.indexStorePath?.pathString ?? "").path, "/b")
+      assertEqual(URL(fileURLWithPath: await buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
     }
   }
 
-  func testCompilationDatabaseBuildSystemIndexStoreSwift2() throws {
-    try checkCompilationDatabaseBuildSystem("""
+  func testCompilationDatabaseBuildSystemIndexStoreSwift2() async throws {
+    try await checkCompilationDatabaseBuildSystem("""
     [
       {
         "file": "/a/a.swift",
@@ -267,12 +267,12 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertEqual(buildSystem.indexStorePath, try AbsolutePath(validating: "/b"))
+      await assertEqual(buildSystem.indexStorePath, try AbsolutePath(validating: "/b"))
     }
   }
 
-  func testCompilationDatabaseBuildSystemIndexStoreSwift3() throws {
-    try checkCompilationDatabaseBuildSystem("""
+  func testCompilationDatabaseBuildSystemIndexStoreSwift3() async throws {
+    try await checkCompilationDatabaseBuildSystem("""
     [
       {
         "file": "/a/a.swift",
@@ -281,12 +281,12 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertEqual(buildSystem.indexStorePath, try AbsolutePath(validating: "/b"))
+      assertEqual(await buildSystem.indexStorePath, try AbsolutePath(validating: "/b"))
     }
   }
 
-  func testCompilationDatabaseBuildSystemIndexStoreSwift4() throws {
-    try checkCompilationDatabaseBuildSystem("""
+  func testCompilationDatabaseBuildSystemIndexStoreSwift4() async throws {
+    try await checkCompilationDatabaseBuildSystem("""
     [
       {
         "file": "/a/a.swift",
@@ -295,12 +295,12 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertNil(buildSystem.indexStorePath)
+      assertNil(await buildSystem.indexStorePath)
     }
   }
 
-  func testCompilationDatabaseBuildSystemIndexStoreClang() throws {
-    try checkCompilationDatabaseBuildSystem("""
+  func testCompilationDatabaseBuildSystemIndexStoreClang() async throws {
+    try await checkCompilationDatabaseBuildSystem("""
     [
       {
         "file": "/a/a.cpp",
@@ -319,16 +319,16 @@ final class CompilationDatabaseTests: XCTestCase {
       }
     ]
     """) { buildSystem in
-      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexStorePath?.pathString ?? "").path, "/b")
-      XCTAssertEqual(URL(fileURLWithPath: buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
+      assertEqual(URL(fileURLWithPath: await buildSystem.indexStorePath?.pathString ?? "").path, "/b")
+      assertEqual(URL(fileURLWithPath: await buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
     }
   }
 }
 
-private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, block: (CompilationDatabaseBuildSystem) throws -> ()) throws {
+private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, block: (CompilationDatabaseBuildSystem) async throws -> ()) async throws {
   let fs = InMemoryFileSystem()
   try fs.createDirectory(AbsolutePath(validating: "/a"))
   try fs.writeFileContents(AbsolutePath(validating: "/a/compile_commands.json"), bytes: compdb)
   let buildSystem = CompilationDatabaseBuildSystem(projectRoot: try AbsolutePath(validating: "/a"), fileSystem: fs)
-  try block(buildSystem)
+  try await block(buildSystem)
 }

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -21,20 +21,21 @@ import SKSwiftPMWorkspace
 import SKTestSupport
 import TSCBasic
 import XCTest
+import LSPTestSupport
 
 import struct PackageModel.BuildFlags
 
 final class SwiftPMWorkspaceTests: XCTestCase {
 
-  func testNoPackage() throws {
+  func testNoPackage() async throws {
     let fs = InMemoryFileSystem()
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
       ])
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.shared
-      XCTAssertThrowsError(try SwiftPMWorkspace(
+      await assertThrowsError(try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -42,9 +43,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testUnparsablePackage() throws {
+  func testUnparsablePackage() async throws {
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
@@ -55,7 +56,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.shared
-      XCTAssertThrowsError(try SwiftPMWorkspace(
+      await assertThrowsError(try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -63,9 +64,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testNoToolchain() throws {
+  func testNoToolchain() async throws {
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
@@ -76,7 +77,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
             """
       ])
       let packageRoot = tempDir.appending(component: "pkg")
-      XCTAssertThrowsError(try SwiftPMWorkspace(
+      await assertThrowsError(try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry(),
         fileSystem: fs,
@@ -84,10 +85,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testBasicSwiftArgs() throws {
+  func testBasicSwiftArgs() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
@@ -99,19 +100,19 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let hostTriple = ws.buildParameters.targetTriple
+      let hostTriple = await ws.buildParameters.targetTriple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
-      XCTAssertEqual(ws.buildPath, build)
-      XCTAssertNotNil(ws.indexStorePath)
-      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      assertEqual(await ws.buildPath, build)
+      assertNotNil(await ws.indexStorePath)
+      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
 
       check(
         "-module-name", "lib", "-incremental", "-emit-dependencies",
@@ -134,10 +135,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testBuildSetup() throws {
+  func testBuildSetup() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
@@ -155,18 +156,18 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           path: packageRoot.appending(component: "non_default_build_path"),
           flags: BuildFlags(cCompilerFlags: ["-m32"], swiftCompilerFlags: ["-typecheck"]))
 
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: config)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let hostTriple = ws.buildParameters.targetTriple
+      let hostTriple = await ws.buildParameters.targetTriple
       let build = buildPath(root: packageRoot, config: config, platform: hostTriple.platformBuildPathComponent)
 
-      XCTAssertEqual(ws.buildPath, build)
-      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      assertEqual(await ws.buildPath, build)
+      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
 
       check("-typecheck", arguments: arguments)
       check("-Xcc", "-m32", arguments: arguments)
@@ -174,10 +175,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testManifestArgs() throws {
+  func testManifestArgs() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
@@ -189,24 +190,24 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
-      let arguments = try ws._settings(for: source.asURI, .swift)!.compilerArguments
+      let arguments = try await ws._settings(for: source.asURI, .swift)!.compilerArguments
 
       check("-swift-version", "4.2", arguments: arguments)
       check(source.pathString, arguments: arguments)
     }
   }
 
-  func testMultiFileSwift() throws {
+  func testMultiFileSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Sources/lib/b.swift": "",
@@ -219,7 +220,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -228,19 +229,19 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
 
-      let argumentsA = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let argumentsA = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: argumentsA)
       check(bswift.pathString, arguments: argumentsA)
-      let argumentsB = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let argumentsB = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: argumentsB)
       check(bswift.pathString, arguments: argumentsB)
     }
   }
 
-  func testMultiTargetSwift() throws {
+  func testMultiTargetSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/libA/a.swift": "",
         "pkg/Sources/libB/b.swift": "",
@@ -259,7 +260,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -267,7 +268,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       checkNot(bswift.pathString, arguments: arguments)
       // Temporary conditional to work around revlock between SourceKit-LSP and SwiftPM
@@ -283,7 +284,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           arguments: arguments)
       }
 
-      let argumentsB = try ws._settings(for: bswift.asURI, .swift)!.compilerArguments
+      let argumentsB = try await ws._settings(for: bswift.asURI, .swift)!.compilerArguments
       check(bswift.pathString, arguments: argumentsB)
       checkNot(aswift.pathString, arguments: argumentsB)
       checkNot("-I", packageRoot.appending(components: "Sources", "libC", "include").pathString,
@@ -291,10 +292,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testUnknownFile() throws {
+  func testUnknownFile() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/libA/a.swift": "",
         "pkg/Sources/libB/b.swift": "",
@@ -309,7 +310,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -317,16 +318,16 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      XCTAssertNotNil(try ws._settings(for: aswift.asURI, .swift))
-      XCTAssertNil(try ws._settings(for: bswift.asURI, .swift))
-      XCTAssertNil(try ws._settings(for: DocumentURI(URL(string: "https://www.apple.com")!), .swift))
+      assertNotNil(try await ws._settings(for: aswift.asURI, .swift))
+      assertNil(try await ws._settings(for: bswift.asURI, .swift))
+      assertNil(try await ws._settings(for: DocumentURI(URL(string: "https://www.apple.com")!), .swift))
     }
   }
 
-  func testBasicCXXArgs() throws {
+  func testBasicCXXArgs() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.cpp": "",
         "pkg/Sources/lib/b.cpp": "",
@@ -341,7 +342,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -349,11 +350,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let bcxx = packageRoot.appending(components: "Sources", "lib", "b.cpp")
-      let hostTriple = ws.buildParameters.targetTriple
+      let hostTriple = await ws.buildParameters.targetTriple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
-      XCTAssertEqual(ws.buildPath, build)
-      XCTAssertNotNil(ws.indexStorePath)
+      assertEqual(await ws.buildPath, build)
+      assertNotNil(await ws.indexStorePath)
 
       let checkArgsCommon = { (arguments: [String]) in
         check("-std=c++14", arguments: arguments)
@@ -376,7 +377,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         checkNot(bcxx.pathString, arguments: arguments)
       }
 
-      let args = try ws._settings(for: acxx.asURI, .cpp)!.compilerArguments
+      let args = try await ws._settings(for: acxx.asURI, .cpp)!.compilerArguments
       checkArgsCommon(args)
 
       URL(fileURLWithPath: build.appending(components: "lib.build", "a.cpp.d").pathString)
@@ -394,7 +395,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       }
 
       let header = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
-      let headerArgs = try ws._settings(for: header.asURI, .cpp)!.compilerArguments
+      let headerArgs = try await ws._settings(for: header.asURI, .cpp)!.compilerArguments
       checkArgsCommon(headerArgs)
 
       check("-c", "-x", "c++-header", try AbsolutePath(validating: URL(fileURLWithPath: header.pathString).path).pathString,
@@ -402,10 +403,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testDeploymentTargetSwift() throws {
+  func testDeploymentTargetSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Package.swift": """
@@ -418,16 +419,16 @@ final class SwiftPMWorkspaceTests: XCTestCase {
             """
       ])
       let packageRoot = tempDir.appending(component: "pkg")
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.shared,
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check("-target", arguments: arguments) // Only one!
-      let hostTriple = ws.buildParameters.targetTriple
+      let hostTriple = await ws.buildParameters.targetTriple
 
       #if os(macOS)
         check("-target",
@@ -438,10 +439,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testSymlinkInWorkspaceSwift() throws {
+  func testSymlinkInWorkspaceSwift() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg_real/Sources/lib/a.swift": "",
         "pkg_real/Package.swift": """
@@ -458,7 +459,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString))
 
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -470,8 +471,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         .appending(components: "Sources", "lib", "a.swift")
       let manifest = packageRoot.appending(components: "Package.swift")
 
-      let arguments1 = try ws._settings(for: aswift1.asURI, .swift)?.compilerArguments
-      let arguments2 = try ws._settings(for: aswift2.asURI, .swift)?.compilerArguments
+      let arguments1 = try await ws._settings(for: aswift1.asURI, .swift)?.compilerArguments
+      let arguments2 = try await ws._settings(for: aswift2.asURI, .swift)?.compilerArguments
       XCTAssertNotNil(arguments1)
       XCTAssertNotNil(arguments2)
       XCTAssertEqual(arguments1, arguments2)
@@ -479,7 +480,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       checkNot(aswift1.pathString, arguments: arguments1 ?? [])
       check(try resolveSymlinks(aswift1).pathString, arguments: arguments1 ?? [])
 
-      let argsManifest = try ws._settings(for: manifest.asURI, .swift)?.compilerArguments
+      let argsManifest = try await ws._settings(for: manifest.asURI, .swift)?.compilerArguments
       XCTAssertNotNil(argsManifest)
 
       checkNot(manifest.pathString, arguments: argsManifest ?? [])
@@ -487,10 +488,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testSymlinkInWorkspaceCXX() throws {
+  func testSymlinkInWorkspaceCXX() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg_real/Sources/lib/a.cpp": "",
         "pkg_real/Sources/lib/b.cpp": "",
@@ -511,7 +512,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString))
 
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -520,22 +521,22 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let ah = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
 
-      let argsCxx = try ws._settings(for: acxx.asURI, .cpp)?.compilerArguments
+      let argsCxx = try await ws._settings(for: acxx.asURI, .cpp)?.compilerArguments
       XCTAssertNotNil(argsCxx)
       check(acxx.pathString, arguments: argsCxx ?? [])
       checkNot(try resolveSymlinks(acxx).pathString, arguments: argsCxx ?? [])
 
-      let argsH = try ws._settings(for: ah.asURI, .cpp)?.compilerArguments
+      let argsH = try await ws._settings(for: ah.asURI, .cpp)?.compilerArguments
       XCTAssertNotNil(argsH)
       checkNot(ah.pathString, arguments: argsH ?? [])
       check(try resolveSymlinks(ah).pathString, arguments: argsH ?? [])
     }
   }
 
-  func testSwiftDerivedSources() throws {
+  func testSwiftDerivedSources() async throws {
     // FIXME: should be possible to use InMemoryFileSystem.
     let fs = localFileSystem
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/a.swift": "",
         "pkg/Sources/lib/a.txt": "",
@@ -552,14 +553,14 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try ws._settings(for: aswift.asURI, .swift)!.compilerArguments
+      let arguments = try await ws._settings(for: aswift.asURI, .swift)!.compilerArguments
       check(aswift.pathString, arguments: arguments)
       XCTAssertNotNil(arguments.firstIndex(where: {
           $0.hasSuffix(".swift") && $0.contains("DerivedSources")
@@ -567,9 +568,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
     }
   }
 
-  func testNestedInvalidPackageSwift() throws {
+  func testNestedInvalidPackageSwift() async throws {
     let fs = InMemoryFileSystem()
-    try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+    try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       try fs.createFiles(root: tempDir, files: [
         "pkg/Sources/lib/Package.swift": "// not a valid package",
         "pkg/Package.swift": """
@@ -581,13 +582,13 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       ])
       let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
       let tr = ToolchainRegistry.shared
-      let ws = try SwiftPMWorkspace(
+      let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: TestSourceKitServer.serverOptions.buildSetup)
 
-      XCTAssertEqual(ws._packageRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
+      assertEqual(await ws._packageRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
     }
   }
 }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -37,6 +37,10 @@ final class TestBuildSystem: BuildSystem {
 
   weak var delegate: BuildSystemDelegate?
 
+  public func setDelegate(_ delegate: BuildSystemDelegate?) async {
+    self.delegate = delegate
+  }
+
   /// Build settings by file.
   var buildSettingsByFile: [DocumentURI: FileBuildSettings] = [:]
 
@@ -106,7 +110,7 @@ final class BuildSystemTests: XCTestCase {
 
       let server = testServer.server!
 
-      self.workspace = Workspace(
+      self.workspace = await Workspace(
         documentManager: DocumentManager(),
         rootUri: nil,
         capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -118,7 +118,7 @@ final class BuildSystemTests: XCTestCase {
 
 
       await server.setWorkspaces([workspace])
-      workspace.buildSystemManager.delegate = server
+      await workspace.buildSystemManager.setDelegate(server)
 
       sk = testServer.client
       _ = try! sk.sendSync(InitializeRequest(

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -60,8 +60,8 @@ final class TestBuildSystem: BuildSystem {
       return
     }
 
-    DispatchQueue.global().async {
-      delegate.fileBuildSettingsChanged([uri: .modified(settings)])
+    Task {
+      await delegate.fileBuildSettingsChanged([uri: .modified(settings)])
     }
   }
 
@@ -196,7 +196,7 @@ final class BuildSystemTests: XCTestCase {
       expectation.fulfill()
     }
 
-    buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -251,7 +251,7 @@ final class BuildSystemTests: XCTestCase {
       XCTAssertEqual(note.params.diagnostics.count, 0)
       expectation.fulfill()
     }
-    buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -304,7 +304,7 @@ final class BuildSystemTests: XCTestCase {
       expectation.fulfill()
     }
 
-    buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -358,7 +358,7 @@ final class BuildSystemTests: XCTestCase {
       XCTAssertEqual(note.params.diagnostics.count, 2)
       expectation.fulfill()
     }
-    buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(primarySettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(primarySettings)])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -388,7 +388,7 @@ final class BuildSystemTests: XCTestCase {
 
     // Modify the build settings and inform the SourceKitServer.
     // This shouldn't trigger new diagnostics since nothing actually changed (false alarm).
-    buildSystem.delegate?.fileBuildSettingsChanged([doc: .removedOrUnavailable])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .removedOrUnavailable])
 
     let expectation = XCTestExpectation(description: "refresh doesn't occur")
     expectation.isInverted = true


### PR DESCRIPTION
This is the last big piece for actorification of the codebase. All follow-up PRs should be about cleaning things up.