### PR TITLE
Make SwiftLanguageServer and ClangLanguageServerShim call directly into SourceKitServer instead of through a LocalConnection

### DIFF
--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -30,12 +30,10 @@ public protocol ToolchainLanguageServer: AnyObject {
   // MARK: - Creation
 
   init?(
-    client: LocalConnection,
+    sourceKitServer: SourceKitServer,
     toolchain: Toolchain,
     options: SourceKitServer.Options,
-    workspace: Workspace,
-    reopenDocuments: @escaping (ToolchainLanguageServer) async -> Void,
-    workspaceForDocument: @escaping (DocumentURI) async -> Workspace?
+    workspace: Workspace
   ) async throws
 
   /// Returns `true` if this instance of the language server can handle opening documents in `workspace`.


### PR DESCRIPTION
`LocalConnection` with its dynamic registration of a message handler made the overall design unnecessarily complicated. If we just call `SourceKitServer` from `ClangLanguageServerShim` and `SwiftLanguageServer` directly, it’s a lot more obvious, what’s going on, IMO. Also, we can remove the `reopenDocuments` and `workspaceForDocument` callbacks this way. 