### PR TITLE
Asynchronously return the request result for folding range requests

### DIFF
--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -87,7 +87,7 @@ public final class LocalConnection {
   /// have forwarded the request to clangd.
   ///
   /// The actual semantic handling of the message happens off this queue.
-  let messageHandlingQueue: AsyncQueue = AsyncQueue()
+  let messageHandlingQueue: AsyncQueue = AsyncQueue(.serial)
 
   var _nextRequestID: Int = 0
 

--- a/Sources/LanguageServerProtocol/Message.swift
+++ b/Sources/LanguageServerProtocol/Message.swift
@@ -28,7 +28,7 @@ public protocol _RequestType: MessageType {
     id: RequestID,
     connection: Connection,
     reply: @escaping (LSPResult<ResponseType>, RequestID) -> Void
-  ) async
+  )
 }
 
 /// A request, which must have a unique `method` name as well as an associated response type.
@@ -54,16 +54,16 @@ extension RequestType {
     id: RequestID,
     connection: Connection,
     reply: @escaping (LSPResult<ResponseType>, RequestID) -> Void
-  ) async {
-    await handler.handle(self, id: id, from: ObjectIdentifier(connection)) { response in
+  ) {
+    handler.handle(self, id: id, from: ObjectIdentifier(connection)) { response in
       reply(response.map({ $0 as ResponseType }), id)
     }
   }
 }
 
 extension NotificationType {
-  public func _handle(_ handler: MessageHandler, connection: Connection) async {
-    await handler.handle(self, from: ObjectIdentifier(connection))
+  public func _handle(_ handler: MessageHandler, connection: Connection) {
+    handler.handle(self, from: ObjectIdentifier(connection))
   }
 }
 

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -40,7 +40,7 @@ public final class JSONRPCConnection {
   /// have forwarded the request to clangd.
   ///
   /// The actual semantic handling of the message happens off this queue.
-  let messageHandlingQueue: AsyncQueue = AsyncQueue()
+  let messageHandlingQueue: AsyncQueue = AsyncQueue(.serial)
   let receiveIO: DispatchIO
   let sendIO: DispatchIO
   let messageRegistry: MessageRegistry

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -45,6 +45,19 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// The queue on which clangd calls us back.
   public let clangdCommunicationQueue: DispatchQueue = DispatchQueue(label: "language-server-queue", qos: .userInitiated)
 
+  /// The queue on which all messages that originate from clangd are handled.
+  ///
+  /// This includes requests and notifications sent *from* clangd and does not
+  /// include replies from clangd.
+  ///
+  /// These are requests and notifications sent *from* clangd, not replies from
+  /// clangd.
+  ///
+  /// Since we are blindly forwarding requests from clangd to the editor, we
+  /// cannot allow concurrent requests. This should be fine since the number of
+  /// requests and notifications sent from clangd to the client is quite small.
+  public let clangdMessageHandlingQueue = AsyncQueue(.serial)
+
   /// The ``SourceKitServer`` instance that created this `ClangLanguageServerShim`.
   ///
   /// Used to send requests and notifications to the editor.
@@ -255,14 +268,16 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// sending a notification that's intended for the editor.
   ///
   /// We should either handle it ourselves or forward it to the editor.
-  func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) async {
-    switch params {
-    case let publishDiags as PublishDiagnosticsNotification:
-      await self.publishDiagnostics(Notification(publishDiags, clientID: clientID))
-    default:
-      // We don't know how to handle any other notifications and ignore them.
-      log("Ignoring unknown notification \(type(of: params))", level: .warning)
-      break
+  nonisolated func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) {
+    clangdMessageHandlingQueue.async {
+      switch params {
+      case let publishDiags as PublishDiagnosticsNotification:
+        await self.publishDiagnostics(Notification(publishDiags, clientID: clientID))
+      default:
+        // We don't know how to handle any other notifications and ignore them.
+        log("Ignoring unknown notification \(type(of: params))", level: .warning)
+        break
+      }
     }
   }
 
@@ -270,26 +285,24 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// sending a notification that's intended for the editor.
   ///
   /// We should either handle it ourselves or forward it to the client.
-  func handle<R: RequestType>(
+  nonisolated func handle<R: RequestType>(
     _ params: R,
     id: RequestID,
     from clientID: ObjectIdentifier,
     reply: @escaping (LSPResult<R.Response>) -> Void
-  ) async {
-    let request = Request(params, id: id, clientID: clientID, cancellation: CancellationToken(), reply: { result in
-      reply(result)
-    })
-    guard let sourceKitServer else {
-      // `SourceKitServer` has been destructed. We are tearing down the language
-      // server. Nothing left to do.
-      request.reply(.failure(.unknown("Connection to the editor closed")))
-      return
-    }
+  ) {
+    clangdMessageHandlingQueue.async {
+      let request = Request(params, id: id, clientID: clientID, cancellation: CancellationToken(), reply: { result in
+        reply(result)
+      })
+      guard let sourceKitServer = await self.sourceKitServer else {
+        // `SourceKitServer` has been destructed. We are tearing down the language
+        // server. Nothing left to do.
+        request.reply(.failure(.unknown("Connection to the editor closed")))
+        return
+      }
 
-    if request.clientID == ObjectIdentifier(self.clangd) {
       await sourceKitServer.sendRequestToClient(request.params, reply: request.reply)
-    } else {
-      request.reply(.failure(ResponseError.methodNotFound(R.method)))
     }
   }
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -136,6 +136,16 @@ public actor SourceKitServer {
   /// The queue on which we communicate with the client.
   public let clientCommunicationQueue: DispatchQueue = DispatchQueue(label: "language-server-queue", qos: .userInitiated)
 
+  /// The queue on which all messages (notifications, requests, responses) are
+  /// handled.
+  ///
+  /// The queue is blocked until the message has been sufficiently handled to
+  /// avoid out-of-order handling of messages. For sourcekitd, this means that
+  /// a request has been sent to sourcekitd and for clangd, this means that we
+  /// have forwarded the request to clangd.
+  ///
+  /// The actual semantic handling of the message happens off this queue.
+  private let messageHandlingQueue = AsyncQueue(.concurrent)
 
   /// The connection to the editor.
   public let client: Connection
@@ -442,116 +452,142 @@ public actor SourceKitServer {
 // MARK: - MessageHandler
 
 extension SourceKitServer: MessageHandler {
-  public func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) async {
-    let notification = Notification(params, clientID: clientID)
-    self._logNotification(notification)
+  public nonisolated func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) {
+    // All of the notifications sourcekit-lsp currently handles might modify the
+    // global state (eg. whether a document is open or its contents) in a way
+    // that changes the results of requsts before and after.
+    // We thus need to ensure that we handle the notifications in order, so they
+    // need to be dispatch barriers.
+    //
+    // Technically, we could optimize this further by having an `AsyncQueue` for
+    // each file, because edits on one file should not block requests on another
+    // file from executing but, at least in Swift, this would get us any real 
+    // benefits at the moment because sourcekitd only has a single, global queue,
+    // instead of a queue per file.
+    // Additionally, usually you are editing one file in a source editor, which
+    // means that concurrent requests to multiple files tend to be rare.
+    messageHandlingQueue.async(barrier: true) {
+      let notification = Notification(params, clientID: clientID)
+      await self._logNotification(notification)
 
-    switch notification {
-    case let notification as Notification<InitializedNotification>:
-      self.clientInitialized(notification)
-    case let notification as Notification<CancelRequestNotification>:
-      self.cancelRequest(notification)
-    case let notification as Notification<ExitNotification>:
-      await self.exit(notification)
-    case let notification as Notification<DidOpenTextDocumentNotification>:
-      await self.openDocument(notification)
-    case let notification as Notification<DidCloseTextDocumentNotification>:
-      await self.closeDocument(notification)
-    case let notification as Notification<DidChangeTextDocumentNotification>:
-      await self.changeDocument(notification)
-    case let notification as Notification<DidChangeWorkspaceFoldersNotification>:
-      await self.didChangeWorkspaceFolders(notification)
-    case let notification as Notification<DidChangeWatchedFilesNotification>:
-      await self.didChangeWatchedFiles(notification)
-    case let notification as Notification<WillSaveTextDocumentNotification>:
-      await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.willSaveDocument)
-    case let notification as Notification<DidSaveTextDocumentNotification>:
-      await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.didSaveDocument)
-    default:
-      break
-    }
-  }
-
-  public func handle<R: RequestType>(_ params: R, id: RequestID, from clientID: ObjectIdentifier, reply: @escaping (LSPResult<R.Response >) -> Void) async {
-    let cancellationToken = CancellationToken()
-    let request = Request(params, id: id, clientID: clientID, cancellation: cancellationToken, reply: { [weak self] result in
-      reply(result)
-      if let self {
-        Task {
-          await self._logResponse(result, id: id, method: R.method)
-        }
+      switch notification {
+      case let notification as Notification<InitializedNotification>:
+        await self.clientInitialized(notification)
+      case let notification as Notification<CancelRequestNotification>:
+        await self.cancelRequest(notification)
+      case let notification as Notification<ExitNotification>:
+        await self.exit(notification)
+      case let notification as Notification<DidOpenTextDocumentNotification>:
+        await self.openDocument(notification)
+      case let notification as Notification<DidCloseTextDocumentNotification>:
+        await self.closeDocument(notification)
+      case let notification as Notification<DidChangeTextDocumentNotification>:
+        await self.changeDocument(notification)
+      case let notification as Notification<DidChangeWorkspaceFoldersNotification>:
+        await self.didChangeWorkspaceFolders(notification)
+      case let notification as Notification<DidChangeWatchedFilesNotification>:
+        await self.didChangeWatchedFiles(notification)
+      case let notification as Notification<WillSaveTextDocumentNotification>:
+        await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.willSaveDocument)
+      case let notification as Notification<DidSaveTextDocumentNotification>:
+        await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.didSaveDocument)
+      default:
+        break
       }
-    })
-
-    self._logRequest(request)
-
-    switch request {
-    case let request as Request<InitializeRequest>:
-      await self.initialize(request)
-    case let request as Request<ShutdownRequest>:
-      await self.shutdown(request)
-    case let request as Request<WorkspaceSymbolsRequest>:
-      self.workspaceSymbols(request)
-    case let request as Request<PollIndexRequest>:
-      self.pollIndex(request)
-    case let request as Request<ExecuteCommandRequest>:
-      await self.executeCommand(request)
-    case let request as Request<CallHierarchyIncomingCallsRequest>:
-      await self.incomingCalls(request)
-    case let request as Request<CallHierarchyOutgoingCallsRequest>:
-      await self.outgoingCalls(request)
-    case let request as Request<TypeHierarchySupertypesRequest>:
-      await self.supertypes(request)
-    case let request as Request<TypeHierarchySubtypesRequest>:
-      await self.subtypes(request)
-    case let request as Request<CompletionRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
-    case let request as Request<HoverRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.hover, fallback: nil)
-    case let request as Request<OpenInterfaceRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.openInterface, fallback: nil)
-    case let request as Request<DeclarationRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.declaration, fallback: nil)
-    case let request as Request<DefinitionRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.definition, fallback: .locations([]))
-    case let request as Request<ReferencesRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.references, fallback: [])
-    case let request as Request<ImplementationRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.implementation, fallback: .locations([]))
-    case let request as Request<CallHierarchyPrepareRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.prepareCallHierarchy, fallback: [])
-    case let request as Request<TypeHierarchyPrepareRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.prepareTypeHierarchy, fallback: [])
-    case let request as Request<SymbolInfoRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.symbolInfo, fallback: [])
-    case let request as Request<DocumentHighlightRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSymbolHighlight, fallback: nil)
-    case let request as Request<FoldingRangeRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.foldingRange, fallback: nil)
-    case let request as Request<DocumentSymbolRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSymbol, fallback: nil)
-    case let request as Request<DocumentColorRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentColor, fallback: [])
-    case let request as Request<DocumentSemanticTokensRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokens, fallback: nil)
-    case let request as Request<DocumentSemanticTokensDeltaRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokensDelta, fallback: nil)
-    case let request as Request<DocumentSemanticTokensRangeRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokensRange, fallback: nil)
-    case let request as Request<ColorPresentationRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.colorPresentation, fallback: [])
-    case let request as Request<CodeActionRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.codeAction, fallback: nil)
-    case let request as Request<InlayHintRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.inlayHint, fallback: [])
-    case let request as Request<DocumentDiagnosticsRequest>:
-      await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentDiagnostic, fallback: .full(.init(items: [])))
-    default:
-      reply(.failure(ResponseError.methodNotFound(R.method)))
     }
   }
 
-  private func _logRequest<R>(_ request: Request<R>) {
+  public nonisolated func handle<R: RequestType>(_ params: R, id: RequestID, from clientID: ObjectIdentifier, reply: @escaping (LSPResult<R.Response >) -> Void) {
+    // All of the requests sourcekit-lsp do not modify global state or require
+    // the client to wait for the result before using the modified global state.
+    // For example
+    //  - `DeclarationRequest` does not modify global state
+    //  - `CodeCompletionRequest` modifies the state of the current code
+    //    completion session but it only makes sense for the client to request
+    //    more results for this completion session after it has received the
+    //    initial results.
+    messageHandlingQueue.async(barrier: false) {
+      let cancellationToken = CancellationToken()
+
+      let request = Request(params, id: id, clientID: clientID, cancellation: cancellationToken, reply: { [weak self] result in
+        reply(result)
+        if let self {
+          Task {
+            await self._logResponse(result, id: id, method: R.method)
+          }
+        }
+      })
+
+      self._logRequest(request)
+
+      switch request {
+      case let request as Request<InitializeRequest>:
+        await self.initialize(request)
+      case let request as Request<ShutdownRequest>:
+        await self.shutdown(request)
+      case let request as Request<WorkspaceSymbolsRequest>:
+        await self.workspaceSymbols(request)
+      case let request as Request<PollIndexRequest>:
+        await self.pollIndex(request)
+      case let request as Request<ExecuteCommandRequest>:
+        await self.executeCommand(request)
+      case let request as Request<CallHierarchyIncomingCallsRequest>:
+        await self.incomingCalls(request)
+      case let request as Request<CallHierarchyOutgoingCallsRequest>:
+        await self.outgoingCalls(request)
+      case let request as Request<TypeHierarchySupertypesRequest>:
+        await self.supertypes(request)
+      case let request as Request<TypeHierarchySubtypesRequest>:
+        await self.subtypes(request)
+      case let request as Request<CompletionRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
+      case let request as Request<HoverRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.hover, fallback: nil)
+      case let request as Request<OpenInterfaceRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.openInterface, fallback: nil)
+      case let request as Request<DeclarationRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.declaration, fallback: nil)
+      case let request as Request<DefinitionRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.definition, fallback: .locations([]))
+      case let request as Request<ReferencesRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.references, fallback: [])
+      case let request as Request<ImplementationRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.implementation, fallback: .locations([]))
+      case let request as Request<CallHierarchyPrepareRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.prepareCallHierarchy, fallback: [])
+      case let request as Request<TypeHierarchyPrepareRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.prepareTypeHierarchy, fallback: [])
+      case let request as Request<SymbolInfoRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.symbolInfo, fallback: [])
+      case let request as Request<DocumentHighlightRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSymbolHighlight, fallback: nil)
+      case let request as Request<FoldingRangeRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.foldingRange, fallback: nil)
+      case let request as Request<DocumentSymbolRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSymbol, fallback: nil)
+      case let request as Request<DocumentColorRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentColor, fallback: [])
+      case let request as Request<DocumentSemanticTokensRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokens, fallback: nil)
+      case let request as Request<DocumentSemanticTokensDeltaRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokensDelta, fallback: nil)
+      case let request as Request<DocumentSemanticTokensRangeRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentSemanticTokensRange, fallback: nil)
+      case let request as Request<ColorPresentationRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.colorPresentation, fallback: [])
+      case let request as Request<CodeActionRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.codeAction, fallback: nil)
+      case let request as Request<InlayHintRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.inlayHint, fallback: [])
+      case let request as Request<DocumentDiagnosticsRequest>:
+        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.documentDiagnostic, fallback: .full(.init(items: [])))
+      default:
+        reply(.failure(ResponseError.methodNotFound(R.method)))
+      }
+    }
+  }
+
+  private nonisolated func _logRequest<R>(_ request: Request<R>) {
     logAsync { currentLevel in
       guard currentLevel >= LogLevel.debug else {
         return "\(type(of: self)): Request<\(R.method)(\(request.id))>"

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -269,6 +269,32 @@ public actor SourceKitServer {
     await requestHandler(request, workspace, languageService)
   }
 
+  private func withLanguageServiceAndWorkspace<RequestType: TextDocumentRequest>(
+    for request: Request<RequestType>,
+    requestHandler: @escaping (RequestType, Workspace, ToolchainLanguageServer) async throws -> RequestType.Response,
+    fallback: RequestType.Response
+  ) async {
+    let doc = request.params.textDocument.uri
+    guard let workspace = await self.workspaceForDocument(uri: doc) else {
+      return request.reply(.failure(.workspaceNotOpen(doc)))
+    }
+
+    guard let languageService = workspace.documentService[doc] else {
+      return request.reply(fallback)
+    }
+
+    do {
+      let result = try await requestHandler(request.params, workspace, languageService)
+      request.reply(.success(result))
+    } catch let error as ResponseError {
+      request.reply(.failure(error))
+    } catch is CancellationError {
+      request.reply(.failure(.cancelled))
+    } catch {
+      request.reply(.failure(.unknown("Unknown error: \(error)")))
+    }
+  }
+
 
   /// Send the given notification to the editor.
   public func sendNotificationToClient(_ notification: some NotificationType) {
@@ -1253,10 +1279,11 @@ extension SourceKitServer {
   }
 
   func foldingRange(
-    _ req: Request<FoldingRangeRequest>,
+    _ req: FoldingRangeRequest,
     workspace: Workspace,
-    languageService: ToolchainLanguageServer) async {
-    await languageService.foldingRange(req)
+    languageService: ToolchainLanguageServer
+  ) async throws -> [FoldingRange]? {
+    return try await languageService.foldingRange(req)
   }
 
   func documentSymbol(
@@ -1322,13 +1349,6 @@ extension SourceKitServer {
       return
     }
 
-    await self.fowardExecuteCommand(req, languageService: languageService)
-  }
-
-  func fowardExecuteCommand(
-    _ req: Request<ExecuteCommandRequest>,
-    languageService: ToolchainLanguageServer
-  ) async {
     let params = req.params
     let executeCommand = ExecuteCommandRequest(command: params.command,
                                                arguments: params.argumentsWithoutSourceKitMetadata)

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -88,7 +88,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func declaration(_ request: Request<DeclarationRequest>) async -> Bool
 
   func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>) async
-  func foldingRange(_ req: Request<FoldingRangeRequest>) async
+  func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
   func documentSymbol(_ req: Request<DocumentSymbolRequest>) async
   func documentColor(_ req: Request<DocumentColorRequest>) async
   func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) async


### PR DESCRIPTION
This is the last infrastructural change to asyncify sourcekit-lsp, everything afterwards should be fairly localized fixes for `FIXME: (async)` comments and the translation of all the other requests to return results asynchronously as a return value.

The basic idea is that we change `Connection` to be a class with synchronous functions again. This ensures that all messages within the connection are handles sequentially. `SourceKitServer` is responsible for transitioning into the Swift concurrency world by having an `AsyncQueue`. That queue is concurrent, which means that requests can be served out-of-order. To ensure that we don’t get out-of-order opens/edits/closes (or any other kind of message that modifies global state), we make these notifications dispatch barriers, which means that all messages before the edit need to be handled before the edit can be processed and all messages received after the edit are handled after the edit has been sent to sourcekitd/clangd.

This kind of concurrent execution matches what we are doing in `sourcekitd` where open/edit/close are dispatch barriers.

Technically, we could optimize this further by having an `AsyncQueue` for each file, because edits on one file should not block requests on another file from executing but, at least in Swift, this would get us any real benefits at the moment because sourcekitd only has a single, global queue, instead of a queue per file. Additionally, usually you are editing one file in a source editor, which means that concurrent requests to multiple files tend to be rare. Thus, I will not pursue this optimization for now.