### PR TITLE
Move semaphore signaling to block main thread until request has received a reply instead of until it has been handled

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -290,8 +290,8 @@ public final class JSONRPCConnection {
       messageHandlingQueue.async {
         await request._handle(self.receiveHandler!, id: id, connection: self) { (response, id) in
           self.sendReply(response, id: id)
+          semaphore?.signal()
         }
-        semaphore?.signal()
       }
       semaphore?.wait()
 


### PR DESCRIPTION
This was causing the sourcekit-lsp integration test to fail.