### PR TITLE
Keep track of build settings in `BuildSystemManager` instead of `SourceKitServer`

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -202,11 +202,7 @@ public actor BuildServerBuildSystem: MessageHandler {
   /// about the changed build settings.
   private func buildSettingsChanged(for document: DocumentURI, settings: FileBuildSettings?) async {
     buildSettings[document] = settings
-    if let settings {
-      await self.delegate?.fileBuildSettingsChanged([document: .modified(settings)])
-    } else {
-      await self.delegate?.fileBuildSettingsChanged([document: .removedOrUnavailable])
-    }
+    await self.delegate?.fileBuildSettingsChanged([document])
   }
 }
 

--- a/Sources/SKCore/BuildSystemDelegate.swift
+++ b/Sources/SKCore/BuildSystemDelegate.swift
@@ -21,11 +21,7 @@ public protocol BuildSystemDelegate: AnyObject {
   func buildTargetsChanged(_ changes: [BuildTargetEvent]) async
 
   /// Notify the delegate that the given files' build settings have changed.
-  ///
-  /// The delegate should cache the new build settings for any of the given
-  /// files that they are interested in.
-  func fileBuildSettingsChanged(
-    _ changedFiles: [DocumentURI: FileBuildSettingsChange]) async
+  func fileBuildSettingsChanged(_ changedFiles: Set<DocumentURI>) async
 
   /// Notify the delegate that the dependencies of the given files have changed
   /// and that ASTs may need to be refreshed. If the given set is empty, assume

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -210,10 +210,8 @@ extension BuildSystemManager {
 
     let newStatus = await self.cachedStatusOrRegisterForSettings(for: mainFile, language: language)
 
-    if let mainChange = newStatus.buildSettingsChange,
-       let delegate = self._delegate {
-      let change = self.convert(change: mainChange, ofMainFile: mainFile, to: uri)
-      await delegate.fileBuildSettingsChanged([uri: change])
+    if newStatus.buildSettingsChange != nil, let delegate = self._delegate {
+      await delegate.fileBuildSettingsChanged([uri])
     }
   }
 
@@ -294,7 +292,7 @@ extension BuildSystemManager {
   /// Update and notify our delegate for the given main file changes if they are
   /// convertible into `FileBuildSettingsChange`.
   func updateAndNotifyStatuses(changes: [DocumentURI: MainFileStatus]) async {
-    var changedWatchedFiles = [DocumentURI: FileBuildSettingsChange]()
+    var changedWatchedFiles = Set<DocumentURI>()
     for (mainFile, status) in changes {
       let watches = self.watchedFiles.filter { $1.mainFile == mainFile }
       guard !watches.isEmpty else {
@@ -310,12 +308,11 @@ extension BuildSystemManager {
       guard prevStatus == .waiting || status.buildSettings != prevStatus?.buildSettings else {
         continue
       }
-      if let change = status.buildSettingsChange {
-        for watch in watches {
-          let newChange =
-            self.convert(change: change, ofMainFile: mainFile, to: watch.key)
-          changedWatchedFiles[watch.key] = newChange
-        }
+      guard status.buildSettingsChange != nil else {
+        continue
+      }
+      for watch in watches {
+        changedWatchedFiles.insert(watch.key)
       }
     }
 
@@ -374,26 +371,26 @@ extension BuildSystemManager {
 
 extension BuildSystemManager: BuildSystemDelegate {
   // FIXME: (async) Make this method isolated once `BuildSystemDelegate` has ben asyncified
-  public nonisolated func fileBuildSettingsChanged(_ changes: [DocumentURI: FileBuildSettingsChange]) {
+  public nonisolated func fileBuildSettingsChanged(_ changes: Set<DocumentURI>) {
     Task {
       await fileBuildSettingsChangedImpl(changes)
     }
   }
 
-  public func fileBuildSettingsChangedImpl(_ changes: [DocumentURI: FileBuildSettingsChange]) async {
-    let statusChanges: [DocumentURI: MainFileStatus] =
-        changes.reduce(into: [:]) { (result, entry) in
-      let mainFile = entry.key
-      let settingsChange = entry.value
+  public func fileBuildSettingsChangedImpl(_ changes: Set<DocumentURI>) async {
+    var statusChanges: [DocumentURI: MainFileStatus] = [:]
+    for mainFile in changes {
       let watches = self.watchedFiles.filter { $1.mainFile == mainFile }
       guard let firstWatch = watches.first else {
         // Possible notification after the file was unregistered. Ignore.
-        return
+        continue
       }
       let newStatus: MainFileStatus
 
-      if let newSettings = settingsChange.newSettings {
-        newStatus = settingsChange.isFallback ? .fallback(newSettings) : .primary(newSettings)
+      let settings = await self.buildSettings(for: mainFile, language: firstWatch.value.language)
+
+      if let settings {
+        newStatus = settings.isFallback ? .fallback(settings.buildSettings) : .primary(settings.buildSettings)
       } else if let fallback = self.fallbackBuildSystem {
         // FIXME: we need to stop threading the language everywhere, or we need the build system
         // itself to pass it in here. Or alternatively cache the fallback settings/language earlier?
@@ -406,7 +403,7 @@ extension BuildSystemManager: BuildSystemDelegate {
       } else {
         newStatus = .unsupported
       }
-      result[mainFile] = newStatus
+      statusChanges[mainFile] = newStatus
     }
     await self.updateAndNotifyStatuses(changes: statusChanges)
   }
@@ -474,7 +471,7 @@ extension BuildSystemManager: MainFilesDelegate {
   public func mainFilesChangedImpl() async {
     let origWatched = self.watchedFiles
     self.watchedFiles = [:]
-    var buildSettingsChanges = [DocumentURI: FileBuildSettingsChange]()
+    var buildSettingsChanges = Set<DocumentURI>()
 
     for (uri, state) in origWatched {
       let mainFiles = self._mainFilesProvider?.mainFilesContainingFile(uri) ?? []
@@ -489,9 +486,8 @@ extension BuildSystemManager: MainFilesDelegate {
 
         let newStatus = await self.cachedStatusOrRegisterForSettings(
             for: newMainFile, language: language)
-        if let change = newStatus.buildSettingsChange {
-          let newChange = self.convert(change: change, ofMainFile: newMainFile, to: uri)
-          buildSettingsChanges[uri] = newChange
+        if newStatus.buildSettingsChange != nil {
+          buildSettingsChanges.insert(uri)
         }
       }
     }

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -148,16 +148,7 @@ extension BuildSystemManager {
     self.mainFilesProvider = mainFilesProvider
   }
 
-  /// Get the build settings for the given document, assuming it has the given
-  /// language.
-  ///
-  /// Returns `nil` if no build settings are available in the build system and
-  /// no fallback build settings can be computed.
-  ///
-  /// `isFallback` is `true` if the build settings couldn't be computed and
-  /// fallback settings are used. These fallback settings are most likely not
-  /// correct and provide limited semantic functionality.
-  public func buildSettings(
+  private func buildSettings(
     for document: DocumentURI,
     language: Language
   ) async -> (buildSettings: FileBuildSettings, isFallback: Bool)? {

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -93,10 +93,6 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
 
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {
     self.watchedFiles[uri] = language
-
-    guard let delegate = self.delegate else { return }
-
-    await delegate.fileBuildSettingsChanged([uri])
   }
 
   /// We don't support change watching.

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -96,8 +96,7 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
 
     guard let delegate = self.delegate else { return }
 
-    let settings = self.settings(for: uri)
-    await delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
+    await delegate.fileBuildSettingsChanged([uri])
   }
 
   /// We don't support change watching.
@@ -148,13 +147,9 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     self.compdb = tryLoadCompilationDatabase(directory: projectRoot, self.fileSystem)
 
     if let delegate = self.delegate {
-      var changedFiles: [DocumentURI: FileBuildSettingsChange] = [:]
+      var changedFiles = Set<DocumentURI>()
       for (uri, _) in self.watchedFiles {
-        if let settings = self.settings(for: uri) {
-          changedFiles[uri] = FileBuildSettingsChange(settings)
-        } else {
-          changedFiles[uri] = .removedOrUnavailable
-        }
+        changedFiles.insert(uri)
       }
       await delegate.fileBuildSettingsChanged(changedFiles)
     }

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -60,11 +60,7 @@ public final class FallbackBuildSystem: BuildSystem {
   }
 
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
-    guard let delegate = self.delegate else { return }
-
-    Task {
-      await delegate.fileBuildSettingsChanged([uri])
-    }
+    // Fallback build systems never change.
   }
 
   /// We don't support change watching.

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -62,9 +62,8 @@ public final class FallbackBuildSystem: BuildSystem {
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
     guard let delegate = self.delegate else { return }
 
-    let settings = self.buildSettings(for: uri, language: language)
     Task {
-      await delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
+      await delegate.fileBuildSettingsChanged([uri])
     }
   }
 

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -242,16 +242,7 @@ extension SwiftPMWorkspace {
     })
 
     guard let delegate = self.delegate else { return }
-    var changedFiles: [DocumentURI: FileBuildSettingsChange] = [:]
-    for (uri, language) in self.watchedFiles {
-      orLog {
-        if let settings = try self.buildSettings(for: uri, language: language) {
-          changedFiles[uri] = FileBuildSettingsChange(settings)
-        } else {
-          changedFiles[uri] = .removedOrUnavailable
-        }
-      }
-    }
+    let changedFiles = Set<DocumentURI>(self.watchedFiles.keys)
     await delegate.fileBuildSettingsChanged(changedFiles)
     await delegate.fileHandlingCapabilityChanged()
   }
@@ -316,11 +307,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
     } catch {
       log("error computing settings: \(error)")
     }
-    if let settings = settings {
-      await delegate.fileBuildSettingsChanged([uri: FileBuildSettingsChange(settings)])
-    } else {
-      await delegate.fileBuildSettingsChanged([uri: .removedOrUnavailable])
-    }
+    await delegate.fileBuildSettingsChanged([uri])
   }
 
   /// Unregister the given file for build-system level change notifications, such as command

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -298,16 +298,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {
     assert(self.watchedFiles[uri] == nil, "Registered twice for change notifications of the same URI")
-    guard let delegate = self.delegate else { return }
     self.watchedFiles[uri] = language
-
-    var settings: FileBuildSettings? = nil
-    do {
-      settings = try self.buildSettings(for: uri, language: language)
-    } catch {
-      log("error computing settings: \(error)")
-    }
-    await delegate.fileBuildSettingsChanged([uri])
   }
 
   /// Unregister the given file for build-system level change notifications, such as command

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -404,7 +404,7 @@ extension ClangLanguageServerShim {
     // Send clangd the build settings for the new file. We need to do this before
     // sending the open notification, so that the initial diagnostics already
     // have build settings.
-    await documentUpdatedBuildSettings(note.textDocument.uri, change: .removedOrUnavailable)
+    await documentUpdatedBuildSettings(note.textDocument.uri)
     clangd.send(note)
   }
 
@@ -427,7 +427,7 @@ extension ClangLanguageServerShim {
 
   // MARK: - Build System Integration
 
-  public func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) async {
+  public func documentUpdatedBuildSettings(_ uri: DocumentURI) async {
     guard let url = uri.fileURL else {
       // FIXME: The clang workspace can probably be reworked to support non-file URIs.
       log("Received updated build settings for non-file URI '\(uri)'. Ignoring the update.")

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -128,7 +128,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     guard let workspace = workspace.value, let language = openDocuments[document] else {
       return nil
     }
-    guard let settings = await workspace.buildSystemManager.buildSettings(for: document, language: language) else {
+    guard let settings = await workspace.buildSystemManager.buildSettingsInferredFromMainFile(for: document, language: language) else {
       return nil
     }
     return ClangBuildSettings(settings.buildSettings, clangPath: clangdPath, isFallback: settings.isFallback)

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -148,12 +148,6 @@ public actor SourceKitServer {
 
   var languageServices: [LanguageServerType: [ToolchainLanguageServer]] = [:]
 
-  /// Documents that are ready for requests and notifications.
-  /// This generally means that the `BuildSystem` has notified of us of build settings.
-  var documentsReady: Set<DocumentURI> = []
-
-  private var documentToPendingQueue: [DocumentURI: DocumentNotificationRequestQueue] = [:]
-
   private let documentManager = DocumentManager()
 
   private var packageLoadingWorkDoneProgress = WorkDoneProgressState("SourceKitLSP.SourceKitServer.reloadPackage", title: "Reloading Package")
@@ -221,10 +215,9 @@ public actor SourceKitServer {
     return bestWorkspace.workspace
   }
 
-  /// Execute `notificationHandler` once the document that it concerns is ready
-  /// and has the initial build settings. These build settings might still be
-  /// incomplete or fallback settings.
-  private func withReadyDocument<NotificationType: TextDocumentNotification>(
+  /// Execute `notificationHandler` with the request as well as the workspace
+  /// and language that handle this document.
+  private func withLanguageServiceAndWorkspace<NotificationType: TextDocumentNotification>(
     for notification: Notification<NotificationType>,
     notificationHandler: @escaping (Notification<NotificationType>, ToolchainLanguageServer) async -> Void
   ) async {
@@ -239,22 +232,15 @@ public actor SourceKitServer {
       return
     }
 
-    // If the document is ready, we can handle it right now.
-    guard !self.documentsReady.contains(doc) else {
-      await notificationHandler(notification, languageService)
-      return
-    }
-
-    // Not ready to handle it, we'll queue it and handle it later.
-    self.documentToPendingQueue[doc, default: DocumentNotificationRequestQueue()].add(operation: {
-      await notificationHandler(notification, languageService)
-    })
+    await notificationHandler(notification, languageService)
   }
 
-  /// Execute `notificationHandler` once the document that it concerns is ready
-  /// and has the initial build settings. These build settings might still be
-  /// incomplete or fallback settings.
-  private func withReadyDocument<RequestType: TextDocumentRequest>(
+  /// Execute `requestHandler` with the request as well as the workspace
+  /// and language that handle this document.
+  ///
+  /// If no language service exists for the document mentioned in the request,
+  /// reply with `fallback`.
+  private func withLanguageServiceAndWorkspace<RequestType: TextDocumentRequest>(
     for request: Request<RequestType>,
     requestHandler: @escaping (Request<RequestType>, Workspace, ToolchainLanguageServer) async -> Void,
     fallback: RequestType.Response
@@ -270,18 +256,7 @@ public actor SourceKitServer {
       return request.reply(fallback)
     }
 
-    // If the document is ready, we can handle it right now.
-    guard !self.documentsReady.contains(doc) else {
-      await requestHandler(request, workspace, languageService)
-      return
-    }
-
-    // Not ready to handle it, we'll queue it and handle it later.
-    self.documentToPendingQueue[doc, default: DocumentNotificationRequestQueue()].add(operation: {
-      await requestHandler(request, workspace, languageService)
-    }, cancellationHandler: {
-      request.reply(fallback)
-    })
+    await requestHandler(request, workspace, languageService)
   }
 
 
@@ -509,9 +484,9 @@ extension SourceKitServer: MessageHandler {
     case let notification as Notification<DidChangeWatchedFilesNotification>:
       await self.didChangeWatchedFiles(notification)
     case let notification as Notification<WillSaveTextDocumentNotification>:
-      await self.withReadyDocument(for: notification, notificationHandler: self.willSaveDocument)
+      await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.willSaveDocument)
     case let notification as Notification<DidSaveTextDocumentNotification>:
-      await self.withReadyDocument(for: notification, notificationHandler: self.didSaveDocument)
+      await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.didSaveDocument)
     default:
       self._handleUnknown(notification)
     }
@@ -550,47 +525,47 @@ extension SourceKitServer: MessageHandler {
     case let request as Request<TypeHierarchySubtypesRequest>:
       await self.subtypes(request)
     case let request as Request<CompletionRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
     case let request as Request<HoverRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.hover, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.hover, fallback: nil)
     case let request as Request<OpenInterfaceRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.openInterface, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.openInterface, fallback: nil)
     case let request as Request<DeclarationRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.declaration, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.declaration, fallback: nil)
     case let request as Request<DefinitionRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.definition, fallback: .locations([]))
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.definition, fallback: .locations([]))
     case let request as Request<ReferencesRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.references, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.references, fallback: [])
     case let request as Request<ImplementationRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.implementation, fallback: .locations([]))
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.implementation, fallback: .locations([]))
     case let request as Request<CallHierarchyPrepareRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.prepareCallHierarchy, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.prepareCallHierarchy, fallback: [])
     case let request as Request<TypeHierarchyPrepareRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.prepareTypeHierarchy, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.prepareTypeHierarchy, fallback: [])
     case let request as Request<SymbolInfoRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.symbolInfo, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.symbolInfo, fallback: [])
     case let request as Request<DocumentHighlightRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentSymbolHighlight, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSymbolHighlight, fallback: nil)
     case let request as Request<FoldingRangeRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.foldingRange, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.foldingRange, fallback: nil)
     case let request as Request<DocumentSymbolRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentSymbol, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSymbol, fallback: nil)
     case let request as Request<DocumentColorRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentColor, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentColor, fallback: [])
     case let request as Request<DocumentSemanticTokensRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokens, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokens, fallback: nil)
     case let request as Request<DocumentSemanticTokensDeltaRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokensDelta, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokensDelta, fallback: nil)
     case let request as Request<DocumentSemanticTokensRangeRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentSemanticTokensRange, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokensRange, fallback: nil)
     case let request as Request<ColorPresentationRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.colorPresentation, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.colorPresentation, fallback: [])
     case let request as Request<CodeActionRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.codeAction, fallback: nil)
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.codeAction, fallback: nil)
     case let request as Request<InlayHintRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.inlayHint, fallback: [])
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.inlayHint, fallback: [])
     case let request as Request<DocumentDiagnosticsRequest>:
-      await self.withReadyDocument(for: request, requestHandler: self.documentDiagnostic, fallback: .full(.init(items: [])))
+      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentDiagnostic, fallback: .full(.init(items: [])))
     default:
       self._handleUnknown(request)
     }
@@ -661,53 +636,15 @@ extension SourceKitServer: BuildSystemDelegate {
   /// - Changed settings for an already open file
   public func fileBuildSettingsChangedImpl(_ changedFiles: Set<DocumentURI>) async {
     for uri in changedFiles {
-      // Non-ready documents should be considered open even though we haven't
-      // opened it with the language service yet.
-      guard self.documentManager.openDocuments.contains(uri) else { continue }
-
-      guard let workspace = await self.workspaceForDocument(uri: uri) else {
-        continue
-      }
-      guard self.documentsReady.contains(uri) else {
-        // Case 1: initial settings for a given file. Now we can process our backlog.
-        log("Initial build settings received for opened file \(uri)")
-
-        guard let service = workspace.documentService[uri] else {
-          // Unexpected: we should have an existing language service if we've registered for
-          // change notifications for an opened but non-ready document.
-          log("No language service for build settings change to non-ready file \(uri)",
-              level: .error)
-
-          // We're in an odd state, cancel pending requests if we have any.
-          self.documentToPendingQueue[uri]?.cancelAll()
-          self.documentToPendingQueue[uri] = nil
-          continue
-        }
-
-        // Notify the language server so it can apply the proper arguments.
-        await service.documentUpdatedBuildSettings(uri)
-
-        // Catch up on any queued notifications and requests.
-        while !(documentToPendingQueue[uri]?.queue.isEmpty ?? true) {
-          // We need to run this loop until convergence since new closures can
-          // get added to `documentToPendingQueue` while we are awaiting the
-          // result of a `task.operation()`.
-          let pendingQueue = documentToPendingQueue[uri]?.queue ?? []
-          documentToPendingQueue[uri]?.queue = []
-          for task in pendingQueue {
-            await task.operation()
-          }
-        }
-        self.documentToPendingQueue[uri] = nil
-        self.documentsReady.insert(uri)
+      guard self.documentManager.openDocuments.contains(uri) else {
         continue
       }
 
-      // Case 2: changed settings for an already open file.
-      log("Build settings changed for opened file \(uri)")
-      if let service = workspace.documentService[uri] {
-        await service.documentUpdatedBuildSettings(uri)
+      guard let service = await self.workspaceForDocument(uri: uri)?.documentService[uri] else {
+        continue
       }
+
+      await service.documentUpdatedBuildSettings(uri)
     }
   }
 
@@ -733,11 +670,6 @@ extension SourceKitServer: BuildSystemDelegate {
         continue
       }
       for uri in self.affectedOpenDocumentsForChangeSet(changedFilesForWorkspace, self.documentManager) {
-        // Make sure the document is ready - otherwise the language service won't
-        // know about the document yet.
-        guard self.documentsReady.contains(uri) else {
-          continue
-        }
         log("Dependencies updated for opened file \(uri)")
         if let service = workspace.documentService[uri] {
           await service.documentDependenciesUpdated(uri)
@@ -1083,15 +1015,7 @@ extension SourceKitServer {
     await workspace.buildSystemManager.registerForChangeNotifications(for: uri, language: language)
 
     // If the document is ready, we can immediately send the notification.
-    guard !documentsReady.contains(uri) else {
-      await service.openDocument(note)
-      return
-    }
-
-    // Need to queue the open call so we can handle it when ready.
-    self.documentToPendingQueue[uri, default: DocumentNotificationRequestQueue()].add(operation: {
-      await service.openDocument(note)
-    })
+    await service.openDocument(note)
   }
 
   func closeDocument(_ note: Notification<DidCloseTextDocumentNotification>) async {
@@ -1112,17 +1036,7 @@ extension SourceKitServer {
 
     await workspace.buildSystemManager.unregisterForChangeNotifications(for: uri)
 
-    // If the document is ready, we can close it now.
-    guard !documentsReady.contains(uri) else {
-      self.documentsReady.remove(uri)
-      await workspace.documentService[uri]?.closeDocument(note)
-      return
-    }
-
-    // Clear any queued notifications via their cancellation handlers.
-    // No need to send the notification since it was never considered opened.
-    self.documentToPendingQueue[uri]?.cancelAll()
-    self.documentToPendingQueue[uri] = nil
+    await workspace.documentService[uri]?.closeDocument(note)
   }
 
   func changeDocument(_ note: Notification<DidChangeTextDocumentNotification>) async {
@@ -1134,17 +1048,8 @@ extension SourceKitServer {
     }
 
     // If the document is ready, we can handle the change right now.
-    guard !documentsReady.contains(uri) else {
-      documentManager.edit(note.params)
-      await workspace.documentService[uri]?.changeDocument(note.params)
-      return
-    }
-
-    // Need to queue the change call so we can handle it when ready.
-    self.documentToPendingQueue[uri, default: DocumentNotificationRequestQueue()].add(operation: {
-      self.documentManager.edit(note.params)
-      await workspace.documentService[uri]?.changeDocument(note.params)
-    })
+    documentManager.edit(note.params)
+    await workspace.documentService[uri]?.changeDocument(note.params)
   }
 
   func willSaveDocument(
@@ -1398,27 +1303,6 @@ extension SourceKitServer {
     }
     guard let languageService = workspace.documentService[uri] else {
       req.reply(nil)
-      return
-    }
-
-    // If the document isn't yet ready, queue the request.
-    guard self.documentsReady.contains(uri) else {
-      let operation = { [weak self] in
-        guard let self = self else { return }
-        // FIXME: (async) This might cause out-of order requests if  tasks of the
-        // same `documentToPendingQueue` are executed out-of-order. To fix this, we should
-        // always wait for build settings before handling a request and remove
-        // documentToPendingQueue.
-        Task {
-          await self.fowardExecuteCommand(req, languageService: languageService)
-        }
-      }
-      let cancellationHandler = {
-        req.reply(nil)
-      }
-
-      self.documentToPendingQueue[uri, default: DocumentNotificationRequestQueue()]
-        .add(operation: operation, cancellationHandler: cancellationHandler)
       return
     }
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -649,7 +649,7 @@ extension SourceKitServer: BuildSystemDelegate {
 
   // FIXME: (async) Make this method isolated once `BuildSystemDelegate` has been asyncified
   /// Non-async variant that executes `fileBuildSettingsChangedImpl` in a new task.
-  public nonisolated func fileBuildSettingsChanged(_ changedFiles: [DocumentURI: FileBuildSettingsChange]) {
+  public nonisolated func fileBuildSettingsChanged(_ changedFiles: Set<DocumentURI>) {
     Task {
       await self.fileBuildSettingsChangedImpl(changedFiles)
     }
@@ -659,10 +659,8 @@ extension SourceKitServer: BuildSystemDelegate {
   /// This has two primary cases:
   /// - Initial settings reported for a given file, now we can fully open it
   /// - Changed settings for an already open file
-  public func fileBuildSettingsChangedImpl(
-    _ changedFiles: [DocumentURI: FileBuildSettingsChange]
-  ) async {
-    for (uri, change) in changedFiles {
+  public func fileBuildSettingsChangedImpl(_ changedFiles: Set<DocumentURI>) async {
+    for uri in changedFiles {
       // Non-ready documents should be considered open even though we haven't
       // opened it with the language service yet.
       guard self.documentManager.openDocuments.contains(uri) else { continue }
@@ -687,7 +685,7 @@ extension SourceKitServer: BuildSystemDelegate {
         }
 
         // Notify the language server so it can apply the proper arguments.
-        await service.documentUpdatedBuildSettings(uri, change: change)
+        await service.documentUpdatedBuildSettings(uri)
 
         // Catch up on any queued notifications and requests.
         while !(documentToPendingQueue[uri]?.queue.isEmpty ?? true) {
@@ -708,7 +706,7 @@ extension SourceKitServer: BuildSystemDelegate {
       // Case 2: changed settings for an already open file.
       log("Build settings changed for opened file \(uri)")
       if let service = workspace.documentService[uri] {
-        await service.documentUpdatedBuildSettings(uri, change: change)
+        await service.documentUpdatedBuildSettings(uri)
       }
     }
   }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -485,7 +485,7 @@ extension SwiftLanguageServer {
         response: dict, for: snapshot, compileCommand: compileCmd)
   }
 
-  public func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) async {
+  public func documentUpdatedBuildSettings(_ uri: DocumentURI) async {
     // We may not have a snapshot if this is called just before `openDocument`.
     guard let snapshot = self.documentManager.latestSnapshot(uri) else {
       return

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -178,7 +178,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
     guard let workspace = await sourceKitServer.workspaceForDocument(uri: document) else {
       return nil
     }
-    if let settings = await workspace.buildSystemManager.buildSettings(for: document, language: .swift) {
+    if let settings = await workspace.buildSystemManager.buildSettingsInferredFromMainFile(for: document, language: .swift) {
       return SwiftCompileCommand(settings.buildSettings, isFallback: settings.isFallback)
     } else {
       return nil

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -70,7 +70,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   /// Sent when the `BuildSystem` has resolved build settings, such as for the intial build settings
   /// or when the settings have changed (e.g. modified build system files). This may be sent before
   /// the respective `DocumentURI` has been opened.
-  func documentUpdatedBuildSettings(_ uri: DocumentURI, change: FileBuildSettingsChange) async
+  func documentUpdatedBuildSettings(_ uri: DocumentURI) async
 
   /// Sent when the `BuildSystem` has detected that dependencies of the given file have changed
   /// (e.g. header files, swiftmodule files, other compiler input files).

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -98,9 +98,8 @@ final class TestDelegate: BuildSystemDelegate {
     }
   }
 
-  func fileBuildSettingsChanged(
-    _ changedFiles: [DocumentURI: FileBuildSettingsChange]) {
-    for (uri, _) in changedFiles {
+  func fileBuildSettingsChanged(_ changedFiles: Set<DocumentURI>) {
+    for uri in changedFiles {
       settingsExpectations[uri]?.fulfill()
     }
   }

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -103,13 +103,13 @@ final class BuildSystemManagerTests: XCTestCase {
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let initial = expectation(description: "initial settings")
-    await del.setExpected([(a, bs.map[a]!, initial, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
 
     bs.map[a] = nil
     let changed = expectation(description: "changed settings")
-    await del.setExpected([(a, nil, changed, #file, #line)])
+    await del.setExpected([(a, .swift, nil, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .removedOrUnavailable])
     try await fulfillmentOfOrThrow([changed])
   }
@@ -126,13 +126,13 @@ final class BuildSystemManagerTests: XCTestCase {
     defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
     let initial = expectation(description: "initial settings")
-    await del.setExpected([(a, nil, initial, #file, #line)])
+    await del.setExpected([(a, .swift, nil, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let changed = expectation(description: "changed settings")
-    await del.setExpected([(a, bs.map[a]!, changed, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
     try await fulfillmentOfOrThrow([changed])
   }
@@ -151,19 +151,19 @@ final class BuildSystemManagerTests: XCTestCase {
     let del = await BSMDelegate(bsm)
     let fallbackSettings = fallback.buildSettings(for: a, language: .swift)
     let initial = expectation(description: "initial fallback settings")
-    await del.setExpected([(a, fallbackSettings, initial, #file, #line)])
+    await del.setExpected([(a, .swift, fallbackSettings, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["non-fallback", "args"])
     let changed = expectation(description: "changed settings")
-    await del.setExpected([(a, bs.map[a]!, changed, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
     try await fulfillmentOfOrThrow([changed])
 
     bs.map[a] = nil
     let revert = expectation(description: "revert to fallback settings")
-    await del.setExpected([(a, fallbackSettings, revert, #file, #line)])
+    await del.setExpected([(a, .swift, fallbackSettings, revert, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .removedOrUnavailable])
     try await fulfillmentOfOrThrow([revert])
   }
@@ -184,18 +184,18 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     bs.map[b] = FileBuildSettings(compilerArguments: ["y"])
     let initial = expectation(description: "initial settings")
-    await del.setExpected([(a, bs.map[a]!, initial, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initial])
     let initialB = expectation(description: "initial settings")
-    await del.setExpected([(b, bs.map[b]!, initialB, #file, #line)])
+    await del.setExpected([(b, .swift, bs.map[b]!, initialB, #file, #line)])
     await bsm.registerForChangeNotifications(for: b, language: .swift)
     try await fulfillmentOfOrThrow([initialB])
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["xx"])
     bs.map[b] = FileBuildSettings(compilerArguments: ["yy"])
     let changed = expectation(description: "changed settings")
-    await del.setExpected([(a, bs.map[a]!, changed, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([a: .modified(bs.map[a]!)])
     try await fulfillmentOfOrThrow([changed])
 
@@ -205,8 +205,8 @@ final class BuildSystemManagerTests: XCTestCase {
     let changedBothA = expectation(description: "changed setting a")
     let changedBothB = expectation(description: "changed setting b")
     await del.setExpected([
-      (a, bs.map[a]!, changedBothA, #file, #line),
-      (b, bs.map[b]!, changedBothB, #file, #line),
+      (a, .swift, bs.map[a]!, changedBothA, #file, #line),
+      (b, .swift, bs.map[b]!, changedBothB, #file, #line),
     ])
     bsm.fileBuildSettingsChanged([
       a:. modified(bs.map[a]!),
@@ -232,19 +232,19 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[b] = FileBuildSettings(compilerArguments: ["b"])
 
     let initialA = expectation(description: "initial settings a")
-    await del.setExpected([(a, bs.map[a]!, initialA, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, initialA, #file, #line)])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     try await fulfillmentOfOrThrow([initialA])
 
     let initialB = expectation(description: "initial settings b")
-    await del.setExpected([(b, bs.map[b]!, initialB, #file, #line)])
+    await del.setExpected([(b, .swift, bs.map[b]!, initialB, #file, #line)])
     await bsm.registerForChangeNotifications(for: b, language: .swift)
     try await fulfillmentOfOrThrow([initialB])
 
     bs.map[a] = nil
     bs.map[b] = nil
     let changed = expectation(description: "changed settings")
-    await del.setExpected([(b, nil, changed, #file, #line)])
+    await del.setExpected([(b, .swift, nil, changed, #file, #line)])
     bsm.fileBuildSettingsChanged([
       b: .removedOrUnavailable
     ])
@@ -274,20 +274,20 @@ final class BuildSystemManagerTests: XCTestCase {
     bs.map[cpp2] = FileBuildSettings(compilerArguments: ["C++ 2"])
 
     let initial = expectation(description: "initial settings via cpp1")
-    await del.setExpected([(h, bs.map[cpp1]!, initial, #file, #line)])
+    await del.setExpected([(h, .c, bs.map[cpp1]!, initial, #file, #line)])
     await bsm.registerForChangeNotifications(for: h, language: .c)
     try await fulfillmentOfOrThrow([initial])
 
     mainFiles.mainFiles[h] = Set([cpp2])
 
     let changed = expectation(description: "changed settings to cpp2")
-    await del.setExpected([(h, bs.map[cpp2]!, changed, #file, #line)])
+    await del.setExpected([(h, .c, bs.map[cpp2]!, changed, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed])
 
     let changed2 = expectation(description: "still cpp2, no update")
     changed2.isInverted = true
-    await del.setExpected([(h, nil, changed2, #file, #line)])
+    await del.setExpected([(h, .c, nil, changed2, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed2], timeout: 1)
 
@@ -295,14 +295,14 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let changed3 = expectation(description: "added main file, no update")
     changed3.isInverted = true
-    await del.setExpected([(h, nil, changed3, #file, #line)])
+    await del.setExpected([(h, .c, nil, changed3, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed3], timeout: 1)
 
     mainFiles.mainFiles[h] = Set([])
 
     let changed4 = expectation(description: "changed settings to []")
-    await del.setExpected([(h, nil, changed4, #file, #line)])
+    await del.setExpected([(h, .c, nil, changed4, #file, #line)])
     await bsm.mainFilesChangedImpl()
     try await fulfillmentOfOrThrow([changed4])
   }
@@ -333,8 +333,8 @@ final class BuildSystemManagerTests: XCTestCase {
     let expectedArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h1.pseudoPath])
     let expectedArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h2.pseudoPath])
     await del.setExpected([
-      (h1, expectedArgsH1, initial1, #file, #line),
-      (h2, expectedArgsH2, initial2, #file, #line),
+      (h1, .c, expectedArgsH1, initial1, #file, #line),
+      (h2, .c, expectedArgsH2, initial2, #file, #line),
     ])
 
     await bsm.registerForChangeNotifications(for: h1, language: .c)
@@ -351,8 +351,8 @@ final class BuildSystemManagerTests: XCTestCase {
     let newArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", newCppArg, h1.pseudoPath])
     let newArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", newCppArg, h2.pseudoPath])
     await del.setExpected([
-      (h1, newArgsH1, changed1, #file, #line),
-      (h2, newArgsH2, changed2, #file, #line),
+      (h1, .c, newArgsH1, changed1, #file, #line),
+      (h2, .c, newArgsH2, changed2, #file, #line),
     ])
     bsm.fileBuildSettingsChanged([cpp: .modified(bs.map[cpp]!)])
 
@@ -381,9 +381,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let initialB = expectation(description: "initial settings b")
     let initialC = expectation(description: "initial settings c")
     await del.setExpected([
-      (a, bs.map[a]!, initialA, #file, #line),
-      (b, bs.map[b]!, initialB, #file, #line),
-      (c, bs.map[c]!, initialC, #file, #line),
+      (a, .swift, bs.map[a]!, initialA, #file, #line),
+      (b, .swift, bs.map[b]!, initialB, #file, #line),
+      (c, .swift, bs.map[c]!, initialC, #file, #line),
     ])
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     await bsm.registerForChangeNotifications(for: b, language: .swift)
@@ -396,7 +396,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let changedB = expectation(description: "changed settings b")
     await del.setExpected([
-      (b, bs.map[b]!, changedB, #file, #line),
+      (b, .swift, bs.map[b]!, changedB, #file, #line),
     ])
 
     await bsm.unregisterForChangeNotifications(for: a)
@@ -434,7 +434,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
     let initial = expectation(description: "initial settings")
-    await del.setExpected([(a, bs.map[a]!, initial, #file, #line)])
+    await del.setExpected([(a, .swift, bs.map[a]!, initial, #file, #line)])
 
     let depUpdate1 = expectation(description: "dependencies update during registration")
     await del.setExpectedDependenciesUpdate([(a, depUpdate1, #file, #line)])
@@ -508,7 +508,7 @@ class ManualBuildSystem: BuildSystem {
 
 /// A `BuildSystemDelegate` setup for testing.
 private actor BSMDelegate: BuildSystemDelegate {
-  fileprivate typealias ExpectedBuildSettingChangedCall = (uri: DocumentURI, settings: FileBuildSettings?, expectation: XCTestExpectation, file: StaticString, line: UInt)
+  fileprivate typealias ExpectedBuildSettingChangedCall = (uri: DocumentURI, language: Language, settings: FileBuildSettings?, expectation: XCTestExpectation, file: StaticString, line: UInt)
   fileprivate typealias ExpectedDependenciesUpdatedCall = (uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt)
 
   let queue: DispatchQueue = DispatchQueue(label: "\(BSMDelegate.self)")
@@ -536,15 +536,15 @@ private actor BSMDelegate: BuildSystemDelegate {
     }()
   }
 
-  func fileBuildSettingsChanged(_ changes: [DocumentURI: FileBuildSettingsChange]) {
-    for (uri, change) in changes {
+  func fileBuildSettingsChanged(_ changes: [DocumentURI: FileBuildSettingsChange]) async {
+    for (uri, _) in changes {
       guard let expected = expected.first(where: { $0.uri == uri }) else {
         XCTFail("unexpected settings change for \(uri)")
         continue
       }
 
       XCTAssertEqual(uri, expected.uri, file: expected.file, line: expected.line)
-      let settings = change.newSettings
+      let settings = await bsm.buildSettingsInferredFromMainFile(for: uri, language: expected.language)?.buildSettings
       XCTAssertEqual(settings, expected.settings, file: expected.file, line: expected.line)
       expected.expectation.fulfill()
     }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -51,17 +51,8 @@ final class TestBuildSystem: BuildSystem {
     return buildSettingsByFile[document]
   }
 
-  func registerForChangeNotifications(for uri: DocumentURI, language: Language) {
+  func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {
     watchedFiles.insert(uri)
-
-    // Inform our delegate of settings for the file if they're available.
-    guard let delegate = self.delegate else {
-      return
-    }
-
-    Task {
-      await delegate.fileBuildSettingsChanged([uri])
-    }
   }
 
   func unregisterForChangeNotifications(for uri: DocumentURI) {
@@ -360,44 +351,6 @@ final class BuildSystemTests: XCTestCase {
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
     try await fulfillmentOfOrThrow([expectation])
-  }
-
-  func testSwiftDocumentBuildSettingsChangedFalseAlarm() async throws {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
-    let doc = DocumentURI(url)
-
-    sk.allowUnexpectedNotification = false
-
-    let documentManager = await self.testServer.server!._documentManager
-
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: doc,
-      language: .swift,
-      version: 12,
-      text: """
-      func
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual("func", documentManager.latestSnapshot(doc)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      // Using fallback system, so we will receive the same syntactic diagnostics from before.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-    })
-
-    // Modify the build settings and inform the SourceKitServer.
-    // This shouldn't trigger new diagnostics since nothing actually changed (false alarm).
-    await buildSystem.delegate?.fileBuildSettingsChanged([doc])
-
-    let expectation = XCTestExpectation(description: "refresh doesn't occur")
-    expectation.isInverted = true
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual("func", documentManager.latestSnapshot(doc)!.text)
-      expectation.fulfill()
-    }
-
-    try await fulfillmentOfOrThrow([expectation], timeout: 1)
   }
 
   func testMainFilesChanged() async throws {

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -55,13 +55,12 @@ final class TestBuildSystem: BuildSystem {
     watchedFiles.insert(uri)
 
     // Inform our delegate of settings for the file if they're available.
-    guard let delegate = self.delegate,
-          let settings = self.buildSettingsByFile[uri] else {
+    guard let delegate = self.delegate else {
       return
     }
 
     Task {
-      await delegate.fileBuildSettingsChanged([uri: .modified(settings)])
+      await delegate.fileBuildSettingsChanged([uri])
     }
   }
 
@@ -196,7 +195,7 @@ final class BuildSystemTests: XCTestCase {
       expectation.fulfill()
     }
 
-    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -251,7 +250,7 @@ final class BuildSystemTests: XCTestCase {
       XCTAssertEqual(note.params.diagnostics.count, 0)
       expectation.fulfill()
     }
-    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -304,7 +303,7 @@ final class BuildSystemTests: XCTestCase {
       expectation.fulfill()
     }
 
-    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(newSettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -358,7 +357,7 @@ final class BuildSystemTests: XCTestCase {
       XCTAssertEqual(note.params.diagnostics.count, 2)
       expectation.fulfill()
     }
-    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .modified(primarySettings)])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
     try await fulfillmentOfOrThrow([expectation])
   }
@@ -388,7 +387,7 @@ final class BuildSystemTests: XCTestCase {
 
     // Modify the build settings and inform the SourceKitServer.
     // This shouldn't trigger new diagnostics since nothing actually changed (false alarm).
-    await buildSystem.delegate?.fileBuildSettingsChanged([doc: .removedOrUnavailable])
+    await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
     let expectation = XCTestExpectation(description: "refresh doesn't occur")
     expectation.isInverted = true

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -63,7 +63,7 @@ final class CompilationDatabaseTests: XCTestCase {
     var didReceiveCorrectHighlight = false
 
     // Updating the build settings takes a few seconds.
-    // Send code completion requests every second until we receive correct results.
+    // Send highlight requests every second until we receive correct results.
     for _ in 0..<30 {
       let postChangeHighlightResponse = try ws.sk.sendSync(highlightRequest)
 


### PR DESCRIPTION
After two minor preliminary commits, there are two core commits here that go hand-in-hand and significantly simplify the build settings handling.

### Change the build system to only notify delegate about changed files, not about new build settings

This defines away an entire class of data races if delegate callbacks are delivered out-of-order. If we aren’t providing the new build settings in the delegate callback, then it doesn’t matter if two `fileBuildSettingsChanged` calls change order since they don’t carry any state. Instead of storing the build settings returned by the delegate call, the language server needs to ask the `BuildSystemManager` for the current build settings of the file.

### Remove tracking of file build settings status in `SourceKitServer` and `BuildSystemManager`

The core idea here is that the toolchain language servers always call into `BuildSystemManager` and `BuildSystemManager` will always reply with build settings. If it hasn’t computed them yet, it will reply with fallback settings.

With that assumption, we can remove the `documentToPendingQueue` from `SourceKitServer` since there are no longer any documents that are pending – everything has a build settings immediately.

Similarly, `BuildSystemManager.mainFileStatuses` also isn’t needed anymore.

And lastly, since we know that `BuildSystemManager.buildSettings` will always return a value `registerForChangeNotifications` is changed not call `fileBuildSettingsChanged` immediately. Instead, it will only cause `fileBuildSettingsChanged` to be called when the file’s build settings change after the `registerForChangeNotifications` call.
