### PR TITLE
Add an overload of `firstNonNil` that allows the default value to be `nil`

### DIFF
--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -27,6 +27,12 @@ fileprivate func firstNonNil<T>(_ optional: T?, _ defaultValue: @autoclosure () 
   return try await defaultValue()
 }
 
+fileprivate func firstNonNil<T>(_ optional: T?, _ defaultValue: @autoclosure () async throws -> T?) async rethrows -> T? {
+  if let optional {
+    return optional
+  }
+  return try await defaultValue()
+}
 
 /// Represents the configuration and state of a project or combination of projects being worked on
 /// together.


### PR DESCRIPTION
Without this overload, `T` was inferred to be `Something?`, thus the first parameter was inferred to be `Something??` and the first parameter was always wrapped in an optional, effectively making `if let optional` never be hit.