### PR TITLE
Fix the `--sync` option of sourcekit-lsp

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -286,14 +286,22 @@ public final class JSONRPCConnection {
         await notification._handle(self.receiveHandler!, connection: self)
       }
     case .request(let request, id: let id):
-      let semaphore: DispatchSemaphore? = syncRequests ? .init(value: 0) : nil
       messageHandlingQueue.async {
-        await request._handle(self.receiveHandler!, id: id, connection: self) { (response, id) in
-          self.sendReply(response, id: id)
+        if self.syncRequests {
+          await withCheckedContinuation { continuation in
+            Task {
+              await request._handle(self.receiveHandler!, id: id, connection: self) { (response, id) in
+                self.sendReply(response, id: id)
+                continuation.resume()
+              }
+            }
+          }
+        } else {
+          await request._handle(self.receiveHandler!, id: id, connection: self) { (response, id) in
+            self.sendReply(response, id: id)
+          }
         }
-        semaphore?.signal()
       }
-      semaphore?.wait()
 
     case .response(let response, id: let id):
       guard let outstanding = outstandingRequests.removeValue(forKey: id) else {


### PR DESCRIPTION
We were waiting for the semaphores outside of the `messageHandlingQueue`, which means that we didn’t actually block the message handling queue until the previous request received a result, effectively rendering `--sync` useless.