### PR TITLE
Don't call closeHandler if it is nil

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -62,7 +62,7 @@ public final class JSONRPCConnection {
 
   /// A handler that will be called asyncronously when the connection is being
   /// closed.
-  var closeHandler: (() async -> Void)! = nil
+  var closeHandler: (() async -> Void)? = nil
 
   public init(
     protocol messageRegistry: MessageRegistry,
@@ -113,9 +113,7 @@ public final class JSONRPCConnection {
     ioGroup.notify(queue: queue) { [weak self] in
       guard let self = self else { return }
       Task {
-        if self.closeHandler != nil {
-          await self.closeHandler()
-        }
+        await self.closeHandler?()
         self.receiveHandler = nil // break retain cycle
       }
     }

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -113,7 +113,9 @@ public final class JSONRPCConnection {
     ioGroup.notify(queue: queue) { [weak self] in
       guard let self = self else { return }
       Task {
-        await self.closeHandler()
+        if self.closeHandler != nil {
+          await self.closeHandler()
+        }
         self.receiveHandler = nil // break retain cycle
       }
     }


### PR DESCRIPTION
Issue: #852 closeHandler callback can be nil in an initializer