### PR TITLE
Asyncify the handling of more requests

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -10,8 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public typealias CodeActionProviderCompletion = (LSPResult<[CodeAction]>) -> Void
-public typealias CodeActionProvider = (CodeActionRequest, @escaping CodeActionProviderCompletion) async -> Void
+public typealias CodeActionProvider = (CodeActionRequest) async throws -> [CodeAction]
 
 /// Request for returning all possible code actions for a given text document and range.
 ///

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -82,6 +82,7 @@ extension SourceKitD {
   }
 
   /// Send the given request and asynchronously receive a reply dictionary (or error) on the given queue.
+  // FIXME: (async) Remove this in favor of the async version
   public func send(
     _ req: SKDRequestDictionary,
     _ queue: DispatchQueue,
@@ -112,7 +113,32 @@ extension SourceKitD {
 
     return handle
   }
-  
+
+  public func send(_ req: SKDRequestDictionary) async throws -> SKDResponseDictionary {
+    logRequest(req)
+
+    return try await withCheckedThrowingContinuation { continuation in
+      var handle: sourcekitd_request_handle_t? = nil
+
+      api.send_request(req.dict, &handle) { [weak self] _resp in
+        guard let self = self else { return }
+
+        let resp = SKDResponse(_resp, sourcekitd: self)
+
+        logResponse(resp)
+
+        guard let dict = resp.value else {
+          continuation.resume(throwing: resp.error!)
+          return
+        }
+
+        continuation.resume(returning: dict)
+      }
+
+      // FIXME: (async) Cancellation
+    }
+  }
+
   public func cancel(_ handle: sourcekitd_request_handle_t) {
     api.cancel_request(handle)
   }

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -515,8 +515,8 @@ extension ClangLanguageServerShim {
     forwardRequestToClangd(req)
   }
 
-  func hover(_ req: Request<HoverRequest>) {
-    forwardRequestToClangd(req)
+  func hover(_ req: HoverRequest) async throws -> HoverResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
   func symbolInfo(_ req: Request<SymbolInfoRequest>) {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -523,8 +523,8 @@ extension ClangLanguageServerShim {
     forwardRequestToClangd(req)
   }
 
-  func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>) {
-    forwardRequestToClangd(req)
+  func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]? {
+    return try await forwardRequestToClangd(req)
   }
 
   func documentSymbol(_ req: Request<DocumentSymbolRequest>) {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -511,8 +511,8 @@ extension ClangLanguageServerShim {
     return true
   }
 
-  func completion(_ req: Request<CompletionRequest>) {
-    forwardRequestToClangd(req)
+  func completion(_ req: CompletionRequest) async throws -> CompletionList {
+    return try await forwardRequestToClangd(req)
   }
 
   func hover(_ req: HoverRequest) async throws -> HoverResponse? {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -582,8 +582,8 @@ extension ClangLanguageServerShim {
 
   // MARK: - Other
 
-  func executeCommand(_ req: Request<ExecuteCommandRequest>) {
-    forwardRequestToClangd(req)
+  func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
+    return try await forwardRequestToClangd(req)
   }
 }
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -565,8 +565,8 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) {
-    forwardRequestToClangd(req)
+  func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport {
+    return try await forwardRequestToClangd(req)
   }
 
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]? {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -531,12 +531,11 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func documentColor(_ req: Request<DocumentColorRequest>) {
-    if self.capabilities?.colorProvider?.isSupported == true {
-      forwardRequestToClangd(req)
-    } else {
-      req.reply(.success([]))
+  func documentColor(_ req: DocumentColorRequest) async throws -> [ColorInformation] {
+    guard self.capabilities?.colorProvider?.isSupported ?? false else {
+      return []
     }
+    return try await forwardRequestToClangd(req)
   }
 
   func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -550,12 +550,11 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func colorPresentation(_ req: Request<ColorPresentationRequest>) {
-    if self.capabilities?.colorProvider?.isSupported == true {
-      forwardRequestToClangd(req)
-    } else {
-      req.reply(.success([]))
+  func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation] {
+    guard self.capabilities?.colorProvider?.isSupported ?? false else {
+      return []
     }
+    return try await forwardRequestToClangd(req)
   }
 
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse? {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -498,10 +498,9 @@ extension ClangLanguageServerShim {
 
 
   /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
-  public func definition(_ req: Request<DefinitionRequest>) -> Bool {
+  public func definition(_ req: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
     // We handle it to provide jump-to-header support for #import/#include.
-    self.forwardRequestToClangd(req)
-    return true
+    return try await self.forwardRequestToClangd(req)
   }
 
   public func declaration(_ req: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse? {
@@ -516,8 +515,8 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func symbolInfo(_ req: Request<SymbolInfoRequest>) {
-    forwardRequestToClangd(req)
+  func symbolInfo(_ req: SymbolInfoRequest) async throws -> [SymbolDetails] {
+    return try await forwardRequestToClangd(req)
   }
 
   func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]? {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -578,8 +578,8 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func openInterface(_ request: Request<OpenInterfaceRequest>) {
-    request.reply(.failure(.unknown("unsupported method")))
+  func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails? {
+    throw ResponseError.unknown("unsupported method")
   }
 
   // MARK: - Other

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -559,8 +559,8 @@ extension ClangLanguageServerShim {
     }
   }
 
-  func codeAction(_ req: Request<CodeActionRequest>) {
-    forwardRequestToClangd(req)
+  func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
   func inlayHint(_ req: Request<InlayHintRequest>) {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -504,11 +504,8 @@ extension ClangLanguageServerShim {
     return true
   }
 
-  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
-  public func declaration(_ req: Request<DeclarationRequest>) -> Bool {
-    // We handle it to provide jump-to-header support for #import/#include.
-    forwardRequestToClangd(req)
-    return true
+  public func declaration(_ req: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
   func completion(_ req: CompletionRequest) async throws -> CompletionList {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -538,16 +538,16 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) {
-    forwardRequestToClangd(req)
+  func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
-  func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) {
-    forwardRequestToClangd(req)
+  func documentSemanticTokensDelta(_ req: DocumentSemanticTokensDeltaRequest) async throws -> DocumentSemanticTokensDeltaResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
-  func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>) {
-    forwardRequestToClangd(req)
+  func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
   func colorPresentation(_ req: Request<ColorPresentationRequest>) {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -527,8 +527,8 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func documentSymbol(_ req: Request<DocumentSymbolRequest>) {
-    forwardRequestToClangd(req)
+  func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse? {
+    return try await forwardRequestToClangd(req)
   }
 
   func documentColor(_ req: Request<DocumentColorRequest>) {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -561,8 +561,8 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func inlayHint(_ req: Request<InlayHintRequest>) {
-    forwardRequestToClangd(req)
+  func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint] {
+    return try await forwardRequestToClangd(req)
   }
 
   func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1268,11 +1268,11 @@ extension SourceKitServer {
   }
 
   func documentColor(
-    _ req: Request<DocumentColorRequest>,
+    _ req: DocumentColorRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentColor(req)
+  ) async throws -> [ColorInformation]{
+    return try await languageService.documentColor(req)
   }
 
   func documentSemanticTokens(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -579,7 +579,7 @@ extension SourceKitServer: MessageHandler {
       case let request as Request<CallHierarchyOutgoingCallsRequest>:
         await self.handleRequest(request, handler: self.outgoingCalls)
       case let request as Request<TypeHierarchySupertypesRequest>:
-        await self.supertypes(request)
+        await self.handleRequest(request, handler: self.supertypes)
       case let request as Request<TypeHierarchySubtypesRequest>:
         await self.subtypes(request)
       case let request as Request<CompletionRequest>:
@@ -1766,11 +1766,10 @@ extension SourceKitServer {
     )
   }
 
-  func supertypes(_ req: Request<TypeHierarchySupertypesRequest>) async {
-    guard let data = extractTypeHierarchyItemData(req.params.item.data),
+  func supertypes(_ req: TypeHierarchySupertypesRequest) async throws -> [TypeHierarchyItem]? {
+    guard let data = extractTypeHierarchyItemData(req.item.data),
           let index = await self.workspaceForDocument(uri: data.uri)?.index else {
-      req.reply([])
-      return
+      return []
     }
 
     // Resolve base types
@@ -1804,7 +1803,7 @@ extension SourceKitServer {
         index: index
       )
     }
-    req.reply(types)
+    return types
   }
 
   func subtypes(_ req: Request<TypeHierarchySubtypesRequest>) async {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -581,7 +581,7 @@ extension SourceKitServer: MessageHandler {
       case let request as Request<TypeHierarchySupertypesRequest>:
         await self.handleRequest(request, handler: self.supertypes)
       case let request as Request<TypeHierarchySubtypesRequest>:
-        await self.subtypes(request)
+        await self.handleRequest(request, handler: self.subtypes)
       case let request as Request<CompletionRequest>:
         await self.handleRequest(for: request, requestHandler: self.completion, fallback: CompletionList(isIncomplete: false, items: []))
       case let request as Request<HoverRequest>:
@@ -1806,11 +1806,10 @@ extension SourceKitServer {
     return types
   }
 
-  func subtypes(_ req: Request<TypeHierarchySubtypesRequest>) async {
-    guard let data = extractTypeHierarchyItemData(req.params.item.data),
+  func subtypes(_ req: TypeHierarchySubtypesRequest) async throws -> [TypeHierarchyItem]? {
+    guard let data = extractTypeHierarchyItemData(req.item.data),
           let index = await self.workspaceForDocument(uri: data.uri)?.index else {
-      req.reply([])
-      return
+      return []
     }
 
     // Resolve child types and extensions
@@ -1835,7 +1834,7 @@ extension SourceKitServer {
         index: index
       )
     }
-    req.reply(types)
+    return types
   }
 
   func pollIndex(_ req: PollIndexRequest) async throws -> VoidResponse {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -569,7 +569,7 @@ extension SourceKitServer: MessageHandler {
       case let request as Request<ShutdownRequest>:
         await self.handleRequest(request, handler: self.shutdown)
       case let request as Request<WorkspaceSymbolsRequest>:
-        await self.workspaceSymbols(request)
+        await self.handleRequest(request, handler: self.workspaceSymbols)
       case let request as Request<PollIndexRequest>:
         await self.pollIndex(request)
       case let request as Request<ExecuteCommandRequest>:
@@ -1228,9 +1228,9 @@ extension SourceKitServer {
 
   /// Handle a workspace/symbol request, returning the SymbolInformation.
   /// - returns: An array with SymbolInformation for each matching symbol in the workspace.
-  func workspaceSymbols(_ req: Request<WorkspaceSymbolsRequest>) {
+  func workspaceSymbols(_ req: WorkspaceSymbolsRequest) async throws -> [WorkspaceSymbolItem]? {
     let symbols = findWorkspaceSymbols(
-      matching: req.params.query
+      matching: req.query
     ).map({symbolOccurrence -> WorkspaceSymbolItem in
       let symbolPosition = Position(
         line: symbolOccurrence.location.line - 1, // 1-based -> 0-based
@@ -1249,7 +1249,7 @@ extension SourceKitServer {
         containerName: symbolOccurrence.getContainerName()
       ))
     })
-    req.reply(symbols)
+    return symbols
   }
 
   /// Forwards a SymbolInfoRequest to the appropriate toolchain service for this document.

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1343,11 +1343,11 @@ extension SourceKitServer {
   }
 
   func inlayHint(
-    _ req: Request<InlayHintRequest>,
+    _ req: InlayHintRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.inlayHint(req)
+  ) async throws -> [InlayHint] {
+    return try await languageService.inlayHint(req)
   }
 
   func documentDiagnostic(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1244,11 +1244,11 @@ extension SourceKitServer {
   }
 
   func documentSymbolHighlight(
-    _ req: Request<DocumentHighlightRequest>,
+    _ req: DocumentHighlightRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentSymbolHighlight(req)
+  ) async throws -> [DocumentHighlight]? {
+    return try await languageService.documentSymbolHighlight(req)
   }
 
   func foldingRange(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1334,23 +1334,12 @@ extension SourceKitServer {
   }
 
   func codeAction(
-    _ req: Request<CodeActionRequest>,
+    _ req: CodeActionRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    let codeAction = CodeActionRequest(range: req.params.range, context: req.params.context,
-                                       textDocument: req.params.textDocument)
-    let callback = { (result: Result<CodeActionRequest.Response, ResponseError>) in
-      switch result {
-      case .success(let reply):
-        req.reply(req.params.injectMetadata(toResponse: reply))
-      default:
-        req.reply(result)
-      }
-    }
-    let request = Request(codeAction, id: req.id, clientID: ObjectIdentifier(self),
-                          cancellation: req.cancellationToken, reply: callback)
-    await languageService.codeAction(request)
+  ) async throws -> CodeActionRequestResponse? {
+    let response = try await languageService.codeAction(req)
+    return req.injectMetadata(toResponse: response)
   }
 
   func inlayHint(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -589,7 +589,7 @@ extension SourceKitServer: MessageHandler {
       case let request as Request<OpenInterfaceRequest>:
         await self.handleRequest(for: request, requestHandler: self.openInterface, fallback: nil)
       case let request as Request<DeclarationRequest>:
-        await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.declaration, fallback: nil)
+        await self.handleRequest(for: request, requestHandler: self.declaration, fallback: nil)
       case let request as Request<DefinitionRequest>:
         await self.withLanguageServiceAndWorkspace(for: request, requestHandler: self.definition, fallback: .locations([]))
       case let request as Request<ReferencesRequest>:
@@ -1428,13 +1428,11 @@ extension SourceKitServer {
   }
 
   func declaration(
-    _ req: Request<DeclarationRequest>,
+    _ req: DeclarationRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    guard await languageService.declaration(req) else {
-      return req.reply(.locations([]))
-    }
+  ) async throws -> LocationsOrLocationLinksResponse? {
+    return try await languageService.declaration(req)
   }
 
   func definition(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1351,11 +1351,11 @@ extension SourceKitServer {
   }
 
   func documentDiagnostic(
-    _ req: Request<DocumentDiagnosticsRequest>,
+    _ req: DocumentDiagnosticsRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentDiagnostic(req)
+  ) async throws -> DocumentDiagnosticReport{
+    return try await languageService.documentDiagnostic(req)
   }
 
   /// Converts a location from the symbol index to an LSP location.

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -571,7 +571,7 @@ extension SourceKitServer: MessageHandler {
       case let request as Request<WorkspaceSymbolsRequest>:
         await self.handleRequest(request, handler: self.workspaceSymbols)
       case let request as Request<PollIndexRequest>:
-        await self.pollIndex(request)
+        await self.handleRequest(request, handler: self.pollIndex)
       case let request as Request<ExecuteCommandRequest>:
         await self.handleRequest(request, handler: self.executeCommand)
       case let request as Request<CallHierarchyIncomingCallsRequest>:
@@ -1841,11 +1841,11 @@ extension SourceKitServer {
     req.reply(types)
   }
 
-  func pollIndex(_ req: Request<PollIndexRequest>) {
+  func pollIndex(_ req: PollIndexRequest) async throws -> VoidResponse {
     for workspace in workspaces {
       workspace.index?.pollForUnitChangesAndWait()
     }
-    req.reply(VoidResponse())
+    return VoidResponse()
   }
 }
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1300,11 +1300,11 @@ extension SourceKitServer {
   }
 
   func colorPresentation(
-    _ req: Request<ColorPresentationRequest>,
+    _ req: ColorPresentationRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.colorPresentation(req)
+  ) async throws -> [ColorPresentation] {
+    return try await languageService.colorPresentation(req)
   }
 
   func executeCommand(_ req: Request<ExecuteCommandRequest>) async {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1276,27 +1276,27 @@ extension SourceKitServer {
   }
 
   func documentSemanticTokens(
-    _ req: Request<DocumentSemanticTokensRequest>,
+    _ req: DocumentSemanticTokensRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentSemanticTokens(req)
+  ) async throws -> DocumentSemanticTokensResponse?{
+    return try await languageService.documentSemanticTokens(req)
   }
 
   func documentSemanticTokensDelta(
-    _ req: Request<DocumentSemanticTokensDeltaRequest>,
+    _ req: DocumentSemanticTokensDeltaRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentSemanticTokensDelta(req)
+  ) async throws -> DocumentSemanticTokensDeltaResponse?{
+    return try await languageService.documentSemanticTokensDelta(req)
   }
 
   func documentSemanticTokensRange(
-    _ req: Request<DocumentSemanticTokensRangeRequest>,
+    _ req: DocumentSemanticTokensRangeRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentSemanticTokensRange(req)
+  ) async throws -> DocumentSemanticTokensResponse?{
+    return try await languageService.documentSemanticTokensRange(req)
   }
 
   func colorPresentation(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -18,6 +18,7 @@ import LanguageServerProtocol
 import LSPLogging
 import SKCore
 import SKSupport
+import SourceKitD
 
 import PackageLoading
 
@@ -288,6 +289,8 @@ public actor SourceKitServer {
       request.reply(.success(result))
     } catch let error as ResponseError {
       request.reply(.failure(error))
+    } catch let error as SKDError {
+      request.reply(.failure(ResponseError(error)))
     } catch is CancellationError {
       request.reply(.failure(.cancelled))
     } catch {
@@ -1156,11 +1159,11 @@ extension SourceKitServer {
   }
 
   func hover(
-    _ req: Request<HoverRequest>,
+    _ req: HoverRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.hover(req)
+  ) async throws -> HoverResponse? {
+    return try await languageService.hover(req)
   }
   
   func openInterface(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -567,7 +567,7 @@ extension SourceKitServer: MessageHandler {
       case let request as Request<InitializeRequest>:
         await self.handleRequest(request, handler: self.initialize)
       case let request as Request<ShutdownRequest>:
-        await self.shutdown(request)
+        await self.handleRequest(request, handler: self.shutdown)
       case let request as Request<WorkspaceSymbolsRequest>:
         await self.workspaceSymbols(request)
       case let request as Request<PollIndexRequest>:
@@ -984,7 +984,7 @@ extension SourceKitServer {
   }
 
 
-  func shutdown(_ request: Request<ShutdownRequest>) async {
+  func shutdown(_ request: ShutdownRequest) async throws -> VoidResponse {
     await prepareForExit()
 
     await withTaskGroup(of: Void.self) { taskGroup in
@@ -1005,7 +1005,7 @@ extension SourceKitServer {
     // Otherwise we might terminate sourcekit-lsp while it still has open
     // connections to the toolchain servers, which could send messages to
     // sourcekit-lsp while it is being deallocated, causing crashes.
-    request.reply(VoidResponse())
+    return VoidResponse()
   }
 
   func exit(_ notification: ExitNotification) async {

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1260,11 +1260,11 @@ extension SourceKitServer {
   }
 
   func documentSymbol(
-    _ req: Request<DocumentSymbolRequest>,
+    _ req: DocumentSymbolRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.documentSymbol(req)
+  ) async throws -> DocumentSymbolResponse?{
+    return try await languageService.documentSymbol(req)
   }
 
   func documentColor(

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1151,11 +1151,11 @@ extension SourceKitServer {
   // MARK: - Language features
 
   func completion(
-    _ req: Request<CompletionRequest>,
+    _ req: CompletionRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async {
-    await languageService.completion(req)
+  ) async throws -> CompletionList {
+    return try await languageService.completion(req)
   }
 
   func hover(

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -848,40 +848,37 @@ extension SwiftLanguageServer {
     return colorInformation(array: results)
   }
 
-  public func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) {
-    let uri = req.params.textDocument.uri
+  public func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse? {
+    let uri = req.textDocument.uri
 
     guard let snapshot = self.documentManager.latestSnapshot(uri) else {
       log("failed to find snapshot for uri \(uri)")
-      req.reply(DocumentSemanticTokensResponse(data: []))
-      return
+      return DocumentSemanticTokensResponse(data: [])
     }
 
     let tokens = snapshot.mergedAndSortedTokens()
     let encodedTokens = tokens.lspEncoded
 
-    req.reply(DocumentSemanticTokensResponse(data: encodedTokens))
+    return DocumentSemanticTokensResponse(data: encodedTokens)
   }
 
-  public func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) {
-    // FIXME: implement semantic tokens delta support.
-    req.reply(nil)
+  public func documentSemanticTokensDelta(_ req: DocumentSemanticTokensDeltaRequest) async throws -> DocumentSemanticTokensDeltaResponse? {
+    return nil
   }
 
-  public func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>) {
-    let uri = req.params.textDocument.uri
-    let range = req.params.range
+  public func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse? {
+    let uri = req.textDocument.uri
+    let range = req.range
 
     guard let snapshot = self.documentManager.latestSnapshot(uri) else {
       log("failed to find snapshot for uri \(uri)")
-      req.reply(DocumentSemanticTokensResponse(data: []))
-      return
+      return DocumentSemanticTokensResponse(data: [])
     }
 
     let tokens = snapshot.mergedAndSortedTokens(in: range)
     let encodedTokens = tokens.lspEncoded
 
-    req.reply(DocumentSemanticTokensResponse(data: encodedTokens))
+    return DocumentSemanticTokensResponse(data: encodedTokens)
   }
 
   public func colorPresentation(_ req: Request<ColorPresentationRequest>) {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -620,9 +620,8 @@ extension SwiftLanguageServer {
     return false
   }
 
-  public func declaration(_ request: Request<DeclarationRequest>) -> Bool {
-    // We don't handle it.
-    return false
+  public func declaration(_ request: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse? {
+    throw ResponseError.unknown("unsupported method")
   }
 
   public func hover(_ req: HoverRequest) async throws -> HoverResponse? {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -881,14 +881,14 @@ extension SwiftLanguageServer {
     return DocumentSemanticTokensResponse(data: encodedTokens)
   }
 
-  public func colorPresentation(_ req: Request<ColorPresentationRequest>) {
-    let color = req.params.color
+  public func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation] {
+    let color = req.color
     // Empty string as a label breaks VSCode color picker
     let label = "Color Literal"
     let newText = "#colorLiteral(red: \(color.red), green: \(color.green), blue: \(color.blue), alpha: \(color.alpha))"
-    let textEdit = TextEdit(range: req.params.range, newText: newText)
+    let textEdit = TextEdit(range: req.range, newText: newText)
     let presentation = ColorPresentation(label: label, textEdit: textEdit, additionalTextEdits: nil)
-    req.reply([presentation])
+    return [presentation]
   }
 
   public func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]? {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -443,7 +443,7 @@ extension SwiftLanguageServer {
 
   public func shutdown() async {
     if let session = self.currentCompletionSession {
-      session.close()
+      await session.close()
       self.currentCompletionSession = nil
     }
     self.sourcekitd.removeNotificationHandler(self)

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -79,7 +79,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   // MARK: - Text Document
 
   func completion(_ req: Request<CompletionRequest>) async
-  func hover(_ req: Request<HoverRequest>) async
+  func hover(_ req: HoverRequest) async throws -> HoverResponse?
   func symbolInfo(_ request: Request<SymbolInfoRequest>) async
   func openInterface(_ request: Request<OpenInterfaceRequest>) async
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -81,7 +81,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func completion(_ req: CompletionRequest) async throws -> CompletionList
   func hover(_ req: HoverRequest) async throws -> HoverResponse?
   func symbolInfo(_ request: Request<SymbolInfoRequest>) async
-  func openInterface(_ request: Request<OpenInterfaceRequest>) async
+  func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails?
 
   /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
   func definition(_ request: Request<DefinitionRequest>) async -> Bool

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -94,7 +94,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse?
   func documentSemanticTokensDelta(_ req: DocumentSemanticTokensDeltaRequest) async throws -> DocumentSemanticTokensDeltaResponse?
   func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse?
-  func colorPresentation(_ req: Request<ColorPresentationRequest>) async
+  func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation]
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: Request<InlayHintRequest>) async
   func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) async

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -85,7 +85,7 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
   func definition(_ request: Request<DefinitionRequest>) async -> Bool
-  func declaration(_ request: Request<DeclarationRequest>) async -> Bool
+  func declaration(_ request: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse?
 
   func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]?
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -95,7 +95,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) async
   func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>) async
   func colorPresentation(_ req: Request<ColorPresentationRequest>) async
-  func codeAction(_ req: Request<CodeActionRequest>) async
+  func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: Request<InlayHintRequest>) async
   func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) async
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -87,7 +87,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func definition(_ request: Request<DefinitionRequest>) async -> Bool
   func declaration(_ request: Request<DeclarationRequest>) async -> Bool
 
-  func documentSymbolHighlight(_ req: Request<DocumentHighlightRequest>) async
+  func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]?
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
   func documentSymbol(_ req: Request<DocumentSymbolRequest>) async
   func documentColor(_ req: Request<DocumentColorRequest>) async

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -90,7 +90,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]?
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
   func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse?
-  func documentColor(_ req: Request<DocumentColorRequest>) async
+  func documentColor(_ req: DocumentColorRequest) async throws -> [ColorInformation]
   func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) async
   func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) async
   func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>) async

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -101,7 +101,7 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   // MARK: - Other
 
-  func executeCommand(_ req: Request<ExecuteCommandRequest>) async
+  func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny?
 
   /// Crash the language server. Should be used for crash recovery testing only.
   func _crash() async

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -89,7 +89,7 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]?
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
-  func documentSymbol(_ req: Request<DocumentSymbolRequest>) async
+  func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse?
   func documentColor(_ req: Request<DocumentColorRequest>) async
   func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) async
   func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) async

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -96,7 +96,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse?
   func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation]
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
-  func inlayHint(_ req: Request<InlayHintRequest>) async
+  func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint]
   func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) async
 
   // MARK: - Other

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -91,9 +91,9 @@ public protocol ToolchainLanguageServer: AnyObject {
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
   func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse?
   func documentColor(_ req: DocumentColorRequest) async throws -> [ColorInformation]
-  func documentSemanticTokens(_ req: Request<DocumentSemanticTokensRequest>) async
-  func documentSemanticTokensDelta(_ req: Request<DocumentSemanticTokensDeltaRequest>) async
-  func documentSemanticTokensRange(_ req: Request<DocumentSemanticTokensRangeRequest>) async
+  func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse?
+  func documentSemanticTokensDelta(_ req: DocumentSemanticTokensDeltaRequest) async throws -> DocumentSemanticTokensDeltaResponse?
+  func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse?
   func colorPresentation(_ req: Request<ColorPresentationRequest>) async
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: Request<InlayHintRequest>) async

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -97,7 +97,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation]
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint]
-  func documentDiagnostic(_ req: Request<DocumentDiagnosticsRequest>) async
+  func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport
 
   // MARK: - Other
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -80,13 +80,13 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   func completion(_ req: CompletionRequest) async throws -> CompletionList
   func hover(_ req: HoverRequest) async throws -> HoverResponse?
-  func symbolInfo(_ request: Request<SymbolInfoRequest>) async
+  func symbolInfo(_ request: SymbolInfoRequest) async throws -> [SymbolDetails]
   func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails?
 
-  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
-  func definition(_ request: Request<DefinitionRequest>) async -> Bool
-  func declaration(_ request: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse?
+  /// - Note: Only called as a fallback if the definition could not be found in the index.
+  func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse?
 
+  func declaration(_ request: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse?
   func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]?
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
   func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse?

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -78,7 +78,7 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   // MARK: - Text Document
 
-  func completion(_ req: Request<CompletionRequest>) async
+  func completion(_ req: CompletionRequest) async throws -> CompletionList
   func hover(_ req: HoverRequest) async throws -> HoverResponse?
   func symbolInfo(_ request: Request<SymbolInfoRequest>) async
   func openInterface(_ request: Request<OpenInterfaceRequest>) async


### PR DESCRIPTION
We can now harvest the benefits of migrating things to Swift concurrency and change the handling of all requests to asynchronously return the response instead of taking the implicit completion handler via the `Request`.

All changes are very straightforward. Again, this is probably best reviewed with whitespace changes hidden.