### PR TITLE
Don't hop on background queue to run `onExit`

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -967,11 +967,7 @@ extension SourceKitServer {
     await prepareForExit()
 
     // Call onExit only once, and hop off queue to allow the handler to call us back.
-    let onExit = self.onExit
-    self.onExit = {}
-    DispatchQueue.global().async {
-      onExit()
-    }
+    self.onExit()
   }
 
   // MARK: - Text synchronization


### PR DESCRIPTION
Since we use Swift Concurrency now, we no longer need to be worried about queues blocking each other, so the queue hopping is no longer necessary.