### PR TITLE
Handle notifications from `sourcekitd` on a serial queue

### DIFF
--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -45,7 +45,7 @@ public protocol SourceKitD: AnyObject {
   func removeNotificationHandler(_ handler: SKDNotificationHandler)
 }
 
-public enum SKDError:Error {
+public enum SKDError: Error, Equatable {
   /// The service has crashed.
   case connectionInterrupted
 


### PR DESCRIPTION
The issue is that we handle the (crash) notifications from sourcekitd on a concurrent queue at the moment.

When sourcekitd crashes, we re-open the documents within it immediately and the re-opening of documents will be sent to sourcekitd (and return) after sourcekitd comes back online.

But since we handle notifications from sourcekitd concurrently at the moment, we might handle the notification that sourcekitd is back online before we had a chance to re-open the documents and now we’re sending a cursor info to sourcekitd for a document that isn’t open.

To fix this, handle notifications from sourcekitd on a serial queue so that we serve them in-order.

rdar://116584307