### PR TITLE
Format using swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,17 @@
+{
+    "version": 1,
+    "lineLength": 120,
+    "indentation": {
+        "spaces": 2
+    },
+    "lineBreakBeforeEachArgument": true,
+    "indentConditionalCompilationBlocks": false,
+    "rules": {
+        "AlwaysUseLowerCamelCase": false,
+        "AmbiguousTrailingClosureOverload": false,
+        "NoBlockComments": false,
+        "OrderedImports": true,
+        "UseLetInEveryBoundCaseVariable": false,
+        "UseSynthesizedInitializer": false
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,241 +1,253 @@
 // swift-tools-version:5.7
 
-import PackageDescription
 import Foundation
+import PackageDescription
 
 // When building the toolchain on the CI, don't add the CI's runpath for the
 // final build before installing.
-let sourcekitLSPLinkSettings : [LinkerSetting]
+let sourcekitLSPLinkSettings: [LinkerSetting]
 if ProcessInfo.processInfo.environment["SOURCEKIT_LSP_CI_INSTALL"] != nil {
-  sourcekitLSPLinkSettings = [ .unsafeFlags(["-no-toolchain-stdlib-rpath"], .when(platforms: [.linux, .android])) ]
+  sourcekitLSPLinkSettings = [.unsafeFlags(["-no-toolchain-stdlib-rpath"], .when(platforms: [.linux, .android]))]
 } else {
   sourcekitLSPLinkSettings = []
 }
 
 let package = Package(
-    name: "SourceKitLSP",
-    platforms: [.macOS("12.0")],
-    products: [
-      .executable(
-        name: "sourcekit-lsp",
-        targets: ["sourcekit-lsp"]
-      ),
-      .library(
-        name: "_SourceKitLSP",
-        targets: ["SourceKitLSP"]
-      ),
-      .library(
-        name: "LSPBindings",
-        targets: [
-          "LanguageServerProtocol",
-          "LanguageServerProtocolJSONRPC",
-        ]
-      )
-    ],
-    dependencies: [
-      // See 'Dependencies' below.
-    ],
-    targets: [
-      .executableTarget(
-        name: "sourcekit-lsp",
-        dependencies: [
-          "LanguageServerProtocolJSONRPC",
-          "SourceKitLSP",
-          .product(name: "ArgumentParser", package: "swift-argument-parser"),
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ],
-        exclude: ["CMakeLists.txt"],
-        linkerSettings: sourcekitLSPLinkSettings),
+  name: "SourceKitLSP",
+  platforms: [.macOS("12.0")],
+  products: [
+    .executable(
+      name: "sourcekit-lsp",
+      targets: ["sourcekit-lsp"]
+    ),
+    .library(
+      name: "_SourceKitLSP",
+      targets: ["SourceKitLSP"]
+    ),
+    .library(
+      name: "LSPBindings",
+      targets: [
+        "LanguageServerProtocol",
+        "LanguageServerProtocolJSONRPC",
+      ]
+    ),
+  ],
+  dependencies: [
+    // See 'Dependencies' below.
+  ],
+  targets: [
+    .executableTarget(
+      name: "sourcekit-lsp",
+      dependencies: [
+        "LanguageServerProtocolJSONRPC",
+        "SourceKitLSP",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ],
+      exclude: ["CMakeLists.txt"],
+      linkerSettings: sourcekitLSPLinkSettings
+    ),
 
-      .target(
-        name: "SourceKitLSP",
-        dependencies: [
-          "BuildServerProtocol",
-          .product(name: "IndexStoreDB", package: "indexstore-db"),
-          "LanguageServerProtocol",
-          "LanguageServerProtocolJSONRPC",
-          "SKCore",
-          "SourceKitD",
-          "SKSwiftPMWorkspace",
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-          .product(name: "SwiftSyntax", package: "swift-syntax"),
-          .product(name: "SwiftParser", package: "swift-syntax"),
-          .product(name: "SwiftIDEUtils", package: "swift-syntax"),
-        ],
-        exclude: ["CMakeLists.txt"]),
+    .target(
+      name: "SourceKitLSP",
+      dependencies: [
+        "BuildServerProtocol",
+        .product(name: "IndexStoreDB", package: "indexstore-db"),
+        "LanguageServerProtocol",
+        "LanguageServerProtocolJSONRPC",
+        "SKCore",
+        "SourceKitD",
+        "SKSwiftPMWorkspace",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(name: "SwiftIDEUtils", package: "swift-syntax"),
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .target(
-        name: "CSKTestSupport",
-        dependencies: []),
-      .target(
-        name: "SKTestSupport",
-        dependencies: [
-          "CSKTestSupport",
-          "LSPTestSupport",
-          "SourceKitLSP",
-          .product(name: "ISDBTestSupport", package: "indexstore-db"),
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ],
-        resources: [
-          .copy("INPUTS"),
-        ]
-      ),
-      .testTarget(
-        name: "SourceKitLSPTests",
-        dependencies: [
-          "SKTestSupport",
-          "SourceKitLSP",
-        ]
-      ),
+    .target(
+      name: "CSKTestSupport",
+      dependencies: []
+    ),
+    .target(
+      name: "SKTestSupport",
+      dependencies: [
+        "CSKTestSupport",
+        "LSPTestSupport",
+        "SourceKitLSP",
+        .product(name: "ISDBTestSupport", package: "indexstore-db"),
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ],
+      resources: [
+        .copy("INPUTS")
+      ]
+    ),
+    .testTarget(
+      name: "SourceKitLSPTests",
+      dependencies: [
+        "SKTestSupport",
+        "SourceKitLSP",
+      ]
+    ),
 
-      .target(
-        name: "SKSwiftPMWorkspace",
-        dependencies: [
-          "BuildServerProtocol",
-          "LanguageServerProtocol",
-          "SKCore",
-          .product(name: "SwiftPM-auto", package: "swift-package-manager")
-        ],
-        exclude: ["CMakeLists.txt"]),
+    .target(
+      name: "SKSwiftPMWorkspace",
+      dependencies: [
+        "BuildServerProtocol",
+        "LanguageServerProtocol",
+        "SKCore",
+        .product(name: "SwiftPM-auto", package: "swift-package-manager"),
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "SKSwiftPMWorkspaceTests",
-        dependencies: [
-          "SKSwiftPMWorkspace",
-          "SKTestSupport",
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ]
-      ),
+    .testTarget(
+      name: "SKSwiftPMWorkspaceTests",
+      dependencies: [
+        "SKSwiftPMWorkspace",
+        "SKTestSupport",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ]
+    ),
 
-      // SKCore: Data structures and algorithms useful across the project, but not necessarily
-      // suitable for use in other packages.
-      .target(
-        name: "SKCore",
-        dependencies: [
-          "SourceKitD",
-          "BuildServerProtocol",
-          "LanguageServerProtocol",
-          "LanguageServerProtocolJSONRPC",
-          "SKSupport",
-          .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ],
-        exclude: ["CMakeLists.txt"]),
+    // SKCore: Data structures and algorithms useful across the project, but not necessarily
+    // suitable for use in other packages.
+    .target(
+      name: "SKCore",
+      dependencies: [
+        "SourceKitD",
+        "BuildServerProtocol",
+        "LanguageServerProtocol",
+        "LanguageServerProtocolJSONRPC",
+        "SKSupport",
+        .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "SKCoreTests",
-        dependencies: [
-          "SKCore",
-          "SKTestSupport",
-        ]
-      ),
+    .testTarget(
+      name: "SKCoreTests",
+      dependencies: [
+        "SKCore",
+        "SKTestSupport",
+      ]
+    ),
 
-      // SourceKitD: Swift bindings for sourcekitd.
-      .target(
-        name: "SourceKitD",
-        dependencies: [
-          "Csourcekitd",
-          "LSPLogging",
-          "SKSupport",
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ],
-        exclude: ["CMakeLists.txt"]),
+    // SourceKitD: Swift bindings for sourcekitd.
+    .target(
+      name: "SourceKitD",
+      dependencies: [
+        "Csourcekitd",
+        "LSPLogging",
+        "SKSupport",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "SourceKitDTests",
-        dependencies: [
-          "SourceKitD",
-          "SKCore",
-          "SKTestSupport",
-        ]
-      ),
+    .testTarget(
+      name: "SourceKitDTests",
+      dependencies: [
+        "SourceKitD",
+        "SKCore",
+        "SKTestSupport",
+      ]
+    ),
 
-      // Csourcekitd: C modules wrapper for sourcekitd.
-      .target(
-        name: "Csourcekitd",
-        dependencies: [],
-        exclude: ["CMakeLists.txt"]),
+    // Csourcekitd: C modules wrapper for sourcekitd.
+    .target(
+      name: "Csourcekitd",
+      dependencies: [],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      // Logging support used in LSP modules.
-      .target(
-        name: "LSPLogging",
-        dependencies: [],
-        exclude: ["CMakeLists.txt"]),
+    // Logging support used in LSP modules.
+    .target(
+      name: "LSPLogging",
+      dependencies: [],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "LSPLoggingTests",
-        dependencies: [
-          "LSPLogging",
-        ]
-      ),
+    .testTarget(
+      name: "LSPLoggingTests",
+      dependencies: [
+        "LSPLogging"
+      ]
+    ),
 
-      .target(
-        name: "LSPTestSupport",
-        dependencies: [
-          "LanguageServerProtocol",
-          "LanguageServerProtocolJSONRPC"
-        ]
-      ),
+    .target(
+      name: "LSPTestSupport",
+      dependencies: [
+        "LanguageServerProtocol",
+        "LanguageServerProtocolJSONRPC",
+      ]
+    ),
 
-      // jsonrpc: LSP connection using jsonrpc over pipes.
-      .target(
-        name: "LanguageServerProtocolJSONRPC",
-        dependencies: [
-          "LanguageServerProtocol",
-          "LSPLogging",
-        ],
-        exclude: ["CMakeLists.txt"]),
+    // jsonrpc: LSP connection using jsonrpc over pipes.
+    .target(
+      name: "LanguageServerProtocolJSONRPC",
+      dependencies: [
+        "LanguageServerProtocol",
+        "LSPLogging",
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "LanguageServerProtocolJSONRPCTests",
-        dependencies: [
-          "LanguageServerProtocolJSONRPC",
-          "LSPTestSupport"
-        ]
-      ),
+    .testTarget(
+      name: "LanguageServerProtocolJSONRPCTests",
+      dependencies: [
+        "LanguageServerProtocolJSONRPC",
+        "LSPTestSupport",
+      ]
+    ),
 
-      // LanguageServerProtocol: The core LSP types, suitable for any LSP implementation.
-      .target(
-        name: "LanguageServerProtocol",
-        dependencies: [
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ],
-        exclude: ["CMakeLists.txt"]),
+    // LanguageServerProtocol: The core LSP types, suitable for any LSP implementation.
+    .target(
+      name: "LanguageServerProtocol",
+      dependencies: [
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "LanguageServerProtocolTests",
-        dependencies: [
-          "LanguageServerProtocol",
-          "LSPTestSupport",
-        ]
-      ),
+    .testTarget(
+      name: "LanguageServerProtocolTests",
+      dependencies: [
+        "LanguageServerProtocol",
+        "LSPTestSupport",
+      ]
+    ),
 
-      // BuildServerProtocol: connection between build server and language server to provide build and index info
-      .target(
-        name: "BuildServerProtocol",
-        dependencies: [
-          "LanguageServerProtocol"
-        ],
-        exclude: ["CMakeLists.txt"]),
+    // BuildServerProtocol: connection between build server and language server to provide build and index info
+    .target(
+      name: "BuildServerProtocol",
+      dependencies: [
+        "LanguageServerProtocol"
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      // SKSupport: Data structures, algorithms and platform-abstraction code that might be generally
-      // useful to any Swift package. Similar in spirit to SwiftPM's Basic module.
-      .target(
-        name: "SKSupport",
-        dependencies: [
-          .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        ],
-        exclude: ["CMakeLists.txt"]),
+    // SKSupport: Data structures, algorithms and platform-abstraction code that might be generally
+    // useful to any Swift package. Similar in spirit to SwiftPM's Basic module.
+    .target(
+      name: "SKSupport",
+      dependencies: [
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+      ],
+      exclude: ["CMakeLists.txt"]
+    ),
 
-      .testTarget(
-        name: "SKSupportTests",
-        dependencies: [
-          "LSPTestSupport",
-          "SKSupport",
-          "SKTestSupport",
-        ]
-      ),
-    ]
+    .testTarget(
+      name: "SKSupportTests",
+      dependencies: [
+        "LSPTestSupport",
+        "SKSupport",
+        "SKTestSupport",
+      ]
+    ),
+  ]
 )
 
 // MARK: Dependencies
@@ -261,6 +273,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     .package(name: "swift-package-manager", path: "../swiftpm"),
     .package(path: "../swift-tools-support-core"),
     .package(path: "../swift-argument-parser"),
-    .package(path: "../swift-syntax")
+    .package(path: "../swift-syntax"),
   ]
 }

--- a/Sources/BuildServerProtocol/BuildTargets.swift
+++ b/Sources/BuildServerProtocol/BuildTargets.swift
@@ -62,13 +62,15 @@ public struct BuildTarget: Codable, Hashable {
   /// The direct upstream build target dependencies of this build target
   public var dependencies: [BuildTargetIdentifier]
 
-  public init(id: BuildTargetIdentifier,
-              displayName: String?,
-              baseDirectory: URI?,
-              tags: [BuildTargetTag],
-              capabilities: BuildTargetCapabilities,
-              languageIds: [Language],
-              dependencies: [BuildTargetIdentifier]) {
+  public init(
+    id: BuildTargetIdentifier,
+    displayName: String?,
+    baseDirectory: URI?,
+    tags: [BuildTargetTag],
+    capabilities: BuildTargetCapabilities,
+    languageIds: [Language],
+    dependencies: [BuildTargetIdentifier]
+  ) {
     self.id = id
     self.displayName = displayName
     self.baseDirectory = baseDirectory

--- a/Sources/BuildServerProtocol/InitializeBuild.swift
+++ b/Sources/BuildServerProtocol/InitializeBuild.swift
@@ -44,7 +44,13 @@ public struct InitializeBuild: RequestType, Hashable {
   /// The capabilities of the client
   public var capabilities: BuildClientCapabilities
 
-  public init(displayName: String, version: String, bspVersion: String, rootUri: URI, capabilities: BuildClientCapabilities) {
+  public init(
+    displayName: String,
+    version: String,
+    bspVersion: String,
+    rootUri: URI,
+    capabilities: BuildClientCapabilities
+  ) {
     self.displayName = displayName
     self.version = version
     self.bspVersion = bspVersion
@@ -66,22 +72,28 @@ public struct BuildClientCapabilities: Codable, Hashable {
 }
 
 public struct InitializeBuildResult: ResponseType, Hashable {
-  /// Name of the server 
+  /// Name of the server
   public var displayName: String
 
-  /// The version of the server 
+  /// The version of the server
   public var version: String
 
-  /// The BSP version that the server speaks 
+  /// The BSP version that the server speaks
   public var bspVersion: String
 
-  /// The capabilities of the build server 
+  /// The capabilities of the build server
   public var capabilities: BuildServerCapabilities
 
   /// Optional metadata about the server
   public var data: LSPAny?
 
-  public init(displayName: String, version: String, bspVersion: String, capabilities: BuildServerCapabilities, data: LSPAny? = nil) {
+  public init(
+    displayName: String,
+    version: String,
+    bspVersion: String,
+    capabilities: BuildServerCapabilities,
+    data: LSPAny? = nil
+  ) {
     self.displayName = displayName
     self.version = version
     self.bspVersion = bspVersion

--- a/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
+++ b/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import LanguageServerProtocol
 
-
 /// The register for changes request is sent from the language
 /// server to the build server to register or unregister for
 /// changes in file options or dependencies. On changes a

--- a/Sources/LSPLogging/LogLevel.swift
+++ b/Sources/LSPLogging/LogLevel.swift
@@ -65,7 +65,7 @@ extension LogLevel {
 
       if let level = LogLevel(rawValue: value) {
         self = level
-      } else if value > LogLevel.debug.rawValue  {
+      } else if value > LogLevel.debug.rawValue {
         self = .debug
       } else {
         return nil

--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 #if canImport(os)
-import os // os_log
+import os  // os_log
 #endif
 
 /// Log the given message.
@@ -52,8 +52,8 @@ public func orLog<R>(
   _ prefix: String = "",
   level: LogLevel = .default,
   logger: Logger = Logger.shared,
-  _ block: () throws -> R?) -> R?
-{
+  _ block: () throws -> R?
+) -> R? {
   do {
     return try block()
   } catch {
@@ -67,8 +67,8 @@ public func orLog<R>(
   _ prefix: String = "",
   level: LogLevel = .default,
   logger: Logger = Logger.shared,
-  _ block: () async throws -> R?) async -> R?
-{
+  _ block: () async throws -> R?
+) async -> R? {
   do {
     return try await block()
   } catch {
@@ -76,7 +76,6 @@ public func orLog<R>(
     return nil
   }
 }
-
 
 /// Logs the time that the given block takes to execute in milliseconds.
 public func logExecutionTime<R>(
@@ -197,7 +196,7 @@ public final class Logger {
     let currentLevel = self.currentLevel
 
     var usedOSLog = false
-#if canImport(os)
+    #if canImport(os)
     if !disableOSLog {
       // If os_log is available, we call it unconditionally since it has its own log-level handling that we respect.
       if #available(macOS 11.0, *) {
@@ -207,7 +206,7 @@ public final class Logger {
       }
       usedOSLog = true
     }
-#endif
+    #endif
 
     if level > currentLevel {
       return

--- a/Sources/LSPTestSupport/Assertions.swift
+++ b/Sources/LSPTestSupport/Assertions.swift
@@ -82,11 +82,14 @@ extension XCTestCase {
     var expecatations: [XCTestExpectation]
 
     var description: String {
-      return "One of the expectation was not fulfilled within timeout: \(expecatations.map(\.description).joined(separator: ", "))"
+      return """
+        One of the expectation was not fulfilled within timeout: \
+        \(expecatations.map(\.description).joined(separator: ", "))
+        """
     }
   }
 
-  /// Wait for the given expectations to be fulfilled. If the expectations aren't 
+  /// Wait for the given expectations to be fulfilled. If the expectations aren't
   /// fulfilled within `timeout`, throw an error, aborting the test execution.
   public func fulfillmentOfOrThrow(
     _ expectations: [XCTestExpectation],

--- a/Sources/LSPTestSupport/CheckCoding.swift
+++ b/Sources/LSPTestSupport/CheckCoding.swift
@@ -17,11 +17,16 @@ import XCTest
 ///
 /// - parameter value: The value to encode/decode.
 /// - parameter json: The expected json encoding.
-public func checkCoding<T>(_ value: T, json: String, file: StaticString = #filePath, line: UInt = #line) where T: Codable & Equatable {
+public func checkCoding<T: Codable & Equatable>(
+  _ value: T,
+  json: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
   encoder.outputFormatting.insert(.sortedKeys)
-  
+
   let data = try! encoder.encode(WrapFragment(value: value))
   let wrappedStr = String(data: data, encoding: .utf8)!
 
@@ -52,7 +57,12 @@ private struct WrapFragment<T>: Equatable, Codable where T: Equatable & Codable 
 ///
 /// - parameter value: The value to encode/decode.
 /// - parameter json: The expected json encoding.
-public func checkDecoding<T>(json: String, expected value: T, file: StaticString = #filePath, line: UInt = #line) where T: Codable & Equatable {
+public func checkDecoding<T: Codable & Equatable>(
+  json: String,
+  expected value: T,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
 
   let wrappedStr = "{\"value\":\(json)}"
   let data = wrappedStr.data(using: .utf8)!
@@ -62,7 +72,14 @@ public func checkDecoding<T>(json: String, expected value: T, file: StaticString
   XCTAssertEqual(value, decodedValue, file: file, line: line)
 }
 
-public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKey: Any] = [:], file: StaticString = #filePath, line: UInt = #line, body: (T) -> Void) where T: Codable {
+public func checkCoding<T>(
+  _ value: T,
+  json: String,
+  userInfo: [CodingUserInfoKey: Any] = [:],
+  file: StaticString = #filePath,
+  line: UInt = #line,
+  body: (T) -> Void
+) where T: Codable {
   let encoder = JSONEncoder()
   encoder.outputFormatting.insert(.prettyPrinted)
   encoder.outputFormatting.insert(.sortedKeys)
@@ -71,7 +88,7 @@ public func checkCoding<T>(_ value: T, json: String, userInfo: [CodingUserInfoKe
     // Remove trailing whitespace to normalize between corelibs and Apple Foundation.
     .trimmingTrailingWhitespace()
   XCTAssertEqual(json, str, file: file, line: line)
-  
+
   let decoder = JSONDecoder()
   decoder.userInfo = userInfo
   let decodedValue = try! decoder.decode(T.self, from: data)

--- a/Sources/LSPTestSupport/PerfTestCase.swift
+++ b/Sources/LSPTestSupport/PerfTestCase.swift
@@ -21,34 +21,34 @@ import XCTest
 /// continuous integration.
 open class PerfTestCase: XCTestCase {
 
-#if !ENABLE_PERF_TESTS
+  #if !ENABLE_PERF_TESTS
 
   #if os(macOS)
-    open override func startMeasuring() {}
-    open override func stopMeasuring() {}
-    open override func measureMetrics(
-      _: [XCTPerformanceMetric],
-      automaticallyStartMeasuring: Bool,
-      for block: () -> Void)
-    {
-      block()
-    }
+  open override func startMeasuring() {}
+  open override func stopMeasuring() {}
+  open override func measureMetrics(
+    _: [XCTPerformanceMetric],
+    automaticallyStartMeasuring: Bool,
+    for block: () -> Void
+  ) {
+    block()
+  }
   #else
-    // In corelibs-xctest, these methods are public, not open, so we can only
-    // shadow them.
-    public func startMeasuring() {}
-    public func stopMeasuring() {}
-    public func measureMetrics(
-      _: [XCTPerformanceMetric],
-      automaticallyStartMeasuring: Bool,
-      for block: () -> Void)
-    {
-      block()
-    }
-    public func measure(block: () -> Void) {
-      block()
-    }
+  // In corelibs-xctest, these methods are public, not open, so we can only
+  // shadow them.
+  public func startMeasuring() {}
+  public func stopMeasuring() {}
+  public func measureMetrics(
+    _: [XCTPerformanceMetric],
+    automaticallyStartMeasuring: Bool,
+    for block: () -> Void
+  ) {
+    block()
+  }
+  public func measure(block: () -> Void) {
+    block()
+  }
   #endif
-#endif
+  #endif
 
 }

--- a/Sources/LSPTestSupport/String+TrimTrailingWhitespace.swift
+++ b/Sources/LSPTestSupport/String+TrimTrailingWhitespace.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 public extension String {
   // This implementation is really slow; to use it outside a test it should be optimized.
   func trimmingTrailingWhitespace() -> String {

--- a/Sources/LSPTestSupport/Timeouts.swift
+++ b/Sources/LSPTestSupport/Timeouts.swift
@@ -13,5 +13,5 @@
 import Foundation
 
 /// The default duration how long tests should wait for responses from
-/// SourceKit-LSP / sourcekitd / clangd. 
+/// SourceKit-LSP / sourcekitd / clangd.
 public let defaultTimeout: TimeInterval = 60

--- a/Sources/LanguageServerProtocol/AsyncQueue.swift
+++ b/Sources/LanguageServerProtocol/AsyncQueue.swift
@@ -124,7 +124,6 @@ public final class AsyncQueue {
         dependencies = [pendingTasks.last].compactMap { $0 }
       }
 
-
       // Schedule the task.
       let task = Task {
         // IMPORTANT: The only throwing call in here must be the call to

--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -19,7 +19,10 @@ public protocol Connection: AnyObject {
   func send<Notification>(_: Notification) where Notification: NotificationType
 
   /// Send a request and (asynchronously) receive a reply.
-  func send<Request>(_: Request, reply: @escaping (LSPResult<Request.Response>) -> Void) -> RequestID where Request: RequestType
+  func send<Request: RequestType>(
+    _: Request,
+    reply: @escaping (LSPResult<Request.Response>) -> Void
+  ) -> RequestID
 
   /// Send a request synchronously. **Use wisely**.
   func sendSync<Request>(_: Request) throws -> Request.Response where Request: RequestType
@@ -54,7 +57,12 @@ public protocol MessageHandler: AnyObject {
   /// handled to avoid out-of-order requests, e.g. once the corresponding
   /// request has been sent to sourcekitd. The actual semantic computation
   /// should occur after the method returns and report the result via `reply`.
-  func handle<Request: RequestType>(_ params: Request, id: RequestID, from clientID: ObjectIdentifier, reply: @escaping (LSPResult<Request.Response>) -> Void)
+  func handle<Request: RequestType>(
+    _ params: Request,
+    id: RequestID,
+    from clientID: ObjectIdentifier,
+    reply: @escaping (LSPResult<Request.Response>) -> Void
+  )
 }
 
 /// A connection between two message handlers in the same process.
@@ -77,7 +85,7 @@ public final class LocalConnection {
 
   /// The queue guarding `_nextRequestID`.
   let queue: DispatchQueue = DispatchQueue(label: "local-connection-queue")
-  
+
   var _nextRequestID: Int = 0
 
   var state: State = .ready

--- a/Sources/LanguageServerProtocol/CustomCodable.swift
+++ b/Sources/LanguageServerProtocol/CustomCodable.swift
@@ -103,7 +103,11 @@ extension KeyedEncodingContainer {
     _ value: CustomCodable<Optional<T>>,
     forKey key: Key
   ) throws {
-    try encodeIfPresent(value.wrappedValue.map {
-      type(of: value).CustomCoder(wrappedValue: $0) }, forKey: key)
+    try encodeIfPresent(
+      value.wrappedValue.map {
+        type(of: value).CustomCoder(wrappedValue: $0)
+      },
+      forKey: key
+    )
   }
 }

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -29,7 +29,6 @@ public struct ErrorCode: RawRepresentable, Codable, Hashable {
   public static let invalidParams: ErrorCode = ErrorCode(rawValue: -32602)
   public static let internalError: ErrorCode = ErrorCode(rawValue: -32603)
 
-
   /// This is the start range of JSON-RPC reserved error codes.
   /// It doesn't denote a real error code. No LSP error codes should
   /// be defined between the start and end range. For backwards
@@ -103,7 +102,10 @@ extension ResponseError {
 
   public static var cancelled: ResponseError = ResponseError(code: .cancelled, message: "request cancelled by client")
 
-  public static var serverCancelled: ResponseError = ResponseError(code: .serverCancelled, message: "request cancelled by server")
+  public static var serverCancelled: ResponseError = ResponseError(
+    code: .serverCancelled,
+    message: "request cancelled by server"
+  )
 
   public static func workspaceNotOpen(_ uri: DocumentURI) -> ResponseError {
     return ResponseError(code: .workspaceNotOpen, message: "No workspace containing '\(uri)' found")
@@ -149,19 +151,40 @@ public struct MessageDecodingError: Error, Hashable {
 }
 
 extension MessageDecodingError {
-  public static func methodNotFound(_ method: String, id: RequestID? = nil, messageKind: MessageKind = .unknown) -> MessageDecodingError {
-    return MessageDecodingError(code: .methodNotFound, message: "method not found: \(method)", id: id, messageKind: messageKind)
+  public static func methodNotFound(
+    _ method: String,
+    id: RequestID? = nil,
+    messageKind: MessageKind = .unknown
+  ) -> MessageDecodingError {
+    return MessageDecodingError(
+      code: .methodNotFound,
+      message: "method not found: \(method)",
+      id: id,
+      messageKind: messageKind
+    )
   }
 
-  public static func invalidRequest(_ reason: String, id: RequestID? = nil, messageKind: MessageKind = .unknown) -> MessageDecodingError {
+  public static func invalidRequest(
+    _ reason: String,
+    id: RequestID? = nil,
+    messageKind: MessageKind = .unknown
+  ) -> MessageDecodingError {
     return MessageDecodingError(code: .invalidRequest, message: reason, id: id, messageKind: messageKind)
   }
 
-  public static func invalidParams(_ reason: String, id: RequestID? = nil, messageKind: MessageKind = .unknown) -> MessageDecodingError {
+  public static func invalidParams(
+    _ reason: String,
+    id: RequestID? = nil,
+    messageKind: MessageKind = .unknown
+  ) -> MessageDecodingError {
     return MessageDecodingError(code: .invalidParams, message: reason, id: id, messageKind: messageKind)
   }
 
-  public static func parseError(_ reason: String, id: RequestID? = nil, messageKind: MessageKind = .unknown) -> MessageDecodingError {
+  public static func parseError(
+    _ reason: String,
+    id: RequestID? = nil,
+    messageKind: MessageKind = .unknown
+  ) -> MessageDecodingError {
     return MessageDecodingError(code: .parseError, message: reason, id: id, messageKind: messageKind)
   }
 }

--- a/Sources/LanguageServerProtocol/MessageRegistry.swift
+++ b/Sources/LanguageServerProtocol/MessageRegistry.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 public final class MessageRegistry {
 
   public static let lspProtocol: MessageRegistry =

--- a/Sources/LanguageServerProtocol/Notifications/DidChangeWorkspaceFoldersNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/DidChangeWorkspaceFoldersNotification.swift
@@ -16,27 +16,27 @@
 ///
 /// Requires the `workspaceFolders` capability on both the client and server.
 public struct DidChangeWorkspaceFoldersNotification: NotificationType {
-    public static let method: String = "workspace/didChangeWorkspaceFolders"
+  public static let method: String = "workspace/didChangeWorkspaceFolders"
 
-    /// The set of changes.
-    public var event: WorkspaceFoldersChangeEvent
+  /// The set of changes.
+  public var event: WorkspaceFoldersChangeEvent
 
-    public init(event: WorkspaceFoldersChangeEvent) {
-        self.event = event
-    }
+  public init(event: WorkspaceFoldersChangeEvent) {
+    self.event = event
+  }
 }
 
 /// The workspace folder change event.
 public struct WorkspaceFoldersChangeEvent: Codable, Hashable {
 
-    /// The array of added workspace folders
-    public var added: [WorkspaceFolder]?
+  /// The array of added workspace folders
+  public var added: [WorkspaceFolder]?
 
-    /// The array of the removed workspace folders
-    public var removed: [WorkspaceFolder]?
+  /// The array of the removed workspace folders
+  public var removed: [WorkspaceFolder]?
 
-    public init(added: [WorkspaceFolder]? = nil, removed: [WorkspaceFolder]? = nil) {
-        self.added = added
-        self.removed = removed
-    }
+  public init(added: [WorkspaceFolder]? = nil, removed: [WorkspaceFolder]? = nil) {
+    self.added = added
+    self.removed = removed
+  }
 }

--- a/Sources/LanguageServerProtocol/Notifications/ExitNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/ExitNotification.swift
@@ -15,5 +15,5 @@
 /// This notification will come after the shutdown request finishes.
 public struct ExitNotification: NotificationType, Hashable {
   public static let method: String = "exit"
-  public init() { }
+  public init() {}
 }

--- a/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
+++ b/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
@@ -96,8 +96,8 @@ public struct DidChangeTextDocumentNotification: NotificationType, Hashable {
   public init(
     textDocument: VersionedTextDocumentIdentifier,
     contentChanges: [TextDocumentContentChangeEvent],
-    forceRebuild: Bool? = nil)
-  {
+    forceRebuild: Bool? = nil
+  ) {
     self.textDocument = textDocument
     self.contentChanges = contentChanges
     self.forceRebuild = forceRebuild
@@ -165,7 +165,7 @@ public struct DidOpenNotebookDocumentNotification: NotificationType, Hashable {
 /// The change notification is sent from the client to the server when a notebook document changes. It is only sent by a client if the server requested the synchronization mode `notebook` in its `notebookDocumentSync` capability.
 public struct DidChangeNotebookDocumentNotification: NotificationType, Hashable {
   public static var method: String = "notebookDocument/didChange"
-  
+
   /// The notebook document that did change. The version number points
   /// to the version after all provided changes have been applied.
   public var notebookDocument: VersionedNotebookDocumentIdentifier

--- a/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
+++ b/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
@@ -38,7 +38,10 @@ public enum WorkDoneProgressKind: Codable, Hashable {
     } else if let end = try? WorkDoneProgressEnd(from: decoder) {
       self = .end(end)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected WorkDoneProgressBegin, WorkDoneProgressReport, or WorkDoneProgressEnd")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected WorkDoneProgressBegin, WorkDoneProgressReport, or WorkDoneProgressEnd"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -101,7 +104,11 @@ public struct WorkDoneProgressBegin: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     guard kind == "begin" else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of WorkDoneProgressBegin is not 'begin'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of WorkDoneProgressBegin is not 'begin'"
+      )
     }
 
     self.title = try container.decode(String.self, forKey: .title)
@@ -109,7 +116,6 @@ public struct WorkDoneProgressBegin: Codable, Hashable {
     self.message = try container.decodeIfPresent(String.self, forKey: .message)
     self.percentage = try container.decodeIfPresent(Int.self, forKey: .percentage)
   }
-
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
@@ -161,14 +167,17 @@ public struct WorkDoneProgressReport: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     guard kind == "report" else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of WorkDoneProgressReport is not 'report'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of WorkDoneProgressReport is not 'report'"
+      )
     }
 
     self.cancellable = try container.decodeIfPresent(Bool.self, forKey: .cancellable)
     self.message = try container.decodeIfPresent(String.self, forKey: .message)
     self.percentage = try container.decodeIfPresent(Int.self, forKey: .percentage)
   }
-
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
@@ -197,12 +206,15 @@ public struct WorkDoneProgressEnd: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     guard kind == "end" else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of WorkDoneProgressReport is not 'end'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of WorkDoneProgressReport is not 'end'"
+      )
     }
 
     self.message = try container.decodeIfPresent(String.self, forKey: .message)
   }
-
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Sources/LanguageServerProtocol/PositionRange.swift
+++ b/Sources/LanguageServerProtocol/PositionRange.swift
@@ -14,7 +14,7 @@ extension Range where Bound == Position {
 
   /// Create a range for a single position.
   public init(_ pos: Position) {
-    self = pos ..< pos
+    self = pos..<pos
   }
 }
 
@@ -74,12 +74,12 @@ public struct PositionRangeArray: CustomCodableWrapper {
 }
 
 extension Range: LSPAnyCodable where Bound == Position {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     guard case .dictionary(let start)? = dictionary[PositionRange.CodingKeys.lowerBound.stringValue],
-          let startPosition = Position(fromLSPDictionary: start),
-          case .dictionary(let end)? = dictionary[PositionRange.CodingKeys.upperBound.stringValue],
-          let endPosition = Position(fromLSPDictionary: end) else
-    {
+      let startPosition = Position(fromLSPDictionary: start),
+      case .dictionary(let end)? = dictionary[PositionRange.CodingKeys.upperBound.stringValue],
+      let endPosition = Position(fromLSPDictionary: end)
+    else {
       return nil
     }
     self = startPosition..<endPosition
@@ -88,7 +88,7 @@ extension Range: LSPAnyCodable where Bound == Position {
   public func encodeToLSPAny() -> LSPAny {
     return .dictionary([
       PositionRange.CodingKeys.lowerBound.stringValue: lowerBound.encodeToLSPAny(),
-      PositionRange.CodingKeys.upperBound.stringValue: upperBound.encodeToLSPAny()
+      PositionRange.CodingKeys.upperBound.stringValue: upperBound.encodeToLSPAny(),
     ])
   }
 }

--- a/Sources/LanguageServerProtocol/Request.swift
+++ b/Sources/LanguageServerProtocol/Request.swift
@@ -38,7 +38,13 @@ public final class Request<R: RequestType> {
   /// The request's cancellation state.
   public let cancellationToken: CancellationToken
 
-  public init(_ request: Params, id: RequestID, clientID: ObjectIdentifier, cancellation: CancellationToken, reply: @escaping (LSPResult<Response>) -> Void) {
+  public init(
+    _ request: Params,
+    id: RequestID,
+    clientID: ObjectIdentifier,
+    cancellation: CancellationToken,
+    reply: @escaping (LSPResult<Response>) -> Void
+  ) {
     self.id = id
     self.clientID = clientID
     self.params = request
@@ -87,22 +93,22 @@ public final class Notification<N: NotificationType> {
 extension Request: CustomStringConvertible {
   public var description: String {
     return """
-    Request<\(R.method)>(
-      id: \(id),
-      clientID: \(clientID),
-      params: \(params)
-    )
-    """
+      Request<\(R.method)>(
+        id: \(id),
+        clientID: \(clientID),
+        params: \(params)
+      )
+      """
   }
 }
 
 extension Notification: CustomStringConvertible {
   public var description: String {
     return """
-    Notification<\(N.method)>(
-      clientID: \(clientID),
-      params: \(params)
-    )
-    """
+      Notification<\(N.method)>(
+        clientID: \(clientID),
+        params: \(params)
+      )
+      """
   }
 }

--- a/Sources/LanguageServerProtocol/RequestID.swift
+++ b/Sources/LanguageServerProtocol/RequestID.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum RequestID: Hashable{
+public enum RequestID: Hashable {
   case string(String)
   case number(Int)
 }

--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -119,7 +119,11 @@ public struct CodeActionContext: Codable, Hashable {
   /// The reason why code actions were requested.
   public var triggerKind: CodeActionTriggerKind?
 
-  public init(diagnostics: [Diagnostic] = [], only: [CodeActionKind]? = nil, triggerKind: CodeActionTriggerKind? = nil) {
+  public init(
+    diagnostics: [Diagnostic] = [],
+    only: [CodeActionKind]? = nil,
+    triggerKind: CodeActionTriggerKind? = nil
+  ) {
     self.diagnostics = diagnostics
     self.only = only
     self.triggerKind = triggerKind
@@ -145,7 +149,13 @@ public struct CodeAction: ResponseType, Hashable {
   /// first the edit is executed and then the command.
   public var command: Command?
 
-  public init(title: String, kind: CodeActionKind? = nil, diagnostics: [Diagnostic]? = nil, edit: WorkspaceEdit? = nil, command: Command? = nil) {
+  public init(
+    title: String,
+    kind: CodeActionKind? = nil,
+    diagnostics: [Diagnostic]? = nil,
+    edit: WorkspaceEdit? = nil,
+    command: Command? = nil
+  ) {
     self.title = title
     self.kind = kind
     self.diagnostics = diagnostics

--- a/Sources/LanguageServerProtocol/Requests/CodeLensRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeLensRefreshRequest.swift
@@ -15,5 +15,5 @@ public struct CodeLensRefreshRequest: RequestType {
 
   public typealias Response = VoidResponse
 
-  public init() { }
+  public init() {}
 }

--- a/Sources/LanguageServerProtocol/Requests/CodeLensRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeLensRequest.swift
@@ -35,7 +35,7 @@ public struct CodeLens: ResponseType, Hashable {
   @CustomCodable<PositionRange>
   public var range: Range<Position>
 
-   /// The command this code lens represents.
+  /// The command this code lens represents.
   public var command: Command?
 
   /// A data entry field that is preserved on a code lens item between

--- a/Sources/LanguageServerProtocol/Requests/ColorPresentationRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ColorPresentationRequest.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The color presentation request is sent from the client to the server to obtain 
-/// a list of presentations for a color value at a given location. Clients can 
-/// use the result to modify a color reference, or show in a color picker 
+/// The color presentation request is sent from the client to the server to obtain
+/// a list of presentations for a color value at a given location. Clients can
+/// use the result to modify a color reference, or show in a color picker
 /// and let users pick one of the presentations
 ///
 /// - Parameters:
@@ -44,7 +44,7 @@ public struct ColorPresentationRequest: TextDocumentRequest, Hashable {
 
 public struct ColorPresentation: ResponseType, Hashable {
   /// The label of this color presentation. It will be shown on the color
-  /// picker header. By default this is also the text that is inserted when 
+  /// picker header. By default this is also the text that is inserted when
   /// selecting this color presentation.
   public var label: String
 
@@ -53,7 +53,7 @@ public struct ColorPresentation: ResponseType, Hashable {
   public var textEdit: TextEdit?
 
   /// An optional array of additional text edits that are applied when
-  /// selecting this color presentation. Edits must not overlap with 
+  /// selecting this color presentation. Edits must not overlap with
   /// the main edit nor with themselves.
   public var additionalTextEdits: [TextEdit]?
 

--- a/Sources/LanguageServerProtocol/Requests/CompletionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CompletionRequest.swift
@@ -42,8 +42,8 @@ public struct CompletionRequest: TextDocumentRequest, Hashable {
     textDocument: TextDocumentIdentifier,
     position: Position,
     context: CompletionContext? = nil,
-    sourcekitlspOptions: SKCompletionOptions? = nil)
-  {
+    sourcekitlspOptions: SKCompletionOptions? = nil
+  ) {
     self.textDocument = textDocument
     self.position = position
     self.context = context
@@ -108,7 +108,10 @@ public struct CompletionList: ResponseType, Hashable {
       } else if let insertReplaceRange = try? InsertReplaceRanges(from: decoder) {
         self = .insertReplaceRanges(insertReplaceRange)
       } else {
-        let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected Range or InsertReplaceRanges")
+        let context = DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Expected Range or InsertReplaceRanges"
+        )
         throw DecodingError.dataCorrupted(context)
       }
     }
@@ -139,7 +142,13 @@ public struct CompletionList: ResponseType, Hashable {
     /// A default data value.
     public var data: LSPAny?
 
-    public init(commitCharacters: [String]? = nil, editRange: ItemDefaultsEditRange? = nil, insertTextFormat: InsertTextFormat? = nil, insertTextMode: InsertTextMode? = nil, data: LSPAny? = nil) {
+    public init(
+      commitCharacters: [String]? = nil,
+      editRange: ItemDefaultsEditRange? = nil,
+      insertTextFormat: InsertTextFormat? = nil,
+      insertTextMode: InsertTextMode? = nil,
+      data: LSPAny? = nil
+    ) {
       self.commitCharacters = commitCharacters
       self.editRange = editRange
       self.insertTextFormat = insertTextFormat
@@ -147,7 +156,6 @@ public struct CompletionList: ResponseType, Hashable {
       self.data = data
     }
   }
-
 
   /// Whether the list of completions is "complete" or not.
   ///
@@ -192,7 +200,10 @@ public struct CompletionList: ResponseType, Hashable {
       return
     } catch {}
 
-    let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected CompletionList or [CompletionItem]")
+    let context = DecodingError.Context(
+      codingPath: decoder.codingPath,
+      debugDescription: "Expected CompletionList or [CompletionItem]"
+    )
     throw DecodingError.dataCorrupted(context)
   }
 }

--- a/Sources/LanguageServerProtocol/Requests/DiagnosticsRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DiagnosticsRefreshRequest.swift
@@ -14,5 +14,5 @@ public struct DiagnosticsRefreshRequest: RequestType {
   public static var method: String = "workspace/diagnostic/refresh"
   public typealias Response = VoidResponse
 
-  public init() { }
+  public init() {}
 }

--- a/Sources/LanguageServerProtocol/Requests/DocumentColorRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentColorRequest.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 /// The document color request is sent from the client to the server to list
-/// all color references found in a given text document. Along with the range, 
+/// all color references found in a given text document. Along with the range,
 /// a color value in RGB is returned.
-/// Clients can use the result to decorate color references in an editor. 
+/// Clients can use the result to decorate color references in an editor.
 ///
 /// - Parameters:
 ///   - textDocument: The document to search for color references.

--- a/Sources/LanguageServerProtocol/Requests/DocumentDiagnosticsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentDiagnosticsRequest.swift
@@ -45,7 +45,10 @@ public enum DocumentDiagnosticReport: ResponseType, Codable, Hashable {
     } else if let unchanged = try? RelatedUnchangedDocumentDiagnosticReport(from: decoder) {
       self = .unchanged(unchanged)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected RelatedFullDocumentDiagnosticReport or RelatedUnchangedDocumentDiagnosticReport")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected RelatedFullDocumentDiagnosticReport or RelatedUnchangedDocumentDiagnosticReport"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -94,7 +97,11 @@ public struct RelatedFullDocumentDiagnosticReport: Codable, Hashable {
   /// a.cpp and result in errors in a header file b.hpp.
   public var relatedDocuments: [DocumentURI: DocumentDiagnosticReport]?
 
-  public init(resultId: String? = nil, items: [Diagnostic], relatedDocuments: [DocumentURI : DocumentDiagnosticReport]? = nil) {
+  public init(
+    resultId: String? = nil,
+    items: [Diagnostic],
+    relatedDocuments: [DocumentURI: DocumentDiagnosticReport]? = nil
+  ) {
     self.resultId = resultId
     self.items = items
     self.relatedDocuments = relatedDocuments
@@ -111,11 +118,18 @@ public struct RelatedFullDocumentDiagnosticReport: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(DocumentDiagnosticReportKind.self, forKey: .kind)
     guard kind == .full else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of FullDocumentDiagnosticReport is not 'full'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of FullDocumentDiagnosticReport is not 'full'"
+      )
     }
     self.resultId = try container.decodeIfPresent(String.self, forKey: .resultId)
     self.items = try container.decode([Diagnostic].self, forKey: .items)
-    self.relatedDocuments = try container.decodeIfPresent([DocumentURI: DocumentDiagnosticReport].self, forKey: .relatedDocuments)
+    self.relatedDocuments = try container.decodeIfPresent(
+      [DocumentURI: DocumentDiagnosticReport].self,
+      forKey: .relatedDocuments
+    )
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -141,7 +155,7 @@ public struct RelatedUnchangedDocumentDiagnosticReport: Codable, Hashable {
   /// a.cpp and result in errors in a header file b.hpp.
   public var relatedDocuments: [DocumentURI: DocumentDiagnosticReport]?
 
-  public init(resultId: String, relatedDocuments: [DocumentURI : DocumentDiagnosticReport]? = nil) {
+  public init(resultId: String, relatedDocuments: [DocumentURI: DocumentDiagnosticReport]? = nil) {
     self.resultId = resultId
     self.relatedDocuments = relatedDocuments
   }
@@ -156,10 +170,17 @@ public struct RelatedUnchangedDocumentDiagnosticReport: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(DocumentDiagnosticReportKind.self, forKey: .kind)
     guard kind == .unchanged else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of FullDocumentDiagnosticReport is not 'unchanged'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of FullDocumentDiagnosticReport is not 'unchanged'"
+      )
     }
     self.resultId = try container.decode(String.self, forKey: .resultId)
-    self.relatedDocuments = try container.decodeIfPresent([DocumentURI: DocumentDiagnosticReport].self, forKey: .relatedDocuments)
+    self.relatedDocuments = try container.decodeIfPresent(
+      [DocumentURI: DocumentDiagnosticReport].self,
+      forKey: .relatedDocuments
+    )
   }
 
   public func encode(to encoder: Encoder) throws {

--- a/Sources/LanguageServerProtocol/Requests/DocumentSymbolRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentSymbolRequest.swift
@@ -12,7 +12,7 @@
 
 /// Request for symbols to display in the document outline.
 ///
-/// This is used to provide list of all symbols in the document and display inside which 
+/// This is used to provide list of all symbols in the document and display inside which
 /// type or function the cursor is currently in.
 ///
 /// Servers that provide document highlights should set the `documentSymbolProvider` server
@@ -44,7 +44,10 @@ public enum DocumentSymbolResponse: ResponseType, Hashable {
     } else if let symbolInformation = try? [SymbolInformation](from: decoder) {
       self = .symbolInformation(symbolInformation)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [DocumentSymbol] or [SymbolInformation]")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected [DocumentSymbol] or [SymbolInformation]"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -59,11 +62,11 @@ public enum DocumentSymbolResponse: ResponseType, Hashable {
   }
 }
 
-/// Represents programming constructs like variables, classes, interfaces etc. that appear 
+/// Represents programming constructs like variables, classes, interfaces etc. that appear
 /// in a document. Document symbols can be hierarchical and they have two ranges: one that encloses
 /// its definition and one that points to its most interesting range, e.g. the range of an identifier.
 public struct DocumentSymbol: Hashable, Codable {
-  
+
   /// The name of this symbol. Will be displayed in the user interface and therefore must not be
   /// an empty string or a string only consisting of white spaces.
   public var name: String
@@ -86,7 +89,7 @@ public struct DocumentSymbol: Hashable, Codable {
   @CustomCodable<PositionRange>
   public var range: Range<Position>
 
-  /// The range that should be selected and revealed when this symbol is being picked, 
+  /// The range that should be selected and revealed when this symbol is being picked,
   /// e.g the name of a function.
   ///
   /// Must be contained by the `range`.
@@ -104,8 +107,8 @@ public struct DocumentSymbol: Hashable, Codable {
     deprecated: Bool? = nil,
     range: Range<Position>,
     selectionRange: Range<Position>,
-    children: [DocumentSymbol]? = nil)
-  {
+    children: [DocumentSymbol]? = nil
+  ) {
     self.name = name
     self.detail = detail
     self.kind = kind

--- a/Sources/LanguageServerProtocol/Requests/FoldingRangeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/FoldingRangeRequest.swift
@@ -64,8 +64,7 @@ public struct FoldingRange: ResponseType, Hashable {
     endUTF16Index: Int? = nil,
     kind: FoldingRangeKind? = nil,
     collapsedText: String? = nil
-  )
-  {
+  ) {
     self.startLine = startLine
     self.startUTF16Index = startUTF16Index
     self.endLine = endLine
@@ -87,7 +86,7 @@ extension FoldingRange: Codable {
 
 extension FoldingRange: Comparable {
 
-  public static func <(lhs: FoldingRange, rhs: FoldingRange) -> Bool {
+  public static func < (lhs: FoldingRange, rhs: FoldingRange) -> Bool {
     return lhs.comparableKey < rhs.comparableKey
   }
 
@@ -96,6 +95,7 @@ extension FoldingRange: Comparable {
       startLine,
       startUTF16Index ?? Int.max,
       endLine, endUTF16Index ?? Int.max,
-      kind?.rawValue ?? "")
+      kind?.rawValue ?? ""
+    )
   }
 }

--- a/Sources/LanguageServerProtocol/Requests/HoverRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/HoverRequest.swift
@@ -77,7 +77,10 @@ extension MarkedString: Codable {
     } else if let codeBlock = try? MarkdownCodeBlock(from: decoder) {
       self = .codeBlock(language: codeBlock.language, value: codeBlock.value)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or MarkdownCodeBlock")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected String or MarkdownCodeBlock"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -95,13 +98,16 @@ extension MarkedString: Codable {
 extension HoverResponseContents: Codable {
   public init(from decoder: Decoder) throws {
     if let value = try? MarkupContent(from: decoder) {
-        self = .markupContent(value)
+      self = .markupContent(value)
     } else if let value = try? [MarkedString](from: decoder) {
-        self = .markedStrings(value)
+      self = .markedStrings(value)
     } else if let value = try? MarkedString(from: decoder) {
       self = .markedStrings([value])
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected MarkedString, [MarkedString], or MarkupContent")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected MarkedString, [MarkedString], or MarkupContent"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }

--- a/Sources/LanguageServerProtocol/Requests/ImplementationRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ImplementationRequest.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The go to implementation request is sent from the client to the server 
-/// to resolve the implementation location of a symbol at a given 
+/// The go to implementation request is sent from the client to the server
+/// to resolve the implementation location of a symbol at a given
 /// text document position.
 ///
-/// Servers that provide Goto Implementation support should set 
+/// Servers that provide Goto Implementation support should set
 /// the `implementationProvider` server capability.
 ///
 /// - Parameters:

--- a/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
@@ -93,8 +93,8 @@ public struct InitializeRequest: RequestType, Hashable {
     initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities,
     trace: Tracing = .off,
-    workspaceFolders: [WorkspaceFolder]?)
-  {
+    workspaceFolders: [WorkspaceFolder]?
+  ) {
     self.processId = processId
     self.clientInfo = clientInfo
     self.locale = locale

--- a/Sources/LanguageServerProtocol/Requests/InlayHintRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlayHintRefreshRequest.swift
@@ -14,5 +14,5 @@ public struct InlayHintRefreshRequest: RequestType {
   public static var method: String = "workspace/inlayHint/refresh"
   public typealias Response = VoidResponse
 
-  public init() { }
+  public init() {}
 }

--- a/Sources/LanguageServerProtocol/Requests/InlayHintRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlayHintRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Request for inline annotations to be displayed in the editor.
-/// 
+///
 /// - Parameters:
 ///   - textDocument: The document for which to provide the inlay hints.
 ///

--- a/Sources/LanguageServerProtocol/Requests/InlineValueRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlineValueRefreshRequest.swift
@@ -14,5 +14,5 @@ struct InlineValueRefreshRequest: RequestType {
   static var method: String = "workspace/inlineValue/refresh"
   typealias Response = VoidResponse
 
-  public init() { }
+  public init() {}
 }

--- a/Sources/LanguageServerProtocol/Requests/InlineValueRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlineValueRequest.swift
@@ -130,7 +130,11 @@ public enum InlineValue: ResponseType, Hashable {
     } else if let evaluatableExpression = try? InlineValueEvaluatableExpression(from: decoder) {
       self = .evaluatableExpression(evaluatableExpression)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected InlineValueText, InlineValueEvaluatableExpression or InlineValueEvaluatableExpression")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription:
+          "Expected InlineValueText, InlineValueEvaluatableExpression or InlineValueEvaluatableExpression"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }

--- a/Sources/LanguageServerProtocol/Requests/LinkedEditingRangeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/LinkedEditingRangeRequest.swift
@@ -27,15 +27,15 @@ public struct LinkedEditingRangeRequest: TextDocumentRequest {
 }
 
 public struct LinkedEditingRanges: ResponseType {
-   /// A list of ranges that can be renamed together. The ranges must have
-   /// identical length and contain identical text content. The ranges cannot
-   /// overlap.
+  /// A list of ranges that can be renamed together. The ranges must have
+  /// identical length and contain identical text content. The ranges cannot
+  /// overlap.
   @CustomCodable<PositionRangeArray>
   public var ranges: [Range<Position>]
 
-   /// An optional word pattern (regular expression) that describes valid
-   /// contents for the given ranges. If no pattern is provided, the client
-   /// configuration's word pattern will be used.
+  /// An optional word pattern (regular expression) that describes valid
+  /// contents for the given ranges. If no pattern is provided, the client
+  /// configuration's word pattern will be used.
   public var wordPattern: String?
 
   public init(ranges: [Range<Position>], wordPattern: String? = nil) {

--- a/Sources/LanguageServerProtocol/Requests/MonikersRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/MonikersRequest.swift
@@ -71,8 +71,6 @@ public struct Moniker: ResponseType, Hashable {
     public static let local = Kind(rawValue: "local")
   }
 
-
-
   /// The scheme of the moniker. For example tsc or .Net
   public var scheme: String
 

--- a/Sources/LanguageServerProtocol/Requests/PrepareRenameRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/PrepareRenameRequest.swift
@@ -42,7 +42,7 @@ public struct PrepareRenameResponse: ResponseType, Hashable {
   /// The range of the symbol
   @CustomCodable<PositionRange>
   public var range: Range<Position>
-  
+
   /// A placeholder text of the string content to be renamed
   public var placeholder: String?
 
@@ -50,7 +50,7 @@ public struct PrepareRenameResponse: ResponseType, Hashable {
     self.range = range
     self.placeholder = placeholder
   }
-  
+
   public init(from decoder: Decoder) throws {
     // Try decoding as PrepareRenameResponse
     do {
@@ -59,18 +59,21 @@ public struct PrepareRenameResponse: ResponseType, Hashable {
       self.placeholder = try container.decode(String.self, forKey: .placeholder)
       return
     } catch {}
-    
+
     // Try decoding as PositionRange
     do {
       self.range = try PositionRange(from: decoder).wrappedValue
       self.placeholder = nil
       return
     } catch {}
-    
-    let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected PrepareRenameResponse or PositionRange")
+
+    let context = DecodingError.Context(
+      codingPath: decoder.codingPath,
+      debugDescription: "Expected PrepareRenameResponse or PositionRange"
+    )
     throw DecodingError.dataCorrupted(context)
   }
-  
+
   public func encode(to encoder: Encoder) throws {
     if let placeholder = placeholder {
       var container = encoder.container(keyedBy: CodingKeys.self)
@@ -80,7 +83,7 @@ public struct PrepareRenameResponse: ResponseType, Hashable {
       try _range.encode(to: encoder)
     }
   }
-  
+
   private enum CodingKeys: String, CodingKey {
     case range
     case placeholder

--- a/Sources/LanguageServerProtocol/Requests/RenameRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/RenameRequest.swift
@@ -32,7 +32,7 @@ public struct RenameRequest: TextDocumentRequest, Hashable {
 
   /// The document location at which the selected symbol is.
   public var position: Position
-  
+
   /// The new name of the symbol. If the given name is not valid the request must return
   /// a ResponseError with an appropriate message set.
   public var newName: String

--- a/Sources/LanguageServerProtocol/Requests/ShowMessageRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ShowMessageRequest.swift
@@ -34,8 +34,8 @@ public struct ShowMessageRequest: RequestType, Hashable {
   public init(
     type: WindowMessageType,
     message: String,
-    actions: [MessageActionItem]?)
-  {
+    actions: [MessageActionItem]?
+  ) {
     self.type = type
     self.message = message
     self.actions = actions

--- a/Sources/LanguageServerProtocol/Requests/ShutdownRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ShutdownRequest.swift
@@ -20,7 +20,7 @@ public struct ShutdownRequest: RequestType, Hashable {
   public static let method: String = "shutdown"
   public typealias Response = VoidResponse
 
-  public init() { }
+  public init() {}
 }
 
 @available(*, deprecated, renamed: "ShutdownRequest")

--- a/Sources/LanguageServerProtocol/Requests/SignatureHelpRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SignatureHelpRequest.swift
@@ -32,7 +32,6 @@ public struct SignatureHelpRequest: TextDocumentRequest {
   }
 }
 
-
 /// How a signature help was triggered.
 public struct SignatureHelpTriggerKind: RawRepresentable, Codable, Hashable {
   public var rawValue: Int
@@ -77,7 +76,12 @@ public struct SignatureHelpContext: Codable, Hashable {
   /// updated based on the user navigating through available signatures.
   public var activeSignatureHelp: SignatureHelp?
 
-  public init(triggerKind: SignatureHelpTriggerKind, triggerCharacter: String? = nil, isRetrigger: Bool, activeSignatureHelp: SignatureHelp? = nil) {
+  public init(
+    triggerKind: SignatureHelpTriggerKind,
+    triggerCharacter: String? = nil,
+    isRetrigger: Bool,
+    activeSignatureHelp: SignatureHelp? = nil
+  ) {
     self.triggerKind = triggerKind
     self.triggerCharacter = triggerCharacter
     self.isRetrigger = isRetrigger
@@ -140,7 +144,12 @@ public struct SignatureInformation: Codable, Hashable {
   /// If provided, this is used in place of `SignatureHelp.activeParameter`.
   public var activeParameter: Int?
 
-  public init(label: String, documentation: StringOrMarkupContent? = nil, parameters: [ParameterInformation]? = nil, activeParameter: Int? = nil) {
+  public init(
+    label: String,
+    documentation: StringOrMarkupContent? = nil,
+    parameters: [ParameterInformation]? = nil,
+    activeParameter: Int? = nil
+  ) {
     self.label = label
     self.documentation = documentation
     self.parameters = parameters
@@ -161,7 +170,10 @@ public struct ParameterInformation: Codable, Hashable {
       } else if let offsets = try? Array<Int>(from: decoder), offsets.count == 2 {
         self = .offsets(start: offsets[0], end: offsets[1])
       } else {
-        let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or an array containing two integers")
+        let context = DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Expected String or an array containing two integers"
+        )
         throw DecodingError.dataCorrupted(context)
       }
     }

--- a/Sources/LanguageServerProtocol/Requests/SymbolInfoRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SymbolInfoRequest.swift
@@ -86,8 +86,8 @@ public struct SymbolDetails: ResponseType, Hashable {
     containerName: String? = nil,
     usr: String?,
     bestLocalDeclaration: Location? = nil,
-    kind: SymbolKind? = nil)
-  {
+    kind: SymbolKind? = nil
+  ) {
     self.name = name
     self.containerName = containerName
     self.usr = usr

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceDiagnosticsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceDiagnosticsRequest.swift
@@ -64,7 +64,7 @@ public struct WorkspaceFullDocumentDiagnosticReport: Codable, Hashable {
   public var uri: DocumentURI
 
   /// The version number for which the diagnostics are reported.
- /// If the document is not marked as open `null` can be provided.
+  /// If the document is not marked as open `null` can be provided.
   public var version: Int?
 
   public init(resultId: String? = nil, items: [Diagnostic], uri: DocumentURI, version: Int? = nil) {
@@ -86,7 +86,11 @@ public struct WorkspaceFullDocumentDiagnosticReport: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(DocumentDiagnosticReportKind.self, forKey: .kind)
     guard kind == .full else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of FullDocumentDiagnosticReport is not 'full'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of FullDocumentDiagnosticReport is not 'full'"
+      )
     }
     self.resultId = try container.decodeIfPresent(String.self, forKey: .resultId)
     self.items = try container.decode([Diagnostic].self, forKey: .items)
@@ -109,7 +113,6 @@ public struct WorkspaceUnchangedDocumentDiagnosticReport: Codable, Hashable {
   /// A result id which will be sent on the next
   /// diagnostic request for the same document.
   public var resultId: String
-
 
   /// The URI for which diagnostic information is reported.
   public var uri: DocumentURI
@@ -135,7 +138,11 @@ public struct WorkspaceUnchangedDocumentDiagnosticReport: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(DocumentDiagnosticReportKind.self, forKey: .kind)
     guard kind == .unchanged else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of FullDocumentDiagnosticReport is not 'unchanged'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of FullDocumentDiagnosticReport is not 'unchanged'"
+      )
     }
     self.resultId = try container.decode(String.self, forKey: .resultId)
     self.uri = try container.decode(DocumentURI.self, forKey: .uri)
@@ -162,7 +169,10 @@ public enum WorkspaceDocumentDiagnosticReport: Codable, Hashable {
     } else if let unchanged = try? WorkspaceUnchangedDocumentDiagnosticReport(from: decoder) {
       self = .unchanged(unchanged)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected WorkspaceFullDocumentDiagnosticReport or WorkspaceUnchangedDocumentDiagnosticReport")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected WorkspaceFullDocumentDiagnosticReport or WorkspaceUnchangedDocumentDiagnosticReport"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceFoldersRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceFoldersRequest.swift
@@ -18,6 +18,6 @@
 /// - Returns: The set of currently open workspace folders. Returns nil if only a single file is
 ///   open. Returns an empty array if a workspace is open but no folders are configured.
 public struct WorkspaceFoldersRequest: RequestType, Hashable {
-    public static let method: String = "workspace/workspaceFolders"
-    public typealias Response = [WorkspaceFolder]?
+  public static let method: String = "workspace/workspaceFolders"
+  public typealias Response = [WorkspaceFolder]?
 }

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolsRequest.swift
@@ -44,7 +44,10 @@ public enum WorkspaceSymbolItem: ResponseType, Hashable {
     } else if let workspaceSymbol = try? WorkspaceSymbol(from: decoder) {
       self = .workspaceSymbol(workspaceSymbol)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected SymbolInformation or WorkspaceSymbol")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected SymbolInformation or WorkspaceSymbol"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -72,12 +75,14 @@ public struct SymbolInformation: Hashable, ResponseType {
 
   public var containerName: String?
 
-  public init(name: String,
-              kind: SymbolKind,
-              tags: [SymbolTag]? = nil,
-              deprecated: Bool? = nil,
-              location: Location,
-              containerName: String? = nil) {
+  public init(
+    name: String,
+    kind: SymbolKind,
+    tags: [SymbolTag]? = nil,
+    deprecated: Bool? = nil,
+    location: Location,
+    containerName: String? = nil
+  ) {
     self.name = name
     self.kind = kind
     self.tags = tags
@@ -107,7 +112,10 @@ public struct WorkspaceSymbol: ResponseType, Hashable {
       } else if let uri = try? WorkspaceSymbolLocation.URI(from: decoder) {
         self = .uri(uri)
       } else {
-        let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected Location or object containing a URI")
+        let context = DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Expected Location or object containing a URI"
+        )
         throw DecodingError.dataCorrupted(context)
       }
     }
@@ -148,7 +156,14 @@ public struct WorkspaceSymbol: ResponseType, Hashable {
   /// workspace symbol request and a workspace symbol resolve request.
   public var data: LSPAny?
 
-  public init(name: String, kind: SymbolKind, tags: [SymbolTag]? = nil, containerName: String? = nil, location: WorkspaceSymbolLocation, data: LSPAny? = nil) {
+  public init(
+    name: String,
+    kind: SymbolKind,
+    tags: [SymbolTag]? = nil,
+    containerName: String? = nil,
+    location: WorkspaceSymbolLocation,
+    data: LSPAny? = nil
+  ) {
     self.name = name
     self.kind = kind
     self.tags = tags

--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -241,7 +241,12 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     /// Whether the client supports the did-save notification.
     public var didSave: Bool? = nil
 
-    public init(dynamicRegistration: Bool? = nil, willSave: Bool? = nil, willSaveWaitUntil: Bool? = nil, didSave: Bool? = nil) {
+    public init(
+      dynamicRegistration: Bool? = nil,
+      willSave: Bool? = nil,
+      willSaveWaitUntil: Bool? = nil,
+      didSave: Bool? = nil
+    ) {
       self.dynamicRegistration = dynamicRegistration
       self.willSave = willSave
       self.willSaveWaitUntil = willSaveWaitUntil
@@ -270,7 +275,13 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
       /// Whether the client supports the `preselect` property on a CompletionItem.
       public var preselectSupport: Bool? = nil
 
-      public init(snippetSupport: Bool? = nil, commitCharactersSupport: Bool? = nil, documentationFormat: [MarkupKind]? = nil, deprecatedSupport: Bool? = nil, preselectSupport: Bool? = nil) {
+      public init(
+        snippetSupport: Bool? = nil,
+        commitCharactersSupport: Bool? = nil,
+        documentationFormat: [MarkupKind]? = nil,
+        deprecatedSupport: Bool? = nil,
+        preselectSupport: Bool? = nil
+      ) {
         self.snippetSupport = snippetSupport
         self.commitCharactersSupport = commitCharactersSupport
         self.documentationFormat = documentationFormat
@@ -306,7 +317,12 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     /// Whether the client supports sending context information in a `textDocument/completion` request.
     public var contextSupport: Bool? = nil
 
-    public init(dynamicRegistration: Bool? = nil, completionItem: CompletionItem? = nil, completionItemKind: CompletionItemKind? = nil, contextSupport: Bool? = nil) {
+    public init(
+      dynamicRegistration: Bool? = nil,
+      completionItem: CompletionItem? = nil,
+      completionItemKind: CompletionItemKind? = nil,
+      contextSupport: Bool? = nil
+    ) {
       self.dynamicRegistration = dynamicRegistration
       self.completionItem = completionItem
       self.completionItemKind = completionItemKind
@@ -390,7 +406,11 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
 
     public var hierarchicalDocumentSymbolSupport: Bool? = nil
 
-    public init(dynamicRegistration: Bool? = nil, symbolKind: SymbolKind? = nil, hierarchicalDocumentSymbolSupport: Bool? = nil) {
+    public init(
+      dynamicRegistration: Bool? = nil,
+      symbolKind: SymbolKind? = nil,
+      hierarchicalDocumentSymbolSupport: Bool? = nil
+    ) {
       self.dynamicRegistration = dynamicRegistration
       self.symbolKind = symbolKind
       self.hierarchicalDocumentSymbolSupport = hierarchicalDocumentSymbolSupport
@@ -472,9 +492,11 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     /// Whether the client supports a `codeDescription` property.
     public var codeDescriptionSupport: Bool? = nil
 
-    public init(relatedInformation: Bool? = nil,
-                codeActionsInline: Bool? = nil,
-                codeDescriptionSupport: Bool? = nil) {
+    public init(
+      relatedInformation: Bool? = nil,
+      codeActionsInline: Bool? = nil,
+      codeDescriptionSupport: Bool? = nil
+    ) {
       self.relatedInformation = relatedInformation
       self.codeActionsInline = codeActionsInline
       self.codeDescriptionSupport = codeDescriptionSupport
@@ -672,7 +694,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   public var inlineValue: DynamicRegistrationCapability? = nil
 
   public var inlayHint: InlayHint? = nil
-  
+
   public var diagnostic: Diagnostic? = nil
 
   public init(
@@ -769,7 +791,6 @@ public struct NotebookDocumentClientCapabilities: Hashable, Codable {
   }
 }
 
-
 /// Window specific client capabilities.
 public struct WindowClientCapabilities: Hashable, Codable {
   /// Show message request client capabilities
@@ -785,7 +806,7 @@ public struct WindowClientCapabilities: Hashable, Codable {
       }
     }
 
-     /// Capabilities specific to the `MessageActionItem` type.
+    /// Capabilities specific to the `MessageActionItem` type.
     public var messageActionItem: MessageActionItem?
 
     public init(messageActionItem: MessageActionItem? = nil) {
@@ -829,13 +850,12 @@ public struct WindowClientCapabilities: Hashable, Codable {
   }
 }
 
-
 /// General client capabilities.
 public struct GeneralClientCapabilities: Hashable, Codable {
   public struct StaleRequestSupport: Hashable, Codable {
     /// The client will actively cancel the request.
     public var cancel: Bool
-    
+
     /// The list of requests for which the client
     /// will retry the request if it receives a
     /// response with error code `ContentModified``
@@ -879,24 +899,24 @@ public struct GeneralClientCapabilities: Hashable, Codable {
     }
   }
 
-   /// A type indicating how positions are encoded,
-   /// specifically what column offsets mean.
-   public enum PositionEncodingKind: String, Hashable, Codable {
+  /// A type indicating how positions are encoded,
+  /// specifically what column offsets mean.
+  public enum PositionEncodingKind: String, Hashable, Codable {
 
-     /// Character offsets count UTF-8 code units (e.g bytes).
+    /// Character offsets count UTF-8 code units (e.g bytes).
     case utf8 = "utf-8"
 
-     /// Character offsets count UTF-16 code units.
-     ///
-     /// This is the default and must always be supported
-     /// by servers
+    /// Character offsets count UTF-16 code units.
+    ///
+    /// This is the default and must always be supported
+    /// by servers
     case utf16 = "utf-16"
 
-     /// Character offsets count UTF-32 code units.
-     ///
-     /// Implementation note: these are the same as Unicode code points,
-     /// so this `PositionEncodingKind` may also be used for an
-     /// encoding-agnostic representation of character offsets.
+    /// Character offsets count UTF-32 code units.
+    ///
+    /// Implementation note: these are the same as Unicode code points,
+    /// so this `PositionEncodingKind` may also be used for an
+    /// encoding-agnostic representation of character offsets.
     case utf32 = "utf-32"
   }
 
@@ -905,10 +925,10 @@ public struct GeneralClientCapabilities: Hashable, Codable {
   /// for which the client will not process the response
   /// anymore since the information is outdated).
   public var staleRequestSupport: StaleRequestSupport?
-  
+
   /// Client capabilities specific to regular expressions.
   public var regularExpressions: RegularExpressions?
-  
+
   /// Client capabilities specific to the client's markdown parser.
   public var markdown: Markdown?
 

--- a/Sources/LanguageServerProtocol/SupportTypes/CodeActionKind.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CodeActionKind.swift
@@ -47,10 +47,10 @@ public struct CodeActionKind: RawRepresentable, Codable, Hashable {
   /// Organize imports action.
   public static let sourceOrganizeImports: CodeActionKind = CodeActionKind(rawValue: "source.organizeImports")
 
-   /// Base kind for a 'fix all' source action: `source.fixAll`.
-   ///
-   /// 'Fix all' actions automatically fix errors that have a clear fix that
-   /// do not require user input. They should not suppress errors or perform
-   /// unsafe fixes such as generating new types or classes.
+  /// Base kind for a 'fix all' source action: `source.fixAll`.
+  ///
+  /// 'Fix all' actions automatically fix errors that have a clear fix that
+  /// do not require user input. They should not suppress errors or perform
+  /// unsafe fixes such as generating new types or classes.
   public static let sourceFixAll: CodeActionKind = CodeActionKind(rawValue: "source.fixAll")
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
@@ -52,7 +52,10 @@ public enum CompletionItemEdit: Codable, Hashable {
     } else if let insertReplaceEdit = try? InsertReplaceEdit(from: decoder) {
       self = .insertReplaceEdit(insertReplaceEdit)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected TextEdit or InsertReplaceEdit")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected TextEdit or InsertReplaceEdit"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -220,19 +223,19 @@ public struct InsertTextMode: RawRepresentable, Codable, Hashable {
     self.rawValue = rawValue
   }
 
-   /// The insertion or replace strings is taken as it is. If the
-   /// value is multi line the lines below the cursor will be
-   /// inserted using the indentation defined in the string value.
-   /// The client will not apply any kind of adjustments to the
-   /// string.
+  /// The insertion or replace strings is taken as it is. If the
+  /// value is multi line the lines below the cursor will be
+  /// inserted using the indentation defined in the string value.
+  /// The client will not apply any kind of adjustments to the
+  /// string.
   public static let asIs = InsertTextMode(rawValue: 1)
 
-   /// The editor adjusts leading whitespace of new lines so that
-   /// they match the indentation up to the cursor of the line for
-   /// which the item is accepted.
-   ///
-   /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
-   /// multi line completion item is indented using 2 tabs and all
-   /// following lines inserted will be indented using 2 tabs as well.
+  /// The editor adjusts leading whitespace of new lines so that
+  /// they match the indentation up to the cursor of the line for
+  /// which the item is accepted.
+  ///
+  /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+  /// multi line completion item is indented using 2 tabs and all
+  /// following lines inserted will be indented using 2 tabs as well.
   public static let adjustIndentation = InsertTextMode(rawValue: 2)
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
@@ -83,8 +83,8 @@ public struct Diagnostic: Codable, Hashable {
     tags: [DiagnosticTag]? = nil,
     relatedInformation: [DiagnosticRelatedInformation]? = nil,
     data: LSPAny? = nil,
-    codeActions: [CodeAction]? = nil)
-  {
+    codeActions: [CodeAction]? = nil
+  ) {
     self._range = CustomCodable<PositionRange>(wrappedValue: range)
     self.severity = severity
     self.code = code

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -12,17 +12,17 @@
 
 import Foundation
 
-import func TSCBasic.resolveSymlinks
 import struct TSCBasic.AbsolutePath
+import func TSCBasic.resolveSymlinks
 
 public struct DocumentURI: Codable, Hashable {
   /// The URL that store the URIs value
   private let storage: URL
 
   public var nativeURI: Self {
-      get throws {
-          DocumentURI(URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: self.pseudoPath)).pathString))
-      }
+    get throws {
+      DocumentURI(URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: self.pseudoPath)).pathString))
+    }
   }
 
   public var fileURL: URL? {

--- a/Sources/LanguageServerProtocol/SupportTypes/FileSystemWatcher.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/FileSystemWatcher.swift
@@ -26,7 +26,7 @@ public struct FileSystemWatcher: Codable, Hashable {
 }
 
 extension FileSystemWatcher: LSPAnyCodable {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     guard let globPatternAny = dictionary[CodingKeys.globPattern.stringValue] else { return nil }
     guard case .string(let globPattern) = globPatternAny else { return nil }
     self.globPattern = globPattern

--- a/Sources/LanguageServerProtocol/SupportTypes/InlayHint.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/InlayHint.swift
@@ -84,7 +84,10 @@ public enum InlayHintLabel: Codable, Hashable {
     } else if let string = try? String(from: decoder) {
       self = .string(string)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [InlayHintLabelPart] or String")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected [InlayHintLabelPart] or String"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }

--- a/Sources/LanguageServerProtocol/SupportTypes/LSPAny.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LSPAny.swift
@@ -112,7 +112,7 @@ extension LSPAny: ExpressibleByArrayLiteral {
 
 extension LSPAny: ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral elements: (String, LSPAny)...) {
-    let dict  = [String: LSPAny](elements, uniquingKeysWith: { first, _ in first })
+    let dict = [String: LSPAny](elements, uniquingKeysWith: { first, _ in first })
     self = .dictionary(dict)
   }
 }
@@ -137,7 +137,7 @@ extension Optional: LSPAnyCodable where Wrapped: LSPAnyCodable {
     self = .some(wrapped)
   }
 
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     return nil
   }
 
@@ -162,7 +162,7 @@ extension Array: LSPAnyCodable where Element: LSPAnyCodable {
     self = result
   }
 
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     return nil
   }
 

--- a/Sources/LanguageServerProtocol/SupportTypes/Language.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Language.swift
@@ -22,12 +22,12 @@ public struct Language: RawRepresentable, Codable, Equatable, Hashable {
   /// Clang-compatible language name suitable for use with `-x <language>`.
   public var xflag: String? {
     switch self {
-      case .swift: return "swift"
-      case .c: return "c"
-      case .cpp: return "c++"
-      case .objective_c: return "objective-c"
-      case .objective_cpp: return "objective-c++"
-      default: return nil
+    case .swift: return "swift"
+    case .c: return "c"
+    case .cpp: return "c++"
+    case .objective_c: return "objective-c"
+    case .objective_cpp: return "objective-c++"
+    default: return nil
     }
   }
 
@@ -106,12 +106,12 @@ extension Language: CustomStringConvertible, CustomDebugStringConvertible {
 
 public extension Language {
   static let abap = Language(rawValue: "abap")
-  static let bat = Language(rawValue: "bat") // Windows Bat
+  static let bat = Language(rawValue: "bat")  // Windows Bat
   static let bibtex = Language(rawValue: "bibtex")
   static let clojure = Language(rawValue: "clojure")
   static let coffeescript = Language(rawValue: "coffeescript")
   static let c = Language(rawValue: "c")
-  static let cpp = Language(rawValue: "cpp") // C++, not C preprocessor
+  static let cpp = Language(rawValue: "cpp")  // C++, not C preprocessor
   static let csharp = Language(rawValue: "csharp")
   static let css = Language(rawValue: "css")
   static let diff = Language(rawValue: "diff")
@@ -143,20 +143,20 @@ public extension Language {
   static let jade = Language(rawValue: "jade")
   static let python = Language(rawValue: "python")
   static let r = Language(rawValue: "r")
-  static let razor = Language(rawValue: "razor") // Razor (cshtml)
+  static let razor = Language(rawValue: "razor")  // Razor (cshtml)
   static let ruby = Language(rawValue: "ruby")
   static let rust = Language(rawValue: "rust")
-  static let scss = Language(rawValue: "scss") // SCSS (syntax using curly brackets)
-  static let sass = Language(rawValue: "sass") // SCSS (indented syntax)
+  static let scss = Language(rawValue: "scss")  // SCSS (syntax using curly brackets)
+  static let sass = Language(rawValue: "sass")  // SCSS (indented syntax)
   static let scala = Language(rawValue: "scala")
   static let shaderLab = Language(rawValue: "shaderlab")
-  static let shellScript = Language(rawValue: "shellscript") // Shell Script (Bash)
+  static let shellScript = Language(rawValue: "shellscript")  // Shell Script (Bash)
   static let sql = Language(rawValue: "sql")
   static let swift = Language(rawValue: "swift")
   static let typeScript = Language(rawValue: "typescript")
-  static let typeScriptReact = Language(rawValue: "typescriptreact") // TypeScript React
+  static let typeScriptReact = Language(rawValue: "typescriptreact")  // TypeScript React
   static let tex = Language(rawValue: "tex")
-  static let vb = Language(rawValue: "vb") // Visual Basic
+  static let vb = Language(rawValue: "vb")  // Visual Basic
   static let xml = Language(rawValue: "xml")
   static let xsl = Language(rawValue: "xsl")
   static let yaml = Language(rawValue: "yaml")

--- a/Sources/LanguageServerProtocol/SupportTypes/LocationLink.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LocationLink.swift
@@ -16,25 +16,27 @@ public struct LocationLink: Codable, Hashable {
   /// Used as the underlined span for mouse interaction. Defaults to the word range at the mouse position.
   @CustomCodable<PositionRange?>
   public var originSelectionRange: Range<Position>?
-  
+
   /// The target resource identifier of this link.
   public var targetUri: DocumentURI
-  
+
   /// The full target range of this link. If the target for example is a symbol then target range is the
   /// range enclosing this symbol not including leading/trailing whitespace but everything else
   /// like comments. This information is typically used to highlight the range in the editor.
   @CustomCodable<PositionRange>
   public var targetRange: Range<Position>
-  
+
   /// The range that should be selected and revealed when this link is being followed, e.g the name of a function.
   /// Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
   @CustomCodable<PositionRange>
   public var targetSelectionRange: Range<Position>
-  
-  public init(originSelectionRange: Range<Position>? = nil,
-              targetUri: DocumentURI,
-              targetRange: Range<Position>,
-              targetSelectionRange: Range<Position>) {
+
+  public init(
+    originSelectionRange: Range<Position>? = nil,
+    targetUri: DocumentURI,
+    targetRange: Range<Position>,
+    targetSelectionRange: Range<Position>
+  ) {
     self._originSelectionRange = CustomCodable<PositionRange?>(wrappedValue: originSelectionRange)
     self.targetUri = targetUri
     self._targetRange = CustomCodable<PositionRange>(wrappedValue: targetRange)

--- a/Sources/LanguageServerProtocol/SupportTypes/LocationsOrLocationLinksResponse.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LocationsOrLocationLinksResponse.swift
@@ -23,7 +23,10 @@ public enum LocationsOrLocationLinksResponse: ResponseType, Hashable {
       // Fallback: Decode single location as array with one element
       self = .locations([location])
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [Location], [LocationLink], or Location")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected [Location], [LocationLink], or Location"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -37,4 +40,3 @@ public enum LocationsOrLocationLinksResponse: ResponseType, Hashable {
     }
   }
 }
-

--- a/Sources/LanguageServerProtocol/SupportTypes/MarkupContent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/MarkupContent.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 /// The kind of markup (plaintext or markdown).
 ///
 /// In LSP, this is a string, so we don't use a closed set.

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookCellTextDocumentFilter.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookCellTextDocumentFilter.swift
@@ -41,7 +41,10 @@ public struct NotebookCellTextDocumentFilter: Codable, Hashable {
       } else if let filter = try? NotebookDocumentFilter(from: decoder) {
         self = .notebookDocumentFilter(filter)
       } else {
-        let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "NotebookFilter must be either a String or NotebookDocumentFilter")
+        let context = DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "NotebookFilter must be either a String or NotebookDocumentFilter"
+        )
         throw DecodingError.dataCorrupted(context)
       }
     }

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookDocument.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookDocument.swift
@@ -88,7 +88,12 @@ public struct NotebookCell: Codable, Hashable {
   /// Additional execution summary information if supported by the client.
   public var executionSummary: ExecutionSummary?
 
-  public init(kind: NotebookCellKind, document: DocumentURI, metadata: LSPObject? = nil, executionSummary: ExecutionSummary? = nil) {
+  public init(
+    kind: NotebookCellKind,
+    document: DocumentURI,
+    metadata: LSPObject? = nil,
+    executionSummary: ExecutionSummary? = nil
+  ) {
     self.kind = kind
     self.document = document
     self.metadata = metadata

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookDocumentChangeEvent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookDocumentChangeEvent.swift
@@ -41,7 +41,11 @@ public struct NotebookDocumentChangeEvent: Codable, Hashable {
     /// Additional closed cell text documents.
     public var didClose: [TextDocumentIdentifier]?
 
-    public init(array: NotebookCellArrayChange, didOpen: [TextDocumentItem]? = nil, didClose: [TextDocumentIdentifier]? = nil) {
+    public init(
+      array: NotebookCellArrayChange,
+      didOpen: [TextDocumentItem]? = nil,
+      didClose: [TextDocumentIdentifier]? = nil
+    ) {
       self.array = array
       self.didOpen = didOpen
       self.didClose = didClose

--- a/Sources/LanguageServerProtocol/SupportTypes/Position.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Position.swift
@@ -39,10 +39,10 @@ extension Position: Comparable {
 }
 
 extension Position: LSPAnyCodable {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     guard case .int(let line) = dictionary[CodingKeys.line.stringValue],
-          case .int(let utf16index) = dictionary[CodingKeys.utf16index.stringValue] else
-    {
+      case .int(let utf16index) = dictionary[CodingKeys.utf16index.stringValue]
+    else {
       return nil
     }
     self.line = line
@@ -52,7 +52,7 @@ extension Position: LSPAnyCodable {
   public func encodeToLSPAny() -> LSPAny {
     return .dictionary([
       CodingKeys.line.stringValue: .int(line),
-      CodingKeys.utf16index.stringValue: .int(utf16index)
+      CodingKeys.utf16index.stringValue: .int(utf16index),
     ])
   }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/PositionEncoding.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/PositionEncoding.swift
@@ -27,10 +27,10 @@ public struct PositionEncodingKind: RawRepresentable, Codable, Hashable {
   /// by servers
   public static let utf16: PositionEncodingKind = PositionEncodingKind(rawValue: "utf-16")
 
-   /// Character offsets count UTF-32 code units.
-   ///
-   /// Implementation note: these are the same as Unicode code points,
-   /// so this `PositionEncodingKind` may also be used for an
-   /// encoding-agnostic representation of character offsets.
+  /// Character offsets count UTF-32 code units.
+  ///
+  /// Implementation note: these are the same as Unicode code points,
+  /// so this `PositionEncodingKind` may also be used for an
+  /// encoding-agnostic representation of character offsets.
   public static let utf32: PositionEncodingKind = PositionEncodingKind(rawValue: "utf-32")
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -45,7 +45,7 @@ public struct TextDocumentRegistrationOptions: RegistrationOptions, Hashable {
 
 /// Protocol for a type which structurally represents`TextDocumentRegistrationOptions`.
 public protocol TextDocumentRegistrationOptionsProtocol {
-  var textDocumentRegistrationOptions: TextDocumentRegistrationOptions {get}
+  var textDocumentRegistrationOptions: TextDocumentRegistrationOptions { get }
 }
 
 /// Code completiion registration options.
@@ -55,7 +55,7 @@ public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRe
 
   public init(documentSelector: DocumentSelector? = nil, completionOptions: CompletionOptions) {
     self.textDocumentRegistrationOptions =
-        TextDocumentRegistrationOptions(documentSelector: documentSelector)
+      TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.completionOptions = completionOptions
   }
 
@@ -81,7 +81,7 @@ public struct FoldingRangeRegistrationOptions: RegistrationOptions, TextDocument
 
   public init(documentSelector: DocumentSelector? = nil, foldingRangeOptions: FoldingRangeOptions) {
     self.textDocumentRegistrationOptions =
-        TextDocumentRegistrationOptions(documentSelector: documentSelector)
+      TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.foldingRangeOptions = foldingRangeOptions
   }
 
@@ -91,7 +91,8 @@ public struct FoldingRangeRegistrationOptions: RegistrationOptions, TextDocument
   }
 }
 
-public struct SemanticTokensRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
+public struct SemanticTokensRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable
+{
   /// Method for registration, which defers from the actual requests' methods
   /// since this registration handles multiple requests.
   public static let method: String = "textDocument/semanticTokens"
@@ -101,7 +102,7 @@ public struct SemanticTokensRegistrationOptions: RegistrationOptions, TextDocume
 
   public init(documentSelector: DocumentSelector? = nil, semanticTokenOptions: SemanticTokensOptions) {
     self.textDocumentRegistrationOptions =
-        TextDocumentRegistrationOptions(documentSelector: documentSelector)
+      TextDocumentRegistrationOptions(documentSelector: documentSelector)
     self.semanticTokenOptions = semanticTokenOptions
   }
 
@@ -110,7 +111,7 @@ public struct SemanticTokensRegistrationOptions: RegistrationOptions, TextDocume
     let legend = semanticTokenOptions.legend
     dict["legend"] = .dictionary([
       "tokenTypes": encode(strings: legend.tokenTypes),
-      "tokenModifiers": encode(strings: legend.tokenModifiers)
+      "tokenModifiers": encode(strings: legend.tokenModifiers),
     ])
     if let range = semanticTokenOptions.range {
       let encodedRange: LSPAny
@@ -160,7 +161,7 @@ public struct InlayHintRegistrationOptions: RegistrationOptions, TextDocumentReg
 public struct DiagnosticRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol {
   public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions
   public var diagnosticOptions: DiagnosticOptions
-  
+
   public init(
     documentSelector: DocumentSelector? = nil,
     diagnosticOptions: DiagnosticOptions

--- a/Sources/LanguageServerProtocol/SupportTypes/SemanticTokens.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SemanticTokens.swift
@@ -33,7 +33,6 @@ public struct SemanticTokensLegend: Codable, Hashable {
   }
 }
 
-
 /// The encoding format for semantic tokens. Currently only `relative` is supported.
 public struct TokenFormat: RawRepresentable, Codable, Hashable {
   public var rawValue: String

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -161,8 +161,7 @@ public struct ServerCapabilities: Codable, Hashable {
     monikerProvider: ValueOrBool<MonikerOptions>? = nil,
     inlineValueProvider: ValueOrBool<TextDocumentAndStaticRegistrationOptions>? = nil,
     experimental: LSPAny? = nil
-  )
-  {
+  ) {
     self.positionEncoding = positionEncoding
     self.textDocumentSync = textDocumentSync
     self.notebookDocumentSync = notebookDocumentSync
@@ -221,7 +220,10 @@ public enum ValueOrBool<ValueType: Codable>: Codable, Hashable where ValueType: 
     } else if let value = try? ValueType(from: decoder) {
       self = .value(value)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected Bool or \(ValueType.self)")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected Bool or \(ValueType.self)"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -246,7 +248,10 @@ public enum TextDocumentSync: Codable, Hashable {
     } else if let kind = try? TextDocumentSyncKind(from: decoder) {
       self = .kind(kind)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected TextDocumentSyncOptions or TextDocumentSyncKind")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected TextDocumentSyncOptions or TextDocumentSyncKind"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -298,11 +303,13 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
   /// Whether save notifications should be sent to the server.
   public var save: ValueOrBool<SaveOptions>?
 
-  public init(openClose: Bool? = true,
-              change: TextDocumentSyncKind? = .incremental,
-              willSave: Bool? = true,
-              willSaveWaitUntil: Bool? = false,
-              save: ValueOrBool<SaveOptions>? = .value(SaveOptions(includeText: false))) {
+  public init(
+    openClose: Bool? = true,
+    change: TextDocumentSyncKind? = .incremental,
+    willSave: Bool? = true,
+    willSaveWaitUntil: Bool? = false,
+    save: ValueOrBool<SaveOptions>? = .value(SaveOptions(includeText: false))
+  ) {
     self.openClose = openClose
     self.change = change
     self.willSave = willSave
@@ -325,7 +332,10 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
       self.change = try TextDocumentSyncKind(from: decoder)
       return
     } catch {}
-    let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected TextDocumentSyncOptions or TextDocumentSyncKind")
+    let context = DecodingError.Context(
+      codingPath: decoder.codingPath,
+      debugDescription: "Expected TextDocumentSyncOptions or TextDocumentSyncKind"
+    )
     throw DecodingError.dataCorrupted(context)
   }
 }
@@ -353,7 +363,10 @@ public enum NotebookFilter: Codable, Hashable {
     } else if let documentFilter = try? DocumentFilter(from: decoder) {
       self = .documentFilter(documentFilter)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or DocumentFilter")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected String or DocumentFilter"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -392,7 +405,7 @@ public struct NotebookDocumentSyncAndStaticRegistrationOptions: Codable, Hashabl
 }
 
 public protocol WorkDoneProgressOptions {
-  var workDoneProgress: Bool?  { get }
+  var workDoneProgress: Bool? { get }
 }
 
 public struct HoverOptions: WorkDoneProgressOptions, Codable, Hashable {
@@ -642,9 +655,11 @@ public enum CodeActionServerCapabilities: Codable, Hashable {
   case supportsCodeActionRequests(Bool)
   case supportsCodeActionRequestsWithLiterals(CodeActionOptions)
 
-  public init(clientCapabilities: TextDocumentClientCapabilities.CodeAction?,
-              codeActionOptions: CodeActionOptions,
-              supportsCodeActions: Bool) {
+  public init(
+    clientCapabilities: TextDocumentClientCapabilities.CodeAction?,
+    codeActionOptions: CodeActionOptions,
+    supportsCodeActions: Bool
+  ) {
     if clientCapabilities?.codeActionLiteralSupport != nil {
       self = .supportsCodeActionRequestsWithLiterals(codeActionOptions)
     } else {

--- a/Sources/LanguageServerProtocol/SupportTypes/StringOrMarkupContent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/StringOrMarkupContent.swift
@@ -20,7 +20,10 @@ public enum StringOrMarkupContent: Codable, Hashable {
     } else if let markupContent = try? MarkupContent(from: decoder) {
       self = .markupContent(markupContent)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or MarkupContent")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected String or MarkupContent"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
@@ -24,7 +24,10 @@ public struct TextDocumentEdit: Hashable, Codable {
       } else if let edit = try? TextEdit(from: decoder) {
         self = .textEdit(edit)
       } else {
-        let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected AnnotatedTextEdit or TextEdit")
+        let context = DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Expected AnnotatedTextEdit or TextEdit"
+        )
         throw DecodingError.dataCorrupted(context)
       }
     }

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentIdentifier.swift
@@ -22,7 +22,7 @@ public struct TextDocumentIdentifier: Hashable, Codable {
 }
 
 extension TextDocumentIdentifier: LSPAnyCodable {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     guard case .string(let uriString)? = dictionary[CodingKeys.uri.stringValue] else {
       return nil
     }

--- a/Sources/LanguageServerProtocol/SupportTypes/TextEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextEdit.swift
@@ -27,10 +27,10 @@ public struct TextEdit: ResponseType, Hashable {
 }
 
 extension TextEdit: LSPAnyCodable {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     guard case .dictionary(let rangeDict) = dictionary[CodingKeys.range.stringValue],
-          case .string(let newText) = dictionary[CodingKeys.newText.stringValue] else
-    {
+      case .string(let newText) = dictionary[CodingKeys.newText.stringValue]
+    else {
       return nil
     }
     guard let range = Range<Position>(fromLSPDictionary: rangeDict) else {
@@ -43,7 +43,7 @@ extension TextEdit: LSPAnyCodable {
   public func encodeToLSPAny() -> LSPAny {
     return .dictionary([
       CodingKeys.range.stringValue: range.encodeToLSPAny(),
-      CodingKeys.newText.stringValue: .string(newText)
+      CodingKeys.newText.stringValue: .string(newText),
     ])
   }
 }
@@ -68,7 +68,6 @@ public struct ChangeAnnotation: Codable, Hashable {
     self.description = description
   }
 }
-
 
 /// An identifier referring to a change annotation managed by a workspace
 /// edit.

--- a/Sources/LanguageServerProtocol/SupportTypes/Tracing.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Tracing.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum Tracing: String, Codable  {
+public enum Tracing: String, Codable {
   case off
   case messages
   case verbose

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceEdit.swift
@@ -26,9 +26,11 @@ public struct WorkspaceEdit: Hashable, ResponseType {
   /// `workspace.changeAnnotationSupport`.
   public var changeAnnotations: [ChangeAnnotationIdentifier: ChangeAnnotation]?
 
-  public init(changes: [DocumentURI: [TextEdit]]? = nil,
-              documentChanges: [WorkspaceEditDocumentChange]? = nil,
-              changeAnnotation: [ChangeAnnotationIdentifier: ChangeAnnotation]? = nil) {
+  public init(
+    changes: [DocumentURI: [TextEdit]]? = nil,
+    documentChanges: [WorkspaceEditDocumentChange]? = nil,
+    changeAnnotation: [ChangeAnnotationIdentifier: ChangeAnnotation]? = nil
+  ) {
     self.changes = changes
     self.documentChanges = documentChanges
     self.changeAnnotations = changeAnnotation
@@ -86,7 +88,10 @@ public enum WorkspaceEditDocumentChange: Codable, Hashable {
     } else if let deleteFile = try? DeleteFile(from: decoder) {
       self = .deleteFile(deleteFile)
     } else {
-      let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected TextDocumentEdit, CreateFile, RenameFile, or DeleteFile")
+      let context = DecodingError.Context(
+        codingPath: decoder.codingPath,
+        debugDescription: "Expected TextDocumentEdit, CreateFile, RenameFile, or DeleteFile"
+      )
       throw DecodingError.dataCorrupted(context)
     }
   }
@@ -105,11 +110,11 @@ public enum WorkspaceEditDocumentChange: Codable, Hashable {
   }
 }
 
- /// Options to create a file.
+/// Options to create a file.
 public struct CreateFileOptions: Codable, Hashable {
-   /// Overwrite existing file. Overwrite wins over `ignoreIfExists`
+  /// Overwrite existing file. Overwrite wins over `ignoreIfExists`
   public var overwrite: Bool?
-   /// Ignore if exists.
+  /// Ignore if exists.
   public var ignoreIfExists: Bool?
 
   public init(overwrite: Bool? = nil, ignoreIfExists: Bool? = nil) {
@@ -118,11 +123,11 @@ public struct CreateFileOptions: Codable, Hashable {
   }
 }
 
- /// Create file operation
+/// Create file operation
 public struct CreateFile: Codable, Hashable {
-   /// The resource to create.
+  /// The resource to create.
   public var uri: DocumentURI
-   /// Additional options
+  /// Additional options
   public var options: CreateFileOptions?
   /// An optional annotation identifier describing the operation.
   public var annotationId: ChangeAnnotationIdentifier?
@@ -146,7 +151,11 @@ public struct CreateFile: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     guard kind == "create" else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of CreateFile is not 'create'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of CreateFile is not 'create'"
+      )
     }
     self.uri = try container.decode(DocumentURI.self, forKey: .uri)
     self.options = try container.decodeIfPresent(CreateFileOptions.self, forKey: .options)
@@ -162,11 +171,11 @@ public struct CreateFile: Codable, Hashable {
   }
 }
 
- /// Rename file options
+/// Rename file options
 public struct RenameFileOptions: Codable, Hashable {
-   /// Overwrite target if existing. Overwrite wins over `ignoreIfExists`
+  /// Overwrite target if existing. Overwrite wins over `ignoreIfExists`
   public var overwrite: Bool?
-   /// Ignores if target exists.
+  /// Ignores if target exists.
   public var ignoreIfExists: Bool?
 
   public init(overwrite: Bool? = nil, ignoreIfExists: Bool? = nil) {
@@ -175,18 +184,23 @@ public struct RenameFileOptions: Codable, Hashable {
   }
 }
 
- /// Rename file operation
+/// Rename file operation
 public struct RenameFile: Codable, Hashable {
-   /// The old (existing) location.
+  /// The old (existing) location.
   public var oldUri: DocumentURI
-   /// The new location.
+  /// The new location.
   public var newUri: DocumentURI
-   /// Rename options.
+  /// Rename options.
   public var options: RenameFileOptions?
   /// An optional annotation identifier describing the operation.
   public var annotationId: ChangeAnnotationIdentifier?
 
-  public init(oldUri: DocumentURI, newUri: DocumentURI, options: RenameFileOptions? = nil, annotationId: ChangeAnnotationIdentifier? = nil) {
+  public init(
+    oldUri: DocumentURI,
+    newUri: DocumentURI,
+    options: RenameFileOptions? = nil,
+    annotationId: ChangeAnnotationIdentifier? = nil
+  ) {
     self.oldUri = oldUri
     self.newUri = newUri
     self.options = options
@@ -207,7 +221,11 @@ public struct RenameFile: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     guard kind == "rename" else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of RenameFile is not 'rename'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of RenameFile is not 'rename'"
+      )
     }
     self.oldUri = try container.decode(DocumentURI.self, forKey: .oldUri)
     self.newUri = try container.decode(DocumentURI.self, forKey: .newUri)
@@ -225,11 +243,11 @@ public struct RenameFile: Codable, Hashable {
   }
 }
 
- /// Delete file options
+/// Delete file options
 public struct DeleteFileOptions: Codable, Hashable {
-   /// Delete the content recursively if a folder is denoted.
+  /// Delete the content recursively if a folder is denoted.
   public var recursive: Bool?
-   /// Ignore the operation if the file doesn't exist.
+  /// Ignore the operation if the file doesn't exist.
   public var ignoreIfNotExists: Bool?
 
   public init(recursive: Bool? = nil, ignoreIfNotExists: Bool? = nil) {
@@ -238,11 +256,11 @@ public struct DeleteFileOptions: Codable, Hashable {
   }
 }
 
- /// Delete file operation
+/// Delete file operation
 public struct DeleteFile: Codable, Hashable {
-   /// The file to delete.
+  /// The file to delete.
   public var uri: DocumentURI
-   /// Delete options.
+  /// Delete options.
   public var options: DeleteFileOptions?
   /// An optional annotation identifier describing the operation.
   public var annotationId: ChangeAnnotationIdentifier?
@@ -266,7 +284,11 @@ public struct DeleteFile: Codable, Hashable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     guard kind == "delete" else {
-      throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Kind of DeleteFile is not 'delete'")
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of DeleteFile is not 'delete'"
+      )
     }
     self.uri = try container.decode(DocumentURI.self, forKey: .uri)
     self.options = try container.decodeIfPresent(DeleteFileOptions.self, forKey: .options)
@@ -283,7 +305,7 @@ public struct DeleteFile: Codable, Hashable {
 }
 
 extension WorkspaceEdit: LSPAnyCodable {
-  public init?(fromLSPDictionary dictionary: [String : LSPAny]) {
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     guard case .dictionary(let lspDict) = dictionary[CodingKeys.changes.stringValue] else {
       return nil
     }

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
@@ -23,7 +23,7 @@ public struct WorkspaceFolder: ResponseType, Hashable, Codable {
     self.uri = uri
 
     self.name = name ?? uri.fileURL?.lastPathComponent ?? "unknown_workspace"
-    
+
     if self.name.isEmpty {
       self.name = "unknown_workspace"
     }

--- a/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -20,9 +19,9 @@ import Musl
 #if canImport(Glibc) || canImport(Musl)
 // This is a lazily initialised global variable that when read for the first time, will ignore SIGPIPE.
 private let globallyIgnoredSIGPIPE: Bool = {
-    /* no F_SETNOSIGPIPE on Linux :( */
-    _ = signal(SIGPIPE, SIG_IGN)
-    return true
+  /* no F_SETNOSIGPIPE on Linux :( */
+  _ = signal(SIGPIPE, SIG_IGN)
+  return true
 }()
 
 internal func globallyDisableSigpipe() {

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -21,7 +21,9 @@ public enum JSONRPCMessage {
 }
 
 extension CodingUserInfoKey {
-  public static let responseTypeCallbackKey: CodingUserInfoKey = CodingUserInfoKey(rawValue: "lsp.jsonrpc.responseTypeCallback")!
+  public static let responseTypeCallbackKey: CodingUserInfoKey = CodingUserInfoKey(
+    rawValue: "lsp.jsonrpc.responseTypeCallback"
+  )!
   public static let messageRegistryKey: CodingUserInfoKey = CodingUserInfoKey(rawValue: "lsp.jsonrpc.messageRegistry")!
 }
 
@@ -78,7 +80,7 @@ extension JSONRPCMessage: Codable {
         }
 
         let params = try messageType.init(from: container.superDecoder(forKey: .params))
-        
+
         self = .request(params, id: id)
 
       case (let id?, nil, true, nil):
@@ -111,14 +113,26 @@ extension JSONRPCMessage: Codable {
       throw error
 
     } catch DecodingError.keyNotFound(let key, _) {
-      throw MessageDecodingError.invalidParams("missing expected parameter: \(key.stringValue)", id: id, messageKind: msgKind)
+      throw MessageDecodingError.invalidParams(
+        "missing expected parameter: \(key.stringValue)",
+        id: id,
+        messageKind: msgKind
+      )
 
     } catch DecodingError.valueNotFound(_, let context) {
-      throw MessageDecodingError.invalidParams("missing expected parameter: \(context.codingPath.last?.stringValue ?? "unknown")", id: id, messageKind: msgKind)
+      throw MessageDecodingError.invalidParams(
+        "missing expected parameter: \(context.codingPath.last?.stringValue ?? "unknown")",
+        id: id,
+        messageKind: msgKind
+      )
 
     } catch DecodingError.typeMismatch(_, let context) {
       let path = context.codingPath.map { $0.stringValue }.joined(separator: ".")
-      throw MessageDecodingError.invalidParams("type mismatch at \(path) : \(context.debugDescription)", id: id, messageKind: msgKind)
+      throw MessageDecodingError.invalidParams(
+        "type mismatch at \(path) : \(context.debugDescription)",
+        id: id,
+        messageKind: msgKind
+      )
 
     } catch {
       throw MessageDecodingError.parseError(error.localizedDescription, id: id, messageKind: msgKind)

--- a/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
@@ -50,7 +50,9 @@ extension RandomAccessCollection where Element == UInt8 {
 
       if key.elementsEqual(JSONRPCMessageHeader.contentLengthKey) {
         guard let count = Int(ascii: value) else {
-          throw MessageDecodingError.parseError("expected integer value in \(String(bytes: value, encoding: .utf8) ?? "<invalid>")")
+          throw MessageDecodingError.parseError(
+            "expected integer value in \(String(bytes: value, encoding: .utf8) ?? "<invalid>")"
+          )
         }
         header.contentLength = count
       }
@@ -73,7 +75,7 @@ extension RandomAccessCollection where Element == UInt8 {
     if self[keyEnd] != JSONRPCMessageHeader.colon {
       throw MessageDecodingError.parseError("expected ':' in message header")
     }
-    let valueStart = index(after:keyEnd)
+    let valueStart = index(after: keyEnd)
     guard let valueEnd = self[valueStart...].firstIndex(of: JSONRPCMessageHeader.separator) else {
       return nil
     }
@@ -86,7 +88,7 @@ extension RandomAccessCollection where Element: Equatable {
 
   /// Returns the first index where the specified subsequence appears or nil.
   @inlinable
-  public func firstIndex<Pattern>(of pattern: Pattern) -> Index? where Pattern: RandomAccessCollection, Pattern.Element == Element {
+  public func firstIndex(of pattern: some RandomAccessCollection<Element>) -> Index? {
 
     if pattern.isEmpty {
       return startIndex
@@ -97,7 +99,7 @@ extension RandomAccessCollection where Element: Equatable {
 
     // FIXME: use a better algorithm (e.g. Boyer-Moore-Horspool).
     var i = startIndex
-    for _ in 0 ..< (count - pattern.count + 1) {
+    for _ in 0..<(count - pattern.count + 1) {
       if self[i...].starts(with: pattern) {
         return i
       }
@@ -112,7 +114,7 @@ extension UInt8 {
   @inlinable
   public var isSpace: Bool {
     switch self {
-    case UInt8(ascii: " "), UInt8(ascii: "\t"), /*LF*/0xa, /*VT*/0xb, /*FF*/0xc, /*CR*/0xd:
+    case UInt8(ascii: " "), UInt8(ascii: "\t"), /*LF*/ 0xa, /*VT*/ 0xb, /*FF*/ 0xc, /*CR*/ 0xd:
       return true
     default:
       return false

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -12,16 +12,18 @@
 
 import SKSupport
 
-import struct TSCBasic.AbsolutePath
 import struct PackageModel.BuildFlags
+import struct TSCBasic.AbsolutePath
 
 /// Build configuration
 public struct BuildSetup {
 
   /// Default configuration
-  public static let `default` = BuildSetup(configuration: .debug,
-                                           path: nil,
-                                           flags: BuildFlags())
+  public static let `default` = BuildSetup(
+    configuration: .debug,
+    path: nil,
+    flags: BuildFlags()
+  )
 
   /// Build configuration (debug|release).
   public var configuration: BuildConfiguration

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import BuildServerProtocol
-import LSPLogging
 import Dispatch
+import LSPLogging
+import LanguageServerProtocol
 
 import struct TSCBasic.AbsolutePath
 
@@ -52,8 +52,12 @@ public actor BuildSystemManager {
 
   /// Create a BuildSystemManager that wraps the given build system. The new
   /// manager will modify the delegate of the underlying build system.
-  public init(buildSystem: BuildSystem?, fallbackBuildSystem: FallbackBuildSystem?,
-              mainFilesProvider: MainFilesProvider?, fallbackSettingsTimeout: DispatchTimeInterval = .seconds(3)) async {
+  public init(
+    buildSystem: BuildSystem?,
+    fallbackBuildSystem: FallbackBuildSystem?,
+    mainFilesProvider: MainFilesProvider?,
+    fallbackSettingsTimeout: DispatchTimeInterval = .seconds(3)
+  ) async {
     let buildSystemHasDelegate = await buildSystem?.delegate != nil
     precondition(!buildSystemHasDelegate)
     self.buildSystem = buildSystem
@@ -80,7 +84,7 @@ extension BuildSystemManager {
   }
 
   public var mainFilesProvider: MainFilesProvider? {
-    get { _mainFilesProvider}
+    get { _mainFilesProvider }
     set { _mainFilesProvider = newValue }
   }
 
@@ -172,13 +176,15 @@ extension BuildSystemManager {
 
 extension BuildSystemManager: BuildSystemDelegate {
   private func watchedFilesReferencing(mainFiles: Set<DocumentURI>) -> Set<DocumentURI> {
-    return Set(watchedFiles.compactMap { (watchedFile, mainFileAndLanguage) in
-      if mainFiles.contains(mainFileAndLanguage.mainFile) {
-        return watchedFile
-      } else {
-        return nil
+    return Set(
+      watchedFiles.compactMap { (watchedFile, mainFileAndLanguage) in
+        if mainFiles.contains(mainFileAndLanguage.mainFile) {
+          return watchedFile
+        } else {
+          return nil
+        }
       }
-    })
+    )
   }
 
   public func fileBuildSettingsChanged(_ changedFiles: Set<DocumentURI>) async {
@@ -251,11 +257,11 @@ extension BuildSystemManager: MainFilesDelegate {
       await delegate.fileBuildSettingsChanged(changedMainFileAssociations)
     }
   }
-  
+
   /// Return the main file that should be used to get build settings for `uri`.
   ///
   /// For Swift or normal C files, this will be the file itself. For header
-  /// files, we pick a main file that includes the header since header files 
+  /// files, we pick a main file that includes the header since header files
   /// don't have build settings by themselves.
   private func mainFile(for uri: DocumentURI, useCache: Bool = true) -> DocumentURI {
     if useCache, let mainFile = self.watchedFiles[uri]?.mainFile {
@@ -272,7 +278,7 @@ extension BuildSystemManager: MainFilesDelegate {
       // If the main files contain the file itself, prefer to use that one
       return uri
     } else if let mainFile = mainFiles.min(by: { $0.pseudoPath < $1.pseudoPath }) {
-      // Pick the lexicographically first main file if it exists. 
+      // Pick the lexicographically first main file if it exists.
       // This makes sure that picking a main file is deterministic.
       return mainFile
     } else {

--- a/Sources/SKCore/CompilationDatabase.swift
+++ b/Sources/SKCore/CompilationDatabase.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKSupport
 import Foundation
+import SKSupport
 
-import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem
 import func TSCBasic.resolveSymlinks
 
@@ -89,7 +89,7 @@ public func tryLoadCompilationDatabase(
 /// See https://clang.llvm.org/docs/JSONCompilationDatabase.html under Alternatives
 public struct FixedCompilationDatabase: CompilationDatabase, Equatable {
   public var allCommands: AnySequence<Command> { AnySequence([]) }
-  
+
   private let fixedArgs: [String]
   private let directory: String
 
@@ -113,7 +113,7 @@ extension FixedCompilationDatabase {
       guard let fileContents = String(data: data, encoding: .utf8) else {
         throw CompilationDatabaseDecodingError.fixedDatabaseDecordingError
       }
-      
+
       fileContents.enumerateLines { line, _ in
         fixedArgs.append(line.trimmingCharacters(in: .whitespacesAndNewlines))
       }
@@ -121,7 +121,6 @@ extension FixedCompilationDatabase {
     self.fixedArgs = fixedArgs
   }
 }
-
 
 /// The JSON clang-compatible compilation database.
 ///
@@ -194,7 +193,7 @@ extension JSONCompilationDatabase {
   public init(file: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
     let bytes = try fileSystem.readFileContents(file)
     try bytes.withUnsafeData { data in
-       self = try JSONDecoder().decode(JSONCompilationDatabase.self, from: data)
+      self = try JSONDecoder().decode(JSONCompilationDatabase.self, from: data)
     }
   }
 }
@@ -274,8 +273,8 @@ public func splitShellEscapedCommand(_ cmd: String) -> [String] {
     mutating func parse() -> [String] {
       while !done {
         switch ch {
-          case UInt8(ascii: " "): next()
-          default: parseString()
+        case UInt8(ascii: " "): next()
+        default: parseString()
         }
       }
       return result

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import BuildServerProtocol
-import LanguageServerProtocol
-import LSPLogging
-import SKSupport
 import Dispatch
-import struct Foundation.URL
+import LSPLogging
+import LanguageServerProtocol
+import SKSupport
 
-import protocol TSCBasic.FileSystem
+import struct Foundation.URL
 import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem
 
 /// A `BuildSystem` based on loading clang-compatible compilation database(s).
@@ -61,7 +61,7 @@ public actor CompilationDatabaseBuildSystem {
         let args = command.commandLine
         for i in args.indices.reversed() {
           if args[i] == "-index-store-path" && i != args.endIndex - 1 {
-            _indexStorePath = try? AbsolutePath(validating: args[i+1])
+            _indexStorePath = try? AbsolutePath(validating: args[i + 1])
             return _indexStorePath
           }
         }
@@ -93,10 +93,12 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
       return nil
     }
     guard let db = database(for: url),
-          let cmd = db[url].first else { return nil }
+      let cmd = db[url].first
+    else { return nil }
     return FileBuildSettings(
       compilerArguments: Array(cmd.commandLine.dropFirst()),
-      workingDirectory: cmd.directory)
+      workingDirectory: cmd.directory
+    )
   }
 
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import BuildServerProtocol
+import Dispatch
+import Foundation
 import LanguageServerProtocol
 import SKSupport
-import Foundation
-import Dispatch
 
 import enum PackageLoading.Platform
-import class TSCBasic.Process
 import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
 
 /// A simple BuildSystem suitable as a fallback when accurate settings are unknown.
 public final class FallbackBuildSystem {
@@ -32,7 +32,10 @@ public final class FallbackBuildSystem {
   /// The path to the SDK.
   public lazy var sdkpath: AbsolutePath? = {
     guard Platform.current == .darwin else { return nil }
-    return try? AbsolutePath(validating: Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx").trimmingCharacters(in: .whitespacesAndNewlines))
+    return try? AbsolutePath(
+      validating: Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    )
   }()
 
   /// Delegate to handle any build system events.

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 import SKSupport
 
 import enum PackageLoading.Platform
@@ -69,8 +69,8 @@ public final class Toolchain {
     swiftc: AbsolutePath? = nil,
     clangd: AbsolutePath? = nil,
     sourcekitd: AbsolutePath? = nil,
-    libIndexStore: AbsolutePath? = nil)
-  {
+    libIndexStore: AbsolutePath? = nil
+  ) {
     self.identifier = identifier
     self.displayName = displayName
     self.path = path
@@ -122,9 +122,8 @@ extension Toolchain {
   @discardableResult
   func searchForTools(_ path: AbsolutePath, _ fs: FileSystem = localFileSystem) -> Bool {
     return
-      searchForTools(binPath: path, fs) ||
-      searchForTools(binPath: path.appending(components: "bin"), fs) ||
-      searchForTools(binPath: path.appending(components: "usr", "bin"), fs)
+      searchForTools(binPath: path, fs) || searchForTools(binPath: path.appending(components: "bin"), fs)
+      || searchForTools(binPath: path.appending(components: "usr", "bin"), fs)
   }
 
   private func searchForTools(binPath: AbsolutePath, _ fs: FileSystem) -> Bool {
@@ -174,22 +173,22 @@ extension Toolchain {
       self.sourcekitd = sourcekitdPath
       foundAny = true
     } else {
-#if os(Windows)
+      #if os(Windows)
       let sourcekitdPath = binPath.appending(component: "sourcekitdInProc\(dylibExt)")
-#else
+      #else
       let sourcekitdPath = libPath.appending(component: "libsourcekitdInProc\(dylibExt)")
-#endif
+      #endif
       if fs.isFile(sourcekitdPath) {
         self.sourcekitd = sourcekitdPath
         foundAny = true
       }
     }
 
-#if os(Windows)
+    #if os(Windows)
     let libIndexStore = binPath.appending(components: "libIndexStore\(dylibExt)")
-#else
+    #else
     let libIndexStore = libPath.appending(components: "libIndexStore\(dylibExt)")
-#endif
+    #endif
     if fs.isFile(libIndexStore) {
       self.libIndexStore = libIndexStore
       foundAny = true
@@ -202,8 +201,8 @@ extension Toolchain {
 /// Find a containing xctoolchain with plist, if available.
 func containingXCToolchain(
   _ path: AbsolutePath,
-  _ fileSystem: FileSystem) -> (XCToolchainPlist, AbsolutePath)?
-{
+  _ fileSystem: FileSystem
+) -> (XCToolchainPlist, AbsolutePath)? {
   var path = path
   while !path.isRoot {
     if path.extension == "xctoolchain" {

--- a/Sources/SKCore/XCToolchainPlist.swift
+++ b/Sources/SKCore/XCToolchainPlist.swift
@@ -12,9 +12,10 @@
 
 import Foundation
 
-import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem
+
 #if os(macOS)
 import struct TSCBasic.RelativePath
 import struct TSCBasic.FileSystemError
@@ -47,10 +48,10 @@ extension XCToolchainPlist {
   /// - parameter path: The directory to search.
   /// - throws: If there is not plist file or it cannot be read.
   init(fromDirectory path: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
-#if os(macOS)
+    #if os(macOS)
     let plistNames = [
-      try RelativePath(validating: "ToolchainInfo.plist"), // Xcode
-      try RelativePath(validating: "Info.plist"), // Swift.org
+      try RelativePath(validating: "ToolchainInfo.plist"),  // Xcode
+      try RelativePath(validating: "Info.plist"),  // Swift.org
     ]
 
     var missingPlistPath: AbsolutePath?
@@ -64,25 +65,25 @@ extension XCToolchainPlist {
     }
 
     throw FileSystemError(.noEntry, missingPlistPath)
-#else
+    #else
     throw Error.unsupportedPlatform
-#endif
+    #endif
   }
 
   /// Returns the plist contents from the xctoolchain at `path`.
   ///
   /// - parameter path: The directory to search.
   init(path: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) throws {
-#if os(macOS)
+    #if os(macOS)
     let bytes = try fileSystem.readFileContents(path)
     self = try bytes.withUnsafeData { data in
       let decoder = PropertyListDecoder()
       var format = PropertyListSerialization.PropertyListFormat.binary
       return try decoder.decode(XCToolchainPlist.self, from: data, format: &format)
     }
-#else
+    #else
     throw Error.unsupportedPlatform
-#endif
+    #endif
   }
 }
 

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -39,7 +39,7 @@ public struct LineTable: Hashable {
   /// - parameter line: Line number (zero-based).
   @inlinable
   public subscript(line: Int) -> Substring {
-    return content[impl[line] ..< (line == count - 1 ? content.endIndex : impl[line + 1])]
+    return content[impl[line]..<(line == count - 1 ? content.endIndex : impl[line + 1])]
   }
 
   /// Translate String.Index to logical line/utf16 pair.
@@ -94,8 +94,8 @@ extension LineTable {
     utf16Offset fromOff: Int,
     toLine: Int,
     utf16Offset toOff: Int,
-    with replacement: String)
-  {
+    with replacement: String
+  ) {
     let start = content.utf16.index(impl[fromLine], offsetBy: fromOff)
     let end = content.utf16.index(impl[toLine], offsetBy: toOff)
 
@@ -115,8 +115,8 @@ extension LineTable {
     fromLine: Int,
     utf16Offset fromOff: Int,
     utf16Length: Int,
-    with replacement: String)
-  {
+    with replacement: String
+  ) {
     let start = content.utf16.index(impl[fromLine], offsetBy: fromOff)
     let end = content.utf16.index(start, offsetBy: utf16Length)
     let (toLine, toOff) = lineAndUTF16ColumnOf(end, fromLine: fromLine)
@@ -176,7 +176,8 @@ extension LineTable {
       line: line,
       column: utf8Column,
       indexFunction: content.utf8.index(_:offsetBy:limitedBy:),
-      distanceFunction: content.utf16.distance(from:to:))
+      distanceFunction: content.utf16.distance(from:to:)
+    )
   }
 
   /// Returns UTF8 column offset at UTF16 version of logical position.
@@ -189,11 +190,17 @@ extension LineTable {
       line: line,
       column: utf16Column,
       indexFunction: content.utf16.index(_:offsetBy:limitedBy:),
-      distanceFunction: content.utf8.distance(from:to:))
+      distanceFunction: content.utf8.distance(from:to:)
+    )
   }
 
   @inlinable
-  func convertColumn(line: Int, column: Int, indexFunction: (Substring.Index, Int, Substring.Index) -> Substring.Index?, distanceFunction: (Substring.Index, Substring.Index) -> Int) -> Int? {
+  func convertColumn(
+    line: Int,
+    column: Int,
+    indexFunction: (Substring.Index, Int, Substring.Index) -> Substring.Index?,
+    distanceFunction: (Substring.Index, Substring.Index) -> Int
+  ) -> Int? {
     guard line < count else {
       // Line out of range.
       return nil

--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -23,9 +23,9 @@ import Musl
 
 public final class DLHandle {
   #if os(Windows)
-    typealias Handle = HMODULE
+  typealias Handle = HMODULE
   #else
-    typealias Handle = UnsafeMutableRawPointer
+  typealias Handle = UnsafeMutableRawPointer
   #endif
   var rawValue: Handle? = nil
 
@@ -40,13 +40,13 @@ public final class DLHandle {
   public func close() throws {
     if let handle = rawValue {
       #if os(Windows)
-        guard FreeLibrary(handle) else {
-          throw DLError.close("Failed to FreeLibrary: \(GetLastError())")
-        }
+      guard FreeLibrary(handle) else {
+        throw DLError.close("Failed to FreeLibrary: \(GetLastError())")
+      }
       #else
-        guard dlclose(handle) == 0 else {
-          throw DLError.close(dlerror() ?? "unknown error")
-        }
+      guard dlclose(handle) == 0 else {
+        throw DLError.close(dlerror() ?? "unknown error")
+      }
       #endif
     }
     rawValue = nil
@@ -67,9 +67,9 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
 
   // Platform-specific flags.
   #if os(macOS)
-    public static let first: DLOpenFlags = DLOpenFlags(rawValue: RTLD_FIRST)
+  public static let first: DLOpenFlags = DLOpenFlags(rawValue: RTLD_FIRST)
   #else
-    public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
+  public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #endif
   #endif
 
@@ -87,13 +87,13 @@ public enum DLError: Swift.Error {
 
 public func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {
   #if os(Windows)
-    guard let handle = path?.withCString(encodedAs: UTF16.self, LoadLibraryW) else {
-      throw DLError.open("LoadLibraryW failed: \(GetLastError())")
-    }
+  guard let handle = path?.withCString(encodedAs: UTF16.self, LoadLibraryW) else {
+    throw DLError.open("LoadLibraryW failed: \(GetLastError())")
+  }
   #else
-    guard let handle = dlopen(path, mode.rawValue) else {
-      throw DLError.open(dlerror() ?? "unknown error")
-    }
+  guard let handle = dlopen(path, mode.rawValue) else {
+    throw DLError.open(dlerror() ?? "unknown error")
+  }
   #endif
   return DLHandle(rawValue: handle)
 }

--- a/Sources/SKTestSupport/Array+SyntaxHighlightingToken.swift
+++ b/Sources/SKTestSupport/Array+SyntaxHighlightingToken.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
 import LanguageServerProtocol
+import SourceKitLSP
 
 extension Array where Element == SyntaxHighlightingToken {
   /// Decodes the LSP representation of syntax highlighting tokens
@@ -40,12 +40,14 @@ extension Array where Element == SyntaxHighlightingToken {
       guard let kind = SyntaxHighlightingToken.Kind(rawValue: rawKind) else { continue }
       let modifiers = SyntaxHighlightingToken.Modifiers(rawValue: rawModifiers)
 
-      append(SyntaxHighlightingToken(
-        start: current,
-        utf16length: length,
-        kind: kind,
-        modifiers: modifiers
-      ))
+      append(
+        SyntaxHighlightingToken(
+          start: current,
+          utf16length: length,
+          kind: kind,
+          modifiers: modifiers
+        )
+      )
     }
   }
 }

--- a/Sources/SKTestSupport/FileSystem.swift
+++ b/Sources/SKTestSupport/FileSystem.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.ByteString
+import protocol TSCBasic.FileSystem
 
 extension FileSystem {
 

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -10,21 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
-import SKSwiftPMWorkspace
+import Foundation
+import ISDBTestSupport
+import ISDBTibs
+import IndexStoreDB
+import LSPTestSupport
 import LanguageServerProtocol
 import SKCore
-import IndexStoreDB
-import ISDBTibs
-import ISDBTestSupport
+import SKSwiftPMWorkspace
+import SourceKitLSP
 import XCTest
-import Foundation
-import LSPTestSupport
 
+import struct PackageModel.BuildFlags
+import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import func TSCBasic.resolveSymlinks
-import struct TSCBasic.AbsolutePath
-import struct PackageModel.BuildFlags
 
 fileprivate extension SourceKitServer {
   func addWorkspace(_ workspace: Workspace) {
@@ -88,7 +88,8 @@ public final class SKSwiftPMTestWorkspace {
     let swiftpm = try await SwiftPMWorkspace(
       workspacePath: sourcePath,
       toolchainRegistry: ToolchainRegistry.shared,
-      buildSetup: buildSetup)
+      buildSetup: buildSetup
+    )
 
     let libIndexStore = try IndexStoreLibrary(dylibPath: toolchain.libIndexStore!.pathString)
 
@@ -101,7 +102,8 @@ public final class SKSwiftPMTestWorkspace {
       databasePath: tmpDir.path,
       library: libIndexStore,
       delegate: indexDelegate,
-      listenToUnitEvents: false)
+      listenToUnitEvents: false
+    )
 
     let server = self.testServer.server!
     let workspace = await Workspace(
@@ -112,7 +114,8 @@ public final class SKSwiftPMTestWorkspace {
       buildSetup: buildSetup,
       underlyingBuildSystem: swiftpm,
       index: index,
-      indexDelegate: indexDelegate)
+      indexDelegate: indexDelegate
+    )
     await workspace.buildSystemManager.setDelegate(server)
     await server.addWorkspace(workspace)
   }
@@ -150,11 +153,16 @@ extension SKSwiftPMTestWorkspace {
 
 extension SKSwiftPMTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: language,
-      version: 1,
-      text: try sources.sourceCache.get(url))))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: language,
+          version: 1,
+          text: try sources.sourceCache.get(url)
+        )
+      )
+    )
   }
 
   public func closeDocument(_ url: URL) {
@@ -164,7 +172,10 @@ extension SKSwiftPMTestWorkspace {
 
 extension XCTestCase {
 
-  public func staticSourceKitSwiftPMWorkspace(name: String, server: TestSourceKitServer? = nil) async throws -> SKSwiftPMTestWorkspace? {
+  public func staticSourceKitSwiftPMWorkspace(
+    name: String,
+    server: TestSourceKitServer? = nil
+  ) async throws -> SKSwiftPMTestWorkspace? {
     let testDirName = testDirectoryName
     let toolchain = ToolchainRegistry.shared.default!
     let workspace = try await SKSwiftPMTestWorkspace(
@@ -181,13 +192,17 @@ extension XCTestCase {
 
     if hasClangFile {
       if toolchain.libIndexStore == nil {
-        fputs("warning: skipping test because libIndexStore is missing;" +
-              "install Clang's IndexStore component\n", stderr)
+        fputs(
+          "warning: skipping test because libIndexStore is missing;" + "install Clang's IndexStore component\n",
+          stderr
+        )
         return nil
       }
       if !TibsToolchain(toolchain).clangHasIndexSupport {
-        fputs("warning: skipping test because '\(toolchain.clang!)' does not " +
-              "have indexstore support; use swift-clang\n", stderr)
+        fputs(
+          "warning: skipping test because '\(toolchain.clang!)' does not have indexstore support; use swift-clang\n",
+          stderr
+        )
         return nil
       }
     }

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -10,20 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
+import Foundation
+import ISDBTestSupport
+import ISDBTibs
+import IndexStoreDB
+import LSPTestSupport
 import LanguageServerProtocol
 import SKCore
 import SKSupport
-import IndexStoreDB
-import ISDBTibs
-import ISDBTestSupport
+import SourceKitLSP
 import XCTest
-import Foundation
-import LSPTestSupport
 
 import enum PackageLoading.Platform
-import struct TSCBasic.AbsolutePath
 import struct PackageModel.BuildFlags
+import struct TSCBasic.AbsolutePath
 
 public typealias URL = Foundation.URL
 
@@ -51,15 +51,15 @@ public final class SKTibsTestWorkspace {
     toolchain: Toolchain,
     clientCapabilities: ClientCapabilities,
     testServer: TestSourceKitServer? = nil
-  ) async throws
-  {
+  ) async throws {
     self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
     self.tibsWorkspace = try TibsTestWorkspace(
       immutableProjectDir: immutableProjectDir,
       persistentBuildDir: persistentBuildDir,
       tmpDir: tmpDir,
       removeTmpDir: removeTmpDir,
-      toolchain: TibsToolchain(toolchain))
+      toolchain: TibsToolchain(toolchain)
+    )
 
     try await initWorkspace(clientCapabilities: clientCapabilities)
   }
@@ -76,7 +76,8 @@ public final class SKTibsTestWorkspace {
     self.tibsWorkspace = try TibsTestWorkspace(
       projectDir: projectDir,
       tmpDir: tmpDir,
-      toolchain: TibsToolchain(toolchain))
+      toolchain: TibsToolchain(toolchain)
+    )
 
     try await initWorkspace(clientCapabilities: clientCapabilities)
   }
@@ -95,7 +96,8 @@ public final class SKTibsTestWorkspace {
       buildSetup: BuildSetup(configuration: .debug, path: buildPath, flags: BuildFlags()),
       underlyingBuildSystem: buildSystem,
       index: index,
-      indexDelegate: indexDelegate)
+      indexDelegate: indexDelegate
+    )
 
     await workspace.buildSystemManager.setDelegate(testServer.server!)
     await testServer.server!.setWorkspaces([workspace])
@@ -113,19 +115,24 @@ extension SKTibsTestWorkspace {
   /// Perform a group of edits to the project sources and optionally rebuild.
   public func edit(
     rebuild: Bool = false,
-    _ block: (inout TestSources.ChangeBuilder, _ current: SourceFileCache) throws -> ()) throws
-  {
+    _ block: (inout TestSources.ChangeBuilder, _ current: SourceFileCache) throws -> ()
+  ) throws {
     try tibsWorkspace.edit(rebuild: rebuild, block)
   }
 }
 
 extension SKTibsTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: language,
-      version: 1,
-      text: try sources.sourceCache.get(url))))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: language,
+          version: 1,
+          text: try sources.sourceCache.get(url)
+        )
+      )
+    )
   }
 }
 
@@ -144,7 +151,8 @@ extension XCTestCase {
         .appendingPathComponent(name, isDirectory: true),
       persistentBuildDir: XCTestCase.productsDirectory
         .appendingPathComponent("sk-tests/\(testDirName)", isDirectory: true),
-      tmpDir: tmpDir ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      tmpDir: tmpDir
+        ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         .appendingPathComponent("sk-test-data/\(testDirName)", isDirectory: true),
       removeTmpDir: removeTmpDir,
       toolchain: ToolchainRegistry.shared.default!,
@@ -153,9 +161,13 @@ extension XCTestCase {
     )
 
     if workspace.builder.targets.contains(where: { target in !target.clangTUs.isEmpty })
-      && !workspace.builder.toolchain.clangHasIndexSupport {
-      fputs("warning: skipping test because '\(workspace.builder.toolchain.clang.path)' does not " +
-            "have indexstore support; use swift-clang\n", stderr)
+      && !workspace.builder.toolchain.clangHasIndexSupport
+    {
+      fputs(
+        "warning: skipping test because '\(workspace.builder.toolchain.clang.path)' does not "
+          + "have indexstore support; use swift-clang\n",
+        stderr
+      )
       return nil
     }
 
@@ -173,15 +185,21 @@ extension XCTestCase {
     let testDirName = testDirectoryName
     let workspace = try await SKTibsTestWorkspace(
       projectDir: XCTestCase.sklspInputsDirectory.appendingPathComponent(name, isDirectory: true),
-      tmpDir: tmpDir ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      tmpDir: tmpDir
+        ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         .appendingPathComponent("sk-test-data/\(testDirName)", isDirectory: true),
       toolchain: ToolchainRegistry.shared.default!,
-      clientCapabilities: clientCapabilities)
+      clientCapabilities: clientCapabilities
+    )
 
     if workspace.builder.targets.contains(where: { target in !target.clangTUs.isEmpty })
-      && !workspace.builder.toolchain.clangHasIndexSupport {
-      fputs("warning: skipping test because '\(workspace.builder.toolchain.clang.path)' does not " +
-            "have indexstore support; use swift-clang\n", stderr)
+      && !workspace.builder.toolchain.clangHasIndexSupport
+    {
+      fputs(
+        "warning: skipping test because '\(workspace.builder.toolchain.clang.path)' does not "
+          + "have indexstore support; use swift-clang\n",
+        stderr
+      )
       return nil
     }
 
@@ -257,7 +275,8 @@ extension TibsToolchain {
       clang: sktc.clang!.asURL,
       libIndexStore: sktc.libIndexStore!.asURL,
       tibs: XCTestCase.productsDirectory.appendingPathComponent("tibs\(execExt)", isDirectory: false),
-      ninja: ninja)
+      ninja: ninja
+    )
   }
 }
 

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -37,11 +38,11 @@ public final class SKDResponse {
       return nil
     }
     switch sourcekitd.api.response_error_get_kind(response) {
-      case SOURCEKITD_ERROR_CONNECTION_INTERRUPTED: return .connectionInterrupted
-      case SOURCEKITD_ERROR_REQUEST_INVALID: return .requestInvalid(description)
-      case SOURCEKITD_ERROR_REQUEST_FAILED: return .requestFailed(description)
-      case SOURCEKITD_ERROR_REQUEST_CANCELLED: return .requestCancelled
-      default: return .requestFailed(description)
+    case SOURCEKITD_ERROR_CONNECTION_INTERRUPTED: return .connectionInterrupted
+    case SOURCEKITD_ERROR_REQUEST_INVALID: return .requestInvalid(description)
+    case SOURCEKITD_ERROR_REQUEST_FAILED: return .requestFailed(description)
+    case SOURCEKITD_ERROR_REQUEST_CANCELLED: return .requestCancelled
+    default: return .requestFailed(description)
     }
   }
 

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Csourcekitd
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -11,11 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import Csourcekitd
-
-import SKSupport
-import LSPLogging
 import Dispatch
 import Foundation
+import LSPLogging
+import SKSupport
 
 /// Access to sourcekitd API, taking care of initialization, shutdown, and notification handler
 /// multiplexing.

--- a/Sources/SourceKitD/SourceKitDImpl.swift
+++ b/Sources/SourceKitD/SourceKitDImpl.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKSupport
 import Foundation
+import SKSupport
 
 import struct TSCBasic.AbsolutePath
 
@@ -99,7 +99,7 @@ public final class SourceKitDImpl: SourceKitD {
   /// Removes a previously registered notification handler.
   public func removeNotificationHandler(_ handler: SKDNotificationHandler) {
     lock.withLock {
-      _notificationHandlers.removeAll(where: { $0.value == nil || $0.value === handler})
+      _notificationHandlers.removeAll(where: { $0.value == nil || $0.value === handler })
     }
   }
 }

--- a/Sources/SourceKitD/sourcekitd_functions.swift
+++ b/Sources/SourceKitD/sourcekitd_functions.swift
@@ -21,7 +21,7 @@ extension sourcekitd_functions_t {
     // MARK: Optional Methods
 
     self.variant_data_get_size = dlsym(sourcekitd, symbol: "sourcekitd_variant_data_get_size")
-    self.variant_data_get_ptr = dlsym(sourcekitd, symbol:"sourcekitd_variant_data_get_ptr")
+    self.variant_data_get_ptr = dlsym(sourcekitd, symbol: "sourcekitd_variant_data_get_ptr")
 
     // MARK: Required Methods
 

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 
 /// Handler responsible for registering a capability with the client.
 public typealias ClientRegistrationHandler = (CapabilityRegistration) -> Void
@@ -31,7 +31,7 @@ public final class CapabilityRegistry {
 
   /// Dynamically registered inlay hint options.
   private var inlayHint: [CapabilityRegistration: InlayHintRegistrationOptions] = [:]
-  
+
   /// Dynamically registered pull diagnostics options.
   private var pullDiagnostics: [CapabilityRegistration: DiagnosticRegistrationOptions] = [:]
 
@@ -66,7 +66,7 @@ public final class CapabilityRegistry {
   public var clientHasDynamicDocumentDiagnosticsRegistration: Bool {
     clientCapabilities.textDocument?.diagnostic?.dynamicRegistration == true
   }
-  
+
   public var clientHasDynamicExecuteCommandRegistration: Bool {
     clientCapabilities.workspace?.executeCommand?.dynamicRegistration == true
   }
@@ -94,17 +94,24 @@ public final class CapabilityRegistry {
     guard clientHasDynamicCompletionRegistration else { return }
     if let registration = registration(for: languages, in: completion) {
       if options != registration.completionOptions {
-        log("Unable to register new completion options \(options) for " +
-            "\(languages) due to pre-existing options \(registration.completionOptions)", level: .warning)
+        log(
+          """
+          Unable to register new completion options \(options) for \
+          "\(languages) due to pre-existing options \(registration.completionOptions)
+          """,
+          level: .warning
+        )
       }
       return
     }
     let registrationOptions = CompletionRegistrationOptions(
       documentSelector: self.documentSelector(for: languages),
-      completionOptions: options)
+      completionOptions: options
+    )
     let registration = CapabilityRegistration(
       method: CompletionRequest.method,
-      registerOptions: self.encode(registrationOptions))
+      registerOptions: self.encode(registrationOptions)
+    )
 
     self.completion[registration] = registrationOptions
 
@@ -118,15 +125,20 @@ public final class CapabilityRegistry {
     guard clientHasDynamicDidChangeWatchedFilesRegistration else { return }
     if let registration = didChangeWatchedFiles {
       if watchers != registration.watchers {
-        log("Unable to register new file system watchers \(watchers) due to pre-existing options \(registration.watchers)", level: .warning)
+        log(
+          "Unable to register new file system watchers \(watchers) due to pre-existing options \(registration.watchers)",
+          level: .warning
+        )
       }
       return
     }
     let registrationOptions = DidChangeWatchedFilesRegistrationOptions(
-      watchers: watchers)
+      watchers: watchers
+    )
     let registration = CapabilityRegistration(
       method: DidChangeWatchedFilesNotification.method,
-      registerOptions: self.encode(registrationOptions))
+      registerOptions: self.encode(registrationOptions)
+    )
 
     self.didChangeWatchedFiles = registrationOptions
 
@@ -144,17 +156,24 @@ public final class CapabilityRegistry {
     guard clientHasDynamicFoldingRangeRegistration else { return }
     if let registration = registration(for: languages, in: foldingRange) {
       if options != registration.foldingRangeOptions {
-        log("Unable to register new folding range options \(options) for " +
-            "\(languages) due to pre-existing options \(registration.foldingRangeOptions)", level: .warning)
+        log(
+          """
+          Unable to register new folding range options \(options) for \
+          \(languages) due to pre-existing options \(registration.foldingRangeOptions)
+          """,
+          level: .warning
+        )
       }
       return
     }
     let registrationOptions = FoldingRangeRegistrationOptions(
       documentSelector: self.documentSelector(for: languages),
-      foldingRangeOptions: options)
+      foldingRangeOptions: options
+    )
     let registration = CapabilityRegistration(
       method: FoldingRangeRequest.method,
-      registerOptions: self.encode(registrationOptions))
+      registerOptions: self.encode(registrationOptions)
+    )
 
     self.foldingRange[registration] = registrationOptions
 
@@ -172,17 +191,24 @@ public final class CapabilityRegistry {
     guard clientHasDynamicSemanticTokensRegistration else { return }
     if let registration = registration(for: languages, in: semanticTokens) {
       if options != registration.semanticTokenOptions {
-        log("Unable to register new semantic tokens options \(options) for " +
-            "\(languages) due to pre-existing options \(registration.semanticTokenOptions)", level: .warning)
+        log(
+          """
+          Unable to register new semantic tokens options \(options) for \
+          \(languages) due to pre-existing options \(registration.semanticTokenOptions)
+          """,
+          level: .warning
+        )
       }
       return
     }
     let registrationOptions = SemanticTokensRegistrationOptions(
       documentSelector: self.documentSelector(for: languages),
-      semanticTokenOptions: options)
+      semanticTokenOptions: options
+    )
     let registration = CapabilityRegistration(
       method: SemanticTokensRegistrationOptions.method,
-      registerOptions: self.encode(registrationOptions))
+      registerOptions: self.encode(registrationOptions)
+    )
 
     self.semanticTokens[registration] = registrationOptions
 
@@ -200,18 +226,25 @@ public final class CapabilityRegistry {
     guard clientHasDynamicInlayHintRegistration else { return }
     if let registration = registration(for: languages, in: inlayHint) {
       if options != registration.inlayHintOptions {
-        log("Unable to register new inlay hint options \(options) for " +
-            "\(languages) due to pre-existing options \(registration.inlayHintOptions)", level: .warning)
+        log(
+          """
+          Unable to register new inlay hint options \(options) for \
+          \(languages) due to pre-existing options \(registration.inlayHintOptions)
+          """,
+          level: .warning
+        )
       }
       return
     }
     let registrationOptions = InlayHintRegistrationOptions(
       documentSelector: self.documentSelector(for: languages),
-      inlayHintOptions: options)
+      inlayHintOptions: options
+    )
     let registration = CapabilityRegistration(
       method: InlayHintRequest.method,
-      registerOptions: self.encode(registrationOptions))
-    
+      registerOptions: self.encode(registrationOptions)
+    )
+
     self.inlayHint[registration] = registrationOptions
 
     registerOnClient(registration)
@@ -227,18 +260,25 @@ public final class CapabilityRegistry {
     guard clientHasDynamicDocumentDiagnosticsRegistration else { return }
     if let registration = registration(for: languages, in: pullDiagnostics) {
       if options != registration.diagnosticOptions {
-        log("Unable to register new pull diagnostics options \(options) for " +
-            "\(languages) due to pre-existing options \(registration.diagnosticOptions)", level: .warning)
+        log(
+          """
+          Unable to register new pull diagnostics options \(options) for \
+          \(languages) due to pre-existing options \(registration.diagnosticOptions)
+          """,
+          level: .warning
+        )
       }
       return
     }
     let registrationOptions = DiagnosticRegistrationOptions(
       documentSelector: self.documentSelector(for: languages),
-      diagnosticOptions: options)
+      diagnosticOptions: options
+    )
     let registration = CapabilityRegistration(
       method: DocumentDiagnosticsRequest.method,
-      registerOptions: self.encode(registrationOptions))
-    
+      registerOptions: self.encode(registrationOptions)
+    )
+
     self.pullDiagnostics[registration] = registrationOptions
 
     registerOnClient(registration)
@@ -263,7 +303,8 @@ public final class CapabilityRegistry {
     let registrationOptions = ExecuteCommandRegistrationOptions(commands: Array(newCommands))
     let registration = CapabilityRegistration(
       method: ExecuteCommandRequest.method,
-      registerOptions: self.encode(registrationOptions))
+      registerOptions: self.encode(registrationOptions)
+    )
 
     registerOnClient(registration)
   }

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 import SKSupport
 
 /// An immutable snapshot of a document at a given time.
@@ -140,7 +140,7 @@ public final class DocumentManager {
   ///   - newVersion: The new version of the document. Must be greater than the
   ///     latest version of the document.
   ///   - edits: The edits to apply to the document
-  ///   - willEditDocument: Optional closure to call before each edit. Will be 
+  ///   - willEditDocument: Optional closure to call before each edit. Will be
   ///     called multiple times if there are multiple edits.
   /// - Returns: The snapshot of the document before the edit and the snapshot
   ///   of the document after the edit.
@@ -162,13 +162,14 @@ public final class DocumentManager {
           willEditDocument(document.latestLineTable, edit)
         }
 
-        if let range = edit.range  {
+        if let range = edit.range {
           document.latestLineTable.replace(
             fromLine: range.lowerBound.line,
             utf16Offset: range.lowerBound.utf16index,
             toLine: range.upperBound.line,
             utf16Offset: range.upperBound.utf16index,
-            with: edit.text)
+            with: edit.text
+          )
         } else {
           // Full text replacement.
           document.latestLineTable = LineTable(edit.text)

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -11,16 +11,18 @@
 //===----------------------------------------------------------------------===//
 
 import IndexStoreDB
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 import SKCore
 
 extension IndexStoreDB: MainFilesProvider {
   public func mainFilesContainingFile(_ uri: DocumentURI) -> Set<DocumentURI> {
     let mainFiles: Set<DocumentURI>
     if let url = uri.fileURL {
-      mainFiles = Set(self.mainFilesContainingFile(path: url.path)
-        .lazy.map({ DocumentURI(URL(fileURLWithPath: $0, isDirectory: false)) }))
+      mainFiles = Set(
+        self.mainFilesContainingFile(path: url.path)
+          .lazy.map({ DocumentURI(URL(fileURLWithPath: $0, isDirectory: false)) })
+      )
     } else {
       mainFiles = []
     }

--- a/Sources/SourceKitLSP/RangeAdjuster.swift
+++ b/Sources/SourceKitLSP/RangeAdjuster.swift
@@ -32,11 +32,10 @@ struct RangeAdjuster {
 
     let replacedLineCount = 1 + editRange.upperBound.line - editRange.lowerBound.line
     let newLines = edit.text.split(separator: "\n", omittingEmptySubsequences: false)
-    let upperUtf16IndexAfterEdit = (
-      newLines.count == 1 ? editRange.lowerBound.utf16index : 0
-    ) + newLines.last!.utf16.count
+    let upperUtf16IndexAfterEdit =
+      (newLines.count == 1 ? editRange.lowerBound.utf16index : 0) + newLines.last!.utf16.count
     self.lastLineCharDelta = upperUtf16IndexAfterEdit - editRange.upperBound.utf16index
-    self.lineDelta = newLines.count - replacedLineCount // may be negative
+    self.lineDelta = newLines.count - replacedLineCount  // may be negative
   }
 
   /// Adjust the pre-edit `range` to the corresponding range in the post-edit document.
@@ -48,7 +47,8 @@ struct RangeAdjuster {
     let lineOffset: Int
     let charOffset: Int
     if range.lowerBound.line == editRange.upperBound.line,
-       range.lowerBound.utf16index >= editRange.upperBound.utf16index {
+      range.lowerBound.utf16index >= editRange.upperBound.utf16index
+    {
       lineOffset = lineDelta
       charOffset = lastLineCharDelta
     } else if range.lowerBound.line > editRange.upperBound.line {
@@ -58,8 +58,14 @@ struct RangeAdjuster {
       lineOffset = 0
       charOffset = 0
     }
-    let newStart = Position(line: range.lowerBound.line + lineOffset, utf16index: range.lowerBound.utf16index + charOffset)
-    let newEnd = Position(line: range.upperBound.line + lineOffset, utf16index: range.upperBound.utf16index + charOffset)
+    let newStart = Position(
+      line: range.lowerBound.line + lineOffset,
+      utf16index: range.lowerBound.utf16index + charOffset
+    )
+    let newEnd = Position(
+      line: range.upperBound.line + lineOffset,
+      utf16index: range.upperBound.utf16index + charOffset
+    )
     return newStart..<newEnd
   }
 }

--- a/Sources/SourceKitLSP/Sequence+AsyncMap.swift
+++ b/Sources/SourceKitLSP/Sequence+AsyncMap.swift
@@ -40,4 +40,3 @@ extension Sequence {
     return result
   }
 }
-

--- a/Sources/SourceKitLSP/SourceKitIndexDelegate.swift
+++ b/Sources/SourceKitLSP/SourceKitIndexDelegate.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Dispatch
 import IndexStoreDB
 import SKCore
-import Dispatch
 
 /// `IndexDelegate` for the SourceKit workspace.
 ///

--- a/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 import SKSupport
 
 /// Represents metadata that SourceKit-LSP injects at every command returned by code actions.
@@ -25,8 +25,8 @@ public struct SourceKitLSPCommandMetadata: Codable, Hashable {
   public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
     let textDocumentKey = CodingKeys.sourcekitlsp_textDocument.stringValue
     guard case .dictionary(let textDocumentDict)? = dictionary[textDocumentKey],
-          let textDocument = TextDocumentIdentifier(fromLSPDictionary: textDocumentDict) else
-    {
+      let textDocument = TextDocumentIdentifier(fromLSPDictionary: textDocumentDict)
+    else {
       return nil
     }
     self.init(textDocument: textDocument)

--- a/Sources/SourceKitLSP/SourceKitServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitServer+Options.swift
@@ -12,8 +12,9 @@
 
 import LanguageServerProtocol
 import SKCore
-import struct TSCBasic.AbsolutePath
 import SKSupport
+
+import struct TSCBasic.AbsolutePath
 
 extension SourceKitServer {
 
@@ -32,7 +33,7 @@ extension SourceKitServer {
 
     /// Options for code-completion.
     public var completionOptions: SKCompletionOptions
-    
+
     /// Override the default directory where generated interfaces will be stored
     public var generatedInterfacesPath: AbsolutePath
 
@@ -41,8 +42,8 @@ extension SourceKitServer {
       clangdOptions: [String] = [],
       indexOptions: IndexOptions = .init(),
       completionOptions: SKCompletionOptions = .init(),
-      generatedInterfacesPath: AbsolutePath = defaultDirectoryForGeneratedInterfaces)
-    {
+      generatedInterfacesPath: AbsolutePath = defaultDirectoryForGeneratedInterfaces
+    ) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
       self.indexOptions = indexOptions

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
-import LSPLogging
-import SourceKitD
 import Dispatch
+import LSPLogging
+import LanguageServerProtocol
+import SourceKitD
 
 /// Represents a code-completion session for a given source location that can be efficiently
 /// re-filtered by calling `update()`.
@@ -48,8 +48,8 @@ actor CodeCompletionSession {
     snapshot: DocumentSnapshot,
     utf8Offset: Int,
     position: Position,
-    compileCommand: SwiftCompileCommand?)
-  {
+    compileCommand: SwiftCompileCommand?
+  ) {
     self.server = server
     self.snapshot = snapshot
     self.utf8StartOffset = utf8Offset
@@ -145,7 +145,13 @@ actor CodeCompletionSession {
       return CompletionList(isIncomplete: false, items: [])
     }
 
-    return self.server.completionsFromSKDResponse(completions, in: snapshot, completionPos: self.position, requestPosition: position, isIncomplete: true)
+    return self.server.completionsFromSKDResponse(
+      completions,
+      in: snapshot,
+      completionPos: self.position,
+      requestPosition: position,
+      isIncomplete: true
+    )
   }
 
   private func optionsDictionary(
@@ -185,12 +191,12 @@ actor CodeCompletionSession {
 
     queue.async {
       switch self.state {
-        case .closed:
-          // Already closed, nothing to do.
-          break
-        case .open:
-          self.sendClose(server)
-          self.state = .closed
+      case .closed:
+        // Already closed, nothing to do.
+        break
+      case .open:
+        self.sendClose(server)
+        self.state = .closed
       }
     }
   }

--- a/Sources/SourceKitLSP/Swift/CommentXML.swift
+++ b/Sources/SourceKitLSP/Swift/CommentXML.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKSupport
 import Foundation
+import SKSupport
 
 #if canImport(FoundationXML)
 import FoundationXML
@@ -78,7 +78,7 @@ private struct XMLToMarkdown {
       out += "```swift\n"
       toMarkdown(node.children)
       out += "\n```\n\n---\n"
-      
+
     case "Name", "USR", "Direction":
       break
 
@@ -120,7 +120,7 @@ private struct XMLToMarkdown {
         toMarkdown(discussion.children)
         inParam = false
       }
-      // FIXME: closure parameters would go here.
+    // FIXME: closure parameters would go here.
 
     case "CodeListing":
       lineNumber = 0
@@ -160,7 +160,7 @@ private struct XMLToMarkdown {
 
     case "Link":
       if let href = node.attributes?.first(where: { $0.name == "href" })?.stringValue {
-        out += "[" 
+        out += "["
         toMarkdown(node.children)
         out += "](\(href))"
       } else {

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -35,10 +35,15 @@ struct CursorInfo {
   /// The refactor actions available at this position.
   var refactorActions: [SemanticRefactorCommand]? = nil
 
-  init(_ symbolInfo: SymbolDetails, annotatedDeclaration: String?, documentationXML: String?, refactorActions: [SemanticRefactorCommand]? = nil) {
+  init(
+    _ symbolInfo: SymbolDetails,
+    annotatedDeclaration: String?,
+    documentationXML: String?,
+    refactorActions: [SemanticRefactorCommand]? = nil
+  ) {
     self.symbolInfo = symbolInfo
     self.annotatedDeclaration = annotatedDeclaration
-    self.documentationXML =  documentationXML
+    self.documentationXML = documentationXML
     self.refactorActions = refactorActions
   }
 }
@@ -86,8 +91,8 @@ extension SwiftLanguageServer {
     additionalParameters appendAdditionalParameters: ((SKDRequestDictionary) -> Void)? = nil
   ) async throws -> CursorInfo? {
     guard let snapshot = documentManager.latestSnapshot(uri) else {
-       throw CursorInfoError.unknownDocument(uri)
-     }
+      throw CursorInfoError.unknownDocument(uri)
+    }
 
     guard let offsetRange = snapshot.utf8OffsetRange(of: range) else {
       throw CursorInfoError.invalidRange(range)
@@ -119,8 +124,8 @@ extension SwiftLanguageServer {
 
     var location: Location? = nil
     if let filepath: String = dict[keys.filepath],
-       let offset: Int = dict[keys.offset],
-       let pos = snapshot.positionOf(utf8Offset: offset)
+      let offset: Int = dict[keys.offset],
+      let pos = snapshot.positionOf(utf8Offset: offset)
     {
       location = Location(uri: DocumentURI(URL(fileURLWithPath: filepath)), range: Range(pos))
     }

--- a/Sources/SourceKitLSP/Swift/EditorPlaceholder.swift
+++ b/Sources/SourceKitLSP/Swift/EditorPlaceholder.swift
@@ -20,8 +20,10 @@ public enum EditorPlaceholder: Hashable {
   static let placeholderSuffix: String = "#>"
 
   public init?(_ skPlaceholder: String) {
-    guard skPlaceholder.hasPrefix(EditorPlaceholder.placeholderPrefix) &&
-          skPlaceholder.hasSuffix(EditorPlaceholder.placeholderSuffix) else {
+    guard
+      skPlaceholder.hasPrefix(EditorPlaceholder.placeholderPrefix)
+        && skPlaceholder.hasSuffix(EditorPlaceholder.placeholderSuffix)
+    else {
       return nil
     }
     var skPlaceholder = skPlaceholder.dropFirst(2).dropLast(2)

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SourceKitD
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 import SKSupport
+import SourceKitD
 
 struct InterfaceInfo {
   var contents: String
@@ -33,12 +33,22 @@ extension SwiftLanguageServer {
       return await self.interfaceDetails(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
     } else {
       // generate interface
-      let interfaceInfo = try await self.openInterface(request: request, uri: uri, name: moduleName, interfaceURI: interfaceDocURI)
+      let interfaceInfo = try await self.openInterface(
+        request: request,
+        uri: uri,
+        name: moduleName,
+        interfaceURI: interfaceDocURI
+      )
       do {
         // write to file
         try interfaceInfo.contents.write(to: interfaceFilePath, atomically: true, encoding: String.Encoding.utf8)
         // store snapshot
-        let snapshot = try self.documentManager.open(interfaceDocURI, language: .swift, version: 0, text: interfaceInfo.contents)
+        let snapshot = try self.documentManager.open(
+          interfaceDocURI,
+          language: .swift,
+          version: 0,
+          text: interfaceInfo.contents
+        )
         return await self.interfaceDetails(request: request, uri: interfaceDocURI, snapshot: snapshot, symbol: symbol)
       } catch {
         throw ResponseError.unknown(error.localizedDescription)
@@ -71,11 +81,11 @@ extension SwiftLanguageServer {
     if let compileCommand = await self.buildSettings(for: uri) {
       skreq[keys.compilerargs] = compileCommand.compilerArgs
     }
-    
+
     let dict = try await self.sourcekitd.send(skreq)
     return InterfaceInfo(contents: dict[keys.sourcetext] ?? "")
   }
-  
+
   private func interfaceDetails(
     request: OpenInterfaceRequest,
     uri: DocumentURI,
@@ -95,7 +105,8 @@ extension SwiftLanguageServer {
 
       let dict = try await self.sourcekitd.send(skreq)
       if let offset: Int = dict[keys.offset],
-         let position = snapshot.positionOf(utf8Offset: offset) {
+        let position = snapshot.positionOf(utf8Offset: offset)
+      {
         return InterfaceDetails(uri: uri, position: position)
       } else {
         return InterfaceDetails(uri: uri, position: nil)

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -49,14 +49,18 @@ struct SemanticRefactoring {
       edits.forEach { _, value in
         // The LSP is zero based, but semantic_refactoring is one based.
         if let startLine: Int = value[keys.line],
-           let startColumn: Int = value[keys.column],
-           let startPosition = snapshot.positionOf(zeroBasedLine: startLine - 1,
-                                                   utf8Column: startColumn - 1),
-           let endLine: Int = value[keys.endline],
-           let endColumn: Int = value[keys.endcolumn],
-           let endPosition = snapshot.positionOf(zeroBasedLine: endLine - 1,
-                                                 utf8Column: endColumn - 1),
-           let text: String = value[keys.text]
+          let startColumn: Int = value[keys.column],
+          let startPosition = snapshot.positionOf(
+            zeroBasedLine: startLine - 1,
+            utf8Column: startColumn - 1
+          ),
+          let endLine: Int = value[keys.endline],
+          let endColumn: Int = value[keys.endcolumn],
+          let endPosition = snapshot.positionOf(
+            zeroBasedLine: endLine - 1,
+            utf8Column: endColumn - 1
+          ),
+          let text: String = value[keys.text]
         {
           // Snippets are only suppored in code completion.
           // Remove SourceKit placeholders in refactoring actions because they can't be represented in the editor properly.

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPLogging
-import SwiftSyntax
+import LanguageServerProtocol
 import SwiftIDEUtils
 import SwiftParser
+import SwiftSyntax
 
 extension SwiftLanguageServer {
   /// Computes an array of syntax highlighting tokens from the syntax tree that
@@ -31,16 +31,20 @@ extension SwiftLanguageServer {
   ) async -> [SyntaxHighlightingToken] {
     let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
     let semanticTokens = await semanticTokensManager.semanticTokens(for: snapshot.id)
-    let range = range.flatMap({ $0.byteSourceRange(in: snapshot) })
-             ?? ByteSourceRange(offset: 0, length: tree.totalLength.utf8Length)
-    return tree
+    let range =
+      range.flatMap({ $0.byteSourceRange(in: snapshot) })
+      ?? ByteSourceRange(offset: 0, length: tree.totalLength.utf8Length)
+    return
+      tree
       .classifications(in: range)
       .flatMap({ $0.highlightingTokens(in: snapshot) })
       .mergingTokens(with: semanticTokens ?? [])
       .sorted { $0.start < $1.start }
   }
 
-  public func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse? {
+  public func documentSemanticTokens(
+    _ req: DocumentSemanticTokensRequest
+  ) async throws -> DocumentSemanticTokensResponse? {
     let uri = req.textDocument.uri
 
     guard let snapshot = self.documentManager.latestSnapshot(uri) else {
@@ -54,11 +58,15 @@ extension SwiftLanguageServer {
     return DocumentSemanticTokensResponse(data: encodedTokens)
   }
 
-  public func documentSemanticTokensDelta(_ req: DocumentSemanticTokensDeltaRequest) async throws -> DocumentSemanticTokensDeltaResponse? {
+  public func documentSemanticTokensDelta(
+    _ req: DocumentSemanticTokensDeltaRequest
+  ) async throws -> DocumentSemanticTokensDeltaResponse? {
     return nil
   }
 
-  public func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse? {
+  public func documentSemanticTokensRange(
+    _ req: DocumentSemanticTokensRangeRequest
+  ) async throws -> DocumentSemanticTokensResponse? {
     let uri = req.textDocument.uri
     let range = req.range
 

--- a/Sources/SourceKitLSP/Swift/SourceKitD+ResponseError.swift
+++ b/Sources/SourceKitLSP/Swift/SourceKitD+ResponseError.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitD
 import LanguageServerProtocol
+import SourceKitD
 
 extension ResponseError {
   public init(_ value: SKDError) {

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitD
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
+import SourceKitD
 
 /// A ranged token in the document used for syntax highlighting.
 public struct SyntaxHighlightingToken: Hashable {
@@ -92,7 +92,7 @@ public struct SyntaxHighlightingToken: Hashable {
       switch self {
       case .namespace: return "namespace"
       case .type: return "type"
-      case .actor: return "class" // LSP doesn’t know about actors. Display actors as classes.
+      case .actor: return "class"  // LSP doesn’t know about actors. Display actors as classes.
       case .class: return "class"
       case .enum: return "enum"
       case .interface: return "interface"
@@ -199,11 +199,11 @@ extension Array where Element == SyntaxHighlightingToken {
 
     for token in self {
       let lineDelta = token.start.line - previous.line
-      let charDelta = token.start.utf16index - (
-        // The character delta is relative to the previous token's start
-        // only if the token is on the previous token's line.
-        previous.line == token.start.line ? previous.utf16index : 0
-      )
+      let charDelta =
+        token.start.utf16index - (
+          // The character delta is relative to the previous token's start
+          // only if the token is on the previous token's line.
+          previous.line == token.start.line ? previous.utf16index : 0)
 
       // We assert that the tokens are actually sorted
       assert(lineDelta >= 0)
@@ -215,7 +215,7 @@ extension Array where Element == SyntaxHighlightingToken {
         UInt32(charDelta),
         UInt32(token.utf16length),
         token.kind.rawValue,
-        token.modifiers.rawValue
+        token.modifiers.rawValue,
       ]
     }
 

--- a/Sources/SourceKitLSP/Swift/SyntaxTreeManager.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxTreeManager.swift
@@ -26,14 +26,15 @@ actor SyntaxTreeManager {
   /// Conceptually, this is a dictionary. To prevent excessive memory usage we
   /// only keep `cacheSize` entries within the array. Older entries are at the
   /// end of the list, newer entries at the front.
-  private var syntaxTreeComputations: [(
-    snapshotID: DocumentSnapshot.ID,
-    computation: SyntaxTreeComputation
-  )] = []
+  private var syntaxTreeComputations:
+    [(
+      snapshotID: DocumentSnapshot.ID,
+      computation: SyntaxTreeComputation
+    )] = []
 
   /// The number of syntax trees to keep.
   ///
-  /// - Note: This has been chosen without scientific measurements. The feeling 
+  /// - Note: This has been chosen without scientific measurements. The feeling
   ///   is that you rarely work on more than 5 files at once and 5 syntax trees
   ///   don't take up too much memory.
   private let cacheSize = 5
@@ -57,7 +58,7 @@ actor SyntaxTreeManager {
   /// will get discarded.
   private func setComputation(for snapshotID: DocumentSnapshot.ID, computation: SyntaxTreeComputation) {
     syntaxTreeComputations.insert((snapshotID, computation), at: 0)
-    
+
     // Remove any syntax trees for old versions of this document.
     syntaxTreeComputations.removeAll(where: { $0.snapshotID < snapshotID })
 

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -59,11 +59,12 @@ struct VariableTypeInfo {
     let keys = dict.sourcekitd.keys
 
     guard let offset: Int = dict[keys.variable_offset],
-          let length: Int = dict[keys.variable_length],
-          let startIndex = snapshot.positionOf(utf8Offset: offset),
-          let endIndex = snapshot.positionOf(utf8Offset: offset + length),
-          let printedType: String = dict[keys.variable_type],
-          let hasExplicitType: Bool = dict[keys.variable_type_explicit] else {
+      let length: Int = dict[keys.variable_length],
+      let startIndex = snapshot.positionOf(utf8Offset: offset),
+      let endIndex = snapshot.positionOf(utf8Offset: offset + length),
+      let printedType: String = dict[keys.variable_type],
+      let hasExplicitType: Bool = dict[keys.variable_type_explicit]
+    else {
       return nil
     }
     let tokenAtOffset = syntaxTree.token(at: AbsolutePosition(utf8Offset: offset))
@@ -103,8 +104,9 @@ extension SwiftLanguageServer {
     skreq[keys.sourcefile] = snapshot.uri.pseudoPath
 
     if let range = range,
-       let start = snapshot.utf8Offset(of: range.lowerBound),
-       let end = snapshot.utf8Offset(of: range.upperBound) {
+      let start = snapshot.utf8Offset(of: range.lowerBound),
+      let end = snapshot.utf8Offset(of: range.upperBound)
+    {
       skreq[keys.offset] = start
       skreq[keys.length] = end - start
     }

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -45,12 +45,14 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   func initializeSync(_ initialize: InitializeRequest) async throws -> InitializeResult
   func clientInitialized(_ initialized: InitializedNotification) async
-  
+
   /// Shut the server down and return once the server has finished shutting down
   func shutdown() async
 
   /// Add a handler that is called whenever the state of the language server changes.
-  func addStateChangeHandler(handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void) async
+  func addStateChangeHandler(
+    handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void
+  ) async
 
   // MARK: - Text synchronization
 
@@ -92,8 +94,12 @@ public protocol ToolchainLanguageServer: AnyObject {
   func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse?
   func documentColor(_ req: DocumentColorRequest) async throws -> [ColorInformation]
   func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse?
-  func documentSemanticTokensDelta(_ req: DocumentSemanticTokensDeltaRequest) async throws -> DocumentSemanticTokensDeltaResponse?
-  func documentSemanticTokensRange(_ req: DocumentSemanticTokensRangeRequest) async throws -> DocumentSemanticTokensResponse?
+  func documentSemanticTokensDelta(
+    _ req: DocumentSemanticTokensDeltaRequest
+  ) async throws -> DocumentSemanticTokensDeltaResponse?
+  func documentSemanticTokensRange(
+    _ req: DocumentSemanticTokensRangeRequest
+  ) async throws -> DocumentSemanticTokensResponse?
   func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation]
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint]

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import IndexStoreDB
-import LanguageServerProtocol
 import LSPLogging
+import LanguageServerProtocol
 import SKCore
 import SKSupport
 import SKSwiftPMWorkspace
@@ -27,7 +27,10 @@ fileprivate func firstNonNil<T>(_ optional: T?, _ defaultValue: @autoclosure () 
   return try await defaultValue()
 }
 
-fileprivate func firstNonNil<T>(_ optional: T?, _ defaultValue: @autoclosure () async throws -> T?) async rethrows -> T? {
+fileprivate func firstNonNil<T>(
+  _ optional: T?,
+  _ defaultValue: @autoclosure () async throws -> T?
+) async rethrows -> T? {
   if let optional {
     return optional
   }
@@ -82,7 +85,8 @@ public final class Workspace {
     self.buildSystemManager = await BuildSystemManager(
       buildSystem: underlyingBuildSystem,
       fallbackBuildSystem: FallbackBuildSystem(buildSetup: buildSetup),
-      mainFilesProvider: index)
+      mainFilesProvider: index
+    )
     indexDelegate?.registerMainFileChanged(buildSystemManager)
   }
 
@@ -125,20 +129,22 @@ public final class Workspace {
     var indexDelegate: SourceKitIndexDelegate? = nil
 
     if let storePath = await firstNonNil(indexOptions.indexStorePath, await buildSystem?.indexStorePath),
-       let dbPath = await firstNonNil(indexOptions.indexDatabasePath, await buildSystem?.indexDatabasePath),
-       let libPath = toolchainRegistry.default?.libIndexStore
+      let dbPath = await firstNonNil(indexOptions.indexDatabasePath, await buildSystem?.indexDatabasePath),
+      let libPath = toolchainRegistry.default?.libIndexStore
     {
       do {
         let lib = try IndexStoreLibrary(dylibPath: libPath.pathString)
         indexDelegate = SourceKitIndexDelegate()
-        let prefixMappings = await firstNonNil(indexOptions.indexPrefixMappings, await buildSystem?.indexPrefixMappings) ?? []
+        let prefixMappings =
+          await firstNonNil(indexOptions.indexPrefixMappings, await buildSystem?.indexPrefixMappings) ?? []
         index = try IndexStoreDB(
           storePath: storePath.pathString,
           databasePath: dbPath.pathString,
           library: lib,
           delegate: indexDelegate,
           listenToUnitEvents: indexOptions.listenToUnitEvents,
-          prefixMappings: prefixMappings.map { PathMapping(original: $0.original, replacement: $0.replacement) })
+          prefixMappings: prefixMappings.map { PathMapping(original: $0.original, replacement: $0.replacement) }
+        )
         log("opened IndexStoreDB at \(dbPath) with store path \(storePath)")
       } catch {
         log("failed to open IndexStoreDB: \(error.localizedDescription)", level: .error)
@@ -153,7 +159,8 @@ public final class Workspace {
       buildSetup: buildSetup,
       underlyingBuildSystem: buildSystem,
       index: index,
-      indexDelegate: indexDelegate)
+      indexDelegate: indexDelegate
+    )
   }
 }
 

--- a/Tests/LSPLoggingTests/SupportTests.swift
+++ b/Tests/LSPLoggingTests/SupportTests.swift
@@ -25,8 +25,18 @@ final class SupportTests: XCTestCase {
 
     func check(expected: [(String, LogLevel)], file: StaticString = #filePath, line: UInt = #line) {
       testLogger.flush()
-      XCTAssert(messages.count == expected.count, "\(messages) does not match expected \(expected)", file: file, line: line)
-      XCTAssert(zip(messages, expected).allSatisfy({ $0.0 == $0.1 }), "\(messages) does not match expected \(expected)", file: file, line: line)
+      XCTAssert(
+        messages.count == expected.count,
+        "\(messages) does not match expected \(expected)",
+        file: file,
+        line: line
+      )
+      XCTAssert(
+        zip(messages, expected).allSatisfy({ $0.0 == $0.1 }),
+        "\(messages) does not match expected \(expected)",
+        file: file,
+        line: line
+      )
       messages.removeAll()
     }
 
@@ -65,7 +75,7 @@ final class SupportTests: XCTestCase {
       ("d", .error),
       ("e", .warning),
       ("f", .info),
-      ])
+    ])
 
     testLogger.currentLevel = .warning
 
@@ -76,7 +86,7 @@ final class SupportTests: XCTestCase {
     check(expected: [
       ("d", .error),
       ("e", .warning),
-      ])
+    ])
 
     testLogger.currentLevel = .error
 
@@ -85,8 +95,8 @@ final class SupportTests: XCTestCase {
     testLogger.log("f", level: .info)
     testLogger.log("g", level: .debug)
     check(expected: [
-      ("d", .error),
-      ])
+      ("d", .error)
+    ])
 
     testLogger.currentLevel = .default
 
@@ -100,7 +110,7 @@ final class SupportTests: XCTestCase {
     check(expected: [
       ("d", .error),
       ("e", .warning),
-      ])
+    ])
 
     // .error
     testLogger.setLogLevel("0")
@@ -110,8 +120,8 @@ final class SupportTests: XCTestCase {
     testLogger.log("f", level: .info)
     testLogger.log("g", level: .debug)
     check(expected: [
-      ("d", .error),
-      ])
+      ("d", .error)
+    ])
 
     // missing - no change
     testLogger.setLogLevel(environmentVariable: "TEST_ENV_LOGGGING_err")
@@ -121,8 +131,8 @@ final class SupportTests: XCTestCase {
     testLogger.log("f", level: .info)
     testLogger.log("g", level: .debug)
     check(expected: [
-      ("d", .error),
-      ])
+      ("d", .error)
+    ])
 
     // invalid - no change
     testLogger.setLogLevel("")
@@ -132,8 +142,8 @@ final class SupportTests: XCTestCase {
     testLogger.log("f", level: .info)
     testLogger.log("g", level: .debug)
     check(expected: [
-      ("d", .error),
-      ])
+      ("d", .error)
+    ])
 
     // invalid - no change
     testLogger.setLogLevel("a3")
@@ -143,8 +153,8 @@ final class SupportTests: XCTestCase {
     testLogger.log("f", level: .info)
     testLogger.log("g", level: .debug)
     check(expected: [
-      ("d", .error),
-      ])
+      ("d", .error)
+    ])
 
     // too high - max out at .debug
     testLogger.setLogLevel("1000")
@@ -158,7 +168,7 @@ final class SupportTests: XCTestCase {
       ("e", .warning),
       ("f", .info),
       ("g", .debug),
-      ])
+    ])
 
     // By string.
     testLogger.setLogLevel("error")
@@ -177,7 +187,7 @@ final class SupportTests: XCTestCase {
     check(expected: [
       ("a", .default),
       ("a", .default),
-      ])
+    ])
 
     testLogger.removeLogHandler(obj)
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/CodingTests.swift
@@ -10,213 +10,335 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPTestSupport
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
-import LSPTestSupport
 import XCTest
 
 final class CodingTests: XCTestCase {
 
   func testMessageCoding() {
-    checkMessageCoding(InitializeRequest(processId: 1, clientInfo: InitializeRequest.ClientInfo(name: "dummy-client", version: "1.0"), locale: "en-US", rootPath: "/foo", rootURI: nil, initializationOptions: nil, capabilities: ClientCapabilities(workspace: nil, textDocument: nil), trace: .off, workspaceFolders: nil), id: .number(2), json: """
-    {
-      "id" : 2,
-      "jsonrpc" : "2.0",
-      "method" : "initialize",
-      "params" : {
-        "capabilities" : {
+    checkMessageCoding(
+      InitializeRequest(
+        processId: 1,
+        clientInfo: InitializeRequest.ClientInfo(name: "dummy-client", version: "1.0"),
+        locale: "en-US",
+        rootPath: "/foo",
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+        trace: .off,
+        workspaceFolders: nil
+      ),
+      id: .number(2),
+      json: """
+        {
+          "id" : 2,
+          "jsonrpc" : "2.0",
+          "method" : "initialize",
+          "params" : {
+            "capabilities" : {
 
-        },
-        "clientInfo" : {
-          "name" : "dummy-client",
-          "version" : "1.0"
-        },
-        "locale" : "en-US",
-        "processId" : 1,
-        "rootPath" : "\\/foo",
-        "trace" : "off"
-      }
-    }
-    """)
-
-    checkMessageCoding(InitializeRequest(processId: 1, rootPath: "/foo", rootURI: nil, initializationOptions: nil, capabilities: ClientCapabilities(workspace: nil, textDocument: nil), trace: .off, workspaceFolders: nil), id: .string("3"), json: """
-    {
-      "id" : "3",
-      "jsonrpc" : "2.0",
-      "method" : "initialize",
-      "params" : {
-        "capabilities" : {
-
-        },
-        "processId" : 1,
-        "rootPath" : "\\/foo",
-        "trace" : "off"
-      }
-    }
-    """)
-
-    checkMessageCoding(CancelRequestNotification(id: .number(1)), json: """
-    {
-      "jsonrpc" : "2.0",
-      "method" : "$\\/cancelRequest",
-      "params" : {
-        "id" : 1
-      }
-    }
-    """)
-
-    checkMessageCoding(InitializedNotification(), json: """
-    {
-      "jsonrpc" : "2.0",
-      "method" : "initialized",
-      "params" : {
-
-      }
-    }
-    """)
-
-    checkMessageCoding(InitializeResult(capabilities: ServerCapabilities(
-      textDocumentSync: .options(TextDocumentSyncOptions(
-        openClose: true,
-        change: .incremental,
-        willSave: true,
-        willSaveWaitUntil: false,
-        save: .value(TextDocumentSyncOptions.SaveOptions(includeText: false))
-      )),
-      completionProvider: CompletionOptions(
-        resolveProvider: false,
-        triggerCharacters: ["."]))), id: .number(2), json: """
-    {
-      "id" : 2,
-      "jsonrpc" : "2.0",
-      "result" : {
-        "capabilities" : {
-          "completionProvider" : {
-            "resolveProvider" : false,
-            "triggerCharacters" : [
-              "."
-            ]
-          },
-          "textDocumentSync" : {
-            "change" : 2,
-            "openClose" : true,
-            "save" : {
-              "includeText" : false
             },
-            "willSave" : true,
-            "willSaveWaitUntil" : false
+            "clientInfo" : {
+              "name" : "dummy-client",
+              "version" : "1.0"
+            },
+            "locale" : "en-US",
+            "processId" : 1,
+            "rootPath" : "\\/foo",
+            "trace" : "off"
           }
         }
-      }
-    }
-    """)
+        """
+    )
 
-    checkMessageCoding(ResponseError.cancelled, id: .number(2), json: """
-    {
-      "error" : {
-        "code" : -32800,
-        "message" : "request cancelled by client"
-      },
-      "id" : 2,
-      "jsonrpc" : "2.0"
-    }
-    """)
+    checkMessageCoding(
+      InitializeRequest(
+        processId: 1,
+        rootPath: "/foo",
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+        trace: .off,
+        workspaceFolders: nil
+      ),
+      id: .string("3"),
+      json: """
+        {
+          "id" : "3",
+          "jsonrpc" : "2.0",
+          "method" : "initialize",
+          "params" : {
+            "capabilities" : {
 
-    checkMessageCoding(ResponseError.methodNotFound("asdf"), id: .number(2), json: """
-    {
-      "error" : {
-        "code" : -32601,
-        "message" : "method not found: asdf"
-      },
-      "id" : 2,
-      "jsonrpc" : "2.0"
-    }
-    """)
+            },
+            "processId" : 1,
+            "rootPath" : "\\/foo",
+            "trace" : "off"
+          }
+        }
+        """
+    )
 
-    checkMessageCoding(ResponseError.cancelled, id: nil, json: """
-    {
-      "error" : {
-        "code" : -32800,
-        "message" : "request cancelled by client"
-      },
-      "id" : null,
-      "jsonrpc" : "2.0"
-    }
-    """)
+    checkMessageCoding(
+      CancelRequestNotification(id: .number(1)),
+      json: """
+        {
+          "jsonrpc" : "2.0",
+          "method" : "$\\/cancelRequest",
+          "params" : {
+            "id" : 1
+          }
+        }
+        """
+    )
+
+    checkMessageCoding(
+      InitializedNotification(),
+      json: """
+        {
+          "jsonrpc" : "2.0",
+          "method" : "initialized",
+          "params" : {
+
+          }
+        }
+        """
+    )
+
+    checkMessageCoding(
+      InitializeResult(
+        capabilities: ServerCapabilities(
+          textDocumentSync: .options(
+            TextDocumentSyncOptions(
+              openClose: true,
+              change: .incremental,
+              willSave: true,
+              willSaveWaitUntil: false,
+              save: .value(TextDocumentSyncOptions.SaveOptions(includeText: false))
+            )
+          ),
+          completionProvider: CompletionOptions(
+            resolveProvider: false,
+            triggerCharacters: ["."]
+          )
+        )
+      ),
+      id: .number(2),
+      json: """
+        {
+          "id" : 2,
+          "jsonrpc" : "2.0",
+          "result" : {
+            "capabilities" : {
+              "completionProvider" : {
+                "resolveProvider" : false,
+                "triggerCharacters" : [
+                  "."
+                ]
+              },
+              "textDocumentSync" : {
+                "change" : 2,
+                "openClose" : true,
+                "save" : {
+                  "includeText" : false
+                },
+                "willSave" : true,
+                "willSaveWaitUntil" : false
+              }
+            }
+          }
+        }
+        """
+    )
+
+    checkMessageCoding(
+      ResponseError.cancelled,
+      id: .number(2),
+      json: """
+        {
+          "error" : {
+            "code" : -32800,
+            "message" : "request cancelled by client"
+          },
+          "id" : 2,
+          "jsonrpc" : "2.0"
+        }
+        """
+    )
+
+    checkMessageCoding(
+      ResponseError.methodNotFound("asdf"),
+      id: .number(2),
+      json: """
+        {
+          "error" : {
+            "code" : -32601,
+            "message" : "method not found: asdf"
+          },
+          "id" : 2,
+          "jsonrpc" : "2.0"
+        }
+        """
+    )
+
+    checkMessageCoding(
+      ResponseError.cancelled,
+      id: nil,
+      json: """
+        {
+          "error" : {
+            "code" : -32800,
+            "message" : "request cancelled by client"
+          },
+          "id" : null,
+          "jsonrpc" : "2.0"
+        }
+        """
+    )
   }
 
   func testMessageDecodingError() {
     // Note: JSON parsing errors are caught at a higher level.
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("jsonrpc version must be 2.0"), json: """
-    {}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest("jsonrpc version must be 2.0"),
+      json: """
+        {}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification"), json: """
-    {"jsonrpc":"2.0"}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest("message not recognized as request, response or notification"),
+      json: """
+        {"jsonrpc":"2.0"}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification"), json: """
-    {"jsonrpc":"2.0","params":{}}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest("message not recognized as request, response or notification"),
+      json: """
+        {"jsonrpc":"2.0","params":{}}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification"), json: """
-    {"jsonrpc":"2.0","result":{}}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest("message not recognized as request, response or notification"),
+      json: """
+        {"jsonrpc":"2.0","result":{}}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.methodNotFound("unknown", messageKind: .notification), json: """
-    {"jsonrpc":"2.0","method":"unknown"}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.methodNotFound("unknown", messageKind: .notification),
+      json: """
+        {"jsonrpc":"2.0","method":"unknown"}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.methodNotFound("unknown", id: .number(2), messageKind: .request), json: """
-    {"jsonrpc":"2.0","id":2,"method":"unknown"}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.methodNotFound("unknown", id: .number(2), messageKind: .request),
+      json: """
+        {"jsonrpc":"2.0","id":2,"method":"unknown"}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.methodNotFound("initialized", id: .number(2), messageKind: .request), json: """
-    {"jsonrpc":"2.0","id":2,"method":"initialized"}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.methodNotFound("initialized", id: .number(2), messageKind: .request),
+      json: """
+        {"jsonrpc":"2.0","id":2,"method":"initialized"}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.methodNotFound("initialize", messageKind: .notification), json: """
-    {"jsonrpc":"2.0","method":"initialize"}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.methodNotFound("initialize", messageKind: .notification),
+      json: """
+        {"jsonrpc":"2.0","method":"initialize"}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidParams("missing expected parameter: params", messageKind: .notification), json: """
-    {"jsonrpc":"2.0","method":"$/cancelRequest"}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidParams("missing expected parameter: params", messageKind: .notification),
+      json: """
+        {"jsonrpc":"2.0","method":"$/cancelRequest"}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidParams("type mismatch at params :", messageKind: .notification), json: """
-    {"jsonrpc":"2.0","method":"$/cancelRequest","params":2}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidParams("type mismatch at params :", messageKind: .notification),
+      json: """
+        {"jsonrpc":"2.0","method":"$/cancelRequest","params":2}
+        """
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidParams("missing expected parameter: id", messageKind: .notification), json: """
-    {"jsonrpc":"2.0","method":"$/cancelRequest","params":{}}
-    """)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidParams("missing expected parameter: id", messageKind: .notification),
+      json: """
+        {"jsonrpc":"2.0","method":"$/cancelRequest","params":{}}
+        """
+    )
 
     let responseTypeCallback: JSONRPCMessage.ResponseTypeCallback = {
       return $0 == .string("unknown") ? nil : InitializeResult.self
     }
 
-    let info = defaultCodingInfo.merging([CodingUserInfoKey.responseTypeCallbackKey: responseTypeCallback]) { (_, new) in new }
+    let info = defaultCodingInfo.merging([CodingUserInfoKey.responseTypeCallbackKey: responseTypeCallback]) {
+      (_, new) in new
+    }
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification", id: .number(2)), json: """
-    {"jsonrpc":"2.0","id":2,"params":{}}
-    """, userInfo: info)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest(
+        "message not recognized as request, response or notification",
+        id: .number(2)
+      ),
+      json: """
+        {"jsonrpc":"2.0","id":2,"params":{}}
+        """,
+      userInfo: info
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification"), json: """
-    {"jsonrpc":"2.0","params":{}}
-    """, userInfo: info)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest("message not recognized as request, response or notification"),
+      json: """
+        {"jsonrpc":"2.0","params":{}}
+        """,
+      userInfo: info
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification", id: .string("3")), json: """
-    {"jsonrpc":"2.0","id":"3","params":{}}
-    """, userInfo: info)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest(
+        "message not recognized as request, response or notification",
+        id: .string("3")
+      ),
+      json: """
+        {"jsonrpc":"2.0","id":"3","params":{}}
+        """,
+      userInfo: info
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidRequest("message not recognized as request, response or notification", id: .string("unknown")), json: """
-    {"jsonrpc":"2.0","id":"unknown","params":{}}
-    """, userInfo: info)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidRequest(
+        "message not recognized as request, response or notification",
+        id: .string("unknown")
+      ),
+      json: """
+        {"jsonrpc":"2.0","id":"unknown","params":{}}
+        """,
+      userInfo: info
+    )
 
-    checkMessageDecodingError(MessageDecodingError.invalidParams("missing expected parameter: capabilities", id: .number(2), messageKind: .response), json: """
-    {"jsonrpc":"2.0","id":2,"result":{}}
-    """, userInfo: info)
+    checkMessageDecodingError(
+      MessageDecodingError.invalidParams(
+        "missing expected parameter: capabilities",
+        id: .number(2),
+        messageKind: .response
+      ),
+      json: """
+        {"jsonrpc":"2.0","id":2,"result":{}}
+        """,
+      userInfo: info
+    )
   }
 
   // SR-16095
@@ -233,7 +355,9 @@ final class CodingTests: XCTestCase {
     decoder.userInfo = defaultCodingInfo
     let decodedValue = try decoder.decode(JSONRPCMessage.self, from: json.data(using: .utf8)!)
 
-    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = decodedValue, let decodedRequest = decodedValueOpaque as? ShutdownRequest else {
+    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = decodedValue,
+      let decodedRequest = decodedValueOpaque as? ShutdownRequest
+    else {
       XCTFail("decodedValue \(decodedValue) is not a ShutdownRequest")
       return
     }
@@ -243,12 +367,19 @@ final class CodingTests: XCTestCase {
   }
 }
 
-let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey:MessageRegistry.lspProtocol]
+let defaultCodingInfo: [CodingUserInfoKey: Any] = [CodingUserInfoKey.messageRegistryKey: MessageRegistry.lspProtocol]
 
-private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: String, file: StaticString = #filePath, line: UInt = #line) where Request: RequestType & Equatable {
+private func checkMessageCoding<Request: RequestType & Equatable>(
+  _ value: Request,
+  id: RequestID,
+  json: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
   checkCoding(JSONRPCMessage.request(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
-
-    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Request else {
+    guard case JSONRPCMessage.request(let decodedValueOpaque, let decodedID) = $0,
+      let decodedValue = decodedValueOpaque as? Request
+    else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -258,10 +389,16 @@ private func checkMessageCoding<Request>(_ value: Request, id: RequestID, json: 
   }
 }
 
-private func checkMessageCoding<Notification>(_ value: Notification, json: String, file: StaticString = #filePath, line: UInt = #line) where Notification: NotificationType & Equatable {
+private func checkMessageCoding<Notification: NotificationType & Equatable>(
+  _ value: Notification,
+  json: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
   checkCoding(JSONRPCMessage.notification(value), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
-
-    guard case JSONRPCMessage.notification(let decodedValueOpaque) = $0, let decodedValue = decodedValueOpaque as? Notification else {
+    guard case JSONRPCMessage.notification(let decodedValueOpaque) = $0,
+      let decodedValue = decodedValueOpaque as? Notification
+    else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -270,8 +407,13 @@ private func checkMessageCoding<Notification>(_ value: Notification, json: Strin
   }
 }
 
-private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json: String, file: StaticString = #filePath, line: UInt = #line) where Response: ResponseType & Equatable {
-
+private func checkMessageCoding<Response: ResponseType & Equatable>(
+  _ value: Response,
+  id: RequestID,
+  json: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
   let callback: JSONRPCMessage.ResponseTypeCallback = {
     return $0 == .string("unknown") ? nil : Response.self
   }
@@ -281,7 +423,9 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
 
   checkCoding(JSONRPCMessage.response(value, id: id), json: json, userInfo: codingInfo, file: file, line: line) {
 
-    guard case JSONRPCMessage.response(let decodedValueOpaque, let decodedID) = $0, let decodedValue = decodedValueOpaque as? Response else {
+    guard case JSONRPCMessage.response(let decodedValueOpaque, let decodedID) = $0,
+      let decodedValue = decodedValueOpaque as? Response
+    else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
       return
     }
@@ -291,8 +435,20 @@ private func checkMessageCoding<Response>(_ value: Response, id: RequestID, json
   }
 }
 
-private func checkMessageCoding(_ value: ResponseError, id: RequestID?, json: String, file: StaticString = #filePath, line: UInt = #line) {
-  checkCoding(JSONRPCMessage.errorResponse(value, id: id), json: json, userInfo: defaultCodingInfo, file: file, line: line) {
+private func checkMessageCoding(
+  _ value: ResponseError,
+  id: RequestID?,
+  json: String,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  checkCoding(
+    JSONRPCMessage.errorResponse(value, id: id),
+    json: json,
+    userInfo: defaultCodingInfo,
+    file: file,
+    line: line
+  ) {
 
     guard case JSONRPCMessage.errorResponse(let decodedValue, let decodedID) = $0 else {
       XCTFail("decodedValue \($0) does not match expected \(value)", file: file, line: line)
@@ -304,7 +460,13 @@ private func checkMessageCoding(_ value: ResponseError, id: RequestID?, json: St
   }
 }
 
-private func checkMessageDecodingError(_ expected: MessageDecodingError, json: String, userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo, file: StaticString = #filePath, line: UInt = #line) {
+private func checkMessageDecodingError(
+  _ expected: MessageDecodingError,
+  json: String,
+  userInfo: [CodingUserInfoKey: Any] = defaultCodingInfo,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
   let data = json.data(using: .utf8)!
   let decoder = JSONDecoder()
   decoder.userInfo = userInfo
@@ -315,8 +477,12 @@ private func checkMessageDecodingError(_ expected: MessageDecodingError, json: S
   } catch let error as MessageDecodingError {
     XCTAssertEqual(expected.code, error.code, file: file, line: line)
     XCTAssertEqual(expected.id, error.id, file: file, line: line)
-    XCTAssertTrue(error.message.hasPrefix(expected.message),
-      "message expected to start with \(expected.message); got \(error.message)", file: file, line: line)
+    XCTAssertTrue(
+      error.message.hasPrefix(expected.message),
+      "message expected to start with \(expected.message); got \(error.message)",
+      file: file,
+      line: line
+    )
   } catch {
     XCTFail("incorrect error seen \(error)", file: file, line: line)
   }

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionPerfTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionPerfTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocolJSONRPC
 import LSPTestSupport
+import LanguageServerProtocolJSONRPC
 import XCTest
 
 class ConnectionPerfTests: PerfTestCase {
@@ -57,11 +57,14 @@ class ConnectionPerfTests: PerfTestCase {
     let client = connection.client
     let sema = DispatchSemaphore(value: 0)
     self.measure {
-      DispatchQueue.concurrentPerform(iterations: 100, execute: { _ in
-        _ = client.send(EchoRequest(string: "hello!")) { _ in
-          sema.signal()
+      DispatchQueue.concurrentPerform(
+        iterations: 100,
+        execute: { _ in
+          _ = client.send(EchoRequest(string: "hello!")) { _ in
+            sema.signal()
+          }
         }
-      })
+      )
       for _ in 1...100 {
         XCTAssertEqual(sema.wait(timeout: .now() + .seconds(Int(defaultTimeout))), .success)
       }

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -17,7 +17,13 @@ import XCTest
 final class MessageParsingTests: XCTestCase {
 
   func testSplitMessage() throws {
-    func check(_ string: String, contentLen: Int? = nil, restLen: Int?, file: StaticString = #filePath, line: UInt = #line) throws {
+    func check(
+      _ string: String,
+      contentLen: Int? = nil,
+      restLen: Int?,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let ((content, header), rest) = try bytes.jsonrpcSplitMessage() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -28,7 +34,12 @@ final class MessageParsingTests: XCTestCase {
       XCTAssertEqual(header.contentLength, contentLen, file: file, line: line)
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
+    func checkError(
+      _ string: String,
+      _ expected: MessageDecodingError,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
       do {
         _ = try [UInt8](string.utf8).jsonrpcSplitMessage()
         XCTFail("missing expected error", file: file, line: line)
@@ -43,17 +54,23 @@ final class MessageParsingTests: XCTestCase {
     try check("Content-Length: 1\r\n\r\n", restLen: nil)
     try check("Content-Length: 2\r\n\r\n{", restLen: nil)
 
-    try check("Content-Length: 0\r\n\r\n", contentLen: 0,  restLen: 0)
-    try check("Content-Length: 0\r\n\r\n{}", contentLen: 0,  restLen: 2)
-    try check("Content-Length: 1\r\n\r\n{}", contentLen: 1,  restLen: 1)
-    try check("Content-Length: 2\r\n\r\n{}", contentLen: 2,  restLen: 0)
-    try check("Content-Length: 2\r\n\r\n{}Co", contentLen: 2,  restLen: 2)
+    try check("Content-Length: 0\r\n\r\n", contentLen: 0, restLen: 0)
+    try check("Content-Length: 0\r\n\r\n{}", contentLen: 0, restLen: 2)
+    try check("Content-Length: 1\r\n\r\n{}", contentLen: 1, restLen: 1)
+    try check("Content-Length: 2\r\n\r\n{}", contentLen: 2, restLen: 0)
+    try check("Content-Length: 2\r\n\r\n{}Co", contentLen: 2, restLen: 2)
 
     checkError("\r\n\r\n{}", MessageDecodingError.parseError("missing Content-Length header"))
   }
 
   func testParseHeader() throws {
-    func check(_ string: String, header expected: JSONRPCMessageHeader? = nil, restLen: Int?, file: StaticString = #filePath, line: UInt = #line) throws {
+    func check(
+      _ string: String,
+      header expected: JSONRPCMessageHeader? = nil,
+      restLen: Int?,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let (header, rest) = try bytes.jsonrcpParseHeader() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -63,7 +80,12 @@ final class MessageParsingTests: XCTestCase {
       XCTAssertEqual(header, expected, file: file, line: line)
     }
 
-    func checkErrorBytes(_ bytes: [UInt8], _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
+    func checkErrorBytes(
+      _ bytes: [UInt8],
+      _ expected: MessageDecodingError,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
       do {
         _ = try bytes.jsonrcpParseHeader()
         XCTFail("missing expected error", file: file, line: line)
@@ -74,7 +96,12 @@ final class MessageParsingTests: XCTestCase {
       }
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
+    func checkError(
+      _ string: String,
+      _ expected: MessageDecodingError,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
       checkErrorBytes([UInt8](string.utf8), expected, file: file, line: line)
     }
 
@@ -91,11 +118,21 @@ final class MessageParsingTests: XCTestCase {
     checkError("Content-Length:0x1\r\n\r\n", MessageDecodingError.parseError("expected integer value in 0x1"))
     checkError("Content-Length:a123\r\n\r\n", MessageDecodingError.parseError("expected integer value in a123"))
 
-    checkErrorBytes([UInt8]("Content-Length: ".utf8) + [0xFF] + [UInt8]("\r\n".utf8), MessageDecodingError.parseError("expected integer value in <invalid>"))
+    checkErrorBytes(
+      [UInt8]("Content-Length: ".utf8) + [0xFF] + [UInt8]("\r\n".utf8),
+      MessageDecodingError.parseError("expected integer value in <invalid>")
+    )
   }
 
   func testParseHeaderField() throws {
-    func check(_ string: String, keyLen: Int? = nil, valueLen: Int? = nil, restLen: Int?, file: StaticString = #filePath, line: UInt = #line) throws {
+    func check(
+      _ string: String,
+      keyLen: Int? = nil,
+      valueLen: Int? = nil,
+      restLen: Int?,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws {
       let bytes: [UInt8] = [UInt8](string.utf8)
       guard let (kv, rest) = try bytes.jsonrpcParseHeaderField() else {
         XCTAssert(restLen == nil, "expected non-empty field", file: file, line: line)
@@ -108,11 +145,16 @@ final class MessageParsingTests: XCTestCase {
       }
       XCTAssertEqual(kv?.value.count, valueLen, "value", file: file, line: line)
       if let value = kv?.value {
-        XCTAssertEqual(value, bytes.dropFirst(kv!.key.count+1).prefix(value.count), file: file, line: line)
+        XCTAssertEqual(value, bytes.dropFirst(kv!.key.count + 1).prefix(value.count), file: file, line: line)
       }
     }
 
-    func checkError(_ string: String, _ expected: MessageDecodingError, file: StaticString = #filePath, line: UInt = #line) {
+    func checkError(
+      _ string: String,
+      _ expected: MessageDecodingError,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
       do {
         _ = try [UInt8](string.utf8).jsonrpcParseHeaderField()
         XCTFail("missing expected error", file: file, line: line)
@@ -190,9 +232,9 @@ final class MessageParsingTests: XCTestCase {
     XCTAssertEqual(Int(ascii: "45"), 45)
     XCTAssertEqual(Int(ascii: "     45    "), 45)
     XCTAssertEqual(Int(ascii: "\(Int.max)"), Int.max)
-    XCTAssertEqual(Int(ascii: "\(Int.max-1)"), Int.max-1)
+    XCTAssertEqual(Int(ascii: "\(Int.max-1)"), Int.max - 1)
     XCTAssertEqual(Int(ascii: "\(Int.min)"), Int.min)
-    XCTAssertEqual(Int(ascii: "\(Int.min+1)"), Int.min+1)
+    XCTAssertEqual(Int(ascii: "\(Int.min+1)"), Int.min + 1)
 
     XCTAssertEqual(Int(ascii: "+0"), 0)
     XCTAssertEqual(Int(ascii: "+1"), 1)
@@ -203,9 +245,9 @@ final class MessageParsingTests: XCTestCase {
     XCTAssertEqual(Int(ascii: "-45"), -45)
     XCTAssertEqual(Int(ascii: "     -45    "), -45)
     XCTAssertEqual(Int(ascii: "+\(Int.max)"), Int.max)
-    XCTAssertEqual(Int(ascii: "+\(Int.max-1)"), Int.max-1)
+    XCTAssertEqual(Int(ascii: "+\(Int.max-1)"), Int.max - 1)
     XCTAssertEqual(Int(ascii: "\(Int.min)"), Int.min)
-    XCTAssertEqual(Int(ascii: "\(Int.min+1)"), Int.min+1)
+    XCTAssertEqual(Int(ascii: "\(Int.min+1)"), Int.min + 1)
 
     XCTAssertEqual(Int(ascii: "1234567890"), 1234567890)
     XCTAssertEqual(Int(ascii: "\n\r \u{b}\u{d}\t45\n\t\r\u{c}"), 45)

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
+import XCTest
 
 final class CodingTests: XCTestCase {
 
@@ -22,7 +22,7 @@ final class CodingTests: XCTestCase {
     // The \\/\\/\\/ is escaping file:// + /foo.swift, which is silly but allowed by json.
     let urljson = "file:\\/\\/\\/foo.swift"
 
-    let range = Position(line: 5, utf16index: 23) ..< Position(line: 6, utf16index: 0)
+    let range = Position(line: 5, utf16index: 23)..<Position(line: 6, utf16index: 0)
     // Range.lowerBound -> start, Range.upperBound -> end
     let rangejson = """
       {
@@ -40,39 +40,54 @@ final class CodingTests: XCTestCase {
     let indent2rangejson = rangejson.indented(2, skipFirstLine: true)
 
     // url -> uri
-    checkCoding(Location(uri: uri, range: range), json: """
-      {
-        "range" : \(indent2rangejson),
-        "uri" : "\(urljson)"
-      }
-      """)
+    checkCoding(
+      Location(uri: uri, range: range),
+      json: """
+        {
+          "range" : \(indent2rangejson),
+          "uri" : "\(urljson)"
+        }
+        """
+    )
 
-    checkCoding(TextEdit(range: range, newText: "foo"), json: """
-      {
-        "newText" : "foo",
-        "range" : \(indent2rangejson)
-      }
-      """)
+    checkCoding(
+      TextEdit(range: range, newText: "foo"),
+      json: """
+        {
+          "newText" : "foo",
+          "range" : \(indent2rangejson)
+        }
+        """
+    )
 
     // url -> uri
-    checkCoding(TextDocumentIdentifier(uri), json: """
-      {
-        "uri" : "\(urljson)"
-      }
-      """)
+    checkCoding(
+      TextDocumentIdentifier(uri),
+      json: """
+        {
+          "uri" : "\(urljson)"
+        }
+        """
+    )
 
-    checkCoding(OptionalVersionedTextDocumentIdentifier(uri, version: nil), json: """
-      {
-        "uri" : "\(urljson)"
-      }
-      """)
+    checkCoding(
+      OptionalVersionedTextDocumentIdentifier(uri, version: nil),
+      json: """
+        {
+          "uri" : "\(urljson)"
+        }
+        """
+    )
 
-    checkCoding(VersionedTextDocumentIdentifier(uri, version: 3), json: """
-      {
-        "uri" : "\(urljson)",
-        "version" : 3
-      }
-      """)
+    checkCoding(
+      VersionedTextDocumentIdentifier(uri, version: 3),
+      json: """
+        {
+          "uri" : "\(urljson)",
+          "version" : 3
+        }
+        """
+    )
 
     checkCoding(
       TextDocumentEdit(
@@ -80,42 +95,53 @@ final class CodingTests: XCTestCase {
         edits: [
           .textEdit(TextEdit(range: range, newText: "foo"))
         ]
-      ), json: """
-      {
-        "edits" : [
-          {
-            "newText" : "foo",
-            "range" : \(rangejson.indented(6, skipFirstLine: true))
+      ),
+      json: """
+        {
+          "edits" : [
+            {
+              "newText" : "foo",
+              "range" : \(rangejson.indented(6, skipFirstLine: true))
+            }
+          ],
+          "textDocument" : {
+            "uri" : "\(urljson)",
+            "version" : 1
           }
-        ],
-        "textDocument" : {
-          "uri" : "\(urljson)",
-          "version" : 1
         }
-      }
-      """)
+        """
+    )
 
     // url -> uri
-    checkCoding(WorkspaceFolder(uri: uri, name: "foo"), json: """
-      {
-        "name" : "foo",
-        "uri" : "\(urljson)"
-      }
-      """)
+    checkCoding(
+      WorkspaceFolder(uri: uri, name: "foo"),
+      json: """
+        {
+          "name" : "foo",
+          "uri" : "\(urljson)"
+        }
+        """
+    )
 
-    checkCoding(WorkspaceFolder(uri: uri), json: """
-      {
-        "name" : "foo.swift",
-        "uri" : "\(urljson)"
-      }
-      """)
+    checkCoding(
+      WorkspaceFolder(uri: uri),
+      json: """
+        {
+          "name" : "foo.swift",
+          "uri" : "\(urljson)"
+        }
+        """
+    )
 
-    checkCoding(WorkspaceFolder(uri: uri, name: ""), json: """
-      {
-        "name" : "unknown_workspace",
-        "uri" : "\(urljson)"
-      }
-      """)
+    checkCoding(
+      WorkspaceFolder(uri: uri, name: ""),
+      json: """
+        {
+          "name" : "unknown_workspace",
+          "uri" : "\(urljson)"
+        }
+        """
+    )
 
     checkCoding(MarkupKind.markdown, json: "\"markdown\"")
     checkCoding(MarkupKind.plaintext, json: "\"plaintext\"")
@@ -136,68 +162,86 @@ final class CodingTests: XCTestCase {
     checkCoding(
       ClientCapabilities(
         workspace: with(WorkspaceClientCapabilities()) { $0.applyEdit = true },
-        textDocument: nil),
+        textDocument: nil
+      ),
       json: """
-      {
-        "workspace" : {
-          "applyEdit" : true
+        {
+          "workspace" : {
+            "applyEdit" : true
+          }
         }
-      }
-      """)
+        """
+    )
 
     checkCoding(
       WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: nil)),
-      json: "{\n\n}")
+      json: "{\n\n}"
+    )
     checkCoding(
       WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: "foo")),
       json: """
-      {
-        "compilationDatabasePath" : "foo"
-      }
-      """)
+        {
+          "compilationDatabasePath" : "foo"
+        }
+        """
+    )
 
     // FIXME: should probably be "unknown"; see comment in WorkspaceSettingsChange decoder.
-    checkDecoding(json: """
-      {
-        "hi": "there"
-      }
-      """, expected: WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: nil)))
+    checkDecoding(
+      json: """
+        {
+          "hi": "there"
+        }
+        """,
+      expected: WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: nil))
+    )
 
     // experimental can be anything
-    checkDecoding(json: """
-      {
-        "experimenal": [1]
-      }
-      """, expected: ClientCapabilities(workspace: nil, textDocument: nil))
+    checkDecoding(
+      json: """
+        {
+          "experimenal": [1]
+        }
+        """,
+      expected: ClientCapabilities(workspace: nil, textDocument: nil)
+    )
 
-    checkDecoding(json: """
-      {
-        "workspace": {
-          "workspaceEdit": {
-            "documentChanges": false
+    checkDecoding(
+      json: """
+        {
+          "workspace": {
+            "workspaceEdit": {
+              "documentChanges": false
+            }
           }
         }
-      }
-      """, expected: ClientCapabilities(
+        """,
+      expected: ClientCapabilities(
         workspace: with(WorkspaceClientCapabilities()) {
           $0.workspaceEdit = WorkspaceClientCapabilities.WorkspaceEdit(documentChanges: false)
         },
-        textDocument: nil))
+        textDocument: nil
+      )
+    )
 
     // ignore unknown keys
-    checkDecoding(json: """
-      {
-        "workspace": {
-          "workspaceEdit": {
-            "ben's unlikley opton": false
+    checkDecoding(
+      json: """
+        {
+          "workspace": {
+            "workspaceEdit": {
+              "ben's unlikley opton": false
+            }
           }
         }
-      }
-      """, expected: ClientCapabilities(
+        """,
+      expected: ClientCapabilities(
         workspace: with(WorkspaceClientCapabilities()) {
           $0.workspaceEdit = WorkspaceClientCapabilities.WorkspaceEdit(documentChanges: nil)
         },
-        textDocument: nil))
+        textDocument: nil
+      )
+    )
 
     checkCoding(RequestID.number(100), json: "100")
     checkCoding(RequestID.string("100"), json: "\"100\"")
@@ -212,227 +256,317 @@ final class CodingTests: XCTestCase {
     checkCoding(DiagnosticCode.number(123), json: "123")
     checkCoding(DiagnosticCode.string("hi"), json: "\"hi\"")
 
-    checkCoding(CodeDescription(href: DocumentURI(string: "file:///some/path")), json: """
-    {
-      "href" : "file:\\/\\/\\/some\\/path"
-    }
-    """)
+    checkCoding(
+      CodeDescription(href: DocumentURI(string: "file:///some/path")),
+      json: """
+        {
+          "href" : "file:\\/\\/\\/some\\/path"
+        }
+        """
+    )
 
     let markup = MarkupContent(kind: .plaintext, value: "a")
-    checkCoding(HoverResponse(contents: .markupContent(markup), range: nil), json: """
-      {
-        "contents" : {
-          "kind" : "plaintext",
-          "value" : "a"
-        }
-      }
-      """)
-
-    checkDecoding(json: """
-    {
-      "contents" : "test"
-    }
-    """, expected: HoverResponse(contents: .markedStrings([.markdown(value: "test")]), range: nil))
-
-    checkCoding(HoverResponse(contents: .markedStrings([.markdown(value: "test"), .codeBlock(language: "swift", value: "let foo = 2")]), range: nil), json: """
-      {
-        "contents" : [
-          "test",
-          {
-            "language" : "swift",
-            "value" : "let foo = 2"
+    checkCoding(
+      HoverResponse(contents: .markupContent(markup), range: nil),
+      json: """
+        {
+          "contents" : {
+            "kind" : "plaintext",
+            "value" : "a"
           }
-        ]
-      }
-      """)
+        }
+        """
+    )
 
-    checkCoding(HoverResponse(contents: .markupContent(markup), range: range), json: """
-      {
-        "contents" : {
-          "kind" : "plaintext",
-          "value" : "a"
-        },
-        "range" : \(rangejson.indented(2, skipFirstLine: true))
-      }
-      """)
+    checkDecoding(
+      json: """
+        {
+          "contents" : "test"
+        }
+        """,
+      expected: HoverResponse(contents: .markedStrings([.markdown(value: "test")]), range: nil)
+    )
 
-    checkCoding(TextDocumentContentChangeEvent(text: "a"), json: """
-      {
-        "text" : "a"
-      }
-      """)
-    checkCoding(TextDocumentContentChangeEvent(range: range, rangeLength: 10, text: "a"), json: """
-      {
-        "range" : \(rangejson.indented(2, skipFirstLine: true)),
-        "rangeLength" : 10,
-        "text" : "a"
-      }
-      """)
-    checkCoding(WorkspaceEdit(changes: [uri: []]), json: """
-      {
-        "changes" : {
-          "\(urljson)" : [
-
+    checkCoding(
+      HoverResponse(
+        contents: .markedStrings([.markdown(value: "test"), .codeBlock(language: "swift", value: "let foo = 2")]),
+        range: nil
+      ),
+      json: """
+        {
+          "contents" : [
+            "test",
+            {
+              "language" : "swift",
+              "value" : "let foo = 2"
+            }
           ]
         }
-      }
-      """)
+        """
+    )
 
-    checkCoding(CompletionList(isIncomplete: true, items: [CompletionItem(label: "abc", kind: .function)]), json: """
-      {
-        "isIncomplete" : true,
-        "items" : [
+    checkCoding(
+      HoverResponse(contents: .markupContent(markup), range: range),
+      json: """
+        {
+          "contents" : {
+            "kind" : "plaintext",
+            "value" : "a"
+          },
+          "range" : \(rangejson.indented(2, skipFirstLine: true))
+        }
+        """
+    )
+
+    checkCoding(
+      TextDocumentContentChangeEvent(text: "a"),
+      json: """
+        {
+          "text" : "a"
+        }
+        """
+    )
+    checkCoding(
+      TextDocumentContentChangeEvent(range: range, rangeLength: 10, text: "a"),
+      json: """
+        {
+          "range" : \(rangejson.indented(2, skipFirstLine: true)),
+          "rangeLength" : 10,
+          "text" : "a"
+        }
+        """
+    )
+    checkCoding(
+      WorkspaceEdit(changes: [uri: []]),
+      json: """
+        {
+          "changes" : {
+            "\(urljson)" : [
+
+            ]
+          }
+        }
+        """
+    )
+
+    checkCoding(
+      CompletionList(isIncomplete: true, items: [CompletionItem(label: "abc", kind: .function)]),
+      json: """
+        {
+          "isIncomplete" : true,
+          "items" : [
+            {
+              "kind" : 3,
+              "label" : "abc"
+            }
+          ]
+        }
+        """
+    )
+
+    checkDecoding(
+      json: """
+        [
           {
             "kind" : 3,
             "label" : "abc"
           }
         ]
-      }
-      """)
+        """,
+      expected: CompletionList(isIncomplete: false, items: [CompletionItem(label: "abc", kind: .function)])
+    )
 
-    checkDecoding(json: """
-      [
+    checkCoding(
+      StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: "some **Markdown***")),
+      json: """
         {
-          "kind" : 3,
-          "label" : "abc"
+          "kind" : "markdown",
+          "value" : "some **Markdown***"
         }
-      ]
-      """, expected: CompletionList(isIncomplete: false, items: [CompletionItem(label: "abc", kind: .function)]))
+        """
+    )
 
-    checkCoding(StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: "some **Markdown***")), json: """
-      {
-        "kind" : "markdown",
-        "value" : "some **Markdown***"
-      }
-      """)
+    checkCoding(
+      StringOrMarkupContent.string("Some documentation"),
+      json: """
+        "Some documentation"
+        """
+    )
 
-    checkCoding(StringOrMarkupContent.string("Some documentation"), json: """
-      "Some documentation"
-      """)
-    
     checkCoding(PrepareRenameResponse(range: range), json: rangejson)
-    
-    checkCoding(PrepareRenameResponse(range: range, placeholder: "somePlaceholder"), json: """
-      {
-        "placeholder" : "somePlaceholder",
-        "range" : \(rangejson.indented(2, skipFirstLine: true))
-      }
-      """)
 
-    checkCoding(LocationsOrLocationLinksResponse.locations([Location(uri: uri, range: range)]), json: """
-      [
+    checkCoding(
+      PrepareRenameResponse(range: range, placeholder: "somePlaceholder"),
+      json: """
         {
-          "range" : \(rangejson.indented(4, skipFirstLine: true)),
+          "placeholder" : "somePlaceholder",
+          "range" : \(rangejson.indented(2, skipFirstLine: true))
+        }
+        """
+    )
+
+    checkCoding(
+      LocationsOrLocationLinksResponse.locations([Location(uri: uri, range: range)]),
+      json: """
+        [
+          {
+            "range" : \(rangejson.indented(4, skipFirstLine: true)),
+            "uri" : "\(urljson)"
+          }
+        ]
+        """
+    )
+
+    checkCoding(
+      LocationsOrLocationLinksResponse.locationLinks([
+        LocationLink(targetUri: uri, targetRange: range, targetSelectionRange: range)
+      ]),
+      json: """
+        [
+          {
+            "targetRange" : \(rangejson.indented(4, skipFirstLine: true)),
+            "targetSelectionRange" : \(rangejson.indented(4, skipFirstLine: true)),
+            "targetUri" : "\(urljson)"
+          }
+        ]
+        """
+    )
+
+    checkDecoding(
+      json: """
+        {
+          "range" : \(rangejson.indented(2, skipFirstLine: true)),
           "uri" : "\(urljson)"
         }
-      ]
-      """)
+        """,
+      expected: LocationsOrLocationLinksResponse.locations([Location(uri: uri, range: range)])
+    )
 
-    checkCoding(LocationsOrLocationLinksResponse.locationLinks([LocationLink(targetUri: uri, targetRange: range, targetSelectionRange: range)]), json: """
-      [
-        {
-          "targetRange" : \(rangejson.indented(4, skipFirstLine: true)),
-          "targetSelectionRange" : \(rangejson.indented(4, skipFirstLine: true)),
-          "targetUri" : "\(urljson)"
-        }
-      ]
-      """)
+    checkCoding(
+      DocumentSymbolResponse.documentSymbols([
+        DocumentSymbol(name: "mySymbol", kind: .function, range: range, selectionRange: range)
+      ]),
+      json: """
+        [
+          {
+            "kind" : 12,
+            "name" : "mySymbol",
+            "range" : \(rangejson.indented(4, skipFirstLine: true)),
+            "selectionRange" : \(rangejson.indented(4, skipFirstLine: true))
+          }
+        ]
+        """
+    )
 
-    checkDecoding(json: """
-      {
-        "range" : \(rangejson.indented(2, skipFirstLine: true)),
-        "uri" : "\(urljson)"
-      }
-      """, expected: LocationsOrLocationLinksResponse.locations([Location(uri: uri, range: range)]))
-
-    checkCoding(DocumentSymbolResponse.documentSymbols([DocumentSymbol(name: "mySymbol", kind: .function, range: range, selectionRange: range)]), json: """
-      [
-        {
-          "kind" : 12,
-          "name" : "mySymbol",
-          "range" : \(rangejson.indented(4, skipFirstLine: true)),
-          "selectionRange" : \(rangejson.indented(4, skipFirstLine: true))
-        }
-      ]
-      """)
-
-    checkCoding(DocumentSymbolResponse.symbolInformation([SymbolInformation(name: "mySymbol", kind: .function, location: Location(uri: uri, range: range))]), json: """
-      [
-        {
-          "kind" : 12,
-          "location" : {
-            "range" : \(rangejson.indented(6, skipFirstLine: true)),
-            "uri" : "\(urljson)"
-          },
-          "name" : "mySymbol"
-        }
-      ]
-      """)
+    checkCoding(
+      DocumentSymbolResponse.symbolInformation([
+        SymbolInformation(name: "mySymbol", kind: .function, location: Location(uri: uri, range: range))
+      ]),
+      json: """
+        [
+          {
+            "kind" : 12,
+            "location" : {
+              "range" : \(rangejson.indented(6, skipFirstLine: true)),
+              "uri" : "\(urljson)"
+            },
+            "name" : "mySymbol"
+          }
+        ]
+        """
+    )
 
     checkCoding(ValueOrBool.value(5), json: "5")
     checkCoding(ValueOrBool<Int>.bool(false), json: "false")
 
-    checkDecoding(json: "2", expected: TextDocumentSyncOptions(openClose: nil, change: .incremental, willSave: nil, willSaveWaitUntil: nil, save: nil))
+    checkDecoding(
+      json: "2",
+      expected: TextDocumentSyncOptions(
+        openClose: nil,
+        change: .incremental,
+        willSave: nil,
+        willSaveWaitUntil: nil,
+        save: nil
+      )
+    )
 
-    checkCoding(TextDocumentSyncOptions(), json: """
-      {
-        "change" : 2,
-        "openClose" : true,
-        "save" : {
-          "includeText" : false
-        },
-        "willSave" : true,
-        "willSaveWaitUntil" : false
-      }
-      """)
-    
-    checkCoding(WorkspaceEdit(documentChanges: [.textDocumentEdit(TextDocumentEdit(textDocument: OptionalVersionedTextDocumentIdentifier(uri, version: 2), edits: []))]), json: """
-      {
-        "documentChanges" : [
-          {
-            "edits" : [
+    checkCoding(
+      TextDocumentSyncOptions(),
+      json: """
+        {
+          "change" : 2,
+          "openClose" : true,
+          "save" : {
+            "includeText" : false
+          },
+          "willSave" : true,
+          "willSaveWaitUntil" : false
+        }
+        """
+    )
 
-            ],
-            "textDocument" : {
-              "uri" : "\(urljson)",
-              "version" : 2
+    checkCoding(
+      WorkspaceEdit(documentChanges: [
+        .textDocumentEdit(
+          TextDocumentEdit(textDocument: OptionalVersionedTextDocumentIdentifier(uri, version: 2), edits: [])
+        )
+      ]),
+      json: """
+        {
+          "documentChanges" : [
+            {
+              "edits" : [
+
+              ],
+              "textDocument" : {
+                "uri" : "\(urljson)",
+                "version" : 2
+              }
             }
-          }
-        ]
-      }
-      """)
-    checkCoding(WorkspaceEdit(documentChanges: [.createFile(CreateFile(uri: uri))]), json: """
-    {
-      "documentChanges" : [
-        {
-          "kind" : "create",
-          "uri" : "\(urljson)"
+          ]
         }
-      ]
-    }
-    """)
-    checkCoding(WorkspaceEdit(documentChanges: [.renameFile(RenameFile(oldUri: uri, newUri: uri))]), json: """
-    {
-      "documentChanges" : [
+        """
+    )
+    checkCoding(
+      WorkspaceEdit(documentChanges: [.createFile(CreateFile(uri: uri))]),
+      json: """
         {
-          "kind" : "rename",
-          "newUri" : "\(urljson)",
-          "oldUri" : "\(urljson)"
+          "documentChanges" : [
+            {
+              "kind" : "create",
+              "uri" : "\(urljson)"
+            }
+          ]
         }
-      ]
-    }
-    """)
-    checkCoding(WorkspaceEdit(documentChanges: [.deleteFile(DeleteFile(uri: uri))]), json: """
-    {
-      "documentChanges" : [
+        """
+    )
+    checkCoding(
+      WorkspaceEdit(documentChanges: [.renameFile(RenameFile(oldUri: uri, newUri: uri))]),
+      json: """
         {
-          "kind" : "delete",
-          "uri" : "\(urljson)"
+          "documentChanges" : [
+            {
+              "kind" : "rename",
+              "newUri" : "\(urljson)",
+              "oldUri" : "\(urljson)"
+            }
+          ]
         }
-      ]
-    }
-    """)
-
+        """
+    )
+    checkCoding(
+      WorkspaceEdit(documentChanges: [.deleteFile(DeleteFile(uri: uri))]),
+      json: """
+        {
+          "documentChanges" : [
+            {
+              "kind" : "delete",
+              "uri" : "\(urljson)"
+            }
+          ]
+        }
+        """
+    )
 
   }
 
@@ -449,21 +583,24 @@ final class CodingTests: XCTestCase {
       var range: Range<Position>
     }
 
-    let range = Position(line: 5, utf16index: 23) ..< Position(line: 6, utf16index: 0)
-    checkCoding(WithPosRange(range: range), json: """
-      {
-        "range" : {
-          "end" : {
-            "character" : 0,
-            "line" : 6
-          },
-          "start" : {
-            "character" : 23,
-            "line" : 5
+    let range = Position(line: 5, utf16index: 23)..<Position(line: 6, utf16index: 0)
+    checkCoding(
+      WithPosRange(range: range),
+      json: """
+        {
+          "range" : {
+            "end" : {
+              "character" : 0,
+              "line" : 6
+            },
+            "start" : {
+              "character" : 23,
+              "line" : 5
+            }
           }
         }
-      }
-      """)
+        """
+    )
   }
 
   func testPositionRangeArray() {
@@ -472,47 +609,50 @@ final class CodingTests: XCTestCase {
       var ranges: [Range<Position>]
     }
     let ranges = [
-      Position(line: 1, utf16index: 0) ..< Position(line: 1, utf16index: 10),
-      Position(line: 2, utf16index: 2) ..< Position(line: 3, utf16index: 0),
-      Position(line: 70, utf16index: 8) ..< Position(line: 70, utf16index: 11)
+      Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 10),
+      Position(line: 2, utf16index: 2)..<Position(line: 3, utf16index: 0),
+      Position(line: 70, utf16index: 8)..<Position(line: 70, utf16index: 11),
     ]
 
-    checkCoding(WithPosRangeArray(ranges: ranges), json: """
-      {
-        "ranges" : [
-          {
-            "end" : {
-              "character" : 10,
-              "line" : 1
+    checkCoding(
+      WithPosRangeArray(ranges: ranges),
+      json: """
+        {
+          "ranges" : [
+            {
+              "end" : {
+                "character" : 10,
+                "line" : 1
+              },
+              "start" : {
+                "character" : 0,
+                "line" : 1
+              }
             },
-            "start" : {
-              "character" : 0,
-              "line" : 1
-            }
-          },
-          {
-            "end" : {
-              "character" : 0,
-              "line" : 3
+            {
+              "end" : {
+                "character" : 0,
+                "line" : 3
+              },
+              "start" : {
+                "character" : 2,
+                "line" : 2
+              }
             },
-            "start" : {
-              "character" : 2,
-              "line" : 2
+            {
+              "end" : {
+                "character" : 11,
+                "line" : 70
+              },
+              "start" : {
+                "character" : 8,
+                "line" : 70
+              }
             }
-          },
-          {
-            "end" : {
-              "character" : 11,
-              "line" : 70
-            },
-            "start" : {
-              "character" : 8,
-              "line" : 70
-            }
-          }
-        ]
-      }
-      """)
+          ]
+        }
+        """
+    )
   }
 
   func testCallHierarchyIncomingCallRanges() {
@@ -524,64 +664,70 @@ final class CodingTests: XCTestCase {
       kind: SymbolKind.method,
       tags: nil,
       uri: uri,
-      range: Position(line: 1, utf16index: 0) ..< Position(line: 2, utf16index: 5),
-      selectionRange: Position(line: 1, utf16index: 0) ..< Position(line: 1, utf16index: 7)
+      range: Position(line: 1, utf16index: 0)..<Position(line: 2, utf16index: 5),
+      selectionRange: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 7)
     )
-    let call = CallHierarchyIncomingCall(from: item, fromRanges: [
-      Position(line: 2, utf16index: 0) ..< Position(line: 2, utf16index: 5),
-      Position(line: 7, utf16index: 10) ..< Position(line: 8, utf16index: 10),
-    ])
-    checkCoding(call, json: """
-      {
-        "from" : {
-          "kind" : 6,
-          "name" : "test",
-          "range" : {
-            "end" : {
-              "character" : 5,
-              "line" : 2
+    let call = CallHierarchyIncomingCall(
+      from: item,
+      fromRanges: [
+        Position(line: 2, utf16index: 0)..<Position(line: 2, utf16index: 5),
+        Position(line: 7, utf16index: 10)..<Position(line: 8, utf16index: 10),
+      ]
+    )
+    checkCoding(
+      call,
+      json: """
+        {
+          "from" : {
+            "kind" : 6,
+            "name" : "test",
+            "range" : {
+              "end" : {
+                "character" : 5,
+                "line" : 2
+              },
+              "start" : {
+                "character" : 0,
+                "line" : 1
+              }
             },
-            "start" : {
-              "character" : 0,
-              "line" : 1
-            }
+            "selectionRange" : {
+              "end" : {
+                "character" : 7,
+                "line" : 1
+              },
+              "start" : {
+                "character" : 0,
+                "line" : 1
+              }
+            },
+            "uri" : "file:\\/\\/\\/foo.swift"
           },
-          "selectionRange" : {
-            "end" : {
-              "character" : 7,
-              "line" : 1
+          "fromRanges" : [
+            {
+              "end" : {
+                "character" : 5,
+                "line" : 2
+              },
+              "start" : {
+                "character" : 0,
+                "line" : 2
+              }
             },
-            "start" : {
-              "character" : 0,
-              "line" : 1
+            {
+              "end" : {
+                "character" : 10,
+                "line" : 8
+              },
+              "start" : {
+                "character" : 10,
+                "line" : 7
+              }
             }
-          },
-          "uri" : "file:\\/\\/\\/foo.swift"
-        },
-        "fromRanges" : [
-          {
-            "end" : {
-              "character" : 5,
-              "line" : 2
-            },
-            "start" : {
-              "character" : 0,
-              "line" : 2
-            }
-          },
-          {
-            "end" : {
-              "character" : 10,
-              "line" : 8
-            },
-            "start" : {
-              "character" : 10,
-              "line" : 7
-            }
-          }
-        ]
-      }
-      """)
+          ]
+        }
+        """
+    )
   }
 
   func testCustomCodableOptional() {
@@ -590,280 +736,40 @@ final class CodingTests: XCTestCase {
       var range: Range<Position>?
     }
 
-    let range = Position(line: 5, utf16index: 23) ..< Position(line: 6, utf16index: 0)
-    checkCoding(WithPosRange(range: range), json: """
-      {
-        "range" : {
-          "end" : {
-            "character" : 0,
-            "line" : 6
-          },
-          "start" : {
-            "character" : 23,
-            "line" : 5
+    let range = Position(line: 5, utf16index: 23)..<Position(line: 6, utf16index: 0)
+    checkCoding(
+      WithPosRange(range: range),
+      json: """
+        {
+          "range" : {
+            "end" : {
+              "character" : 0,
+              "line" : 6
+            },
+            "start" : {
+              "character" : 23,
+              "line" : 5
+            }
           }
         }
-      }
-      """)
+        """
+    )
 
-    checkCoding(WithPosRange(range: nil), json: """
-      {
+    checkCoding(
+      WithPosRange(range: nil),
+      json: """
+        {
 
-      }
-      """)
+        }
+        """
+    )
   }
 
   func testCompletionListItemDefaultsEditRange() {
-    checkCoding(CompletionList.ItemDefaultsEditRange.range(Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)), json: """
-    {
-      "end" : {
-        "character" : 3,
-        "line" : 4
-      },
-      "start" : {
-        "character" : 14,
-        "line" : 3
-      }
-    }
-    """)
-
-    checkCoding(CompletionList.ItemDefaultsEditRange.insertReplaceRanges(.init(
-      insert: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      replace: Position(line: 5, utf16index: 12)..<Position(line: 6, utf16index: 2)
-    )), json: """
-    {
-      "insert" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
-        }
-      },
-      "replace" : {
-        "end" : {
-          "character" : 2,
-          "line" : 6
-        },
-        "start" : {
-          "character" : 12,
-          "line" : 5
-        }
-      }
-    }
-    """)
-  }
-
-  func testProgressToken() {
-    checkCoding(ProgressToken.integer(3), json: "3")
-    checkCoding(ProgressToken.string("foobar"), json: #""foobar""#)
-  }
-
-  func testDocumentDiagnosticReport() {
-    checkCoding(DocumentDiagnosticReport.full(RelatedFullDocumentDiagnosticReport(items: [])), json: """
-    {
-      "items" : [
-
-      ],
-      "kind" : "full"
-    }
-    """)
-
-    checkCoding(DocumentDiagnosticReport.full(RelatedFullDocumentDiagnosticReport(resultId: "myResults", items: [])), json: """
-    {
-      "items" : [
-
-      ],
-      "kind" : "full",
-      "resultId" : "myResults"
-    }
-    """)
-
-    checkCoding(DocumentDiagnosticReport.full(RelatedFullDocumentDiagnosticReport(
-      resultId: "myResults",
-      items: [],
-      relatedDocuments: [
-        DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(RelatedUnchangedDocumentDiagnosticReport(resultId: "myOtherResults"))
-      ]
-    )), json: #"""
-    {
-      "items" : [
-
-      ],
-      "kind" : "full",
-      "relatedDocuments" : [
-        "file:\/\/\/some\/path",
+    checkCoding(
+      CompletionList.ItemDefaultsEditRange.range(Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)),
+      json: """
         {
-          "kind" : "unchanged",
-          "resultId" : "myOtherResults"
-        }
-      ],
-      "resultId" : "myResults"
-    }
-    """#)
-
-    checkCoding(DocumentDiagnosticReport.unchanged(RelatedUnchangedDocumentDiagnosticReport(resultId: "myResults")), json: """
-    {
-      "kind" : "unchanged",
-      "resultId" : "myResults"
-    }
-    """)
-
-    checkCoding(DocumentDiagnosticReport.unchanged(RelatedUnchangedDocumentDiagnosticReport(resultId: "myResults", relatedDocuments: [
-      DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(RelatedUnchangedDocumentDiagnosticReport(resultId: "myOtherResults"))
-    ])), json: #"""
-    {
-      "kind" : "unchanged",
-      "relatedDocuments" : [
-        "file:\/\/\/some\/path",
-        {
-          "kind" : "unchanged",
-          "resultId" : "myOtherResults"
-        }
-      ],
-      "resultId" : "myResults"
-    }
-    """#)
-  }
-
-  func testInlineValue() {
-    checkCoding(InlineValue.text(InlineValueText(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      text: "xxx"
-    )), json: """
-    {
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
-        }
-      },
-      "text" : "xxx"
-    }
-    """)
-
-    checkCoding(InlineValue.variableLookup(InlineValueVariableLookup(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      variableName: "myVar",
-      caseSensitiveLookup: true
-    )), json: """
-    {
-      "caseSensitiveLookup" : true,
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
-        }
-      },
-      "variableName" : "myVar"
-    }
-    """)
-
-    checkCoding(InlineValue.evaluatableExpression(InlineValueEvaluatableExpression(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      expression: "myExpr"
-    )), json: """
-    {
-      "expression" : "myExpr",
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
-        }
-      }
-    }
-    """)
-  }
-
-  func testSelectionRange() {
-    checkCoding(SelectionRange(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      parent: SelectionRange(range: Position(line: 1, utf16index: 13)..<Position(line: 5, utf16index: 13))
-    ), json: """
-    {
-      "parent" : {
-        "range" : {
-          "end" : {
-            "character" : 13,
-            "line" : 5
-          },
-          "start" : {
-            "character" : 13,
-            "line" : 1
-          }
-        }
-      },
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
-        }
-      }
-    }
-    """)
-  }
-
-  func testParameterInformationLabel() {
-    checkCoding(ParameterInformation.Label.string("hello"), json: #""hello""#)
-    checkCoding(ParameterInformation.Label.offsets(start: 4, end: 8), json: """
-    [
-      4,
-      8
-    ]
-    """)
-  }
-
-  func testWorkspaceDocumentDiagnosticReport() {
-    checkCoding(WorkspaceDocumentDiagnosticReport.full(WorkspaceFullDocumentDiagnosticReport(items: [], uri: DocumentURI(string: "file:///some/path"))), json: #"""
-    {
-      "items" : [
-
-      ],
-      "kind" : "full",
-      "uri" : "file:\/\/\/some\/path"
-    }
-    """#)
-
-    checkCoding(WorkspaceDocumentDiagnosticReport.unchanged(WorkspaceUnchangedDocumentDiagnosticReport(resultId: "myResults", uri: DocumentURI(string: "file:///some/path"))), json: #"""
-    {
-      "kind" : "unchanged",
-      "resultId" : "myResults",
-      "uri" : "file:\/\/\/some\/path"
-    }
-    """#)
-  }
-
-  func testWorkspaceSymbolItem() {
-    checkCoding(WorkspaceSymbolItem.symbolInformation(SymbolInformation(
-      name: "mySym",
-      kind: .constant,
-      location: Location(
-        uri: DocumentURI(string: "file:///some/path"),
-        range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)
-      )
-    )), json: #"""
-    {
-      "kind" : 14,
-      "location" : {
-        "range" : {
           "end" : {
             "character" : 3,
             "line" : 4
@@ -872,199 +778,569 @@ final class CodingTests: XCTestCase {
             "character" : 14,
             "line" : 3
           }
-        },
-        "uri" : "file:\/\/\/some\/path"
-      },
-      "name" : "mySym"
-    }
-    """#)
+        }
+        """
+    )
 
-    checkCoding(WorkspaceSymbolItem.workspaceSymbol(WorkspaceSymbol(
-      name: "mySym",
-      kind: .boolean,
-      location: WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: DocumentURI(string: "file:///some/path")))
-    )), json: #"""
-    {
-      "kind" : 17,
-      "location" : {
-        "uri" : "file:\/\/\/some\/path"
-      },
-      "name" : "mySym"
-    }
-    """#)
+    checkCoding(
+      CompletionList.ItemDefaultsEditRange.insertReplaceRanges(
+        .init(
+          insert: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          replace: Position(line: 5, utf16index: 12)..<Position(line: 6, utf16index: 2)
+        )
+      ),
+      json: """
+        {
+          "insert" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          },
+          "replace" : {
+            "end" : {
+              "character" : 2,
+              "line" : 6
+            },
+            "start" : {
+              "character" : 12,
+              "line" : 5
+            }
+          }
+        }
+        """
+    )
+  }
+
+  func testProgressToken() {
+    checkCoding(ProgressToken.integer(3), json: "3")
+    checkCoding(ProgressToken.string("foobar"), json: #""foobar""#)
+  }
+
+  func testDocumentDiagnosticReport() {
+    checkCoding(
+      DocumentDiagnosticReport.full(RelatedFullDocumentDiagnosticReport(items: [])),
+      json: """
+        {
+          "items" : [
+
+          ],
+          "kind" : "full"
+        }
+        """
+    )
+
+    checkCoding(
+      DocumentDiagnosticReport.full(RelatedFullDocumentDiagnosticReport(resultId: "myResults", items: [])),
+      json: """
+        {
+          "items" : [
+
+          ],
+          "kind" : "full",
+          "resultId" : "myResults"
+        }
+        """
+    )
+
+    checkCoding(
+      DocumentDiagnosticReport.full(
+        RelatedFullDocumentDiagnosticReport(
+          resultId: "myResults",
+          items: [],
+          relatedDocuments: [
+            DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(
+              RelatedUnchangedDocumentDiagnosticReport(resultId: "myOtherResults")
+            )
+          ]
+        )
+      ),
+      json: #"""
+        {
+          "items" : [
+
+          ],
+          "kind" : "full",
+          "relatedDocuments" : [
+            "file:\/\/\/some\/path",
+            {
+              "kind" : "unchanged",
+              "resultId" : "myOtherResults"
+            }
+          ],
+          "resultId" : "myResults"
+        }
+        """#
+    )
+
+    checkCoding(
+      DocumentDiagnosticReport.unchanged(RelatedUnchangedDocumentDiagnosticReport(resultId: "myResults")),
+      json: """
+        {
+          "kind" : "unchanged",
+          "resultId" : "myResults"
+        }
+        """
+    )
+
+    checkCoding(
+      DocumentDiagnosticReport.unchanged(
+        RelatedUnchangedDocumentDiagnosticReport(
+          resultId: "myResults",
+          relatedDocuments: [
+            DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(
+              RelatedUnchangedDocumentDiagnosticReport(resultId: "myOtherResults")
+            )
+          ]
+        )
+      ),
+      json: #"""
+        {
+          "kind" : "unchanged",
+          "relatedDocuments" : [
+            "file:\/\/\/some\/path",
+            {
+              "kind" : "unchanged",
+              "resultId" : "myOtherResults"
+            }
+          ],
+          "resultId" : "myResults"
+        }
+        """#
+    )
+  }
+
+  func testInlineValue() {
+    checkCoding(
+      InlineValue.text(
+        InlineValueText(
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          text: "xxx"
+        )
+      ),
+      json: """
+        {
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          },
+          "text" : "xxx"
+        }
+        """
+    )
+
+    checkCoding(
+      InlineValue.variableLookup(
+        InlineValueVariableLookup(
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          variableName: "myVar",
+          caseSensitiveLookup: true
+        )
+      ),
+      json: """
+        {
+          "caseSensitiveLookup" : true,
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          },
+          "variableName" : "myVar"
+        }
+        """
+    )
+
+    checkCoding(
+      InlineValue.evaluatableExpression(
+        InlineValueEvaluatableExpression(
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          expression: "myExpr"
+        )
+      ),
+      json: """
+        {
+          "expression" : "myExpr",
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          }
+        }
+        """
+    )
+  }
+
+  func testSelectionRange() {
+    checkCoding(
+      SelectionRange(
+        range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+        parent: SelectionRange(range: Position(line: 1, utf16index: 13)..<Position(line: 5, utf16index: 13))
+      ),
+      json: """
+        {
+          "parent" : {
+            "range" : {
+              "end" : {
+                "character" : 13,
+                "line" : 5
+              },
+              "start" : {
+                "character" : 13,
+                "line" : 1
+              }
+            }
+          },
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          }
+        }
+        """
+    )
+  }
+
+  func testParameterInformationLabel() {
+    checkCoding(ParameterInformation.Label.string("hello"), json: #""hello""#)
+    checkCoding(
+      ParameterInformation.Label.offsets(start: 4, end: 8),
+      json: """
+        [
+          4,
+          8
+        ]
+        """
+    )
+  }
+
+  func testWorkspaceDocumentDiagnosticReport() {
+    checkCoding(
+      WorkspaceDocumentDiagnosticReport.full(
+        WorkspaceFullDocumentDiagnosticReport(items: [], uri: DocumentURI(string: "file:///some/path"))
+      ),
+      json: #"""
+        {
+          "items" : [
+
+          ],
+          "kind" : "full",
+          "uri" : "file:\/\/\/some\/path"
+        }
+        """#
+    )
+
+    checkCoding(
+      WorkspaceDocumentDiagnosticReport.unchanged(
+        WorkspaceUnchangedDocumentDiagnosticReport(resultId: "myResults", uri: DocumentURI(string: "file:///some/path"))
+      ),
+      json: #"""
+        {
+          "kind" : "unchanged",
+          "resultId" : "myResults",
+          "uri" : "file:\/\/\/some\/path"
+        }
+        """#
+    )
+  }
+
+  func testWorkspaceSymbolItem() {
+    checkCoding(
+      WorkspaceSymbolItem.symbolInformation(
+        SymbolInformation(
+          name: "mySym",
+          kind: .constant,
+          location: Location(
+            uri: DocumentURI(string: "file:///some/path"),
+            range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)
+          )
+        )
+      ),
+      json: #"""
+        {
+          "kind" : 14,
+          "location" : {
+            "range" : {
+              "end" : {
+                "character" : 3,
+                "line" : 4
+              },
+              "start" : {
+                "character" : 14,
+                "line" : 3
+              }
+            },
+            "uri" : "file:\/\/\/some\/path"
+          },
+          "name" : "mySym"
+        }
+        """#
+    )
+
+    checkCoding(
+      WorkspaceSymbolItem.workspaceSymbol(
+        WorkspaceSymbol(
+          name: "mySym",
+          kind: .boolean,
+          location: WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: DocumentURI(string: "file:///some/path")))
+        )
+      ),
+      json: #"""
+        {
+          "kind" : 17,
+          "location" : {
+            "uri" : "file:\/\/\/some\/path"
+          },
+          "name" : "mySym"
+        }
+        """#
+    )
   }
 
   func testWorkspapceSymbolLocation() {
-    checkCoding(WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: DocumentURI(string: "file:///some/path"))), json: #"""
-    {
-      "uri" : "file:\/\/\/some\/path"
-    }
-    """#)
-
-    checkCoding(WorkspaceSymbol.WorkspaceSymbolLocation.location(Location(
-      uri: DocumentURI(string: "file:///some/path"),
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)
-    )), json: #"""
-    {
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
+    checkCoding(
+      WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: DocumentURI(string: "file:///some/path"))),
+      json: #"""
+        {
+          "uri" : "file:\/\/\/some\/path"
         }
-      },
-      "uri" : "file:\/\/\/some\/path"
-    }
-    """#)
+        """#
+    )
+
+    checkCoding(
+      WorkspaceSymbol.WorkspaceSymbolLocation.location(
+        Location(
+          uri: DocumentURI(string: "file:///some/path"),
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)
+        )
+      ),
+      json: #"""
+        {
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          },
+          "uri" : "file:\/\/\/some\/path"
+        }
+        """#
+    )
   }
 
   func testCompletionItemEdit() {
-    checkCoding(CompletionItemEdit.textEdit(TextEdit(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      newText: "some new text"
-    )), json: """
-    {
-      "newText" : "some new text",
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
+    checkCoding(
+      CompletionItemEdit.textEdit(
+        TextEdit(
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          newText: "some new text"
+        )
+      ),
+      json: """
+        {
+          "newText" : "some new text",
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          }
         }
-      }
-    }
-    """)
+        """
+    )
 
-    checkCoding(CompletionItemEdit.insertReplaceEdit(InsertReplaceEdit(
-      newText: "some new text",
-      insert: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      replace: Position(line: 2, utf16index: 8)..<Position(line: 2, utf16index: 9)
-    )), json: """
-    {
-      "insert" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
+    checkCoding(
+      CompletionItemEdit.insertReplaceEdit(
+        InsertReplaceEdit(
+          newText: "some new text",
+          insert: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          replace: Position(line: 2, utf16index: 8)..<Position(line: 2, utf16index: 9)
+        )
+      ),
+      json: """
+        {
+          "insert" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          },
+          "newText" : "some new text",
+          "replace" : {
+            "end" : {
+              "character" : 9,
+              "line" : 2
+            },
+            "start" : {
+              "character" : 8,
+              "line" : 2
+            }
+          }
         }
-      },
-      "newText" : "some new text",
-      "replace" : {
-        "end" : {
-          "character" : 9,
-          "line" : 2
-        },
-        "start" : {
-          "character" : 8,
-          "line" : 2
-        }
-      }
-    }
-    """)
+        """
+    )
   }
 
   func testNotebookCellTextDocumentFilter() {
     checkCoding(NotebookCellTextDocumentFilter.NotebookFilter.string("abc"), json: #""abc""#)
-    checkCoding(NotebookCellTextDocumentFilter.NotebookFilter.notebookDocumentFilter(NotebookDocumentFilter(pattern: "xxx")), json: """
-    {
-      "pattern" : "xxx"
-    }
-    """)
+    checkCoding(
+      NotebookCellTextDocumentFilter.NotebookFilter.notebookDocumentFilter(NotebookDocumentFilter(pattern: "xxx")),
+      json: """
+        {
+          "pattern" : "xxx"
+        }
+        """
+    )
   }
 
   func testStringOrMarkupContent() {
     checkCoding(StringOrMarkupContent.string("hello"), json: #""hello""#)
-    checkCoding(StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: "hello")), json: """
-    {
-      "kind" : "markdown",
-      "value" : "hello"
-    }
-    """)
+    checkCoding(
+      StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: "hello")),
+      json: """
+        {
+          "kind" : "markdown",
+          "value" : "hello"
+        }
+        """
+    )
   }
 
   func testTextDocumentEdit() {
-    checkCoding(TextDocumentEdit.Edit.textEdit(TextEdit(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      newText: "some new text"
-    )), json: """
-    {
-      "newText" : "some new text",
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
+    checkCoding(
+      TextDocumentEdit.Edit.textEdit(
+        TextEdit(
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          newText: "some new text"
+        )
+      ),
+      json: """
+        {
+          "newText" : "some new text",
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          }
         }
-      }
-    }
-    """)
+        """
+    )
 
-    checkCoding(TextDocumentEdit.Edit.annotatedTextEdit(AnnotatedTextEdit(
-      range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
-      newText: "some new text",
-      annotationId: "change-34"
-    )), json: """
-    {
-      "annotationId" : "change-34",
-      "newText" : "some new text",
-      "range" : {
-        "end" : {
-          "character" : 3,
-          "line" : 4
-        },
-        "start" : {
-          "character" : 14,
-          "line" : 3
+    checkCoding(
+      TextDocumentEdit.Edit.annotatedTextEdit(
+        AnnotatedTextEdit(
+          range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3),
+          newText: "some new text",
+          annotationId: "change-34"
+        )
+      ),
+      json: """
+        {
+          "annotationId" : "change-34",
+          "newText" : "some new text",
+          "range" : {
+            "end" : {
+              "character" : 3,
+              "line" : 4
+            },
+            "start" : {
+              "character" : 14,
+              "line" : 3
+            }
+          }
         }
-      }
-    }
-    """)
+        """
+    )
   }
 
   func testWorkDoneProgress() {
-    checkCoding(WorkDoneProgress(token: ProgressToken.integer(3), value: WorkDoneProgressKind.begin(WorkDoneProgressBegin(title: "My Work"))), json: """
-    {
-      "token" : 3,
-      "value" : {
-        "kind" : "begin",
-        "title" : "My Work"
-      }
-    }
-    """)
+    checkCoding(
+      WorkDoneProgress(
+        token: ProgressToken.integer(3),
+        value: WorkDoneProgressKind.begin(WorkDoneProgressBegin(title: "My Work"))
+      ),
+      json: """
+        {
+          "token" : 3,
+          "value" : {
+            "kind" : "begin",
+            "title" : "My Work"
+          }
+        }
+        """
+    )
   }
 
   func testWorkDoneProgressType() {
-    checkCoding(WorkDoneProgressKind.begin(WorkDoneProgressBegin(title: "My Work")), json: """
-    {
-      "kind" : "begin",
-      "title" : "My Work"
-    }
-    """)
+    checkCoding(
+      WorkDoneProgressKind.begin(WorkDoneProgressBegin(title: "My Work")),
+      json: """
+        {
+          "kind" : "begin",
+          "title" : "My Work"
+        }
+        """
+    )
 
-    checkCoding(WorkDoneProgressKind.report(WorkDoneProgressReport(message: "Still working")), json: """
-    {
-      "kind" : "report",
-      "message" : "Still working"
-    }
-    """)
+    checkCoding(
+      WorkDoneProgressKind.report(WorkDoneProgressReport(message: "Still working")),
+      json: """
+        {
+          "kind" : "report",
+          "message" : "Still working"
+        }
+        """
+    )
 
-    checkCoding(WorkDoneProgressKind.end(WorkDoneProgressEnd()), json: """
-    {
-      "kind" : "end"
-    }
-    """)
+    checkCoding(
+      WorkDoneProgressKind.end(WorkDoneProgressEnd()),
+      json: """
+        {
+          "kind" : "end"
+        }
+        """
+    )
   }
 }
 

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import XCTest
 
 // Workaround ambiguity with Foundation.

--- a/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
+++ b/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
-
 import XCTest
 
 fileprivate func AssertDataIsString(

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -12,8 +12,8 @@
 
 import BuildServerProtocol
 import Foundation
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import SKTestSupport
 import TSCBasic
@@ -22,9 +22,11 @@ import XCTest
 final class BuildServerBuildSystemTests: XCTestCase {
 
   var root: AbsolutePath {
-    try! AbsolutePath(validating: XCTestCase.sklspInputsDirectory
-      .appendingPathComponent(testDirectoryName, isDirectory: true).path)
-  } 
+    try! AbsolutePath(
+      validating: XCTestCase.sklspInputsDirectory
+        .appendingPathComponent(testDirectoryName, isDirectory: true).path
+    )
+  }
   let buildFolder = try! AbsolutePath(validating: NSTemporaryDirectory())
 
   func testServerInitialize() async throws {
@@ -63,9 +65,11 @@ final class BuildServerBuildSystemTests: XCTestCase {
     let expectation = XCTestExpectation(description: "target changed")
     let targetIdentifier = BuildTargetIdentifier(uri: DocumentURI(string: "build://target/a"))
     let buildSystemDelegate = TestDelegate(targetExpectations: [
-      BuildTargetEvent(target: targetIdentifier,
+      BuildTargetEvent(
+        target: targetIdentifier,
         kind: .created,
-        data: .dictionary(["key": "value"])): expectation,
+        data: .dictionary(["key": "value"])
+      ): expectation
     ])
     defer {
       // BuildSystemManager has a weak reference to delegate. Keep it alive.
@@ -81,12 +85,14 @@ final class BuildServerBuildSystemTests: XCTestCase {
 final class TestDelegate: BuildSystemDelegate {
 
   let settingsExpectations: [DocumentURI: XCTestExpectation]
-  let targetExpectations: [BuildTargetEvent:XCTestExpectation]
-  let dependenciesUpdatedExpectations: [DocumentURI:XCTestExpectation]
+  let targetExpectations: [BuildTargetEvent: XCTestExpectation]
+  let dependenciesUpdatedExpectations: [DocumentURI: XCTestExpectation]
 
-  public init(settingsExpectations: [DocumentURI:XCTestExpectation] = [:],
-              targetExpectations: [BuildTargetEvent:XCTestExpectation] = [:],
-              dependenciesUpdatedExpectations: [DocumentURI:XCTestExpectation] = [:]) {
+  public init(
+    settingsExpectations: [DocumentURI: XCTestExpectation] = [:],
+    targetExpectations: [BuildTargetEvent: XCTestExpectation] = [:],
+    dependenciesUpdatedExpectations: [DocumentURI: XCTestExpectation] = [:]
+  ) {
     self.settingsExpectations = settingsExpectations
     self.targetExpectations = targetExpectations
     self.dependenciesUpdatedExpectations = dependenciesUpdatedExpectations

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import BuildServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import TSCBasic
 import XCTest
@@ -36,8 +36,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: nil,
       fallbackBuildSystem: FallbackBuildSystem(buildSetup: .default),
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
 
     await assertEqual(bsm._cachedMainFile(for: a), nil)
     await assertEqual(bsm._cachedMainFile(for: b), nil)
@@ -97,8 +98,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
@@ -120,8 +122,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     assertNil(await bsm.buildSettingsInferredFromMainFile(for: a, language: .swift)?.buildSettings)
@@ -142,8 +145,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: fallback,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
     let fallbackSettings = fallback.buildSettings(for: a, language: .swift)
     await bsm.registerForChangeNotifications(for: a, language: .swift)
@@ -171,8 +175,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
@@ -211,8 +216,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["a"])
@@ -247,8 +253,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     bs.map[cpp1] = FileBuildSettings(compilerArguments: ["C++ 1"])
@@ -299,18 +306,18 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     let cppArg = "C++ Main File"
     bs.map[cpp] = FileBuildSettings(compilerArguments: [cppArg, cpp.pseudoPath])
 
-
     await bsm.registerForChangeNotifications(for: h1, language: .c)
 
     await bsm.registerForChangeNotifications(for: h2, language: .c)
-    
+
     let expectedArgsH1 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h1.pseudoPath])
     let expectedArgsH2 = FileBuildSettings(compilerArguments: ["-xc++", cppArg, h2.pseudoPath])
     assertEqual(await bsm.buildSettingsInferredFromMainFile(for: h1, language: .c)?.buildSettings, expectedArgsH1)
@@ -341,8 +348,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["a"])
@@ -362,7 +370,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let changedB = expectation(description: "changed settings b")
     await del.setExpected([
-      (b, .swift, bs.map[b]!, changedB, #file, #line),
+      (b, .swift, bs.map[b]!, changedB, #file, #line)
     ])
 
     await bsm.unregisterForChangeNotifications(for: a)
@@ -383,8 +391,9 @@ final class BuildSystemManagerTests: XCTestCase {
     let bsm = await BuildSystemManager(
       buildSystem: bs,
       fallbackBuildSystem: nil,
-      mainFilesProvider: mainFiles)
-    defer { withExtendedLifetime(bsm) {} } // Keep BSM alive for callbacks.
+      mainFilesProvider: mainFiles
+    )
+    defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
 
     bs.map[a] = FileBuildSettings(compilerArguments: ["x"])
@@ -456,8 +465,13 @@ class ManualBuildSystem: BuildSystem {
 
 /// A `BuildSystemDelegate` setup for testing.
 private actor BSMDelegate: BuildSystemDelegate {
-  fileprivate typealias ExpectedBuildSettingChangedCall = (uri: DocumentURI, language: Language, settings: FileBuildSettings?, expectation: XCTestExpectation, file: StaticString, line: UInt)
-  fileprivate typealias ExpectedDependenciesUpdatedCall = (uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt)
+  fileprivate typealias ExpectedBuildSettingChangedCall = (
+    uri: DocumentURI, language: Language, settings: FileBuildSettings?, expectation: XCTestExpectation,
+    file: StaticString, line: UInt
+  )
+  fileprivate typealias ExpectedDependenciesUpdatedCall = (
+    uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt
+  )
 
   let queue: DispatchQueue = DispatchQueue(label: "\(BSMDelegate.self)")
   unowned let bsm: BuildSystemManager
@@ -468,7 +482,8 @@ private actor BSMDelegate: BuildSystemDelegate {
     self.expected = expected
   }
 
-  var expectedDependenciesUpdate: [(uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt)] = []
+  var expectedDependenciesUpdate: [(uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt)] =
+    []
 
   /// - Note: Needed to set `expected` outside of the actor's isolation context.
   func setExpectedDependenciesUpdate(_ expectedDependenciesUpdated: [ExpectedDependenciesUpdatedCall]) {
@@ -510,6 +525,6 @@ private actor BSMDelegate: BuildSystemDelegate {
       expected.expectation.fulfill()
     }
   }
-  
+
   func fileHandlingCapabilityChanged() {}
 }

--- a/Tests/SKCoreTests/CompilationDatabasePerfTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabasePerfTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import TSCBasic
 import XCTest
@@ -24,7 +24,7 @@ final class CompilationDatabasePerfTests: PerfTestCase {
         input += " \"foo\(i) \""
       } else if i % 10 == 6 {
         input += " fo\'o\(i) \'"
-      } else if i % 3 == 0{
+      } else if i % 3 == 0 {
         input += " foo\(i)-------a-long--string-of---------stuff"
       } else {
         input += " foo\(i)"

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -10,15 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import TSCBasic
 import XCTest
 
 final class CompilationDatabaseTests: XCTestCase {
   func testSplitShellEscapedCommand() {
-    func check(_ str: String, _ expected: [String], file: StaticString=#filePath, line: UInt=#line) {
+    func check(_ str: String, _ expected: [String], file: StaticString = #filePath, line: UInt = #line) {
       XCTAssertEqual(splitShellEscapedCommand(str), expected, file: file, line: line)
     }
 
@@ -60,28 +60,45 @@ final class CompilationDatabaseTests: XCTestCase {
 
   func testEncodeCompDBCommand() throws {
     // Requires JSONEncoder.OutputFormatting.sortedKeys
-    func check(_ cmd: CompilationDatabase.Command, _ expected: String, file: StaticString = #filePath, line: UInt = #line) throws {
+    func check(
+      _ cmd: CompilationDatabase.Command,
+      _ expected: String,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws {
       let encoder = JSONEncoder()
       encoder.outputFormatting.insert(.sortedKeys)
       let encodedString = try String(data: encoder.encode(cmd), encoding: .utf8)
       XCTAssertEqual(encodedString, expected, file: file, line: line)
     }
 
-    try check(.init(directory: "a", filename: "b", commandLine: [], output: "c"), """
+    try check(
+      .init(directory: "a", filename: "b", commandLine: [], output: "c"),
+      """
       {"arguments":[],"directory":"a","file":"b","output":"c"}
-      """)
-    try check(.init(directory: "a", filename: "b", commandLine: ["c", "d"], output: nil), """
+      """
+    )
+    try check(
+      .init(directory: "a", filename: "b", commandLine: ["c", "d"], output: nil),
+      """
       {"arguments":["c","d"],"directory":"a","file":"b"}
-      """)
+      """
+    )
   }
 
   func testDecodeCompDBCommand() throws {
-    func check(_ str: String, _ expected: CompilationDatabase.Command, file: StaticString = #filePath, line: UInt = #line) throws {
+    func check(
+      _ str: String,
+      _ expected: CompilationDatabase.Command,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws {
       let cmd = try JSONDecoder().decode(CompilationDatabase.Command.self, from: str.data(using: .utf8)!)
       XCTAssertEqual(cmd, expected, file: file, line: line)
     }
 
-    try check("""
+    try check(
+      """
       {
         "arguments" : [
 
@@ -90,8 +107,11 @@ final class CompilationDatabaseTests: XCTestCase {
         "file" : "b",
         "output" : "c"
       }
-      """, .init(directory: "a", filename: "b", commandLine: [], output: "c"))
-    try check("""
+      """,
+      .init(directory: "a", filename: "b", commandLine: [], output: "c")
+    )
+    try check(
+      """
       {
         "arguments" : [
           "c",
@@ -100,15 +120,19 @@ final class CompilationDatabaseTests: XCTestCase {
         "directory" : "a",
         "file" : "b"
       }
-      """, .init(directory: "a", filename: "b", commandLine: ["c", "d"], output: nil))
+      """,
+      .init(directory: "a", filename: "b", commandLine: ["c", "d"], output: nil)
+    )
 
-    try check("""
+    try check(
+      """
       {
         "directory":"a",
         "file":"b.cpp",
         "command": "/usr/bin/clang++ -std=c++11 -DFOO b.cpp"
       }
-      """, .init(
+      """,
+      .init(
         directory: "a",
         filename: "b.cpp",
         commandLine: [
@@ -118,41 +142,53 @@ final class CompilationDatabaseTests: XCTestCase {
           "b.cpp",
         ],
         output: nil
-    ))
+      )
+    )
 
-    XCTAssertThrowsError(try JSONDecoder().decode(CompilationDatabase.Command.self, from: """
-      {"directory":"a","file":"b"}
-    """.data(using: .utf8)!))
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(
+        CompilationDatabase.Command.self,
+        from: """
+            {"directory":"a","file":"b"}
+          """.data(using: .utf8)!
+      )
+    )
   }
 
   func testJSONCompilationDatabaseCoding() {
-    checkCoding(JSONCompilationDatabase([]), json: """
-      [
+    checkCoding(
+      JSONCompilationDatabase([]),
+      json: """
+        [
 
-      ]
-      """)
+        ]
+        """
+    )
     let db = JSONCompilationDatabase([
       .init(directory: "a", filename: "b", commandLine: [], output: nil),
       .init(directory: "c", filename: "b", commandLine: [], output: nil),
-      ])
-    checkCoding(db, json: """
-      [
-        {
-          "arguments" : [
+    ])
+    checkCoding(
+      db,
+      json: """
+        [
+          {
+            "arguments" : [
 
-          ],
-          "directory" : "a",
-          "file" : "b"
-        },
-        {
-          "arguments" : [
+            ],
+            "directory" : "a",
+            "file" : "b"
+          },
+          {
+            "arguments" : [
 
-          ],
-          "directory" : "c",
-          "file" : "b"
-        }
-      ]
-      """)
+            ],
+            "directory" : "c",
+            "file" : "b"
+          }
+        ]
+        """
+    )
   }
 
   func testJSONCompilationDatabaseLookup() {
@@ -172,15 +208,18 @@ final class CompilationDatabaseTests: XCTestCase {
     try fs.createDirectory(AbsolutePath(validating: "/a"))
     XCTAssertNil(tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs))
 
-    try fs.writeFileContents(AbsolutePath(validating: "/a/compile_commands.json"), bytes: """
-      [
-        {
-          "file": "/a/a.swift",
-          "directory": "/a",
-          "arguments": ["swiftc", "/a/a.swift"]
-        }
-      ]
-      """)
+    try fs.writeFileContents(
+      AbsolutePath(validating: "/a/compile_commands.json"),
+      bytes: """
+        [
+          {
+            "file": "/a/a.swift",
+            "directory": "/a",
+            "arguments": ["swiftc", "/a/a.swift"]
+          }
+        ]
+        """
+    )
 
     XCTAssertNotNil(tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs))
   }
@@ -190,34 +229,47 @@ final class CompilationDatabaseTests: XCTestCase {
     try fs.createDirectory(try AbsolutePath(validating: "/a"))
     XCTAssertNil(tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs))
 
-    try fs.writeFileContents(try AbsolutePath(validating: "/a/compile_flags.txt"), bytes: """
-      -xc++
-      -I
-      libwidget/include/
-      """)
+    try fs.writeFileContents(
+      try AbsolutePath(validating: "/a/compile_flags.txt"),
+      bytes: """
+        -xc++
+        -I
+        libwidget/include/
+        """
+    )
 
     let db = tryLoadCompilationDatabase(directory: try AbsolutePath(validating: "/a"), fs)
     XCTAssertNotNil(db)
 
-    XCTAssertEqual(db![URL(fileURLWithPath: "/a/b")], [
-      CompilationDatabase.Command(directory: try AbsolutePath(validating: "/a").pathString,
-                                  filename: "/a/b",
-                                  commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"],
-                                  output: nil)
-    ])
+    XCTAssertEqual(
+      db![URL(fileURLWithPath: "/a/b")],
+      [
+        CompilationDatabase.Command(
+          directory: try AbsolutePath(validating: "/a").pathString,
+          filename: "/a/b",
+          commandLine: ["clang", "-xc++", "-I", "libwidget/include/", "/a/b"],
+          output: nil
+        )
+      ]
+    )
   }
 
   func testCompilationDatabaseBuildSystem() async throws {
-    try await checkCompilationDatabaseBuildSystem("""
-    [
-      {
-        "file": "/a/a.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-swift-version", "4", "/a/a.swift"]
-      }
-    ]
-    """) { buildSystem in
-      let settings = await buildSystem.buildSettings(for: DocumentURI(URL(fileURLWithPath: "/a/a.swift")), language: .swift)
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "/a/a.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-swift-version", "4", "/a/a.swift"]
+        }
+      ]
+      """
+    ) { buildSystem in
+      let settings = await buildSystem.buildSettings(
+        for: DocumentURI(URL(fileURLWithPath: "/a/a.swift")),
+        language: .swift
+      )
       XCTAssertNotNil(settings)
       XCTAssertEqual(settings?.workingDirectory, "/a")
       XCTAssertEqual(settings?.compilerArguments, ["-swift-version", "4", "/a/a.swift"])
@@ -233,99 +285,112 @@ final class CompilationDatabaseTests: XCTestCase {
   }
 
   func testCompilationDatabaseBuildSystemIndexStoreSwift1() async throws {
-    try await checkCompilationDatabaseBuildSystem("""
-    [
-      {
-        "file": "/a/a.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-swift-version", "4", "/a/a.swift", "-index-store-path", "/b"]
-      }
-    ]
-    """) { buildSystem in
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "/a/a.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-swift-version", "4", "/a/a.swift", "-index-store-path", "/b"]
+        }
+      ]
+      """
+    ) { buildSystem in
       assertEqual(URL(fileURLWithPath: await buildSystem.indexStorePath?.pathString ?? "").path, "/b")
       assertEqual(URL(fileURLWithPath: await buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
     }
   }
 
   func testCompilationDatabaseBuildSystemIndexStoreSwift2() async throws {
-    try await checkCompilationDatabaseBuildSystem("""
-    [
-      {
-        "file": "/a/a.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-swift-version", "4", "/a/a.swift"]
-      },
-      {
-        "file": "/a/b.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-swift-version", "4", "/a/b.swift"]
-      },
-      {
-        "file": "/a/c.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-swift-version", "4", "/a/c.swift", "-index-store-path", "/b"]
-      }
-    ]
-    """) { buildSystem in
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "/a/a.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-swift-version", "4", "/a/a.swift"]
+        },
+        {
+          "file": "/a/b.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-swift-version", "4", "/a/b.swift"]
+        },
+        {
+          "file": "/a/c.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-swift-version", "4", "/a/c.swift", "-index-store-path", "/b"]
+        }
+      ]
+      """
+    ) { buildSystem in
       await assertEqual(buildSystem.indexStorePath, try AbsolutePath(validating: "/b"))
     }
   }
 
   func testCompilationDatabaseBuildSystemIndexStoreSwift3() async throws {
-    try await checkCompilationDatabaseBuildSystem("""
-    [
-      {
-        "file": "/a/a.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-index-store-path", "/b", "-swift-version", "4", "/a/a.swift"]
-      }
-    ]
-    """) { buildSystem in
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "/a/a.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-index-store-path", "/b", "-swift-version", "4", "/a/a.swift"]
+        }
+      ]
+      """
+    ) { buildSystem in
       assertEqual(await buildSystem.indexStorePath, try AbsolutePath(validating: "/b"))
     }
   }
 
   func testCompilationDatabaseBuildSystemIndexStoreSwift4() async throws {
-    try await checkCompilationDatabaseBuildSystem("""
-    [
-      {
-        "file": "/a/a.swift",
-        "directory": "/a",
-        "arguments": ["swiftc", "-swift-version", "4", "/a/c.swift", "-index-store-path"]
-      }
-    ]
-    """) { buildSystem in
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "/a/a.swift",
+          "directory": "/a",
+          "arguments": ["swiftc", "-swift-version", "4", "/a/c.swift", "-index-store-path"]
+        }
+      ]
+      """
+    ) { buildSystem in
       assertNil(await buildSystem.indexStorePath)
     }
   }
 
   func testCompilationDatabaseBuildSystemIndexStoreClang() async throws {
-    try await checkCompilationDatabaseBuildSystem("""
-    [
-      {
-        "file": "/a/a.cpp",
-        "directory": "/a",
-        "arguments": ["clang", "/a/a.cpp"]
-      },
-      {
-        "file": "/a/b.cpp",
-        "directory": "/a",
-        "arguments": ["clang", "/a/b.cpp"]
-      },
-      {
-        "file": "/a/c.cpp",
-        "directory": "/a",
-        "arguments": ["clang", "/a/c.cpp", "-index-store-path", "/b"]
-      }
-    ]
-    """) { buildSystem in
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "/a/a.cpp",
+          "directory": "/a",
+          "arguments": ["clang", "/a/a.cpp"]
+        },
+        {
+          "file": "/a/b.cpp",
+          "directory": "/a",
+          "arguments": ["clang", "/a/b.cpp"]
+        },
+        {
+          "file": "/a/c.cpp",
+          "directory": "/a",
+          "arguments": ["clang", "/a/c.cpp", "-index-store-path", "/b"]
+        }
+      ]
+      """
+    ) { buildSystem in
       assertEqual(URL(fileURLWithPath: await buildSystem.indexStorePath?.pathString ?? "").path, "/b")
       assertEqual(URL(fileURLWithPath: await buildSystem.indexDatabasePath?.pathString ?? "").path, "/IndexDatabase")
     }
   }
 }
 
-private func checkCompilationDatabaseBuildSystem(_ compdb: ByteString, block: (CompilationDatabaseBuildSystem) async throws -> ()) async throws {
+private func checkCompilationDatabaseBuildSystem(
+  _ compdb: ByteString,
+  block: (CompilationDatabaseBuildSystem) async throws -> ()
+) async throws {
   let fs = InMemoryFileSystem()
   try fs.createDirectory(AbsolutePath(validating: "/a"))
   try fs.writeFileContents(AbsolutePath(validating: "/a/compile_commands.json"), bytes: compdb)

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -33,78 +33,104 @@ final class FallbackBuildSystemTests: XCTestCase {
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
-    XCTAssertEqual(args, [
-      "-sdk",
-      sdk.pathString,
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      args,
+      [
+        "-sdk",
+        sdk.pathString,
+        source.pathString,
+      ]
+    )
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments, [
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments,
+      [
+        source.pathString
+      ]
+    )
   }
 
   func testSwiftWithCustomFlags() throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.swift")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(swiftCompilerFlags: [
-      "-Xfrontend",
-      "-debug-constraints"
-    ]))
+    let buildSetup = BuildSetup(
+      configuration: .debug,
+      path: nil,
+      flags: BuildFlags(swiftCompilerFlags: [
+        "-Xfrontend",
+        "-debug-constraints",
+      ])
+    )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
     let args = bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments
-    XCTAssertEqual(args, [
-      "-Xfrontend",
-      "-debug-constraints",
-      "-sdk",
-      sdk.pathString,
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      args,
+      [
+        "-Xfrontend",
+        "-debug-constraints",
+        "-sdk",
+        sdk.pathString,
+        source.pathString,
+      ]
+    )
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments, [
-      "-Xfrontend",
-      "-debug-constraints",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments,
+      [
+        "-Xfrontend",
+        "-debug-constraints",
+        source.pathString,
+      ]
+    )
   }
 
   func testSwiftWithCustomSDKFlag() throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.swift")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(swiftCompilerFlags: [
-      "-sdk",
-      "/some/custom/sdk",
-      "-Xfrontend",
-      "-debug-constraints",
-    ]))
+    let buildSetup = BuildSetup(
+      configuration: .debug,
+      path: nil,
+      flags: BuildFlags(swiftCompilerFlags: [
+        "-sdk",
+        "/some/custom/sdk",
+        "-Xfrontend",
+        "-debug-constraints",
+      ])
+    )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments, [
-      "-sdk",
-      "/some/custom/sdk",
-      "-Xfrontend",
-      "-debug-constraints",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments,
+      [
+        "-sdk",
+        "/some/custom/sdk",
+        "-Xfrontend",
+        "-debug-constraints",
+        source.pathString,
+      ]
+    )
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments, [
-      "-sdk",
-      "/some/custom/sdk",
-      "-Xfrontend",
-      "-debug-constraints",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments,
+      [
+        "-sdk",
+        "/some/custom/sdk",
+        "-Xfrontend",
+        "-debug-constraints",
+        source.pathString,
+      ]
+    )
   }
 
   func testCXX() throws {
@@ -118,112 +144,154 @@ final class FallbackBuildSystemTests: XCTestCase {
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
-    XCTAssertEqual(args, [
-      "-isysroot",
-      sdk.pathString,
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      args,
+      [
+        "-isysroot",
+        sdk.pathString,
+        source.pathString,
+      ]
+    )
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+      [
+        source.pathString
+      ]
+    )
   }
 
   func testCXXWithCustomFlags() throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.cpp")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cxxCompilerFlags: [
-      "-v"
-    ]))
+    let buildSetup = BuildSetup(
+      configuration: .debug,
+      path: nil,
+      flags: BuildFlags(cxxCompilerFlags: [
+        "-v"
+      ])
+    )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
-      "-v",
-      "-isysroot",
-      sdk.pathString,
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+      [
+        "-v",
+        "-isysroot",
+        sdk.pathString,
+        source.pathString,
+      ]
+    )
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
-      "-v",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+      [
+        "-v",
+        source.pathString,
+      ]
+    )
   }
 
   func testCXXWithCustomIsysroot() throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.cpp")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cxxCompilerFlags: [
-      "-isysroot",
-      "/my/custom/sdk",
-      "-v"
-    ]))
+    let buildSetup = BuildSetup(
+      configuration: .debug,
+      path: nil,
+      flags: BuildFlags(cxxCompilerFlags: [
+        "-isysroot",
+        "/my/custom/sdk",
+        "-v",
+      ])
+    )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = sdk
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
-      "-isysroot",
-      "/my/custom/sdk",
-      "-v",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+      [
+        "-isysroot",
+        "/my/custom/sdk",
+        "-v",
+        source.pathString,
+      ]
+    )
 
     bs.sdkpath = nil
 
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments, [
-      "-isysroot",
-      "/my/custom/sdk",
-      "-v",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+      [
+        "-isysroot",
+        "/my/custom/sdk",
+        "-v",
+        source.pathString,
+      ]
+    )
   }
 
   func testC() throws {
     let source = try AbsolutePath(validating: "/my/source.c")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments, [
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments,
+      [
+        source.pathString
+      ]
+    )
   }
 
   func testCWithCustomFlags() throws {
     let source = try AbsolutePath(validating: "/my/source.c")
 
-    let buildSetup = BuildSetup(configuration: .debug, path: nil, flags: BuildFlags(cCompilerFlags: [
-      "-v"
-    ]))
+    let buildSetup = BuildSetup(
+      configuration: .debug,
+      path: nil,
+      flags: BuildFlags(cCompilerFlags: [
+        "-v"
+      ])
+    )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments, [
-      "-v",
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments,
+      [
+        "-v",
+        source.pathString,
+      ]
+    )
   }
 
   func testObjC() throws {
     let source = try AbsolutePath(validating: "/my/source.m")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .objective_c)?.compilerArguments, [
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .objective_c)?.compilerArguments,
+      [
+        source.pathString
+      ]
+    )
   }
 
   func testObjCXX() throws {
     let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
     bs.sdkpath = nil
-    XCTAssertEqual(bs.buildSettings(for: source.asURI, language: .objective_cpp)?.compilerArguments, [
-      source.pathString,
-    ])
+    XCTAssertEqual(
+      bs.buildSettings(for: source.asURI, language: .objective_cpp)?.compilerArguments,
+      [
+        source.pathString
+      ]
+    )
   }
 
   func testUnknown() throws {

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -43,7 +43,9 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     let a = Toolchain(identifier: "a", displayName: "a", path: nil)
     try tr.registerToolchain(a)
-    try tr.registerToolchain(Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil))
+    try tr.registerToolchain(
+      Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil)
+    )
     XCTAssertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
     tr.default = a
     XCTAssertEqual(tr.default?.identifier, "a")
@@ -68,8 +70,8 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testSearchDarwin() throws {
-// FIXME: requires PropertyListEncoder
-#if os(macOS)
+    // FIXME: requires PropertyListEncoder
+    #if os(macOS)
     let fs = InMemoryFileSystem()
     let tr1 = ToolchainRegistry(fs)
     tr1.darwinToolchainOverride = nil
@@ -80,8 +82,10 @@ final class ToolchainRegistryTests: XCTestCase {
     try makeXCToolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
       opensource: false,
-      toolchains.appending(component: "XcodeDefault.xctoolchain"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "XcodeDefault.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
 
     XCTAssertNil(tr1.default)
     XCTAssert(tr1.toolchains.isEmpty)
@@ -108,13 +112,17 @@ final class ToolchainRegistryTests: XCTestCase {
     try makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
-      toolchains.appending(component: "A.xctoolchain"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "A.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
     try makeXCToolchain(
       identifier: "com.apple.fake.B",
       opensource: false,
-      toolchains.appending(component: "B.xctoolchain"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "B.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
 
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 3)
@@ -122,13 +130,17 @@ final class ToolchainRegistryTests: XCTestCase {
     try makeXCToolchain(
       identifier: "com.apple.fake.C",
       opensource: false,
-      toolchains.appending(component: "C.wrong_extension"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "C.wrong_extension"),
+      fs,
+      sourcekitd: true
+    )
     try makeXCToolchain(
       identifier: "com.apple.fake.D",
       opensource: false,
-      toolchains.appending(component: "D_no_extension"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "D_no_extension"),
+      fs,
+      sourcekitd: true
+    )
 
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 3)
@@ -136,8 +148,10 @@ final class ToolchainRegistryTests: XCTestCase {
     try makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
-      toolchains.appending(component: "E.xctoolchain"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "E.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
 
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 3)
@@ -145,13 +159,17 @@ final class ToolchainRegistryTests: XCTestCase {
     try makeXCToolchain(
       identifier: "org.fake.global.A",
       opensource: true,
-      try AbsolutePath(validating: "/Library/Developer/Toolchains/A.xctoolchain"), fs,
-      sourcekitd: true)
+      try AbsolutePath(validating: "/Library/Developer/Toolchains/A.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
     try makeXCToolchain(
       identifier: "org.fake.global.B",
       opensource: true,
-      try AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"), fs,
-      sourcekitd: true)
+      try AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
 
     tr.scanForToolchains(fs)
     XCTAssertEqual(tr.toolchains.count, 5)
@@ -160,8 +178,10 @@ final class ToolchainRegistryTests: XCTestCase {
     try makeXCToolchain(
       identifier: "org.fake.explicit",
       opensource: false,
-      toolchains.appending(component: "Explicit.xctoolchain"), fs,
-      sourcekitd: true)
+      toolchains.appending(component: "Explicit.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
 
     let tc = Toolchain(path, fs)
     XCTAssertNotNil(tc)
@@ -173,9 +193,15 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertEqual(tc?.path, tcBin?.path)
     XCTAssertEqual(tc?.displayName, tcBin?.displayName)
 
-
     let trInstall = ToolchainRegistry()
-    trInstall.scanForToolchains(installPath: path.appending(components: "usr", "bin"), environmentVariables: [], xcodes: [], xctoolchainSearchPaths: [], pathVariables: [], fs)
+    trInstall.scanForToolchains(
+      installPath: path.appending(components: "usr", "bin"),
+      environmentVariables: [],
+      xcodes: [],
+      xctoolchainSearchPaths: [],
+      pathVariables: [],
+      fs
+    )
     XCTAssertEqual(trInstall.default?.identifier, "org.fake.explicit")
     XCTAssertEqual(trInstall.default?.path, path)
 
@@ -187,7 +213,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let checkByDir = ToolchainRegistry()
     checkByDir.scanForToolchains(xctoolchainSearchPath: toolchains, fs)
     XCTAssertEqual(checkByDir.toolchains.count, 4)
-#endif
+    #endif
   }
 
   func testSearchPATH() throws {
@@ -199,13 +225,16 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tr.default)
     XCTAssert(tr.toolchains.isEmpty)
 
-#if os(Windows)
+    #if os(Windows)
     let separator: String = ";"
-#else
+    #else
     let separator: String = ":"
-#endif
+    #endif
 
-    try ProcessEnv.setVar("SOURCEKIT_PATH", value: ["/bogus", binPath.pathString, "/bogus2"].joined(separator: separator))
+    try ProcessEnv.setVar(
+      "SOURCEKIT_PATH",
+      value: ["/bogus", binPath.pathString, "/bogus2"].joined(separator: separator)
+    )
     defer { try! ProcessEnv.setVar("SOURCEKIT_PATH", value: "") }
 
     tr.scanForToolchains(fs)
@@ -224,7 +253,10 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tc.libIndexStore)
 
     let binPath2 = try AbsolutePath(validating: "/other/my_toolchain/bin")
-    try ProcessEnv.setVar("SOME_TEST_ENV_PATH", value: ["/bogus", binPath2.pathString, "bogus2"].joined(separator: separator))
+    try ProcessEnv.setVar(
+      "SOME_TEST_ENV_PATH",
+      value: ["/bogus", binPath2.pathString, "bogus2"].joined(separator: separator)
+    )
     try makeToolchain(binPath: binPath2, fs, sourcekitd: true)
     tr.scanForToolchains(pathVariables: ["NOPE", "SOME_TEST_ENV_PATH", "MORE_NOPE"], fs)
 
@@ -279,7 +311,8 @@ final class ToolchainRegistryTests: XCTestCase {
     tr.scanForToolchains(
       environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],
       setDefault: false,
-      fs)
+      fs
+    )
 
     guard let tc = tr.toolchains.first(where: { tc in tc.path == binPath.parentDirectory }) else {
       XCTFail("couldn't find expected toolchain")
@@ -300,30 +333,32 @@ final class ToolchainRegistryTests: XCTestCase {
     try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
       let path = tempDir.appending(components: "A.xctoolchain", "usr")
       try makeToolchain(
-        binPath: path.appending(component: "bin"), fs,
+        binPath: path.appending(component: "bin"),
+        fs,
         clang: true,
         clangd: true,
         swiftc: true,
         shouldChmod: false,
-        sourcekitd: true)
+        sourcekitd: true
+      )
 
-      try fs.writeFileContents(path.appending(components: "bin", "other") , bytes: "")
+      try fs.writeFileContents(path.appending(components: "bin", "other"), bytes: "")
 
       let t1 = Toolchain(path.parentDirectory, fs)!
       XCTAssertNotNil(t1.sourcekitd)
-#if os(Windows)
+      #if os(Windows)
       // Windows does not have file permissions but rather checks the contents
       // which have been written out.
       XCTAssertNotNil(t1.clang)
       XCTAssertNotNil(t1.clangd)
       XCTAssertNotNil(t1.swiftc)
-#else
+      #else
       XCTAssertNil(t1.clang)
       XCTAssertNil(t1.clangd)
       XCTAssertNil(t1.swiftc)
-#endif
+      #endif
 
-#if !os(Windows)
+      #if !os(Windows)
       func chmodRX(_ path: AbsolutePath) {
         XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
       }
@@ -332,7 +367,7 @@ final class ToolchainRegistryTests: XCTestCase {
       chmodRX(path.appending(components: "bin", "clangd"))
       chmodRX(path.appending(components: "bin", "swiftc"))
       chmodRX(path.appending(components: "bin", "other"))
-#endif
+      #endif
 
       let t2 = Toolchain(path.parentDirectory, fs)!
       XCTAssertNotNil(t2.sourcekitd)
@@ -383,8 +418,10 @@ final class ToolchainRegistryTests: XCTestCase {
     let tr = ToolchainRegistry()
     let toolchain = Toolchain(identifier: "a", displayName: "a", path: nil)
     try tr.registerToolchain(toolchain)
-    XCTAssertThrowsError(try tr.registerToolchain(toolchain),
-                         "Expected error registering toolchain twice") { e in
+    XCTAssertThrowsError(
+      try tr.registerToolchain(toolchain),
+      "Expected error registering toolchain twice"
+    ) { e in
       guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainIdentifier else {
         XCTFail("Expected .duplicateToolchainIdentifier not \(e)")
         return
@@ -398,8 +435,10 @@ final class ToolchainRegistryTests: XCTestCase {
     let first = Toolchain(identifier: "a", displayName: "a", path: path)
     let second = Toolchain(identifier: "b", displayName: "b", path: path)
     try tr.registerToolchain(first)
-    XCTAssertThrowsError(try tr.registerToolchain(second),
-                         "Expected error registering toolchain twice") { e in
+    XCTAssertThrowsError(
+      try tr.registerToolchain(second),
+      "Expected error registering toolchain twice"
+    ) { e in
       guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainPath else {
         XCTFail("Error mismatch: expected duplicateToolchainPath not \(e)")
         return
@@ -409,12 +448,16 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testDuplicateXcodeError() throws {
     let tr = ToolchainRegistry()
-    let xcodeToolchain = Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
-                                   displayName: "a",
-                                   path: try AbsolutePath(validating: "/versionA"))
+    let xcodeToolchain = Toolchain(
+      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
+      displayName: "a",
+      path: try AbsolutePath(validating: "/versionA")
+    )
     try tr.registerToolchain(xcodeToolchain)
-    XCTAssertThrowsError(try tr.registerToolchain(xcodeToolchain),
-                         "Expected error registering toolchain twice") { e in
+    XCTAssertThrowsError(
+      try tr.registerToolchain(xcodeToolchain),
+      "Expected error registering toolchain twice"
+    ) { e in
       guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainPath else {
         XCTFail("Error mismatch: expected duplicateToolchainPath not \(e)")
         return
@@ -425,13 +468,17 @@ final class ToolchainRegistryTests: XCTestCase {
   func testMultipleXcodes() throws {
     let tr = ToolchainRegistry()
     let pathA = try AbsolutePath(validating: "/versionA")
-    let xcodeA = Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
-                           displayName: "a",
-                           path: pathA)
+    let xcodeA = Toolchain(
+      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
+      displayName: "a",
+      path: pathA
+    )
     let pathB = try AbsolutePath(validating: "/versionB")
-    let xcodeB = Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
-                           displayName: "b",
-                           path: pathB)
+    let xcodeB = Toolchain(
+      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
+      displayName: "b",
+      path: pathB
+    )
     try tr.registerToolchain(xcodeA)
     try tr.registerToolchain(xcodeB)
     XCTAssert(tr.toolchain(path: pathA) === xcodeA)
@@ -466,7 +513,11 @@ final class ToolchainRegistryTests: XCTestCase {
     try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: "/t2/bin")
 
     let tr = ToolchainRegistry()
-    tr.scanForToolchains(installPath: try AbsolutePath(validating: "/t1/bin"), environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"], fs)
+    tr.scanForToolchains(
+      installPath: try AbsolutePath(validating: "/t1/bin"),
+      environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
+      fs
+    )
     XCTAssertEqual(tr.toolchains.count, 2)
 
     // Env variable wins.
@@ -483,7 +534,7 @@ private func makeXCToolchain(
   clang: Bool = false,
   clangd: Bool = false,
   swiftc: Bool = false,
-  shouldChmod: Bool = true, // whether to mark exec
+  shouldChmod: Bool = true,  // whether to mark exec
   sourcekitd: Bool = false,
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
@@ -491,10 +542,14 @@ private func makeXCToolchain(
   try fs.createDirectory(path, recursive: true)
   let infoPlistPath = path.appending(component: opensource ? "Info.plist" : "ToolchainInfo.plist")
   let infoPlist = try PropertyListEncoder().encode(
-    XCToolchainPlist(identifier: identifier, displayName: "name-\(identifier)"))
-  try fs.writeFileContents(infoPlistPath, body: { stream in
-    stream.write(infoPlist)
-  })
+    XCToolchainPlist(identifier: identifier, displayName: "name-\(identifier)")
+  )
+  try fs.writeFileContents(
+    infoPlistPath,
+    body: { stream in
+      stream.write(infoPlist)
+    }
+  )
 
   try makeToolchain(
     binPath: path.appending(components: "usr", "bin"),
@@ -505,7 +560,8 @@ private func makeXCToolchain(
     shouldChmod: shouldChmod,
     sourcekitd: sourcekitd,
     sourcekitdInProc: sourcekitdInProc,
-    libIndexStore: libIndexStore)
+    libIndexStore: libIndexStore
+  )
 }
 #endif
 
@@ -515,13 +571,15 @@ private func makeToolchain(
   clang: Bool = false,
   clangd: Bool = false,
   swiftc: Bool = false,
-  shouldChmod: Bool = true, // whether to mark exec
+  shouldChmod: Bool = true,  // whether to mark exec
   sourcekitd: Bool = false,
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
 ) throws {
-  precondition(!clang && !swiftc && !clangd || !shouldChmod,
-    "Cannot make toolchain binaries exectuable with InMemoryFileSystem")
+  precondition(
+    !clang && !swiftc && !clangd || !shouldChmod,
+    "Cannot make toolchain binaries exectuable with InMemoryFileSystem"
+  )
 
   // tiny PE binary from: https://archive.is/w01DO
   let contents: [UInt8] = [
@@ -533,7 +591,7 @@ private func makeToolchain(
     0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x02
+    0x02,
   ]
 
   let libPath = binPath.parentDirectory.appending(component: "lib")
@@ -542,11 +600,11 @@ private func makeToolchain(
 
   let makeExec = { (path: AbsolutePath) in
     try fs.writeFileContents(path, bytes: ByteString(contents))
-#if !os(Windows)
+    #if !os(Windows)
     if shouldChmod {
       XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
     }
-#endif
+    #endif
   }
 
   let execExt = Platform.current?.executableExtension ?? ""
@@ -565,21 +623,21 @@ private func makeToolchain(
 
   if sourcekitd {
     try fs.createDirectory(libPath.appending(component: "sourcekitd.framework"))
-    try fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd") , bytes: "")
+    try fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd"), bytes: "")
   }
   if sourcekitdInProc {
-#if os(Windows)
-    try fs.writeFileContents(binPath.appending(component: "sourcekitdInProc\(dylibSuffix)") , bytes: "")
-#else
-    try fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibSuffix)") , bytes: "")
-#endif
+    #if os(Windows)
+    try fs.writeFileContents(binPath.appending(component: "sourcekitdInProc\(dylibSuffix)"), bytes: "")
+    #else
+    try fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibSuffix)"), bytes: "")
+    #endif
   }
   if libIndexStore {
-#if os(Windows)
+    #if os(Windows)
     // Windows has a prefix of `lib` on this particular library ...
-    try fs.writeFileContents(binPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
-#else
-    try fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibSuffix)") , bytes: "")
-#endif
+    try fs.writeFileContents(binPath.appending(component: "libIndexStore\(dylibSuffix)"), bytes: "")
+    #else
+    try fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibSuffix)"), bytes: "")
+    #endif
   }
 }

--- a/Tests/SKSupportTests/SupportPerfTests.swift
+++ b/Tests/SKSupportTests/SupportPerfTests.swift
@@ -19,9 +19,10 @@ final class SupportPerfTests: PerfTestCase {
 
   func testLineTableAppendPerf() {
 
-    let characters: [Character] = [
-      "\t", "\n"
-    ] + (32...126).map { Character(UnicodeScalar($0)) }
+    let characters: [Character] =
+      [
+        "\t", "\n",
+      ] + (32...126).map { Character(UnicodeScalar($0)) }
 
     #if DEBUG || !ENABLE_PERF_TESTS
     let iterations = 1_000
@@ -47,8 +48,9 @@ final class SupportPerfTests: PerfTestCase {
   }
 
   func testLineTableSingleCharEditPerf() {
-    let characters: [Character] = [
-      "\t", "\n"
+    let characters: [Character] =
+      [
+        "\t", "\n",
       ] + (32...126).map { Character(UnicodeScalar($0)) }
 
     #if DEBUG || !ENABLE_PERF_TESTS
@@ -71,12 +73,12 @@ final class SupportPerfTests: PerfTestCase {
       self.startMeasuring()
 
       for _ in 1...iterations {
-        let line = (0 ..< (t.count-1)).randomElement(using: &lcg) ?? 0
-        let col = (0 ..< t[line].utf16.count).randomElement(using: &lcg) ?? 0
+        let line = (0..<(t.count - 1)).randomElement(using: &lcg) ?? 0
+        let col = (0..<t[line].utf16.count).randomElement(using: &lcg) ?? 0
         let len = t[line].isEmpty ? 0 : Bool.random() ? 1 : 0
         var newText = String(characters.randomElement(using: &lcg)!)
         if len == 1 && Bool.random(using: &lcg) {
-          newText = "" // deletion
+          newText = ""  // deletion
         }
 
         t.replace(fromLine: line, utf16Offset: col, utf16Length: len, with: newText)

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -23,7 +23,12 @@ final class SupportTests: XCTestCase {
 
   func checkOffsets(_ string: String, _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
     let table = LineTable(string)
-    XCTAssertEqual(table.map { string.utf8.distance(from: string.startIndex, to: $0.startIndex) }, expected, file: file, line: line)
+    XCTAssertEqual(
+      table.map { string.utf8.distance(from: string.startIndex, to: $0.startIndex) },
+      expected,
+      file: file,
+      line: line
+    )
   }
 
   func testLineTable() {
@@ -68,7 +73,13 @@ final class SupportTests: XCTestCase {
     XCTAssertEqual(LineTable("\n")[1], "")
   }
 
-  func checkLineAndColumns(_ table: LineTable, _ utf8Offset: Int, _ expected: (line: Int, utf16Column: Int)?, file: StaticString = #filePath, line: UInt = #line) {
+  func checkLineAndColumns(
+    _ table: LineTable,
+    _ utf8Offset: Int,
+    _ expected: (line: Int, utf16Column: Int)?,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
     switch (table.lineAndUTF16ColumnOf(utf8Offset: utf8Offset), expected) {
     case (nil, nil):
       break
@@ -79,20 +90,44 @@ final class SupportTests: XCTestCase {
     }
   }
 
-  func checkUTF8OffsetOf(_ table: LineTable, _ query: (line: Int, utf16Column: Int), _ expected: Int?, file: StaticString = #filePath, line: UInt = #line) {
-    XCTAssertEqual(table.utf8OffsetOf(line: query.line, utf16Column: query.utf16Column), expected, file: file, line: line)
+  func checkUTF8OffsetOf(
+    _ table: LineTable,
+    _ query: (line: Int, utf16Column: Int),
+    _ expected: Int?,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    XCTAssertEqual(
+      table.utf8OffsetOf(line: query.line, utf16Column: query.utf16Column),
+      expected,
+      file: file,
+      line: line
+    )
   }
 
-    func checkUTF16ColumnAt(_ table: LineTable, _ query: (line: Int, utf8Column: Int), _ expected: Int?, file: StaticString = #filePath, line: UInt = #line) {
-    XCTAssertEqual(table.utf16ColumnAt(line: query.line, utf8Column: query.utf8Column), expected, file: file, line: line)
+  func checkUTF16ColumnAt(
+    _ table: LineTable,
+    _ query: (line: Int, utf8Column: Int),
+    _ expected: Int?,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    XCTAssertEqual(
+      table.utf16ColumnAt(line: query.line, utf8Column: query.utf8Column),
+      expected,
+      file: file,
+      line: line
+    )
   }
 
   func testLineTableLinePositionTranslation() {
-    let t1 = LineTable("""
+    let t1 = LineTable(
+      """
       0123
       5678
       abcd
-      """)
+      """
+    )
     checkLineAndColumns(t1, 0, (line: 0, utf16Column: 0))
     checkLineAndColumns(t1, 2, (line: 0, utf16Column: 2))
     checkLineAndColumns(t1, 4, (line: 0, utf16Column: 4))
@@ -120,11 +155,13 @@ final class SupportTests: XCTestCase {
     checkUTF16ColumnAt(t1, (line: 2, utf8Column: 0), 0)
     checkUTF16ColumnAt(t1, (line: 3, utf8Column: 0), nil)
 
-    let t2 = LineTable("""
+    let t2 = LineTable(
+      """
       こんにちは
       안녕하세요
       \u{1F600}\u{1F648}
-      """)
+      """
+    )
     checkLineAndColumns(t2, 0, (line: 0, utf16Column: 0))
     checkLineAndColumns(t2, 15, (line: 0, utf16Column: 5))
     checkLineAndColumns(t2, 19, (line: 1, utf16Column: 1))
@@ -169,10 +206,12 @@ final class SupportTests: XCTestCase {
     t.replace(fromLine: 2, utf16Offset: 1, utf16Length: 0, with: "\n")
     XCTAssertEqual(t, LineTable("\n\na\n"))
 
-    t = LineTable("""
-    abcd
-    efgh
-    """)
+    t = LineTable(
+      """
+      abcd
+      efgh
+      """
+    )
 
     t.replace(fromLine: 0, utf16Offset: 2, toLine: 1, utf16Offset: 1, with: "x")
     XCTAssertEqual(t, LineTable("abxfgh"))

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+import ISDBTestSupport
+import ISDBTibs
 import LSPTestSupport
-import SourceKitD
 import SKCore
 import SKSupport
+import SourceKitD
 import TSCBasic
-import ISDBTibs
-import ISDBTestSupport
-import Foundation
 import XCTest
 
 import enum PackageLoading.Platform
@@ -30,7 +30,8 @@ final class SourceKitDTests: XCTestCase {
   override class func setUp() {
     sourcekitdPath = ToolchainRegistry.shared.default!.sourcekitd!
     guard case .darwin? = Platform.current else { return }
-    sdkpath = try? Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx").trimmingCharacters(in: .whitespacesAndNewlines)
+    sdkpath = try? Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   func testMultipleNotificationHandlers() throws {
@@ -41,7 +42,7 @@ final class SourceKitDTests: XCTestCase {
 
     let isExpectedNotification = { (response: SKDResponse) -> Bool in
       if let notification: sourcekitd_uid_t = response.value?[keys.notification],
-         let name: String = response.value?[keys.name]
+        let name: String = response.value?[keys.name]
       {
         return name == path && notification == sourcekitd.values.notification_documentupdate
       }

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -57,7 +57,8 @@ final class CallHierarchyTests: XCTestCase {
         return ""
       }
       guard case let .dictionary(data) = item.data,
-            case let .string(usr) = data["usr"] else {
+        case let .string(usr) = data["usr"]
+      else {
         XCTFail("unable to find usr in call hierarchy in item data dictionary")
         return ""
       }
@@ -68,13 +69,19 @@ final class CallHierarchyTests: XCTestCase {
 
     func testLoc(_ name: String) -> TestLocation {
       ws.testLoc(name)
-    }  
+    }
 
     func loc(_ name: String) -> Location {
       Location(badUTF16: ws.testLoc(name))
     }
 
-    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", usr: String, at locName: String) throws -> CallHierarchyItem {
+    func item(
+      _ name: String,
+      _ kind: SymbolKind,
+      detail: String = "main",
+      usr: String,
+      at locName: String
+    ) throws -> CallHierarchyItem {
       let location = loc(locName)
       return CallHierarchyItem(
         name: name,
@@ -86,7 +93,7 @@ final class CallHierarchyTests: XCTestCase {
         selectionRange: location.range,
         data: .dictionary([
           "usr": .string(usr),
-          "uri": .string(try location.uri.nativeURI.stringValue)
+          "uri": .string(try location.uri.nativeURI.stringValue),
         ])
       )
     }
@@ -113,28 +120,43 @@ final class CallHierarchyTests: XCTestCase {
     // Test outgoing call hierarchy
 
     XCTAssertEqual(try outgoingCalls(at: testLoc("a")), [])
-    XCTAssertEqual(try outgoingCalls(at: testLoc("b")), [
-      outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "b->a"),
-      outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "b->c"),
-      outCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
-    ])
-    XCTAssertEqual(try outgoingCalls(at: testLoc("c")), [
-      outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "c->a"),
-      outCall(try item("d()", .function, usr: dUsr, at: "d"), at: "c->d"),
-      outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->c"),
-    ])
+    XCTAssertEqual(
+      try outgoingCalls(at: testLoc("b")),
+      [
+        outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "b->a"),
+        outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "b->c"),
+        outCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
+      ]
+    )
+    XCTAssertEqual(
+      try outgoingCalls(at: testLoc("c")),
+      [
+        outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "c->a"),
+        outCall(try item("d()", .function, usr: dUsr, at: "d"), at: "c->d"),
+        outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->c"),
+      ]
+    )
 
     // Test incoming call hierarchy
 
-    XCTAssertEqual(try incomingCalls(at: testLoc("a")), [
-      inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->a"),
-      inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->a"),
-    ])
-    XCTAssertEqual(try incomingCalls(at: testLoc("b")), [
-      inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
-    ])
-    XCTAssertEqual(try incomingCalls(at: testLoc("d")), [
-      inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->d"),
-    ])
+    XCTAssertEqual(
+      try incomingCalls(at: testLoc("a")),
+      [
+        inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->a"),
+        inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->a"),
+      ]
+    )
+    XCTAssertEqual(
+      try incomingCalls(at: testLoc("b")),
+      [
+        inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b")
+      ]
+    )
+    XCTAssertEqual(
+      try incomingCalls(at: testLoc("d")),
+      [
+        inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->d")
+      ]
+    )
   }
 }

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -48,32 +48,36 @@ final class CodeActionTests: XCTestCase {
     var data: Data
     var response: CodeActionRequestResponse
     capabilityJson =
-    """
-     {
-       "dynamicRegistration": true,
-       "codeActionLiteralSupport" : {
-         "codeActionKind": {
-           "valueSet": []
+      """
+       {
+         "dynamicRegistration": true,
+         "codeActionLiteralSupport" : {
+           "codeActionKind": {
+             "valueSet": []
+           }
          }
        }
-     }
-    """
+      """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
-                                             from: data)
+    capabilities = try JSONDecoder().decode(
+      TextDocumentClientCapabilities.CodeAction.self,
+      from: data
+    )
     response = .init(codeActions: [codeAction, codeAction2], clientCapabilities: capabilities)
     let actions = try JSONDecoder().decode([CodeAction].self, from: JSONEncoder().encode(response))
     XCTAssertEqual(actions, [codeAction, codeAction2])
 
     capabilityJson =
-    """
-    {
-      "dynamicRegistration": true
-    }
-    """
+      """
+      {
+        "dynamicRegistration": true
+      }
+      """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
-                                             from: data)
+    capabilities = try JSONDecoder().decode(
+      TextDocumentClientCapabilities.CodeAction.self,
+      from: data
+    )
     response = .init(codeActions: [codeAction, codeAction2], clientCapabilities: capabilities)
     let commands = try JSONDecoder().decode([Command].self, from: JSONEncoder().encode(response))
     XCTAssertEqual(commands, [command])
@@ -95,37 +99,41 @@ final class CodeActionTests: XCTestCase {
     var data: Data
     var response: CodeActionRequestResponse
     capabilityJson =
-    """
-    {
-      "dynamicRegistration": true,
-      "codeActionLiteralSupport" : {
-        "codeActionKind": {
-          "valueSet": ["refactor"]
+      """
+      {
+        "dynamicRegistration": true,
+        "codeActionLiteralSupport" : {
+          "codeActionKind": {
+            "valueSet": ["refactor"]
+          }
         }
       }
-    }
-    """
+      """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
-                                             from: data)
+    capabilities = try JSONDecoder().decode(
+      TextDocumentClientCapabilities.CodeAction.self,
+      from: data
+    )
 
     response = .init(codeActions: actions, clientCapabilities: capabilities)
     XCTAssertEqual(response, .codeActions([unspecifiedAction, refactorAction, quickfixAction]))
 
     capabilityJson =
-    """
-    {
-      "dynamicRegistration": true,
-      "codeActionLiteralSupport" : {
-        "codeActionKind": {
-          "valueSet": []
+      """
+      {
+        "dynamicRegistration": true,
+        "codeActionLiteralSupport" : {
+          "codeActionKind": {
+            "valueSet": []
+          }
         }
       }
-    }
-    """
+      """
     data = capabilityJson.data(using: .utf8)!
-    capabilities = try JSONDecoder().decode(TextDocumentClientCapabilities.CodeAction.self,
-                                             from: data)
+    capabilities = try JSONDecoder().decode(
+      TextDocumentClientCapabilities.CodeAction.self,
+      from: data
+    )
 
     response = .init(codeActions: actions, clientCapabilities: capabilities)
     XCTAssertEqual(response, .codeActions([unspecifiedAction, refactorAction, quickfixAction]))
@@ -143,25 +151,36 @@ final class CodeActionTests: XCTestCase {
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
     let codeAction = CodeAction(title: "1")
     let codeAction2 = CodeAction(title: "2", command: command)
-    let request = CodeActionRequest(range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 1),
-                                    context: .init(diagnostics: [], only: nil),
-                                    textDocument: textDocument)
+    let request = CodeActionRequest(
+      range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 1),
+      context: .init(diagnostics: [], only: nil),
+      textDocument: textDocument
+    )
     var response = request.injectMetadata(toResponse: .commands([command]))
-    XCTAssertEqual(response,
-          .commands([
-            Command(title: command.title,
-                    command: command.command,
-                    arguments: command.arguments! + [expectedMetadata])
-          ])
+    XCTAssertEqual(
+      response,
+      .commands([
+        Command(
+          title: command.title,
+          command: command.command,
+          arguments: command.arguments! + [expectedMetadata]
+        )
+      ])
     )
     response = request.injectMetadata(toResponse: .codeActions([codeAction, codeAction2]))
-    XCTAssertEqual(response,
-          .codeActions([codeAction,
-            CodeAction(title: codeAction2.title,
-                       command: Command(title: command.title,
-                                        command: command.command,
-                                        arguments: command.arguments! + [expectedMetadata]))
-          ])
+    XCTAssertEqual(
+      response,
+      .codeActions([
+        codeAction,
+        CodeAction(
+          title: codeAction2.title,
+          command: Command(
+            title: command.title,
+            command: command.command,
+            arguments: command.arguments! + [expectedMetadata]
+          )
+        ),
+      ])
     )
     response = request.injectMetadata(toResponse: nil)
     XCTAssertNil(response)
@@ -169,7 +188,7 @@ final class CodeActionTests: XCTestCase {
 
   func testCommandEncoding() throws {
     let dictionary: LSPAny = ["1": [nil, 2], "2": "text", "3": ["4": [1, 2]]]
-    let array: LSPAny = [1, [2,"string"], dictionary]
+    let array: LSPAny = [1, [2, "string"], dictionary]
     let arguments: LSPAny = [1, 2.2, "text", nil, array, dictionary]
     let command = Command(title: "Command", command: "command.id", arguments: [arguments, arguments])
     let decoded = try JSONDecoder().decode(Command.self, from: JSONEncoder().encode(command))
@@ -212,15 +231,24 @@ final class CodeActionTests: XCTestCase {
     let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
     let result = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
 
-    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.localize.string", "positionRange": ["start": ["character": 43, "line": 1], "end": ["character": 43, "line": 1]], "title": "Localize String", "textDocument": ["uri": .string(loc.url.absoluteString)]]
+    let expectedCommandArgs: LSPAny = [
+      "actionString": "source.refactoring.kind.localize.string",
+      "positionRange": ["start": ["character": 43, "line": 1], "end": ["character": 43, "line": 1]],
+      "title": "Localize String",
+      "textDocument": ["uri": .string(loc.url.absoluteString)],
+    ]
 
     let metadataArguments: LSPAny = ["sourcekitlsp_textDocument": ["uri": .string(loc.url.absoluteString)]]
-    let expectedCommand = Command(title: "Localize String",
-                                  command: "semantic.refactor.command",
-                                  arguments: [expectedCommandArgs] + [metadataArguments])
-    let expectedCodeAction = CodeAction(title: "Localize String",
-                                        kind: .refactor,
-                                        command: expectedCommand)
+    let expectedCommand = Command(
+      title: "Localize String",
+      command: "semantic.refactor.command",
+      arguments: [expectedCommandArgs] + [metadataArguments]
+    )
+    let expectedCodeAction = CodeAction(
+      title: "Localize String",
+      kind: .refactor,
+      command: expectedCommand
+    )
 
     XCTAssertEqual(result, .codeActions([expectedCodeAction]))
   }
@@ -234,17 +262,30 @@ final class CodeActionTests: XCTestCase {
     XCTAssertEqual(rangeStartLoc.url, rangeEndLoc.url)
 
     let textDocument = TextDocumentIdentifier(rangeStartLoc.url)
-    let request = CodeActionRequest(range: rangeStartLoc.position..<rangeEndLoc.position, context: .init(), textDocument: textDocument)
+    let request = CodeActionRequest(
+      range: rangeStartLoc.position..<rangeEndLoc.position,
+      context: .init(),
+      textDocument: textDocument
+    )
     let result = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
 
-    let expectedCommandArgs: LSPAny = ["actionString": "source.refactoring.kind.extract.function", "positionRange": ["start": ["character": 21, "line": 1], "end": ["character": 27, "line": 2]], "title": "Extract Method", "textDocument": ["uri": .string(rangeStartLoc.url.absoluteString)]]
+    let expectedCommandArgs: LSPAny = [
+      "actionString": "source.refactoring.kind.extract.function",
+      "positionRange": ["start": ["character": 21, "line": 1], "end": ["character": 27, "line": 2]],
+      "title": "Extract Method",
+      "textDocument": ["uri": .string(rangeStartLoc.url.absoluteString)],
+    ]
     let metadataArguments: LSPAny = ["sourcekitlsp_textDocument": ["uri": .string(rangeStartLoc.url.absoluteString)]]
-    let expectedCommand = Command(title: "Extract Method",
-                                  command: "semantic.refactor.command",
-                                  arguments: [expectedCommandArgs] + [metadataArguments])
-    let expectedCodeAction = CodeAction(title: "Extract Method",
-                                        kind: .refactor,
-                                        command: expectedCommand)
+    let expectedCommand = Command(
+      title: "Extract Method",
+      command: "semantic.refactor.command",
+      arguments: [expectedCommandArgs] + [metadataArguments]
+    )
+    let expectedCodeAction = CodeAction(
+      title: "Extract Method",
+      kind: .refactor,
+      command: expectedCommand
+    )
 
     XCTAssertEqual(result, .codeActions([expectedCodeAction]))
   }
@@ -260,7 +301,7 @@ final class CodeActionTests: XCTestCase {
     let syntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics received")
     let semanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics received")
 
-    ws.sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // syntactic diagnostics
       XCTAssertEqual(note.params.uri, def.docUri)
       XCTAssertEqual(note.params.diagnostics, [])
@@ -268,7 +309,7 @@ final class CodeActionTests: XCTestCase {
     }
 
     var diags: [Diagnostic]! = nil
-    ws.sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // semantic diagnostics
       XCTAssertEqual(note.params.uri, def.docUri)
       XCTAssertEqual(note.params.diagnostics.count, 1)
@@ -279,7 +320,11 @@ final class CodeActionTests: XCTestCase {
     try await fulfillmentOfOrThrow([syntacticDiagnosticsReceived, semanticDiagnosticsReceived])
 
     let textDocument = TextDocumentIdentifier(def.url)
-    let actionsRequest = CodeActionRequest(range: def.position..<def.position, context: .init(diagnostics: diags), textDocument: textDocument)
+    let actionsRequest = CodeActionRequest(
+      range: def.position..<def.position,
+      context: .init(diagnostics: diags),
+      textDocument: textDocument
+    )
     let actionResult = try ws.sk.sendSync(actionsRequest)
 
     guard case .codeActions(let codeActions) = actionResult else {
@@ -294,13 +339,16 @@ final class CodeActionTests: XCTestCase {
     guard let change = quickFixAction.edit?.changes?[def.docUri]?.spm_only else {
       return XCTFail("Expected exactly one change")
     }
-    XCTAssertEqual(change.newText.trimmingTrailingWhitespace(), """
+    XCTAssertEqual(
+      change.newText.trimmingTrailingWhitespace(),
+      """
 
-        func foo() {
+          func foo() {
 
-        }
+          }
 
-    """)
+      """
+    )
 
     // Check that the refactor action contains snippets
     guard let refactorAction = codeActions.filter({ $0.kind == .refactor }).spm_only else {
@@ -319,13 +367,16 @@ final class CodeActionTests: XCTestCase {
       guard let change = request.params.edit.changes?[def.docUri]?.spm_only else {
         return XCTFail("Expected exactly one edit")
       }
-      XCTAssertEqual(change.newText.trimmingTrailingWhitespace(), """
+      XCTAssertEqual(
+        change.newText.trimmingTrailingWhitespace(),
+        """
 
-          func foo() {
+            func foo() {
 
-          }
+            }
 
-      """)
+        """
+      )
       request.reply(ApplyEditResponse(applied: true, failureReason: nil))
     }
     _ = try ws.sk.sendSync(ExecuteCommandRequest(command: command.command, arguments: command.arguments))

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -12,9 +12,9 @@
 
 import Foundation
 import LanguageServerProtocol
-import XCTest
 import SKCore
 import TSCBasic
+import XCTest
 
 final class CompilationDatabaseTests: XCTestCase {
   func testModifyCompilationDatabase() async throws {
@@ -25,12 +25,18 @@ final class CompilationDatabaseTests: XCTestCase {
 
     // Do a sanity check and verify that we get the expected result from a hover response before modifing the compile commands.
 
-    let highlightRequest = DocumentHighlightRequest(textDocument: loc.docIdentifier, position: Position(line: 9, utf16index: 3))
+    let highlightRequest = DocumentHighlightRequest(
+      textDocument: loc.docIdentifier,
+      position: Position(line: 9, utf16index: 3)
+    )
     let preChangeHighlightResponse = try ws.sk.sendSync(highlightRequest)
-    XCTAssertEqual(preChangeHighlightResponse, [
-      DocumentHighlight(range: Position(line: 3, utf16index: 5)..<Position(line: 3, utf16index: 8), kind: .text),
-      DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text)
-    ])
+    XCTAssertEqual(
+      preChangeHighlightResponse,
+      [
+        DocumentHighlight(range: Position(line: 3, utf16index: 5)..<Position(line: 3, utf16index: 8), kind: .text),
+        DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text),
+      ]
+    )
 
     // Remove -DFOO from the compile commands.
 
@@ -38,7 +44,8 @@ final class CompilationDatabaseTests: XCTestCase {
 
     _ = try ws.sources.edit({ builder in
       let compilationDatabase = try JSONCompilationDatabase(file: AbsolutePath(validating: compilationDatabaseUrl.path))
-      let newCommands = compilationDatabase.allCommands.map { (command: CompilationDatabaseCompileCommand) -> CompilationDatabaseCompileCommand in
+      let newCommands = compilationDatabase.allCommands.map {
+        (command: CompilationDatabaseCompileCommand) -> CompilationDatabaseCompileCommand in
         var command = command
         command.commandLine.removeAll(where: { $0 == "-DFOO" })
         return command
@@ -49,15 +56,17 @@ final class CompilationDatabaseTests: XCTestCase {
       builder.write(newCompilationDatabaseStr, to: compilationDatabaseUrl)
     })
 
-    ws.sk.send(DidChangeWatchedFilesNotification(changes: [
-      FileEvent(uri: DocumentURI(compilationDatabaseUrl), type: .changed)
-    ]))
+    ws.sk.send(
+      DidChangeWatchedFilesNotification(changes: [
+        FileEvent(uri: DocumentURI(compilationDatabaseUrl), type: .changed)
+      ])
+    )
 
     // DocumentHighlight should now point to the definition in the `#else` block.
 
     let expectedPostEditHighlight = [
       DocumentHighlight(range: Position(line: 5, utf16index: 5)..<Position(line: 5, utf16index: 8), kind: .text),
-      DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text)
+      DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text),
     ]
 
     var didReceiveCorrectHighlight = false

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -35,25 +35,32 @@ final class DocumentSymbolTests: XCTestCase {
     sk = connection.client
     var documentCapabilities = TextDocumentClientCapabilities()
     documentCapabilities.documentSymbol = capabilities
-    _ = try sk.sendSync(InitializeRequest(
-      processId: nil,
-      rootPath: nil,
-      rootURI: nil,
-      initializationOptions: nil,
-      capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
-      trace: .off,
-      workspaceFolders: nil))
+    _ = try sk.sendSync(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
+        trace: .off,
+        workspaceFolders: nil
+      )
+    )
   }
 
   func performDocumentSymbolRequest(text: String) throws -> DocumentSymbolResponse {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .swift,
-      version: 17,
-      text: text
-    )))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .swift,
+          version: 17,
+          text: text
+        )
+      )
+    )
 
     let request = DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))
     return try sk.sendSync(request)!
@@ -79,21 +86,24 @@ final class DocumentSymbolTests: XCTestCase {
     try initialize(capabilities: capabilities)
 
     let text = """
-    struct Foo { }
-    """
+      struct Foo { }
+      """
     let symbols = try performDocumentSymbolRequest(text: text)
 
-    XCTAssertEqual(symbols, .documentSymbols([
-      DocumentSymbol(
-        name: "Foo",
-        detail: nil,
-        kind: .struct,
-        deprecated: nil,
-        range: range(from: (0, 0), to: (0, 14)),
-        selectionRange: range(from: (0, 7), to: (0, 10)),
-        children: []
-      ),
-    ]))
+    XCTAssertEqual(
+      symbols,
+      .documentSymbols([
+        DocumentSymbol(
+          name: "Foo",
+          detail: nil,
+          kind: .struct,
+          deprecated: nil,
+          range: range(from: (0, 0), to: (0, 14)),
+          selectionRange: range(from: (0, 7), to: (0, 10)),
+          children: []
+        )
+      ])
+    )
   }
 
   func testUnicode() throws {
@@ -101,9 +111,9 @@ final class DocumentSymbolTests: XCTestCase {
     try initialize(capabilities: capabilities)
 
     let text = """
-    struct Żółć { }
-    struct 🍰 { }
-    """
+      struct Żółć { }
+      struct 🍰 { }
+      """
     let symbols = try performDocumentSymbolRequest(text: text)
 
     // while not ascii, these are still single code unit
@@ -112,26 +122,29 @@ final class DocumentSymbolTests: XCTestCase {
     // but cake is two utf-16 code units
     let cakeRange = range(from: (1, 0), to: (1, 13))
     let cakeSelectionRange = range(from: (1, 7), to: (1, 9))
-    XCTAssertEqual(symbols, .documentSymbols([
-      DocumentSymbol(
-        name: "Żółć",
-        detail: nil,
-        kind: .struct,
-        deprecated: nil,
-        range: żółćRange,
-        selectionRange: żółćSelectionRange,
-        children: []
-      ),
-      DocumentSymbol(
-        name: "🍰",
-        detail: nil,
-        kind: .struct,
-        deprecated: nil,
-        range: cakeRange,
-        selectionRange: cakeSelectionRange,
-        children: []
-      ),
-    ]))
+    XCTAssertEqual(
+      symbols,
+      .documentSymbols([
+        DocumentSymbol(
+          name: "Żółć",
+          detail: nil,
+          kind: .struct,
+          deprecated: nil,
+          range: żółćRange,
+          selectionRange: żółćSelectionRange,
+          children: []
+        ),
+        DocumentSymbol(
+          name: "🍰",
+          detail: nil,
+          kind: .struct,
+          deprecated: nil,
+          range: cakeRange,
+          selectionRange: cakeSelectionRange,
+          children: []
+        ),
+      ])
+    )
   }
 
   func testEnum() throws {
@@ -139,75 +152,77 @@ final class DocumentSymbolTests: XCTestCase {
     try initialize(capabilities: capabilities)
 
     let text = """
-    enum Foo {
-      case first
-      case second, third
-      case fourth(Int), fifth
-      func notACase() { }; case sixth
-      case seventh, eight(Int, String)
-      enum SubEnum {
-        case a, b
+      enum Foo {
+        case first
+        case second, third
+        case fourth(Int), fifth
+        func notACase() { }; case sixth
+        case seventh, eight(Int, String)
+        enum SubEnum {
+          case a, b
+        }
+        case ninth(someName: Int)
       }
-      case ninth(someName: Int)
-    }
-    """
+      """
     let symbols = try performDocumentSymbolRequest(text: text)
 
-    XCTAssertEqual(symbols, .documentSymbols([
-      DocumentSymbol(
-        name: "Foo",
-        detail: nil,
-        kind: .enum,
-        deprecated: nil,
-        range: range(from: (0, 0), to: (10, 1)),
-        selectionRange: range(from: (0, 5), to: (0, 8)),
-        children: [
-          DocumentSymbol(
-            name: "first",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (1, 7), to: (1, 12)),
-            selectionRange: range(from: (1, 7), to: (1, 12)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "second",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (2, 7), to: (2, 13)),
-            selectionRange: range(from: (2, 7), to: (2, 13)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "third",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (2, 15), to: (2, 20)),
-            selectionRange: range(from: (2, 15), to: (2, 20)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "fourth(_:)",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (3, 7), to: (3, 18)),
-            selectionRange: range(from: (3, 7), to: (3, 18)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "fifth",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (3, 20), to: (3, 25)),
-            selectionRange: range(from: (3, 20), to: (3, 25)),
-            children: []
-          ),
-          DocumentSymbol(
+    XCTAssertEqual(
+      symbols,
+      .documentSymbols([
+        DocumentSymbol(
+          name: "Foo",
+          detail: nil,
+          kind: .enum,
+          deprecated: nil,
+          range: range(from: (0, 0), to: (10, 1)),
+          selectionRange: range(from: (0, 5), to: (0, 8)),
+          children: [
+            DocumentSymbol(
+              name: "first",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (1, 7), to: (1, 12)),
+              selectionRange: range(from: (1, 7), to: (1, 12)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "second",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (2, 7), to: (2, 13)),
+              selectionRange: range(from: (2, 7), to: (2, 13)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "third",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (2, 15), to: (2, 20)),
+              selectionRange: range(from: (2, 15), to: (2, 20)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "fourth(_:)",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (3, 7), to: (3, 18)),
+              selectionRange: range(from: (3, 7), to: (3, 18)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "fifth",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (3, 20), to: (3, 25)),
+              selectionRange: range(from: (3, 20), to: (3, 25)),
+              children: []
+            ),
+            DocumentSymbol(
               name: "notACase()",
               detail: nil,
               kind: .method,
@@ -215,8 +230,8 @@ final class DocumentSymbolTests: XCTestCase {
               range: range(from: (4, 2), to: (4, 21)),
               selectionRange: range(from: (4, 7), to: (4, 17)),
               children: []
-          ),
-          DocumentSymbol(
+            ),
+            DocumentSymbol(
               name: "sixth",
               detail: nil,
               kind: .enumMember,
@@ -224,65 +239,66 @@ final class DocumentSymbolTests: XCTestCase {
               range: range(from: (4, 28), to: (4, 33)),
               selectionRange: range(from: (4, 28), to: (4, 33)),
               children: []
-          ),
-          DocumentSymbol(
-            name: "seventh",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (5, 7), to: (5, 14)),
-            selectionRange: range(from: (5, 7), to: (5, 14)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "eight(_:_:)",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (5, 16), to: (5, 34)),
-            selectionRange: range(from: (5, 16), to: (5, 34)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "SubEnum",
-            detail: nil,
-            kind: .enum,
-            deprecated: nil,
-            range: range(from: (6, 2), to: (8, 3)),
-            selectionRange: range(from: (6, 7), to: (6, 14)),
-            children: [
-              DocumentSymbol(
-                name: "a",
-                detail: nil,
-                kind: .enumMember,
-                deprecated: nil,
-                range: range(from: (7, 9), to: (7, 10)),
-                selectionRange: range(from: (7, 9), to: (7, 10)),
-                children: []
-              ),
-              DocumentSymbol(
-                name: "b",
-                detail: nil,
-                kind: .enumMember,
-                deprecated: nil,
-                range: range(from: (7, 12), to: (7, 13)),
-                selectionRange: range(from: (7, 12), to: (7, 13)),
-                children: []
-              )
-            ]
-          ),
-          DocumentSymbol(
-            name: "ninth(someName:)",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (9, 7), to: (9, 27)),
-            selectionRange: range(from: (9, 7), to: (9, 27)),
-            children: []
-          )
-        ]
-      )
-    ]))
+            ),
+            DocumentSymbol(
+              name: "seventh",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (5, 7), to: (5, 14)),
+              selectionRange: range(from: (5, 7), to: (5, 14)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "eight(_:_:)",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (5, 16), to: (5, 34)),
+              selectionRange: range(from: (5, 16), to: (5, 34)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "SubEnum",
+              detail: nil,
+              kind: .enum,
+              deprecated: nil,
+              range: range(from: (6, 2), to: (8, 3)),
+              selectionRange: range(from: (6, 7), to: (6, 14)),
+              children: [
+                DocumentSymbol(
+                  name: "a",
+                  detail: nil,
+                  kind: .enumMember,
+                  deprecated: nil,
+                  range: range(from: (7, 9), to: (7, 10)),
+                  selectionRange: range(from: (7, 9), to: (7, 10)),
+                  children: []
+                ),
+                DocumentSymbol(
+                  name: "b",
+                  detail: nil,
+                  kind: .enumMember,
+                  deprecated: nil,
+                  range: range(from: (7, 12), to: (7, 13)),
+                  selectionRange: range(from: (7, 12), to: (7, 13)),
+                  children: []
+                ),
+              ]
+            ),
+            DocumentSymbol(
+              name: "ninth(someName:)",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (9, 7), to: (9, 27)),
+              selectionRange: range(from: (9, 7), to: (9, 27)),
+              children: []
+            ),
+          ]
+        )
+      ])
+    )
   }
 
   func testAll() throws {
@@ -290,356 +306,359 @@ final class DocumentSymbolTests: XCTestCase {
     try initialize(capabilities: capabilities)
 
     let text = """
-    // struct ThisIsCommentedOut { }
-    /* struct ThisOneToo { } */
-    extension Int { }
-    struct Struct { }
-    class Class { }
-    enum Enum { case enumMember }
-    protocol Interface { func f() }
-    func function() { }
-    var variable = 0
-    let constant = 0
-    var computedVariable: Int { return 0 }
-    func +(lhs: Struct, rhs: Struct) { }
-    prefix func -(rhs: Struct) { }
-    func f<TypeParameter>(type: TypeParameter.Type) { }
-    struct S<TypeParameter> { }
-    class Foo {
-      func method() { }
-      static func staticMethod() { }
-      class func classMethod() { }
-      var property = 0
-      let constantProperty = 0
-      var computedProperty: Int { return 0 }
-      init() { }
-      static var staticProperty = 0
-      static let staticConstantProperty = 0
-      static var staticComputedProperty: Int { return 0 }
-      class var classProperty: Int { return 0 }
-      func f() {
-        let localConstant = 0
-        var localVariable = 0
-        var localComputedVariable: Int { return 0 }
-        func localFunction() { }
+      // struct ThisIsCommentedOut { }
+      /* struct ThisOneToo { } */
+      extension Int { }
+      struct Struct { }
+      class Class { }
+      enum Enum { case enumMember }
+      protocol Interface { func f() }
+      func function() { }
+      var variable = 0
+      let constant = 0
+      var computedVariable: Int { return 0 }
+      func +(lhs: Struct, rhs: Struct) { }
+      prefix func -(rhs: Struct) { }
+      func f<TypeParameter>(type: TypeParameter.Type) { }
+      struct S<TypeParameter> { }
+      class Foo {
+        func method() { }
+        static func staticMethod() { }
+        class func classMethod() { }
+        var property = 0
+        let constantProperty = 0
+        var computedProperty: Int { return 0 }
+        init() { }
+        static var staticProperty = 0
+        static let staticConstantProperty = 0
+        static var staticComputedProperty: Int { return 0 }
+        class var classProperty: Int { return 0 }
+        func f() {
+          let localConstant = 0
+          var localVariable = 0
+          var localComputedVariable: Int { return 0 }
+          func localFunction() { }
+        }
       }
-    }
-    """
+      """
     let symbols = try performDocumentSymbolRequest(text: text)
 
-    XCTAssertEqual(symbols, .documentSymbols([
-      DocumentSymbol(
-        name: "Int",
-        detail: nil,
-        kind: .namespace,
-        deprecated: nil,
-        range: range(from: (2, 0), to: (2, 17)),
-        selectionRange: range(from: (2, 10), to: (2, 13)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "Struct",
-        detail: nil,
-        kind: .struct,
-        deprecated: nil,
-        range: range(from: (3, 0), to: (3, 17)),
-        selectionRange: range(from: (3, 7), to: (3, 13)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "Class",
-        detail: nil,
-        kind: .class,
-        deprecated: nil,
-        range: range(from: (4, 0), to: (4, 15)),
-        selectionRange: range(from: (4, 6), to: (4, 11)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "Enum",
-        detail: nil,
-        kind: .enum,
-        deprecated: nil,
-        range: range(from: (5, 0), to: (5, 29)),
-        selectionRange: range(from: (5, 5), to: (5, 9)),
-        children: [
-          DocumentSymbol(
-            name: "enumMember",
-            detail: nil,
-            kind: .enumMember,
-            deprecated: nil,
-            range: range(from: (5, 17), to: (5, 27)),
-            selectionRange: range(from: (5, 17), to: (5, 27)),
-            children: []
-          )
-        ]
-      ),
-      DocumentSymbol(
-        name: "Interface",
-        detail: nil,
-        kind: .interface,
-        deprecated: nil,
-        range: range(from: (6, 0), to: (6, 31)),
-        selectionRange: range(from: (6, 9), to: (6, 18)),
-        children: [
-          DocumentSymbol(
-            name: "f()",
-            detail: nil,
-            kind: .method,
-            deprecated: nil,
-            range: range(from: (6, 21), to: (6, 29)),
-            selectionRange: range(from: (6, 26), to: (6, 29)),
-            children: []
-          )
-        ]
-      ),
-      DocumentSymbol(
-        name: "function()",
-        detail: nil,
-        kind: .function,
-        deprecated: nil,
-        range: range(from: (7, 0), to: (7, 19)),
-        selectionRange: range(from: (7, 5), to: (7, 15)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "variable",
-        detail: nil,
-        kind: .variable,
-        deprecated: nil,
-        range: range(from: (8, 0), to: (8, 16)),
-        selectionRange: range(from: (8, 4), to: (8, 12)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "constant",
-        detail: nil,
-        kind: .variable,
-        deprecated: nil,
-        range: range(from: (9, 0), to: (9, 16)),
-        selectionRange: range(from: (9, 4), to: (9, 12)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "computedVariable",
-        detail: "Int",
-        kind: .variable,
-        deprecated: nil,
-        range: range(from: (10, 0), to: (10, 38)),
-        selectionRange: range(from: (10, 4), to: (10, 20)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "+(_:_:)",
-        detail: nil,
-        kind: .function,
-        deprecated: nil,
-        range: range(from: (11, 0), to: (11, 36)),
-        selectionRange: range(from: (11, 5), to: (11, 32)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "-(_:)",
-        detail: nil,
-        kind: .function,
-        deprecated: nil,
-        range: range(from: (12, 7), to: (12, 30)),
-        selectionRange: range(from: (12, 12), to: (12, 26)),
-        children: []
-      ),
-      DocumentSymbol(
-        name: "f(type:)",
-        detail: nil,
-        kind: .function,
-        deprecated: nil,
-        range: range(from: (13, 0), to: (13, 51)),
-        selectionRange: range(from: (13, 5), to: (13, 47)),
-        children: [
-          DocumentSymbol(
-            name: "TypeParameter",
-            detail: nil,
-            kind: .typeParameter,
-            deprecated: nil,
-            range: range(from: (13, 7), to: (13, 20)),
-            selectionRange: range(from: (13, 7), to: (13, 20)),
-            children: []
-          )
-        ]
-      ),
-      DocumentSymbol(
-        name: "S",
-        detail: nil,
-        kind: .struct,
-        deprecated: nil,
-        range: range(from: (14, 0), to: (14, 27)),
-        selectionRange: range(from: (14, 7), to: (14, 8)),
-        children: [
-          DocumentSymbol(
-            name: "TypeParameter",
-            detail: nil,
-            kind: .typeParameter,
-            deprecated: nil,
-            range: range(from: (14, 9), to: (14, 22)),
-            selectionRange: range(from: (14, 9), to: (14, 22)),
-            children: []
-          )
-        ]
-      ),
-      DocumentSymbol(
-        name: "Foo",
-        detail: nil,
-        kind: .class,
-        deprecated: nil,
-        range: range(from: (15, 0), to: (33, 1)),
-        selectionRange: range(from: (15, 6), to: (15, 9)),
-        children: [
-          DocumentSymbol(
-            name: "method()",
-            detail: nil,
-            kind: .method,
-            deprecated: nil,
-            range: range(from: (16, 2), to: (16, 19)),
-            selectionRange: range(from: (16, 7), to: (16, 15)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "staticMethod()",
-            detail: nil,
-            kind: .method,
-            deprecated: nil,
-            range: range(from: (17, 2), to: (17, 32)),
-            selectionRange: range(from: (17, 14), to: (17, 28)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "classMethod()",
-            detail: nil,
-            kind: .method,
-            deprecated: nil,
-            range: range(from: (18, 2), to: (18, 30)),
-            selectionRange: range(from: (18, 13), to: (18, 26)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "property",
-            detail: nil,
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (19, 2), to: (19, 18)),
-            selectionRange: range(from: (19, 6), to: (19, 14)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "constantProperty",
-            detail: nil,
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (20, 2), to: (20, 26)),
-            selectionRange: range(from: (20, 6), to: (20, 22)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "computedProperty",
-            detail: "Int",
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (21, 2), to: (21, 40)),
-            selectionRange: range(from: (21, 6), to: (21, 22)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "init()",
-            detail: nil,
-            kind: .method,
-            deprecated: nil,
-            range: range(from: (22, 2), to: (22, 12)),
-            selectionRange: range(from: (22, 2), to: (22, 8)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "staticProperty",
-            detail: nil,
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (23, 2), to: (23, 31)),
-            selectionRange: range(from: (23, 13), to: (23, 27)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "staticConstantProperty",
-            detail: nil,
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (24, 2), to: (24, 39)),
-            selectionRange: range(from: (24, 13), to: (24, 35)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "staticComputedProperty",
-            detail: "Int",
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (25, 2), to: (25, 53)),
-            selectionRange: range(from: (25, 13), to: (25, 35)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "classProperty",
-            detail: "Int",
-            kind: .property,
-            deprecated: nil,
-            range: range(from: (26, 2), to: (26, 43)),
-            selectionRange: range(from: (26, 12), to: (26, 25)),
-            children: []
-          ),
-          DocumentSymbol(
-            name: "f()",
-            detail: nil,
-            kind: .method,
-            deprecated: nil,
-            range: range(from: (27, 2), to: (32, 3)),
-            selectionRange: range(from: (27, 7), to: (27, 10)),
-            children: [
-              DocumentSymbol(
-                name: "localConstant",
-                detail: nil,
-                kind: .variable,
-                deprecated: nil,
-                range: range(from: (28, 4), to: (28, 25)),
-                selectionRange: range(from: (28, 8), to: (28, 21)),
-                children: []
-              ),
-              DocumentSymbol(
-                name: "localVariable",
-                detail: nil,
-                kind: .variable,
-                deprecated: nil,
-                range: range(from: (29, 4), to: (29, 25)),
-                selectionRange: range(from: (29, 8), to: (29, 21)),
-                children: []
-              ),
-              DocumentSymbol(
-                name: "localComputedVariable",
-                detail: "Int",
-                kind: .variable,
-                deprecated: nil,
-                range: range(from: (30, 4), to: (30, 47)),
-                selectionRange: range(from: (30, 8), to: (30, 29)),
-                children: []
-              ),
-              DocumentSymbol(
-                name: "localFunction()",
-                detail: nil,
-                kind: .function,
-                deprecated: nil,
-                range: range(from: (31, 4), to: (31, 28)),
-                selectionRange: range(from: (31, 9), to: (31, 24)),
-                children: []
-              )
-            ]
-          )
-        ]
-      )
-    ]))
+    XCTAssertEqual(
+      symbols,
+      .documentSymbols([
+        DocumentSymbol(
+          name: "Int",
+          detail: nil,
+          kind: .namespace,
+          deprecated: nil,
+          range: range(from: (2, 0), to: (2, 17)),
+          selectionRange: range(from: (2, 10), to: (2, 13)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "Struct",
+          detail: nil,
+          kind: .struct,
+          deprecated: nil,
+          range: range(from: (3, 0), to: (3, 17)),
+          selectionRange: range(from: (3, 7), to: (3, 13)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "Class",
+          detail: nil,
+          kind: .class,
+          deprecated: nil,
+          range: range(from: (4, 0), to: (4, 15)),
+          selectionRange: range(from: (4, 6), to: (4, 11)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "Enum",
+          detail: nil,
+          kind: .enum,
+          deprecated: nil,
+          range: range(from: (5, 0), to: (5, 29)),
+          selectionRange: range(from: (5, 5), to: (5, 9)),
+          children: [
+            DocumentSymbol(
+              name: "enumMember",
+              detail: nil,
+              kind: .enumMember,
+              deprecated: nil,
+              range: range(from: (5, 17), to: (5, 27)),
+              selectionRange: range(from: (5, 17), to: (5, 27)),
+              children: []
+            )
+          ]
+        ),
+        DocumentSymbol(
+          name: "Interface",
+          detail: nil,
+          kind: .interface,
+          deprecated: nil,
+          range: range(from: (6, 0), to: (6, 31)),
+          selectionRange: range(from: (6, 9), to: (6, 18)),
+          children: [
+            DocumentSymbol(
+              name: "f()",
+              detail: nil,
+              kind: .method,
+              deprecated: nil,
+              range: range(from: (6, 21), to: (6, 29)),
+              selectionRange: range(from: (6, 26), to: (6, 29)),
+              children: []
+            )
+          ]
+        ),
+        DocumentSymbol(
+          name: "function()",
+          detail: nil,
+          kind: .function,
+          deprecated: nil,
+          range: range(from: (7, 0), to: (7, 19)),
+          selectionRange: range(from: (7, 5), to: (7, 15)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "variable",
+          detail: nil,
+          kind: .variable,
+          deprecated: nil,
+          range: range(from: (8, 0), to: (8, 16)),
+          selectionRange: range(from: (8, 4), to: (8, 12)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "constant",
+          detail: nil,
+          kind: .variable,
+          deprecated: nil,
+          range: range(from: (9, 0), to: (9, 16)),
+          selectionRange: range(from: (9, 4), to: (9, 12)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "computedVariable",
+          detail: "Int",
+          kind: .variable,
+          deprecated: nil,
+          range: range(from: (10, 0), to: (10, 38)),
+          selectionRange: range(from: (10, 4), to: (10, 20)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "+(_:_:)",
+          detail: nil,
+          kind: .function,
+          deprecated: nil,
+          range: range(from: (11, 0), to: (11, 36)),
+          selectionRange: range(from: (11, 5), to: (11, 32)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "-(_:)",
+          detail: nil,
+          kind: .function,
+          deprecated: nil,
+          range: range(from: (12, 7), to: (12, 30)),
+          selectionRange: range(from: (12, 12), to: (12, 26)),
+          children: []
+        ),
+        DocumentSymbol(
+          name: "f(type:)",
+          detail: nil,
+          kind: .function,
+          deprecated: nil,
+          range: range(from: (13, 0), to: (13, 51)),
+          selectionRange: range(from: (13, 5), to: (13, 47)),
+          children: [
+            DocumentSymbol(
+              name: "TypeParameter",
+              detail: nil,
+              kind: .typeParameter,
+              deprecated: nil,
+              range: range(from: (13, 7), to: (13, 20)),
+              selectionRange: range(from: (13, 7), to: (13, 20)),
+              children: []
+            )
+          ]
+        ),
+        DocumentSymbol(
+          name: "S",
+          detail: nil,
+          kind: .struct,
+          deprecated: nil,
+          range: range(from: (14, 0), to: (14, 27)),
+          selectionRange: range(from: (14, 7), to: (14, 8)),
+          children: [
+            DocumentSymbol(
+              name: "TypeParameter",
+              detail: nil,
+              kind: .typeParameter,
+              deprecated: nil,
+              range: range(from: (14, 9), to: (14, 22)),
+              selectionRange: range(from: (14, 9), to: (14, 22)),
+              children: []
+            )
+          ]
+        ),
+        DocumentSymbol(
+          name: "Foo",
+          detail: nil,
+          kind: .class,
+          deprecated: nil,
+          range: range(from: (15, 0), to: (33, 1)),
+          selectionRange: range(from: (15, 6), to: (15, 9)),
+          children: [
+            DocumentSymbol(
+              name: "method()",
+              detail: nil,
+              kind: .method,
+              deprecated: nil,
+              range: range(from: (16, 2), to: (16, 19)),
+              selectionRange: range(from: (16, 7), to: (16, 15)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "staticMethod()",
+              detail: nil,
+              kind: .method,
+              deprecated: nil,
+              range: range(from: (17, 2), to: (17, 32)),
+              selectionRange: range(from: (17, 14), to: (17, 28)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "classMethod()",
+              detail: nil,
+              kind: .method,
+              deprecated: nil,
+              range: range(from: (18, 2), to: (18, 30)),
+              selectionRange: range(from: (18, 13), to: (18, 26)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "property",
+              detail: nil,
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (19, 2), to: (19, 18)),
+              selectionRange: range(from: (19, 6), to: (19, 14)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "constantProperty",
+              detail: nil,
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (20, 2), to: (20, 26)),
+              selectionRange: range(from: (20, 6), to: (20, 22)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "computedProperty",
+              detail: "Int",
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (21, 2), to: (21, 40)),
+              selectionRange: range(from: (21, 6), to: (21, 22)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "init()",
+              detail: nil,
+              kind: .method,
+              deprecated: nil,
+              range: range(from: (22, 2), to: (22, 12)),
+              selectionRange: range(from: (22, 2), to: (22, 8)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "staticProperty",
+              detail: nil,
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (23, 2), to: (23, 31)),
+              selectionRange: range(from: (23, 13), to: (23, 27)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "staticConstantProperty",
+              detail: nil,
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (24, 2), to: (24, 39)),
+              selectionRange: range(from: (24, 13), to: (24, 35)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "staticComputedProperty",
+              detail: "Int",
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (25, 2), to: (25, 53)),
+              selectionRange: range(from: (25, 13), to: (25, 35)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "classProperty",
+              detail: "Int",
+              kind: .property,
+              deprecated: nil,
+              range: range(from: (26, 2), to: (26, 43)),
+              selectionRange: range(from: (26, 12), to: (26, 25)),
+              children: []
+            ),
+            DocumentSymbol(
+              name: "f()",
+              detail: nil,
+              kind: .method,
+              deprecated: nil,
+              range: range(from: (27, 2), to: (32, 3)),
+              selectionRange: range(from: (27, 7), to: (27, 10)),
+              children: [
+                DocumentSymbol(
+                  name: "localConstant",
+                  detail: nil,
+                  kind: .variable,
+                  deprecated: nil,
+                  range: range(from: (28, 4), to: (28, 25)),
+                  selectionRange: range(from: (28, 8), to: (28, 21)),
+                  children: []
+                ),
+                DocumentSymbol(
+                  name: "localVariable",
+                  detail: nil,
+                  kind: .variable,
+                  deprecated: nil,
+                  range: range(from: (29, 4), to: (29, 25)),
+                  selectionRange: range(from: (29, 8), to: (29, 21)),
+                  children: []
+                ),
+                DocumentSymbol(
+                  name: "localComputedVariable",
+                  detail: "Int",
+                  kind: .variable,
+                  deprecated: nil,
+                  range: range(from: (30, 4), to: (30, 47)),
+                  selectionRange: range(from: (30, 8), to: (30, 29)),
+                  children: []
+                ),
+                DocumentSymbol(
+                  name: "localFunction()",
+                  detail: nil,
+                  kind: .function,
+                  deprecated: nil,
+                  range: range(from: (31, 4), to: (31, 28)),
+                  selectionRange: range(from: (31, 9), to: (31, 24)),
+                  children: []
+                ),
+              ]
+            ),
+          ]
+        ),
+      ])
+    )
   }
 }

--- a/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -32,14 +32,17 @@ final class ExecuteCommandTests: XCTestCase {
   override func setUp() {
     connection = TestSourceKitServer()
     sk = connection.client
-    _ = try! sk.sendSync(InitializeRequest(
-      processId: nil,
-      rootPath: nil,
-      rootURI: nil,
-      initializationOptions: nil,
-      capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
-      trace: .off,
-      workspaceFolders: nil))
+    _ = try! sk.sendSync(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+        trace: .off,
+        workspaceFolders: nil
+      )
+    )
   }
 
   func testLocationSemanticRefactoring() async throws {
@@ -49,10 +52,12 @@ final class ExecuteCommandTests: XCTestCase {
 
     let textDocument = TextDocumentIdentifier(loc.url)
 
-    let args = SemanticRefactorCommand(title: "Localize String",
-                                       actionString: "source.refactoring.kind.localize.string",
-                                       positionRange: loc.position..<loc.position,
-                                       textDocument: textDocument)
+    let args = SemanticRefactorCommand(
+      title: "Localize String",
+      actionString: "source.refactoring.kind.localize.string",
+      positionRange: loc.position..<loc.position,
+      textDocument: textDocument
+    )
 
     let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
 
@@ -72,14 +77,21 @@ final class ExecuteCommandTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(WorkspaceEdit(fromLSPDictionary: resultDict), WorkspaceEdit(changes: [
-      DocumentURI(loc.url): [
-        TextEdit(range: Position(line: 1, utf16index: 29)..<Position(line: 1, utf16index: 29),
-                 newText: "NSLocalizedString("),
-        TextEdit(range: Position(line: 1, utf16index: 44)..<Position(line: 1, utf16index: 44),
-                 newText: ", comment: \"\")")
-      ]
-    ]))
+    XCTAssertEqual(
+      WorkspaceEdit(fromLSPDictionary: resultDict),
+      WorkspaceEdit(changes: [
+        DocumentURI(loc.url): [
+          TextEdit(
+            range: Position(line: 1, utf16index: 29)..<Position(line: 1, utf16index: 29),
+            newText: "NSLocalizedString("
+          ),
+          TextEdit(
+            range: Position(line: 1, utf16index: 44)..<Position(line: 1, utf16index: 44),
+            newText: ", comment: \"\")"
+          ),
+        ]
+      ])
+    )
   }
 
   func testRangeSemanticRefactoring() async throws {
@@ -92,10 +104,12 @@ final class ExecuteCommandTests: XCTestCase {
     let startPosition = Position(line: 1, utf16index: 2)
     let endPosition = Position(line: 2, utf16index: 10)
 
-    let args = SemanticRefactorCommand(title: "Extract Method",
-                                       actionString: "source.refactoring.kind.extract.function",
-                                       positionRange: startPosition..<endPosition,
-                                       textDocument: textDocument)
+    let args = SemanticRefactorCommand(
+      title: "Extract Method",
+      actionString: "source.refactoring.kind.extract.function",
+      positionRange: startPosition..<endPosition,
+      textDocument: textDocument
+    )
 
     let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
 
@@ -115,14 +129,22 @@ final class ExecuteCommandTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(WorkspaceEdit(fromLSPDictionary: resultDict), WorkspaceEdit(changes: [
-      DocumentURI(loc.url): [
-        TextEdit(range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
-                 newText: "fileprivate func extractedFunc() -> String {\n/*sr:extractStart*/var a = \"/*sr:string*/\"\n  return a\n}\n\n"),
-        TextEdit(range: Position(line: 1, utf16index: 2)..<Position(line: 2, utf16index: 10),
-                 newText: "return extractedFunc()")
-      ]
-    ]))
+    XCTAssertEqual(
+      WorkspaceEdit(fromLSPDictionary: resultDict),
+      WorkspaceEdit(changes: [
+        DocumentURI(loc.url): [
+          TextEdit(
+            range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
+            newText:
+              "fileprivate func extractedFunc() -> String {\n/*sr:extractStart*/var a = \"/*sr:string*/\"\n  return a\n}\n\n"
+          ),
+          TextEdit(
+            range: Position(line: 1, utf16index: 2)..<Position(line: 2, utf16index: 10),
+            newText: "return extractedFunc()"
+          ),
+        ]
+      ])
+    )
   }
 
   func testLSPCommandMetadataRetrieval() {

--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -18,12 +18,18 @@ final class FoldingRangeTests: XCTestCase {
 
   typealias FoldingRangeCapabilities = TextDocumentClientCapabilities.FoldingRange
 
-  func initializeWorkspace(withCapabilities capabilities: FoldingRangeCapabilities, testLoc: String) async throws -> (SKTibsTestWorkspace, DocumentURI)? {
+  func initializeWorkspace(withCapabilities capabilities: FoldingRangeCapabilities, testLoc: String) async throws -> (
+    SKTibsTestWorkspace, DocumentURI
+  )? {
     var documentCapabilities = TextDocumentClientCapabilities()
     documentCapabilities.foldingRange = capabilities
     let capabilities = ClientCapabilities(workspace: nil, textDocument: documentCapabilities)
-    guard let ws = try await staticSourceKitTibsWorkspace(name: "FoldingRange",
-                                                    clientCapabilities: capabilities) else { return nil }
+    guard
+      let ws = try await staticSourceKitTibsWorkspace(
+        name: "FoldingRange",
+        clientCapabilities: capabilities
+      )
+    else { return nil }
     let loc = ws.testLoc(testLoc)
     try ws.openDocument(loc.url, language: .swift)
     return (ws, DocumentURI(loc.url))
@@ -33,7 +39,9 @@ final class FoldingRangeTests: XCTestCase {
     var capabilities = FoldingRangeCapabilities()
     capabilities.lineFoldingOnly = false
 
-    guard let (ws, uri) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:base") else { return }
+    guard let (ws, uri) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:base") else {
+      return
+    }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
@@ -60,7 +68,9 @@ final class FoldingRangeTests: XCTestCase {
     var capabilities = FoldingRangeCapabilities()
     capabilities.lineFoldingOnly = true
 
-    guard let (ws, uri) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:base") else { return }
+    guard let (ws, uri) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:base") else {
+      return
+    }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
@@ -85,7 +95,9 @@ final class FoldingRangeTests: XCTestCase {
       var capabilities = FoldingRangeCapabilities()
       capabilities.lineFoldingOnly = false
       capabilities.rangeLimit = limit
-      guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:base") else { return }
+      guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:base") else {
+        return
+      }
       let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
       let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
       XCTAssertEqual(ranges?.count, expectedRanges, "Failed rangeLimit test at line \(line)")
@@ -101,7 +113,9 @@ final class FoldingRangeTests: XCTestCase {
   func testNoRanges() async throws {
     let capabilities = FoldingRangeCapabilities()
 
-    guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:empty") else { return }
+    guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:empty") else {
+      return
+    }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
@@ -114,7 +128,12 @@ final class FoldingRangeTests: XCTestCase {
     // Test that we only report the folding range once.
     let capabilities = FoldingRangeCapabilities()
 
-    guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:multilineDocLineComment") else { return }
+    guard
+      let (ws, url) = try await initializeWorkspace(
+        withCapabilities: capabilities,
+        testLoc: "fr:multilineDocLineComment"
+      )
+    else { return }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
@@ -125,7 +144,7 @@ final class FoldingRangeTests: XCTestCase {
       FoldingRange(startLine: 7, startUTF16Index: 0, endLine: 8, endUTF16Index: 21, kind: .comment),
       FoldingRange(startLine: 10, startUTF16Index: 0, endLine: 10, endUTF16Index: 44, kind: .comment),
       FoldingRange(startLine: 11, startUTF16Index: 12, endLine: 11, endUTF16Index: 12),
-      FoldingRange(startLine: 13, startUTF16Index: 0, endLine: 13, endUTF16Index: 30, kind: .comment)
+      FoldingRange(startLine: 13, startUTF16Index: 0, endLine: 13, endUTF16Index: 30, kind: .comment),
     ]
 
     XCTAssertEqual(ranges, expected)
@@ -136,7 +155,8 @@ final class FoldingRangeTests: XCTestCase {
     // Test that we only report the folding range once.
     let capabilities = FoldingRangeCapabilities()
 
-    guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:duplicateRanges") else { return }
+    guard let (ws, url) = try await initializeWorkspace(withCapabilities: capabilities, testLoc: "fr:duplicateRanges")
+    else { return }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
     let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -35,12 +35,19 @@ final class ImplementationTests: XCTestCase {
     }
     func testLoc(_ name: String) -> TestLocation {
       ws.testLoc(name)
-    }  
+    }
     func loc(_ name: String) throws -> Location {
       let location: TestLocation = ws.testLoc(name)
-      return Location(badUTF16: TestLocation(url: try location.docUri.nativeURI.fileURL!, line: location.line, utf8Column: location.utf8Column, utf16Column: location.utf16Column))
+      return Location(
+        badUTF16: TestLocation(
+          url: try location.docUri.nativeURI.fileURL!,
+          line: location.line,
+          utf8Column: location.utf8Column,
+          utf16Column: location.utf16Column
+        )
+      )
     }
-    
+
     try XCTAssertEqual(impls(at: testLoc("Protocol")), [loc("StructConformance")])
     try XCTAssertEqual(impls(at: testLoc("ProtocolStaticVar")), [loc("StructStaticVar")])
     try XCTAssertEqual(impls(at: testLoc("ProtocolStaticFunction")), [loc("StructStaticFunction")])
@@ -52,18 +59,33 @@ final class ImplementationTests: XCTestCase {
     try XCTAssertEqual(impls(at: testLoc("ClassVariable")), [loc("SubclassVariable")])
     try XCTAssertEqual(impls(at: testLoc("ClassFunction")), [loc("SubclassFunction")])
 
-    try XCTAssertEqual(impls(at: testLoc("Sepulcidae")), [loc("ParapamphiliinaeConformance"), loc("XyelulinaeConformance"), loc("TrematothoracinaeConformance")])
-    try XCTAssertEqual(impls(at: testLoc("Parapamphiliinae")), [loc("MicramphiliusConformance"), loc("PamparaphiliusConformance")])
+    try XCTAssertEqual(
+      impls(at: testLoc("Sepulcidae")),
+      [loc("ParapamphiliinaeConformance"), loc("XyelulinaeConformance"), loc("TrematothoracinaeConformance")]
+    )
+    try XCTAssertEqual(
+      impls(at: testLoc("Parapamphiliinae")),
+      [loc("MicramphiliusConformance"), loc("PamparaphiliusConformance")]
+    )
     try XCTAssertEqual(impls(at: testLoc("Xyelulinae")), [loc("XyelulaConformance")])
     try XCTAssertEqual(impls(at: testLoc("Trematothoracinae")), [])
 
     try XCTAssertEqual(impls(at: testLoc("Prozaiczne")), [loc("MurkwiaConformance2"), loc("SepulkaConformance1")])
-    try XCTAssertEqual(impls(at: testLoc("Sepulkowate")), [loc("MurkwiaConformance1"), loc("SepulkaConformance2"), loc("PćmaŁagodnaConformance"), loc("PćmaZwyczajnaConformance")])
+    try XCTAssertEqual(
+      impls(at: testLoc("Sepulkowate")),
+      [
+        loc("MurkwiaConformance1"), loc("SepulkaConformance2"), loc("PćmaŁagodnaConformance"),
+        loc("PćmaZwyczajnaConformance"),
+      ]
+    )
     // FIXME: sourcekit returns wrong locations for the function (subclasses that don't override it, and extensions that don't implement it)
     // try XCTAssertEqual(impls(at: testLoc("rozpocznijSepulenie")), [loc("MurkwiaFunc"), loc("SepulkaFunc"), loc("PćmaŁagodnaFunc"), loc("PćmaZwyczajnaFunc")])
     try XCTAssertEqual(impls(at: testLoc("Murkwia")), [])
     try XCTAssertEqual(impls(at: testLoc("MurkwiaFunc")), [])
-    try XCTAssertEqual(impls(at: testLoc("Sepulka")), [loc("SepulkaDwuusznaConformance"), loc("SepulkaPrzechylnaConformance")])
+    try XCTAssertEqual(
+      impls(at: testLoc("Sepulka")),
+      [loc("SepulkaDwuusznaConformance"), loc("SepulkaPrzechylnaConformance")]
+    )
     try XCTAssertEqual(impls(at: testLoc("SepulkaVar")), [loc("SepulkaDwuusznaVar"), loc("SepulkaPrzechylnaVar")])
     try XCTAssertEqual(impls(at: testLoc("SepulkaFunc")), [])
   }

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -31,26 +31,32 @@ final class InlayHintTests: XCTestCase {
   override func setUp() {
     connection = TestSourceKitServer()
     sk = connection.client
-    _ = try! sk.sendSync(InitializeRequest(
-      processId: nil,
-      rootPath: nil,
-      rootURI: nil,
-      initializationOptions: nil,
-      capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
-      trace: .off,
-      workspaceFolders: nil
-    ))
+    _ = try! sk.sendSync(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
+        trace: .off,
+        workspaceFolders: nil
+      )
+    )
   }
 
   func performInlayHintRequest(text: String, range: Range<Position>? = nil) throws -> [InlayHint] {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
-    
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .swift,
-      version: 17,
-      text: text
-    )))
+
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .swift,
+          version: 17,
+          text: text
+        )
+      )
+    )
 
     let request = InlayHintRequest(textDocument: TextDocumentIdentifier(url), range: range)
 
@@ -61,7 +67,8 @@ final class InlayHintTests: XCTestCase {
     }
   }
 
-  private func makeInlayHint(position: Position, kind: InlayHintKind, label: String, hasEdit: Bool = true) -> InlayHint {
+  private func makeInlayHint(position: Position, kind: InlayHintKind, label: String, hasEdit: Bool = true) -> InlayHint
+  {
     let textEdits: [TextEdit]?
     if hasEdit {
       textEdits = [TextEdit(range: position..<position, newText: label)]
@@ -84,144 +91,156 @@ final class InlayHintTests: XCTestCase {
 
   func testBindings() throws {
     let text = """
-    let x = 4
-    var y = "test" + "123"
-    """
+      let x = 4
+      var y = "test" + "123"
+      """
     let hints = try performInlayHintRequest(text: text)
-    XCTAssertEqual(hints, [
-      makeInlayHint(
-        position: Position(line: 0, utf16index: 5),
-        kind: .type,
-        label: ": Int"
-      ),
-      makeInlayHint(
-        position: Position(line: 1, utf16index: 5),
-        kind: .type,
-        label: ": String"
-      ),
-    ])
+    XCTAssertEqual(
+      hints,
+      [
+        makeInlayHint(
+          position: Position(line: 0, utf16index: 5),
+          kind: .type,
+          label: ": Int"
+        ),
+        makeInlayHint(
+          position: Position(line: 1, utf16index: 5),
+          kind: .type,
+          label: ": String"
+        ),
+      ]
+    )
   }
 
   func testRanged() throws {
     let text = """
-    func square(_ x: Double) -> Double {
-      let result = x * x
-      return result
-    }
+      func square(_ x: Double) -> Double {
+        let result = x * x
+        return result
+      }
 
-    func collatz(_ n: Int) -> Int {
-      let even = n % 2 == 0
-      let result = even ? (n / 2) : (3 * n + 1)
-      return result
-    }
-    """
+      func collatz(_ n: Int) -> Int {
+        let even = n % 2 == 0
+        let result = even ? (n / 2) : (3 * n + 1)
+        return result
+      }
+      """
     let range = Position(line: 6, utf16index: 0)..<Position(line: 9, utf16index: 0)
     let hints = try performInlayHintRequest(text: text, range: range)
-    XCTAssertEqual(hints, [
-      makeInlayHint(
-        position: Position(line: 6, utf16index: 10),
-        kind: .type,
-        label: ": Bool"
-      ),
-      makeInlayHint(
-        position: Position(line: 7, utf16index: 12),
-        kind: .type,
-        label: ": Int"
-      )
-    ])
+    XCTAssertEqual(
+      hints,
+      [
+        makeInlayHint(
+          position: Position(line: 6, utf16index: 10),
+          kind: .type,
+          label: ": Bool"
+        ),
+        makeInlayHint(
+          position: Position(line: 7, utf16index: 12),
+          kind: .type,
+          label: ": Int"
+        ),
+      ]
+    )
   }
 
   func testFields() throws {
     let text = """
-    class X {
-      let instanceMember = 3
-      static let staticMember = "abc"
-    }
+      class X {
+        let instanceMember = 3
+        static let staticMember = "abc"
+      }
 
-    struct Y {
-      var instanceMember = "def" + "ghi"
-      static let staticMember = 1 + 2
-    }
+      struct Y {
+        var instanceMember = "def" + "ghi"
+        static let staticMember = 1 + 2
+      }
 
-    enum Z {
-      static let staticMember = 3.0
-    }
-    """
+      enum Z {
+        static let staticMember = 3.0
+      }
+      """
     let hints = try performInlayHintRequest(text: text)
-    XCTAssertEqual(hints, [
-      makeInlayHint(
-        position: Position(line: 1, utf16index: 20),
-        kind: .type,
-        label: ": Int"
-      ),
-      makeInlayHint(
-        position: Position(line: 2, utf16index: 25),
-        kind: .type,
-        label: ": String"
-      ),
-      makeInlayHint(
-        position: Position(line: 6, utf16index: 20),
-        kind: .type,
-        label: ": String"
-      ),
-      makeInlayHint(
-        position: Position(line: 7, utf16index: 25),
-        kind: .type,
-        label: ": Int"
-      ),
-      makeInlayHint(
-        position: Position(line: 11, utf16index: 25),
-        kind: .type,
-        label: ": Double"
-      ),
-    ])
+    XCTAssertEqual(
+      hints,
+      [
+        makeInlayHint(
+          position: Position(line: 1, utf16index: 20),
+          kind: .type,
+          label: ": Int"
+        ),
+        makeInlayHint(
+          position: Position(line: 2, utf16index: 25),
+          kind: .type,
+          label: ": String"
+        ),
+        makeInlayHint(
+          position: Position(line: 6, utf16index: 20),
+          kind: .type,
+          label: ": String"
+        ),
+        makeInlayHint(
+          position: Position(line: 7, utf16index: 25),
+          kind: .type,
+          label: ": Int"
+        ),
+        makeInlayHint(
+          position: Position(line: 11, utf16index: 25),
+          kind: .type,
+          label: ": Double"
+        ),
+      ]
+    )
   }
 
   func testExplicitTypeAnnotation() throws {
     let text = """
-    let x: String = "abc"
-    
-    struct X {
-      var y: Int = 34
-    }
-    """
+      let x: String = "abc"
+
+      struct X {
+        var y: Int = 34
+      }
+      """
     let hints = try performInlayHintRequest(text: text)
     XCTAssertEqual(hints, [])
   }
 
   func testClosureParams() throws {
     let text = """
-    func f(x: Int) {}
+      func f(x: Int) {}
 
-    let g = { (x: Int) in }
-    let h: (String) -> String = { x in x }
-    let i: (Double, Double) -> Double = { (x, y) in
-      x + y
-    }
-    """
+      let g = { (x: Int) in }
+      let h: (String) -> String = { x in x }
+      let i: (Double, Double) -> Double = { (x, y) in
+        x + y
+      }
+      """
     let hints = try performInlayHintRequest(text: text)
-    XCTAssertEqual(hints, [
-      makeInlayHint(
-        position: Position(line: 2, utf16index: 5),
-        kind: .type,
-        label: ": (Int) -> ()"
-      ),
-      makeInlayHint(
-        position: Position(line: 3, utf16index: 31),
-        kind: .type,
-        label: ": String",
-        hasEdit: false
-      ),
-      makeInlayHint(
-        position: Position(line: 4, utf16index: 40),
-        kind: .type,
-        label: ": Double"
-      ),
-      makeInlayHint(
-        position: Position(line: 4, utf16index: 43),
-        kind: .type,
-        label: ": Double"
-      )
-    ])
+    XCTAssertEqual(
+      hints,
+      [
+        makeInlayHint(
+          position: Position(line: 2, utf16index: 5),
+          kind: .type,
+          label: ": (Int) -> ()"
+        ),
+        makeInlayHint(
+          position: Position(line: 3, utf16index: 31),
+          kind: .type,
+          label: ": String",
+          hasEdit: false
+        ),
+        makeInlayHint(
+          position: Position(line: 4, utf16index: 40),
+          kind: .type,
+          label: ": Double"
+        ),
+        makeInlayHint(
+          position: Position(line: 4, utf16index: 43),
+          kind: .type,
+          label: ": Double"
+        ),
+      ]
+    )
   }
 }

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import SKTestSupport
 import XCTest
@@ -19,7 +19,7 @@ import XCTest
 final class LocalClangTests: XCTestCase {
 
   /// Whether to fail tests if clangd cannot be found.
-  static let requireClangd: Bool = false // Note: Swift CI doesn't build clangd on all jobs
+  static let requireClangd: Bool = false  // Note: Swift CI doesn't build clangd on all jobs
 
   /// Whether clangd exists in the toolchain.
   var haveClangd: Bool = false
@@ -44,14 +44,17 @@ final class LocalClangTests: XCTestCase {
       hierarchicalDocumentSymbolSupport: true
     )
     let textDocument = TextDocumentClientCapabilities(documentSymbol: documentSymbol)
-    _ = try! sk.sendSync(InitializeRequest(
+    _ = try! sk.sendSync(
+      InitializeRequest(
         processId: nil,
         rootPath: nil,
         rootURI: nil,
         initializationOptions: nil,
         capabilities: ClientCapabilities(workspace: nil, textDocument: textDocument),
         trace: .off,
-        workspaceFolders: nil))
+        workspaceFolders: nil
+      )
+    )
   }
 
   override func tearDown() {
@@ -63,28 +66,36 @@ final class LocalClangTests: XCTestCase {
 
   func testSymbolInfo() throws {
     guard haveClangd else { return }
-#if os(Windows)
+    #if os(Windows)
     let url = URL(fileURLWithPath: "C:/a.cpp")
-#else
+    #else
     let url = URL(fileURLWithPath: "/a.cpp")
-#endif
+    #endif
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .cpp,
-      version: 1,
-      text: """
-      struct S {
-        void foo() {
-          int local = 1;
-        }
-      };
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .cpp,
+          version: 1,
+          text: """
+            struct S {
+              void foo() {
+                int local = 1;
+              }
+            };
+            """
+        )
+      )
+    )
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 0, utf16index: 7)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 0, utf16index: 7)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -95,9 +106,12 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 1, utf16index: 7)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 1, utf16index: 7)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -108,9 +122,12 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 2, utf16index: 8)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 2, utf16index: 8)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -121,9 +138,12 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 3, utf16index: 0)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 3, utf16index: 0)
+        )
+      )
 
       XCTAssertEqual(resp.count, 0)
     }
@@ -131,52 +151,65 @@ final class LocalClangTests: XCTestCase {
 
   func testFoldingRange() throws {
     guard haveClangd else { return }
-#if os(Windows)
+    #if os(Windows)
     let url = URL(fileURLWithPath: "C:/a.cpp")
-#else
+    #else
     let url = URL(fileURLWithPath: "/a.cpp")
-#endif
+    #endif
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .cpp,
-      version: 1,
-      text: """
-      struct S {
-        void foo() {
-          int local = 1;
-        }
-      };
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .cpp,
+          version: 1,
+          text: """
+            struct S {
+              void foo() {
+                int local = 1;
+              }
+            };
+            """
+        )
+      )
+    )
 
     let resp = try sk.sendSync(FoldingRangeRequest(textDocument: TextDocumentIdentifier(url)))
     if let resp = resp {
-      XCTAssertEqual(resp, [
-        FoldingRange(startLine: 0, startUTF16Index: 10, endLine: 4, kind: .region),
-        FoldingRange(startLine: 1, startUTF16Index: 14, endLine: 3, endUTF16Index: 2, kind: .region),
-      ])
+      XCTAssertEqual(
+        resp,
+        [
+          FoldingRange(startLine: 0, startUTF16Index: 10, endLine: 4, kind: .region),
+          FoldingRange(startLine: 1, startUTF16Index: 14, endLine: 3, endUTF16Index: 2, kind: .region),
+        ]
+      )
     }
   }
 
   func testDocumentSymbols() throws {
     guard haveClangd else { return }
-#if os(Windows)
+    #if os(Windows)
     let url = URL(fileURLWithPath: "C:/a.cpp")
-#else
+    #else
     let url = URL(fileURLWithPath: "/a.cpp")
-#endif
+    #endif
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .cpp,
-      version: 1,
-      text: """
-      struct S {
-        void foo() {
-          int local = 1;
-        }
-      };
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .cpp,
+          version: 1,
+          text: """
+            struct S {
+              void foo() {
+                int local = 1;
+              }
+            };
+            """
+        )
+      )
+    )
 
     guard let resp = try sk.sendSync(DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))) else {
       XCTFail("Invalid document symbol response")
@@ -204,9 +237,10 @@ final class LocalClangTests: XCTestCase {
       let diagnostics = note.params.diagnostics
       // It seems we either get no diagnostics or a `-Wswitch` warning. Either is fine
       // as long as our code action works properly.
-      XCTAssert(diagnostics.isEmpty ||
-                  (diagnostics.count == 1 && diagnostics.first?.code == .string("-Wswitch")),
-                "Unexpected diagnostics \(diagnostics)")
+      XCTAssert(
+        diagnostics.isEmpty || (diagnostics.count == 1 && diagnostics.first?.code == .string("-Wswitch")),
+        "Unexpected diagnostics \(diagnostics)"
+      )
       expectation.fulfill()
     }
 
@@ -241,7 +275,9 @@ final class LocalClangTests: XCTestCase {
     }
 
     let executeCommand = ExecuteCommandRequest(
-      command: command.command, arguments: command.arguments)
+      command: command.command,
+      arguments: command.arguments
+    )
     _ = try ws.sk.sendSync(executeCommand)
 
     try await fulfillmentOfOrThrow([applyEdit])
@@ -258,8 +294,10 @@ final class LocalClangTests: XCTestCase {
     ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
       // Don't use exact equality because of differences in recent clang.
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range,
-        Position(loc) ..< Position(ws.testLoc("unused_b:end")))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(loc)..<Position(ws.testLoc("unused_b:end"))
+      )
       XCTAssertEqual(note.params.diagnostics.first?.severity, .warning)
       XCTAssertEqual(note.params.diagnostics.first?.message, "Unused variable 'b'")
       expectation.fulfill()
@@ -311,8 +349,10 @@ final class LocalClangTests: XCTestCase {
       XCTAssertNotNil(reply)
     } catch let e {
       if let error = e as? ResponseError {
-        try XCTSkipIf(error.code == ErrorCode.methodNotFound,
-                  "clangd does not support semantic tokens")
+        try XCTSkipIf(
+          error.code == ErrorCode.methodNotFound,
+          "clangd does not support semantic tokens"
+        )
       }
       throw e
     }
@@ -350,7 +390,11 @@ final class LocalClangTests: XCTestCase {
       updatedNotificationsReceived.fulfill()
     })
 
-    let clangdServer = await ws.testServer.server!._languageService(for: cFileLoc.docUri, .cpp, in: ws.testServer.server!.workspaceForDocument(uri: cFileLoc.docUri)!)!
+    let clangdServer = await ws.testServer.server!._languageService(
+      for: cFileLoc.docUri,
+      .cpp,
+      in: ws.testServer.server!.workspaceForDocument(uri: cFileLoc.docUri)!
+    )!
 
     await clangdServer.documentDependenciesUpdated(cFileLoc.docUri)
 

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPLogging
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
-import XCTest
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
+import XCTest
 
 // Workaround ambiguity with Foundation.
 typealias Notification = LanguageServerProtocol.Notification
@@ -33,21 +33,27 @@ final class LocalSwiftTests: XCTestCase {
   override func setUp() {
     connection = TestSourceKitServer()
     sk = connection.client
-    _ = try! sk.sendSync(InitializeRequest(
+    _ = try! sk.sendSync(
+      InitializeRequest(
         processId: nil,
         rootPath: nil,
         rootURI: nil,
         initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil,
-                                         textDocument: TextDocumentClientCapabilities(
-                                          codeAction: .init(
-                                            codeActionLiteralSupport: .init(
-                                              codeActionKind: .init(valueSet: [.quickFix])
-                                          )),
-                                          publishDiagnostics: .init(codeDescriptionSupport: true)
-                                         )),
+        capabilities: ClientCapabilities(
+          workspace: nil,
+          textDocument: TextDocumentClientCapabilities(
+            codeAction: .init(
+              codeActionLiteralSupport: .init(
+                codeActionKind: .init(valueSet: [.quickFix])
+              )
+            ),
+            publishDiagnostics: .init(codeDescriptionSupport: true)
+          )
+        ),
         trace: .off,
-        workspaceFolders: nil))
+        workspaceFolders: nil
+      )
+    )
   }
 
   override func tearDown() {
@@ -63,124 +69,184 @@ final class LocalSwiftTests: XCTestCase {
 
     let documentManager = await connection.server!._documentManager
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: 12,
-      text: """
-      func
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual("func", documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 4))
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual("func", documentManager.latestSnapshot(uri)!.text)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 4)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 13), contentChanges: [
-      .init(range: Range(Position(line: 0, utf16index: 4)), text: " foo() {}\n")
-    ]), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 1 - syntactic")
-      // 1 = remaining semantic error
-      // 0 = semantic update finished already
-      XCTAssertEqual(note.params.version, 13)
-      XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual("func foo() {}\n", documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 1 - semantic")
-      XCTAssertEqual(note.params.version, 13)
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-    })
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 13),
+        contentChanges: [
+          .init(range: Range(Position(line: 0, utf16index: 4)), text: " foo() {}\n")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 1 - syntactic")
+        // 1 = remaining semantic error
+        // 0 = semantic update finished already
+        XCTAssertEqual(note.params.version, 13)
+        XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual("func foo() {}\n", documentManager.latestSnapshot(uri)!.text)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 1 - semantic")
+        XCTAssertEqual(note.params.version, 13)
+        XCTAssertEqual(note.params.diagnostics.count, 0)
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 14), contentChanges: [
-      .init(range: Range(Position(line: 1, utf16index: 0)), text: "bar()")
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 14),
+        contentChanges: [
+          .init(range: Range(Position(line: 1, utf16index: 0)), text: "bar()")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 2 - syntactic")
         XCTAssertEqual(note.params.version, 14)
         // 1 = semantic update finished already
         // 0 = only syntactic
         XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func foo() {}
-        bar()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 2 - semantic")
-      XCTAssertEqual(note.params.version, 14)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 1, utf16index: 0))
-    })
+        XCTAssertEqual(
+          """
+          func foo() {}
+          bar()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 2 - semantic")
+        XCTAssertEqual(note.params.version, 14)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 1, utf16index: 0)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 14), contentChanges: [
-      .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "foo")
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 14),
+        contentChanges: [
+          .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "foo")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 3 - syntactic")
         // 1 = remaining semantic error
         // 0 = semantic update finished already
         XCTAssertEqual(note.params.version, 14)
         XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func foo() {}
-        foo()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 3 - semantic")
-      XCTAssertEqual(note.params.version, 14)
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-    })
+        XCTAssertEqual(
+          """
+          func foo() {}
+          foo()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 3 - semantic")
+        XCTAssertEqual(note.params.version, 14)
+        XCTAssertEqual(note.params.diagnostics.count, 0)
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 15), contentChanges: [
-      .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "fooTypo")
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 15),
+        contentChanges: [
+          .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "fooTypo")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 4 - syntactic")
         XCTAssertEqual(note.params.version, 15)
         // 1 = semantic update finished already
         // 0 = only syntactic
         XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func foo() {}
-        fooTypo()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 4 - semantic")
-      XCTAssertEqual(note.params.version, 15)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 1, utf16index: 0))
-    })
+        XCTAssertEqual(
+          """
+          func foo() {}
+          fooTypo()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 4 - semantic")
+        XCTAssertEqual(note.params.version, 15)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 1, utf16index: 0)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 16), contentChanges: [
-      .init(range: nil, text: """
-      func bar() {}
-      foo()
-      """)
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 16),
+        contentChanges: [
+          .init(
+            range: nil,
+            text: """
+              func bar() {}
+              foo()
+              """
+          )
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 5 - syntactic")
         XCTAssertEqual(note.params.version, 16)
         // Could be remaining semantic error or new one.
         XCTAssertEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func bar() {}
-        foo()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 5 - semantic")
-      XCTAssertEqual(note.params.version, 16)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 1, utf16index: 0))
-    })
+        XCTAssertEqual(
+          """
+          func bar() {}
+          foo()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 5 - semantic")
+        XCTAssertEqual(note.params.version, 16)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 1, utf16index: 0)
+        )
+      }
+    )
   }
 
   func testEditingNonURL() async {
@@ -190,124 +256,184 @@ final class LocalSwiftTests: XCTestCase {
 
     let documentManager = await connection.server!._documentManager
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: 12,
-      text: """
-      func
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual("func", documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 4))
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual("func", documentManager.latestSnapshot(uri)!.text)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 4)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 13), contentChanges: [
-      .init(range: Range(Position(line: 0, utf16index: 4)), text: " foo() {}\n")
-    ]), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 1 - syntactic")
-      XCTAssertEqual(note.params.version, 13)
-      // 1 = remaining semantic error
-      // 0 = semantic update finished already
-      XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual("func foo() {}\n", documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 1 - semantic")
-      XCTAssertEqual(note.params.version, 13)
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-    })
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 13),
+        contentChanges: [
+          .init(range: Range(Position(line: 0, utf16index: 4)), text: " foo() {}\n")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 1 - syntactic")
+        XCTAssertEqual(note.params.version, 13)
+        // 1 = remaining semantic error
+        // 0 = semantic update finished already
+        XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual("func foo() {}\n", documentManager.latestSnapshot(uri)!.text)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 1 - semantic")
+        XCTAssertEqual(note.params.version, 13)
+        XCTAssertEqual(note.params.diagnostics.count, 0)
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 14), contentChanges: [
-      .init(range: Range(Position(line: 1, utf16index: 0)), text: "bar()")
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 14),
+        contentChanges: [
+          .init(range: Range(Position(line: 1, utf16index: 0)), text: "bar()")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 2 - syntactic")
         XCTAssertEqual(note.params.version, 14)
         // 1 = semantic update finished already
         // 0 = only syntactic
         XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func foo() {}
-        bar()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 2 - semantic")
-      XCTAssertEqual(note.params.version, 14)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 1, utf16index: 0))
-    })
+        XCTAssertEqual(
+          """
+          func foo() {}
+          bar()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 2 - semantic")
+        XCTAssertEqual(note.params.version, 14)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 1, utf16index: 0)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 14), contentChanges: [
-      .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "foo")
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 14),
+        contentChanges: [
+          .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "foo")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 3 - syntactic")
         XCTAssertEqual(note.params.version, 14)
         // 1 = remaining semantic error
         // 0 = semantic update finished already
         XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func foo() {}
-        foo()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 3 - semantic")
-      XCTAssertEqual(note.params.version, 14)
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-    })
+        XCTAssertEqual(
+          """
+          func foo() {}
+          foo()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 3 - semantic")
+        XCTAssertEqual(note.params.version, 14)
+        XCTAssertEqual(note.params.diagnostics.count, 0)
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 15), contentChanges: [
-      .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "fooTypo")
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 15),
+        contentChanges: [
+          .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "fooTypo")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 4 - syntactic")
         XCTAssertEqual(note.params.version, 15)
         // 1 = semantic update finished already
         // 0 = only syntactic
         XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func foo() {}
-        fooTypo()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 4 - semantic")
-      XCTAssertEqual(note.params.version, 15)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 1, utf16index: 0))
-    })
+        XCTAssertEqual(
+          """
+          func foo() {}
+          fooTypo()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 4 - semantic")
+        XCTAssertEqual(note.params.version, 15)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 1, utf16index: 0)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 16), contentChanges: [
-      .init(range: nil, text: """
-      func bar() {}
-      foo()
-      """)
-      ]), { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 16),
+        contentChanges: [
+          .init(
+            range: nil,
+            text: """
+              func bar() {}
+              foo()
+              """
+          )
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
         log("Received diagnostics for edit 5 - syntactic")
         XCTAssertEqual(note.params.version, 16)
-         // Could be remaining semantic error or new one.
+        // Could be remaining semantic error or new one.
         XCTAssertEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual("""
-        func bar() {}
-        foo()
-        """, documentManager.latestSnapshot(uri)!.text)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 5 - semantic")
-      XCTAssertEqual(note.params.version, 16)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 1, utf16index: 0))
-    })
+        XCTAssertEqual(
+          """
+          func bar() {}
+          foo()
+          """,
+          documentManager.latestSnapshot(uri)!.text
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 5 - semantic")
+        XCTAssertEqual(note.params.version, 16)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 1, utf16index: 0)
+        )
+      }
+    )
   }
 
   func testExcludedDocumentSchemeDiagnostics() {
@@ -317,32 +443,42 @@ final class LocalSwiftTests: XCTestCase {
     let excludedURI = DocumentURI(string: "git:/a.swift")
 
     let text = """
-    func
-    """
+      func
+      """
 
     sk.allowUnexpectedNotification = false
 
     // Open the excluded URI first so our later notification handlers can confirm
     // that no diagnostics were emitted for this excluded URI.
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: excludedURI,
-      language: .swift,
-      version: 1,
-      text: text
-    )))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: excludedURI,
+          language: .swift,
+          version: 1,
+          text: text
+        )
+      )
+    )
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: includedURI,
-      language: .swift,
-      version: 1,
-      text: text
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.uri, includedURI)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.uri, includedURI)
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: includedURI,
+          language: .swift,
+          version: 1,
+          text: text
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.uri, includedURI)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.uri, includedURI)
+      }
+    )
   }
 
   func testCrossFileDiagnostics() {
@@ -353,57 +489,82 @@ final class LocalSwiftTests: XCTestCase {
 
     sk.allowUnexpectedNotification = false
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uriA, language: .swift, version: 12,
-      text: """
-      foo()
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.version, 12)
-      // 1 = semantic update finished already
-      // 0 = only syntactic
-      XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 0))
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uriA,
+          language: .swift,
+          version: 12,
+          text: """
+            foo()
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.version, 12)
+        // 1 = semantic update finished already
+        // 0 = only syntactic
+        XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 0)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uriB, language: .swift, version: 12,
-      text: """
-      bar()
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.version, 12)
-      // 1 = semantic update finished already
-      // 0 = only syntactic
-      XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 0))
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uriB,
+          language: .swift,
+          version: 12,
+          text: """
+            bar()
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.version, 12)
+        // 1 = semantic update finished already
+        // 0 = only syntactic
+        XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 0)
+        )
+      }
+    )
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uriA, version: 13), contentChanges: [
-      .init(range: nil, text: "foo()\n")
-    ]), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 1 - syntactic")
-      XCTAssertEqual(note.params.version, 13)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for edit 1 - semantic")
-      XCTAssertEqual(note.params.version, 13)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-    })
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uriA, version: 13),
+        contentChanges: [
+          .init(range: nil, text: "foo()\n")
+        ]
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 1 - syntactic")
+        XCTAssertEqual(note.params.version, 13)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for edit 1 - semantic")
+        XCTAssertEqual(note.params.version, 13)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+      }
+    )
   }
 
   func testDiagnosticsReopen() {
@@ -411,49 +572,68 @@ final class LocalSwiftTests: XCTestCase {
     let uriA = DocumentURI(urlA)
     sk.allowUnexpectedNotification = false
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uriA, language: .swift, version: 12,
-      text: """
-      foo()
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.version, 12)
-      // 1 = semantic update finished already
-      // 0 = only syntactic
-      XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.version, 12)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 0))
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uriA,
+          language: .swift,
+          version: 12,
+          text: """
+            foo()
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.version, 12)
+        // 1 = semantic update finished already
+        // 0 = only syntactic
+        XCTAssertLessThanOrEqual(note.params.diagnostics.count, 1)
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.version, 12)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 0)
+        )
+      }
+    )
 
     sk.send(DidCloseTextDocumentNotification(textDocument: .init(urlA)))
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uriA, language: .swift, version: 13,
-      text: """
-      var
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-      XCTAssertEqual(note.params.version, 13)
-      // 1 = syntactic, no cached semantic diagnostic from previous version
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 3))
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.version, 13)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(
-        note.params.diagnostics.first?.range.lowerBound,
-        Position(line: 0, utf16index: 3))
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uriA,
+          language: .swift,
+          version: 13,
+          text: """
+            var
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+        XCTAssertEqual(note.params.version, 13)
+        // 1 = syntactic, no cached semantic diagnostic from previous version
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 3)
+        )
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.version, 13)
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(
+          note.params.diagnostics.first?.range.lowerBound,
+          Position(line: 0, utf16index: 3)
+        )
+      }
+    )
   }
 
   func testEducationalNotesAreUsedAsDiagnosticCodes() {
@@ -462,18 +642,26 @@ final class LocalSwiftTests: XCTestCase {
 
     sk.allowUnexpectedNotification = false
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: "@propertyWrapper struct Bar {}"
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      let diag = note.params.diagnostics.first!
-      XCTAssertEqual(diag.code, .string("property-wrapper-requirements"))
-      XCTAssertEqual(diag.codeDescription?.href.fileURL?.lastPathComponent, "property-wrapper-requirements.md")
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: "@propertyWrapper struct Bar {}"
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        let diag = note.params.diagnostics.first!
+        XCTAssertEqual(diag.code, .string("property-wrapper-requirements"))
+        XCTAssertEqual(diag.codeDescription?.href.fileURL?.lastPathComponent, "property-wrapper-requirements.md")
+      }
+    )
   }
 
   func testFixitsAreIncludedInPublishDiagnostics() {
@@ -482,32 +670,47 @@ final class LocalSwiftTests: XCTestCase {
 
     sk.allowUnexpectedNotification = false
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      func foo() {
-        let a = 2
-      }
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      let diag = note.params.diagnostics.first!
-      XCTAssertNotNil(diag.codeActions)
-      XCTAssertEqual(diag.codeActions!.count, 1)
-      let fixit = diag.codeActions!.first!
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func foo() {
+              let a = 2
+            }
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        let diag = note.params.diagnostics.first!
+        XCTAssertNotNil(diag.codeActions)
+        XCTAssertEqual(diag.codeActions!.count, 1)
+        let fixit = diag.codeActions!.first!
 
-      // Expected Fix-it: Replace `let a` with `_` because it's never used
-      let expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 7), newText: "_")
-      XCTAssertEqual(fixit, CodeAction(
-        title: "Replace 'let a' with '_'",
-        kind: .quickFix,
-        diagnostics: nil,
-        edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
-        command: nil))
-    })
+        // Expected Fix-it: Replace `let a` with `_` because it's never used
+        let expectedTextEdit = TextEdit(
+          range: Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 7),
+          newText: "_"
+        )
+        XCTAssertEqual(
+          fixit,
+          CodeAction(
+            title: "Replace 'let a' with '_'",
+            kind: .quickFix,
+            diagnostics: nil,
+            edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
+            command: nil
+          )
+        )
+      }
+    )
   }
 
   func testFixitsAreIncludedInPublishDiagnosticsNotes() {
@@ -516,51 +719,73 @@ final class LocalSwiftTests: XCTestCase {
 
     sk.allowUnexpectedNotification = false
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      func foo(a: Int?) {
-        _ = a.bigEndian
-      }
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      let diag = note.params.diagnostics.first!
-      XCTAssertEqual(diag.relatedInformation?.count, 2)
-      if let note1 = diag.relatedInformation?.first(where: { $0.message.contains("'?'") }) {
-        XCTAssertEqual(note1.codeActions?.count, 1)
-        if let fixit = note1.codeActions?.first {
-          // Expected Fix-it: Replace `let a` with `_` because it's never used
-          let expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 7)..<Position(line: 1, utf16index: 7), newText: "?")
-          XCTAssertEqual(fixit, CodeAction(
-            title: "chain the optional using '?' to access member 'bigEndian' only for non-'nil' base values",
-            kind: .quickFix,
-            diagnostics: nil,
-            edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
-            command: nil))
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func foo(a: Int?) {
+              _ = a.bigEndian
+            }
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        let diag = note.params.diagnostics.first!
+        XCTAssertEqual(diag.relatedInformation?.count, 2)
+        if let note1 = diag.relatedInformation?.first(where: { $0.message.contains("'?'") }) {
+          XCTAssertEqual(note1.codeActions?.count, 1)
+          if let fixit = note1.codeActions?.first {
+            // Expected Fix-it: Replace `let a` with `_` because it's never used
+            let expectedTextEdit = TextEdit(
+              range: Position(line: 1, utf16index: 7)..<Position(line: 1, utf16index: 7),
+              newText: "?"
+            )
+            XCTAssertEqual(
+              fixit,
+              CodeAction(
+                title: "chain the optional using '?' to access member 'bigEndian' only for non-'nil' base values",
+                kind: .quickFix,
+                diagnostics: nil,
+                edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
+                command: nil
+              )
+            )
+          }
+        } else {
+          XCTFail("missing '?' note")
         }
-      } else {
-        XCTFail("missing '?' note")
-      }
-      if let note2 = diag.relatedInformation?.first(where: { $0.message.contains("'!'") }) {
-        XCTAssertEqual(note2.codeActions?.count, 1)
-        if let fixit = note2.codeActions?.first {
-          // Expected Fix-it: Replace `let a` with `_` because it's never used
-          let expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 7)..<Position(line: 1, utf16index: 7), newText: "!")
-          XCTAssertEqual(fixit, CodeAction(
-            title: "force-unwrap using '!' to abort execution if the optional value contains 'nil'",
-            kind: .quickFix,
-            diagnostics: nil,
-            edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
-            command: nil))
+        if let note2 = diag.relatedInformation?.first(where: { $0.message.contains("'!'") }) {
+          XCTAssertEqual(note2.codeActions?.count, 1)
+          if let fixit = note2.codeActions?.first {
+            // Expected Fix-it: Replace `let a` with `_` because it's never used
+            let expectedTextEdit = TextEdit(
+              range: Position(line: 1, utf16index: 7)..<Position(line: 1, utf16index: 7),
+              newText: "!"
+            )
+            XCTAssertEqual(
+              fixit,
+              CodeAction(
+                title: "force-unwrap using '!' to abort execution if the optional value contains 'nil'",
+                kind: .quickFix,
+                diagnostics: nil,
+                edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
+                command: nil
+              )
+            )
+          }
+        } else {
+          XCTFail("missing '!' note")
         }
-      } else {
-        XCTFail("missing '!' note")
       }
-    })
+    )
   }
 
   func testFixitInsert() {
@@ -569,32 +794,47 @@ final class LocalSwiftTests: XCTestCase {
 
     sk.allowUnexpectedNotification = false
 
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      func foo() {
-        print("")print("")
-      }
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      let diag = note.params.diagnostics.first!
-      XCTAssertNotNil(diag.codeActions)
-      XCTAssertEqual(diag.codeActions!.count, 1)
-      let fixit = diag.codeActions!.first!
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func foo() {
+              print("")print("")
+            }
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        let diag = note.params.diagnostics.first!
+        XCTAssertNotNil(diag.codeActions)
+        XCTAssertEqual(diag.codeActions!.count, 1)
+        let fixit = diag.codeActions!.first!
 
-      // Expected Fix-it: Insert `;`
-      let expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 11)..<Position(line: 1, utf16index: 11), newText: ";")
-      XCTAssertEqual(fixit, CodeAction(
-        title: "Insert ';'",
-        kind: .quickFix,
-        diagnostics: nil,
-        edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
-        command: nil))
-    })
+        // Expected Fix-it: Insert `;`
+        let expectedTextEdit = TextEdit(
+          range: Position(line: 1, utf16index: 11)..<Position(line: 1, utf16index: 11),
+          newText: ";"
+        )
+        XCTAssertEqual(
+          fixit,
+          CodeAction(
+            title: "Insert ';'",
+            kind: .quickFix,
+            diagnostics: nil,
+            edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
+            command: nil
+          )
+        )
+      }
+    )
   }
 
   func testFixitTitle() {
@@ -608,24 +848,35 @@ final class LocalSwiftTests: XCTestCase {
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic? = nil
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      func foo() {
-        let a = 2
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func foo() {
+              let a = 2
+            }
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        diagnostic = note.params.diagnostics.first
       }
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      diagnostic = note.params.diagnostics.first
-    })
+    )
 
     let request = CodeActionRequest(
       range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 11),
-      context: CodeActionContext(diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")], only: nil),
+      context: CodeActionContext(
+        diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")],
+        only: nil
+      ),
       textDocument: TextDocumentIdentifier(uri)
     )
     let response = try sk.sendSync(request)
@@ -635,7 +886,7 @@ final class LocalSwiftTests: XCTestCase {
       XCTFail("Expected code actions as response")
       return
     }
-    let quickFixes = codeActions.filter{ $0.kind == .quickFix }
+    let quickFixes = codeActions.filter { $0.kind == .quickFix }
     XCTAssertEqual(quickFixes.count, 1)
     let fixit = quickFixes.first!
 
@@ -644,13 +895,20 @@ final class LocalSwiftTests: XCTestCase {
     expectedDiagnostic.codeActions = nil
 
     // Expected Fix-it: Replace `let a` with `_` because it's never used
-    let expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 7), newText: "_")
-    XCTAssertEqual(fixit, CodeAction(
-      title: "Replace 'let a' with '_'",
-      kind: .quickFix,
-      diagnostics: [expectedDiagnostic],
-      edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
-      command: nil))
+    let expectedTextEdit = TextEdit(
+      range: Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 7),
+      newText: "_"
+    )
+    XCTAssertEqual(
+      fixit,
+      CodeAction(
+        title: "Replace 'let a' with '_'",
+        kind: .quickFix,
+        diagnostics: [expectedDiagnostic],
+        edit: WorkspaceEdit(changes: [uri: [expectedTextEdit]], documentChanges: nil),
+        command: nil
+      )
+    )
   }
 
   func testFixitsAreReturnedFromCodeActionsNotes() throws {
@@ -658,24 +916,35 @@ final class LocalSwiftTests: XCTestCase {
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic?
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      func foo(a: Int?) {
-        _ = a.bigEndian
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            func foo(a: Int?) {
+              _ = a.bigEndian
+            }
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        diagnostic = note.params.diagnostics.first
       }
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      diagnostic = note.params.diagnostics.first
-    })
+    )
 
     let request = CodeActionRequest(
       range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 11),
-      context: CodeActionContext(diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")], only: nil),
+      context: CodeActionContext(
+        diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")],
+        only: nil
+      ),
       textDocument: TextDocumentIdentifier(uri)
     )
     let response = try sk.sendSync(request)
@@ -685,10 +954,13 @@ final class LocalSwiftTests: XCTestCase {
       XCTFail("Expected code actions as response")
       return
     }
-    let quickFixes = codeActions.filter{ $0.kind == .quickFix }
+    let quickFixes = codeActions.filter { $0.kind == .quickFix }
     XCTAssertEqual(quickFixes.count, 2)
 
-    var expectedTextEdit = TextEdit(range: Position(line: 1, utf16index: 7)..<Position(line: 1, utf16index: 7), newText: "_")
+    var expectedTextEdit = TextEdit(
+      range: Position(line: 1, utf16index: 7)..<Position(line: 1, utf16index: 7),
+      newText: "_"
+    )
 
     for fixit in quickFixes {
       if fixit.title.contains("!") {
@@ -713,23 +985,34 @@ final class LocalSwiftTests: XCTestCase {
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic?
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      @available(*, introduced: 10, deprecated: 11)
-      func foo() {}
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      diagnostic = note.params.diagnostics.first
-    })
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            @available(*, introduced: 10, deprecated: 11)
+            func foo() {}
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        diagnostic = note.params.diagnostics.first
+      }
+    )
 
     let request = CodeActionRequest(
       range: Position(line: 0, utf16index: 1)..<Position(line: 0, utf16index: 10),
-      context: CodeActionContext(diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")], only: nil),
+      context: CodeActionContext(
+        diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")],
+        only: nil
+      ),
       textDocument: TextDocumentIdentifier(uri)
     )
     let response = try sk.sendSync(request)
@@ -739,16 +1022,19 @@ final class LocalSwiftTests: XCTestCase {
       XCTFail("Expected code actions as response")
       return
     }
-    let quickFixes = codeActions.filter{ $0.kind == .quickFix }
+    let quickFixes = codeActions.filter { $0.kind == .quickFix }
     XCTAssertEqual(quickFixes.count, 1)
-    guard let fixit = quickFixes.first  else { return }
+    guard let fixit = quickFixes.first else { return }
 
     XCTAssertEqual(fixit.title, "Remove ': 10'...")
     XCTAssertEqual(fixit.diagnostics?.count, 1)
-    XCTAssertEqual(fixit.edit?.changes?[uri], [
-      TextEdit(range: Position(line: 0, utf16index: 24)..<Position(line: 0, utf16index: 28), newText: ""),
-      TextEdit(range: Position(line: 0, utf16index: 40)..<Position(line: 0, utf16index: 44), newText: ""),
-    ])
+    XCTAssertEqual(
+      fixit.edit?.changes?[uri],
+      [
+        TextEdit(range: Position(line: 0, utf16index: 24)..<Position(line: 0, utf16index: 28), newText: ""),
+        TextEdit(range: Position(line: 0, utf16index: 40)..<Position(line: 0, utf16index: 44), newText: ""),
+      ]
+    )
   }
 
   func testMuliEditFixitCodeActionNote() throws {
@@ -756,26 +1042,37 @@ final class LocalSwiftTests: XCTestCase {
     let uri = DocumentURI(url)
 
     var diagnostic: Diagnostic?
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri, language: .swift, version: 12,
-      text: """
-      @available(*, deprecated, renamed: "new(_:hotness:)")
-      func old(and: Int, busted: Int) {}
-      func test() {
-        old(and: 1, busted: 2)
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 12,
+          text: """
+            @available(*, deprecated, renamed: "new(_:hotness:)")
+            func old(and: Int, busted: Int) {}
+            func test() {
+              old(and: 1, busted: 2)
+            }
+            """
+        )
+      ),
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: Notification<PublishDiagnosticsNotification>) in
+        log("Received diagnostics for open - semantic")
+        XCTAssertEqual(note.params.diagnostics.count, 1)
+        diagnostic = note.params.diagnostics.first!
       }
-      """
-    )), { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: Notification<PublishDiagnosticsNotification>) in
-      log("Received diagnostics for open - semantic")
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      diagnostic = note.params.diagnostics.first!
-    })
+    )
 
     let request = CodeActionRequest(
       range: Position(line: 3, utf16index: 2)..<Position(line: 3, utf16index: 2),
-      context: CodeActionContext(diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")], only: nil),
+      context: CodeActionContext(
+        diagnostics: [try XCTUnwrap(diagnostic, "expected diagnostic to be available")],
+        only: nil
+      ),
       textDocument: TextDocumentIdentifier(uri)
     )
     let response = try sk.sendSync(request)
@@ -785,104 +1082,156 @@ final class LocalSwiftTests: XCTestCase {
       XCTFail("Expected code actions as response")
       return
     }
-    let quickFixes = codeActions.filter{ $0.kind == .quickFix }
+    let quickFixes = codeActions.filter { $0.kind == .quickFix }
     XCTAssertEqual(quickFixes.count, 1)
-    guard let fixit = quickFixes.first  else { return }
+    guard let fixit = quickFixes.first else { return }
 
     XCTAssertEqual(fixit.title, "use 'new(_:hotness:)' instead")
     XCTAssertEqual(fixit.diagnostics?.count, 1)
     XCTAssert(fixit.diagnostics?.first?.message.contains("is deprecated") == true)
-    XCTAssertEqual(fixit.edit?.changes?[uri], [
-      TextEdit(range: Position(line: 3, utf16index: 2)..<Position(line: 3, utf16index: 5), newText: "new"),
-      TextEdit(range: Position(line: 3, utf16index: 6)..<Position(line: 3, utf16index: 11), newText: ""),
-      TextEdit(range: Position(line: 3, utf16index: 14)..<Position(line: 3, utf16index: 20), newText: "hotness"),
-    ])
+    XCTAssertEqual(
+      fixit.edit?.changes?[uri],
+      [
+        TextEdit(range: Position(line: 3, utf16index: 2)..<Position(line: 3, utf16index: 5), newText: "new"),
+        TextEdit(range: Position(line: 3, utf16index: 6)..<Position(line: 3, utf16index: 11), newText: ""),
+        TextEdit(range: Position(line: 3, utf16index: 14)..<Position(line: 3, utf16index: 20), newText: "hotness"),
+      ]
+    )
   }
 
   func testXMLToMarkdownDeclaration() {
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Declaration>func foo(_ bar: <Type usr="fake">Baz</Type>)</Declaration>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Declaration>func foo(_ bar: <Type usr="fake">Baz</Type>)</Declaration>
+        """
+      ),
+      """
       ```swift
       func foo(_ bar: Baz)
       ```
 
       ---
 
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Declaration>func foo() -&gt; <Type>Bar</Type></Declaration>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Declaration>func foo() -&gt; <Type>Bar</Type></Declaration>
+        """
+      ),
+      """
       ```swift
       func foo() -> Bar
       ```
 
       ---
 
-      """)
-	  XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Link href="https://example.com">My Link</Link>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Link href="https://example.com">My Link</Link>
+        """
+      ),
+      """
       [My Link](https://example.com)
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Link>My Invalid Link</Link>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Link>My Invalid Link</Link>
+        """
+      ),
+      """
       My Invalid Link
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Declaration>func replacingOccurrences&lt;Target, Replacement&gt;(of target: Target, with replacement: Replacement, options: <Type usr="s:SS">String</Type>.<Type usr="s:SS10FoundationE14CompareOptionsa">CompareOptions</Type> = default, range searchRange: <Type usr="s:Sn">Range</Type>&lt;<Type usr="s:SS">String</Type>.<Type usr="s:SS5IndexV">Index</Type>&gt;? = default) -&gt; <Type usr="s:SS">String</Type> where Target : <Type usr="s:Sy">StringProtocol</Type>, Replacement : <Type usr="s:Sy">StringProtocol</Type></Declaration>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Declaration>func replacingOccurrences&lt;Target, Replacement&gt;(of target: Target, with replacement: Replacement, options: <Type usr="s:SS">String</Type>.<Type usr="s:SS10FoundationE14CompareOptionsa">CompareOptions</Type> = default, range searchRange: <Type usr="s:Sn">Range</Type>&lt;<Type usr="s:SS">String</Type>.<Type usr="s:SS5IndexV">Index</Type>&gt;? = default) -&gt; <Type usr="s:SS">String</Type> where Target : <Type usr="s:Sy">StringProtocol</Type>, Replacement : <Type usr="s:Sy">StringProtocol</Type></Declaration>
+        """
+      ),
+      """
       ```swift
       func replacingOccurrences<Target, Replacement>(of target: Target, with replacement: Replacement, options: String.CompareOptions = default, range searchRange: Range<String.Index>? = default) -> String where Target : StringProtocol, Replacement : StringProtocol
       ```
 
       ---
 
-      """)
+      """
+    )
   }
 
   func testXMLToMarkdownComment() {
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><Declaration>var foo</Declaration></Class>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><Declaration>var foo</Declaration></Class>
+        """
+      ),
+      """
       ```swift
       var foo
       ```
 
       ---
 
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><Name>foo</Name><Declaration>var foo</Declaration></Class>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><Name>foo</Name><Declaration>var foo</Declaration></Class>
+        """
+      ),
+      """
       ```swift
       var foo
       ```
 
       ---
 
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><USR>asdf</USR><Declaration>var foo</Declaration><Name>foo</Name></Class>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><USR>asdf</USR><Declaration>var foo</Declaration><Name>foo</Name></Class>
+        """
+      ),
+      """
       ```swift
       var foo
       ```
 
       ---
 
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><Abstract>FOO</Abstract></Class>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><Abstract>FOO</Abstract></Class>
+        """
+      ),
+      """
       FOO
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><Abstract>FOO</Abstract><Declaration>var foo</Declaration></Class>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><Abstract>FOO</Abstract><Declaration>var foo</Declaration></Class>
+        """
+      ),
+      """
       FOO
 
       ```swift
@@ -891,60 +1240,90 @@ final class LocalSwiftTests: XCTestCase {
 
       ---
 
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><Abstract>FOO</Abstract><Discussion>BAR</Discussion></Class>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><Abstract>FOO</Abstract><Discussion>BAR</Discussion></Class>
+        """
+      ),
+      """
       FOO
 
       ### Discussion
 
       BAR
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><Para>A</Para><Para>B</Para><Para>C</Para></Class>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><Para>A</Para><Para>B</Para><Para>C</Para></Class>
+        """
+      ),
+      """
       A
 
       B
 
       C
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <CodeListing>a</CodeListing>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <CodeListing>a</CodeListing>
+        """
+      ),
+      """
       ```
       a
       ```
 
 
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered></CodeListing>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered></CodeListing>
+        """
+      ),
+      """
       ```
       1.\ta
       ```
 
 
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing>
-      """), """
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing>
+        """
+      ),
+      """
       ```
       1.\ta
       2.\tb
       ```
 
-      
-      """)
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Class><CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing><CodeListing><zCodeLineNumbered>c</zCodeLineNumbered><zCodeLineNumbered>d</zCodeLineNumbered></CodeListing></Class>
-      """), """
+
+      """
+    )
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Class><CodeListing><zCodeLineNumbered>a</zCodeLineNumbered><zCodeLineNumbered>b</zCodeLineNumbered></CodeListing><CodeListing><zCodeLineNumbered>c</zCodeLineNumbered><zCodeLineNumbered>d</zCodeLineNumbered></CodeListing></Class>
+        """
+      ),
+      """
       ```
       1.\ta
       2.\tb
@@ -956,74 +1335,90 @@ final class LocalSwiftTests: XCTestCase {
       ```
 
 
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Para>a b c <codeVoice>d e f</codeVoice> g h i</Para>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Para>a b c <codeVoice>d e f</codeVoice> g h i</Para>
+        """
+      ),
+      """
       a b c `d e f` g h i
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Para>a b c <emphasis>d e f</emphasis> g h i</Para>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Para>a b c <emphasis>d e f</emphasis> g h i</Para>
+        """
+      ),
+      """
       a b c *d e f* g h i
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Para>a b c <bold>d e f</bold> g h i</Para>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Para>a b c <bold>d e f</bold> g h i</Para>
+        """
+      ),
+      """
       a b c **d e f** g h i
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Para>a b c<h1>d e f</h1>g h i</Para>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Para>a b c<h1>d e f</h1>g h i</Para>
+        """
+      ),
+      """
       a b c
 
       # d e f
 
       g h i
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <Para>a b c<h3>d e f</h3>g h i</Para>
-      """), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <Para>a b c<h3>d e f</h3>g h i</Para>
+        """
+      ),
+      """
       a b c
 
       ### d e f
 
       g h i
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown(
-      "<Class>" +
-        "<Name>String</Name>" +
-        "<USR>s:SS</USR>" +
-        "<Declaration>struct String</Declaration>" +
-        "<CommentParts>" +
-          "<Abstract>" +
-            "<Para>A Unicode s</Para>" +
-          "</Abstract>" +
-          "<Discussion>" +
-            "<Para>A string is a series of characters, such as <codeVoice>&quot;Swift&quot;</codeVoice>, that forms a collection. " +
-                  "The <codeVoice>String</codeVoice> type bridges with the Objective-C class <codeVoice>NSString</codeVoice> and offers" +
-            "</Para>" +
-            "<Para>You can create new strings A <emphasis>string literal</emphasis> i" +
-            "</Para>" +
-            "<CodeListing language=\"swift\">" +
-              "<zCodeLineNumbered><![CDATA[let greeting = \"Welcome!\"]]></zCodeLineNumbered>" +
-              "<zCodeLineNumbered></zCodeLineNumbered>" +
-            "</CodeListing>" +
-            "<Para>...</Para>" +
-            "<CodeListing language=\"swift\">" +
-              "<zCodeLineNumbered><![CDATA[let greeting = \"Welcome!\"]]></zCodeLineNumbered>" +
-              "<zCodeLineNumbered></zCodeLineNumbered>" +
-            "</CodeListing>" +
-          "</Discussion>" +
-        "</CommentParts>" +
-      "</Class>"
-      ), """
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        "<Class>" + "<Name>String</Name>" + "<USR>s:SS</USR>" + "<Declaration>struct String</Declaration>"
+          + "<CommentParts>" + "<Abstract>"
+          + "<Para>A Unicode s</Para>" + "</Abstract>" + "<Discussion>"
+          + "<Para>A string is a series of characters, such as <codeVoice>&quot;Swift&quot;</codeVoice>, that forms a collection. "
+          + "The <codeVoice>String</codeVoice> type bridges with the Objective-C class <codeVoice>NSString</codeVoice> and offers"
+          + "</Para>"
+          + "<Para>You can create new strings A <emphasis>string literal</emphasis> i" + "</Para>"
+          + "<CodeListing language=\"swift\">"
+          + "<zCodeLineNumbered><![CDATA[let greeting = \"Welcome!\"]]></zCodeLineNumbered>"
+          + "<zCodeLineNumbered></zCodeLineNumbered>" + "</CodeListing>"
+          + "<Para>...</Para>" + "<CodeListing language=\"swift\">"
+          + "<zCodeLineNumbered><![CDATA[let greeting = \"Welcome!\"]]></zCodeLineNumbered>"
+          + "<zCodeLineNumbered></zCodeLineNumbered>" + "</CodeListing>" + "</Discussion>" + "</CommentParts>"
+          + "</Class>"
+      ),
+      """
       ```swift
       struct String
       ```
@@ -1050,110 +1445,115 @@ final class LocalSwiftTests: XCTestCase {
       ```
 
 
-      """)
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown(
-      "<Function file=\"DocumentManager.swift\" line=\"92\" column=\"15\">" +
-        "<CommentParts>" +
-          "<Abstract><Para>Applies the given edits to the document.</Para></Abstract>" +
-          "<Parameters>" +
-            "<Parameter>" +
-              "<Name>editCallback</Name>" +
-              "<Direction isExplicit=\"0\">in</Direction>" +
-              "<Discussion><Para>Optional closure to call for each edit.</Para></Discussion>" +
-            "</Parameter>" +
-            "<Parameter>" +
-              "<Name>before</Name>" +
-              "<Direction isExplicit=\"0\">in</Direction>" +
-              "<Discussion><Para>The document contents <emphasis>before</emphasis> the edit is applied.</Para></Discussion>" +
-            "</Parameter>" +
-          "</Parameters>" +
-        "</CommentParts>" +
-      "</Function>"), """
-    Applies the given edits to the document.
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        "<Function file=\"DocumentManager.swift\" line=\"92\" column=\"15\">" + "<CommentParts>"
+          + "<Abstract><Para>Applies the given edits to the document.</Para></Abstract>" + "<Parameters>"
+          + "<Parameter>" + "<Name>editCallback</Name>"
+          + "<Direction isExplicit=\"0\">in</Direction>"
+          + "<Discussion><Para>Optional closure to call for each edit.</Para></Discussion>" + "</Parameter>"
+          + "<Parameter>" + "<Name>before</Name>" + "<Direction isExplicit=\"0\">in</Direction>"
+          + "<Discussion><Para>The document contents <emphasis>before</emphasis> the edit is applied.</Para></Discussion>"
+          + "</Parameter>" + "</Parameters>"
+          + "</CommentParts>" + "</Function>"
+      ),
+      """
+      Applies the given edits to the document.
 
-    - Parameters:
-        - editCallback: Optional closure to call for each edit.
-        - before: The document contents *before* the edit is applied.
-    """)
+      - Parameters:
+          - editCallback: Optional closure to call for each edit.
+          - before: The document contents *before* the edit is applied.
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <ResultDiscussion><Para>The contents of the file after all the edits are applied.</Para></ResultDiscussion>
-      """), """
-    ### Returns
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <ResultDiscussion><Para>The contents of the file after all the edits are applied.</Para></ResultDiscussion>
+        """
+      ),
+      """
+      ### Returns
 
-    The contents of the file after all the edits are applied.
-    """)
+      The contents of the file after all the edits are applied.
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown("""
-      <ThrowsDiscussion><Para>Error.missingDocument if the document is not open.</Para></ThrowsDiscussion>
-      """), """
-    ### Throws
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        """
+        <ThrowsDiscussion><Para>Error.missingDocument if the document is not open.</Para></ThrowsDiscussion>
+        """
+      ),
+      """
+      ### Throws
 
-    Error.missingDocument if the document is not open.
-    """)
+      Error.missingDocument if the document is not open.
+      """
+    )
 
-    XCTAssertEqual(try xmlDocumentationToMarkdown(
-      "<Class>" +
-        "<Name>S</Name>" +
-        "<USR>s:1a1SV</USR>" +
-        "<Declaration>struct S</Declaration>" +
-        "<CommentParts>" +
-          "<Discussion>" +
-            #"<CodeListing language="swift">"# +
-              "<zCodeLineNumbered>" +
-                "<![CDATA[let S = 12456]]>" +
-              "</zCodeLineNumbered>" +
-              "<zCodeLineNumbered></zCodeLineNumbered>" +
-            "</CodeListing>" +
-            "<rawHTML>" +
-              "<![CDATA[<h2>]]>" +
-            "</rawHTML>Title<rawHTML>" +
-              "<![CDATA[</h2>]]>" +
-            "</rawHTML>" +
-            "<Para>Details.</Para>" +
-          "</Discussion>" +
-        "</CommentParts>" +
-      "</Class>"), """
-    ```swift
-    struct S
-    ```
+    XCTAssertEqual(
+      try xmlDocumentationToMarkdown(
+        "<Class>" + "<Name>S</Name>" + "<USR>s:1a1SV</USR>" + "<Declaration>struct S</Declaration>" + "<CommentParts>"
+          + "<Discussion>"
+          + #"<CodeListing language="swift">"# + "<zCodeLineNumbered>" + "<![CDATA[let S = 12456]]>"
+          + "</zCodeLineNumbered>"
+          + "<zCodeLineNumbered></zCodeLineNumbered>" + "</CodeListing>" + "<rawHTML>" + "<![CDATA[<h2>]]>"
+          + "</rawHTML>Title<rawHTML>" + "<![CDATA[</h2>]]>"
+          + "</rawHTML>" + "<Para>Details.</Para>" + "</Discussion>" + "</CommentParts>" + "</Class>"
+      ),
+      """
+      ```swift
+      struct S
+      ```
 
-    ---
-    ### Discussion
+      ---
+      ### Discussion
 
-    ```swift
-    1.\tlet S = 12456
-    2.\t
-    ```
+      ```swift
+      1.\tlet S = 12456
+      2.\t
+      ```
 
-    <h2>Title</h2>
+      <h2>Title</h2>
 
-    Details.
-    """)
+      Details.
+      """
+    )
   }
 
   func testSymbolInfo() throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: 1,
-      text: """
-      import Foundation
-      struct S {
-        func foo() {
-          var local = 1
-        }
-      }
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 1,
+          text: """
+            import Foundation
+            struct S {
+              func foo() {
+                var local = 1
+              }
+            }
+            """
+        )
+      )
+    )
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 0, utf16index: 7)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 0, utf16index: 7)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -1166,11 +1566,14 @@ final class LocalSwiftTests: XCTestCase {
         XCTAssertEqual(sym.bestLocalDeclaration?.range.lowerBound.utf16index, nil)
       }
     }
-    
+
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 1, utf16index: 7)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 1, utf16index: 7)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -1184,9 +1587,12 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 2, utf16index: 7)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 2, utf16index: 7)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -1200,9 +1606,12 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 3, utf16index: 8)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 3, utf16index: 8)
+        )
+      )
 
       XCTAssertEqual(resp.count, 1)
       if let sym = resp.first {
@@ -1216,9 +1625,12 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(SymbolInfoRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 3, utf16index: 0)))
+      let resp = try sk.sendSync(
+        SymbolInfoRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 3, utf16index: 0)
+        )
+      )
 
       XCTAssertEqual(resp.count, 0)
     }
@@ -1228,21 +1640,29 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: 1,
-      text: """
-      /// This is a doc comment for S.
-      ///
-      /// Details.
-      struct S {}
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 1,
+          text: """
+            /// This is a doc comment for S.
+            ///
+            /// Details.
+            struct S {}
+            """
+        )
+      )
+    )
 
     do {
-      let resp = try sk.sendSync(HoverRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 3, utf16index: 7)))
+      let resp = try sk.sendSync(
+        HoverRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 3, utf16index: 7)
+        )
+      )
 
       XCTAssertNotNil(resp)
       if let hover = resp {
@@ -1252,7 +1672,9 @@ final class LocalSwiftTests: XCTestCase {
           return
         }
         XCTAssertEqual(content.kind, .markdown)
-        XCTAssertEqual(content.value, """
+        XCTAssertEqual(
+          content.value,
+          """
           S
           ```swift
           struct S
@@ -1264,14 +1686,18 @@ final class LocalSwiftTests: XCTestCase {
           ### Discussion
 
           Details.
-          """)
+          """
+        )
       }
     }
 
     do {
-      let resp = try sk.sendSync(HoverRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 0, utf16index: 7)))
+      let resp = try sk.sendSync(
+        HoverRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 0, utf16index: 7)
+        )
+      )
 
       XCTAssertNil(resp)
     }
@@ -1280,21 +1706,29 @@ final class LocalSwiftTests: XCTestCase {
   func testHoverNameEscaping() throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .swift,
-      version: 1,
-      text: """
-      /// this is **bold** documentation
-      func test(_ a: Int, _ b: Int) { }
-      /// this is *italic* documentation
-      func *%*(lhs: String, rhs: String) { }
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .swift,
+          version: 1,
+          text: """
+            /// this is **bold** documentation
+            func test(_ a: Int, _ b: Int) { }
+            /// this is *italic* documentation
+            func *%*(lhs: String, rhs: String) { }
+            """
+        )
+      )
+    )
 
     do {
-      let resp = try sk.sendSync(HoverRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 1, utf16index: 7)))
+      let resp = try sk.sendSync(
+        HoverRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 1, utf16index: 7)
+        )
+      )
 
       XCTAssertNotNil(resp)
       if let hover = resp {
@@ -1304,7 +1738,9 @@ final class LocalSwiftTests: XCTestCase {
           return
         }
         XCTAssertEqual(content.kind, .markdown)
-        XCTAssertEqual(content.value, ##"""
+        XCTAssertEqual(
+          content.value,
+          ##"""
           test(\_:\_:)
           ```swift
           func test(_ a: Int, _ b: Int)
@@ -1312,14 +1748,18 @@ final class LocalSwiftTests: XCTestCase {
 
           ---
           this is **bold** documentation
-          """##)
+          """##
+        )
       }
     }
 
     do {
-      let resp = try sk.sendSync(HoverRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 3, utf16index: 7)))
+      let resp = try sk.sendSync(
+        HoverRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 3, utf16index: 7)
+        )
+      )
 
       XCTAssertNotNil(resp)
       if let hover = resp {
@@ -1329,7 +1769,9 @@ final class LocalSwiftTests: XCTestCase {
           return
         }
         XCTAssertEqual(content.kind, .markdown)
-        XCTAssertEqual(content.value, ##"""
+        XCTAssertEqual(
+          content.value,
+          ##"""
           \*%\*(\_:\_:)
           ```swift
           func *%* (lhs: String, rhs: String)
@@ -1337,40 +1779,52 @@ final class LocalSwiftTests: XCTestCase {
 
           ---
           this is *italic* documentation
-          """##)
+          """##
+        )
       }
     }
   }
-  
+
   func testDocumentSymbolHighlight() throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: 1,
-      text: """
-      func test() {
-        let a = 1
-        let b = 2
-        let ccc = 3
-        _ = b
-        _ = ccc + ccc
-      }
-      """)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 1,
+          text: """
+            func test() {
+              let a = 1
+              let b = 2
+              let ccc = 3
+              _ = b
+              _ = ccc + ccc
+            }
+            """
+        )
+      )
+    )
 
     do {
-      let resp = try sk.sendSync(DocumentHighlightRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 0, utf16index: 0)))
+      let resp = try sk.sendSync(
+        DocumentHighlightRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 0, utf16index: 0)
+        )
+      )
       XCTAssertEqual(resp?.count, 0)
     }
 
     do {
-      let resp = try sk.sendSync(DocumentHighlightRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 1, utf16index: 6)))
+      let resp = try sk.sendSync(
+        DocumentHighlightRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 1, utf16index: 6)
+        )
+      )
       XCTAssertEqual(resp?.count, 1)
       if let highlight = resp?.first {
         XCTAssertEqual(highlight.range.lowerBound.line, 1)
@@ -1381,9 +1835,12 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(DocumentHighlightRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 2, utf16index: 6)))
+      let resp = try sk.sendSync(
+        DocumentHighlightRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 2, utf16index: 6)
+        )
+      )
       XCTAssertEqual(resp?.count, 2)
       if let highlight = resp?.first {
         XCTAssertEqual(highlight.range.lowerBound.line, 2)
@@ -1400,9 +1857,12 @@ final class LocalSwiftTests: XCTestCase {
     }
 
     do {
-      let resp = try sk.sendSync(DocumentHighlightRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 3, utf16index: 6)))
+      let resp = try sk.sendSync(
+        DocumentHighlightRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 3, utf16index: 6)
+        )
+      )
       XCTAssertEqual(resp?.count, 3)
       if let highlight = resp?.first {
         XCTAssertEqual(highlight.range.lowerBound.line, 3)
@@ -1426,32 +1886,28 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEditorPlaceholderParsing() {
-    var text = "<#basic placeholder" +
-    "#>" // Need to end this in another line so Xcode doesn't treat it as a real placeholder
+    var text = "<#basic placeholder" + "#>"  // Need to end this in another line so Xcode doesn't treat it as a real placeholder
     var data = EditorPlaceholder(text)
     XCTAssertNotNil(data)
     if let data = data {
       XCTAssertEqual(data, .basic("basic placeholder"))
       XCTAssertEqual(data.displayName, "basic placeholder")
     }
-    text = "<#T##x: Int##Int" +
-    "#>"
+    text = "<#T##x: Int##Int" + "#>"
     data = EditorPlaceholder(text)
     XCTAssertNotNil(data)
     if let data = data {
       XCTAssertEqual(data, .typed(displayName: "x: Int", type: "Int", typeForExpansion: "Int"))
       XCTAssertEqual(data.displayName, "x: Int")
     }
-    text = "<#T##x: Int##Blah##()->Int" +
-    "#>"
+    text = "<#T##x: Int##Blah##()->Int" + "#>"
     data = EditorPlaceholder(text)
     XCTAssertNotNil(data)
     if let data = data {
       XCTAssertEqual(data, .typed(displayName: "x: Int", type: "Blah", typeForExpansion: "()->Int"))
       XCTAssertEqual(data.displayName, "x: Int")
     }
-    text = "<#T##Int" +
-    "#>"
+    text = "<#T##Int" + "#>"
     data = EditorPlaceholder(text)
     XCTAssertNotNil(data)
     if let data = data {
@@ -1473,52 +1929,70 @@ final class LocalSwiftTests: XCTestCase {
     text = "<#foo#"
     data = EditorPlaceholder(text)
     XCTAssertNil(data)
-    text = " <#foo" +
-    "#>"
+    text = " <#foo" + "#>"
     data = EditorPlaceholder(text)
     XCTAssertNil(data)
   }
-  
+
   func testIncrementalParse() async throws {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
     var reusedNodes: [Syntax] = []
-    let swiftLanguageServer = await connection.server!._languageService(for: uri, .swift, in: connection.server!.workspaceForDocument(uri: uri)!) as! SwiftLanguageServer
+    let swiftLanguageServer =
+      await connection.server!._languageService(
+        for: uri,
+        .swift,
+        in: connection.server!.workspaceForDocument(uri: uri)!
+      ) as! SwiftLanguageServer
     await swiftLanguageServer.setReusedNodeCallback({ reusedNodes.append($0) })
     sk.allowUnexpectedNotification = false
-    
-    sk.sendNoteSync(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: 0,
-      text: """
-      func foo() {
+
+    sk.sendNoteSync(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: 0,
+          text: """
+            func foo() {
+            }
+            class bar {
+            }
+            """
+        )
+      ),
+      { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
+        log("Received diagnostics for open - syntactic")
+      },
+      { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
+        log("Received diagnostics for open - semantic")
       }
-      class bar {
-      }
-      """
-    )), { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
-      log("Received diagnostics for open - syntactic")
-    }, { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
-      log("Received diagnostics for open - semantic")
-    })
+    )
 
     // Send a request that triggers a syntax tree to be built.
     _ = try sk.sendSync(FoldingRangeRequest(textDocument: .init(uri)))
 
-    sk.sendNoteSync(DidChangeTextDocumentNotification(textDocument: .init(uri, version: 1), contentChanges: [
-      .init(range: Range(Position(line: 2, utf16index: 7)), text: "a"),
-    ]), { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
-      log("Received diagnostics for text edit - syntactic")
-    }, { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
-      log("Received diagnostics for text edit - semantic")
-    })
-    
+    sk.sendNoteSync(
+      DidChangeTextDocumentNotification(
+        textDocument: .init(uri, version: 1),
+        contentChanges: [
+          .init(range: Range(Position(line: 2, utf16index: 7)), text: "a")
+        ]
+      ),
+      { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
+        log("Received diagnostics for text edit - syntactic")
+      },
+      { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
+        log("Received diagnostics for text edit - semantic")
+      }
+    )
+
     XCTAssertEqual(reusedNodes.count, 1)
-    
+
     let firstNode = try XCTUnwrap(reusedNodes.first)
-    XCTAssertEqual(firstNode.description,
+    XCTAssertEqual(
+      firstNode.description,
       """
       func foo() {
       }

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
+import IndexStoreDB
+import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import SKTestSupport
-import LanguageServerProtocol
-import LSPTestSupport
-import IndexStoreDB
+import SourceKitLSP
 import XCTest
 
 final class MainFilesProviderTests: XCTestCase {
@@ -65,15 +65,21 @@ final class MainFilesProviderTests: XCTestCase {
     try await fulfillmentOfOrThrow([mainFilesDelegate.expectation])
 
     try ws.edit { changes, _ in
-      changes.write("""
+      changes.write(
+        """
         #include "bridging.h"
         void d_new(void) { bridging(); }
-        """, to: d.fileURL!)
+        """,
+        to: d.fileURL!
+      )
 
-      changes.write("""
-      #include "unique.h"
-      void c_new(void) { unique(); }
-      """, to: c.fileURL!)
+      changes.write(
+        """
+        #include "unique.h"
+        void c_new(void) { unique(); }
+        """,
+        to: c.fileURL!
+      )
     }
 
     mainFilesDelegate.expectation = expectation(description: "main files changed after edit")

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import XCTest
 
@@ -32,156 +32,208 @@ final class PublishDiagnosticsTests: XCTestCase {
     connection = TestSourceKitServer()
     sk = connection.client
     let documentCapabilities = TextDocumentClientCapabilities()
-    _ = try! sk.sendSync(InitializeRequest(
-      processId: nil,
-      rootPath: nil,
-      rootURI: nil,
-      initializationOptions: nil,
-      capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
-      trace: .off,
-      workspaceFolders: nil))
+    _ = try! sk.sendSync(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
+        trace: .off,
+        workspaceFolders: nil
+      )
+    )
   }
 
   override func tearDown() {
     sk = nil
     connection = nil
   }
-  
+
   private func openDocument(text: String) {
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: version,
-      text: text
-    )))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: version,
+          text: text
+        )
+      )
+    )
     version += 1
   }
 
   private func editDocument(changes: [TextDocumentContentChangeEvent]) {
-    sk.send(DidChangeTextDocumentNotification(
-      textDocument: VersionedTextDocumentIdentifier(
-        uri,
-        version: version
-      ),
-      contentChanges: changes
-    ))
+    sk.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(
+          uri,
+          version: version
+        ),
+        contentChanges: changes
+      )
+    )
   }
 
   func testUnknownIdentifierDiagnostic() {
     let syntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics received")
     let semanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics received")
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // Unresolved identifier is not a syntactic diagnostic.
       XCTAssertEqual(note.params.diagnostics, [])
       syntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
+      )
       semanticDiagnosticsReceived.fulfill()
     }
 
-    openDocument(text: """
-    func foo() {
-      invalid
-    }
-    """)
+    openDocument(
+      text: """
+        func foo() {
+          invalid
+        }
+        """
+    )
 
     self.wait(for: [syntacticDiagnosticsReceived, semanticDiagnosticsReceived], timeout: defaultTimeout)
   }
 
   func testRangeShiftAfterNewlineAdded() {
-    let initialSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after open received")
+    let initialSyntacticDiagnosticsReceived = self.expectation(
+      description: "Syntactic diagnotistics after open received"
+    )
     let initialSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after open received")
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // Unresolved identifier is not a syntactic diagnostic.
       XCTAssertEqual(note.params.diagnostics, [])
       initialSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
+      )
       initialSemanticDiagnosticsReceived.fulfill()
     }
 
-    openDocument(text: """
-    func foo() {
-      invalid
-    }
-    """)
+    openDocument(
+      text: """
+        func foo() {
+          invalid
+        }
+        """
+    )
 
     self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: defaultTimeout)
 
-    let editedSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after edit received")
+    let editedSyntacticDiagnosticsReceived = self.expectation(
+      description: "Syntactic diagnotistics after edit received"
+    )
     let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // We should report the semantic diagnostic reported by the edit range-shifted
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9)
+      )
       editedSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9)
+      )
       editedSemanticDiagnosticsReceived.fulfill()
     }
 
     editDocument(changes: [
-      TextDocumentContentChangeEvent(range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0), rangeLength: 0, text: "\n")
+      TextDocumentContentChangeEvent(
+        range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
+        rangeLength: 0,
+        text: "\n"
+      )
     ])
 
     self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: defaultTimeout)
   }
 
   func testRangeShiftAfterNewlineRemoved() {
-    let initialSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after open received")
+    let initialSyntacticDiagnosticsReceived = self.expectation(
+      description: "Syntactic diagnotistics after open received"
+    )
     let initialSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after open received")
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // Unresolved identifier is not a syntactic diagnostic.
       XCTAssertEqual(note.params.diagnostics, [])
       initialSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9)
+      )
       initialSemanticDiagnosticsReceived.fulfill()
     }
 
-    openDocument(text: """
+    openDocument(
+      text: """
 
-    func foo() {
-      invalid
-    }
-    """)
+        func foo() {
+          invalid
+        }
+        """
+    )
 
     self.wait(for: [initialSyntacticDiagnosticsReceived, initialSemanticDiagnosticsReceived], timeout: defaultTimeout)
 
-    let editedSyntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics after edit received")
+    let editedSyntacticDiagnosticsReceived = self.expectation(
+      description: "Syntactic diagnotistics after edit received"
+    )
     let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // We should report the semantic diagnostic reported by the edit range-shifted
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
+      )
       editedSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(note.params.diagnostics.first?.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+      XCTAssertEqual(
+        note.params.diagnostics.first?.range,
+        Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
+      )
       editedSemanticDiagnosticsReceived.fulfill()
     }
 
     editDocument(changes: [
-      TextDocumentContentChangeEvent(range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 0), rangeLength: 1, text: "")
+      TextDocumentContentChangeEvent(
+        range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 0),
+        rangeLength: 1,
+        text: ""
+      )
     ])
 
     self.wait(for: [editedSyntacticDiagnosticsReceived, editedSemanticDiagnosticsReceived], timeout: defaultTimeout)

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -40,33 +40,35 @@ final class SemanticTokensTests: XCTestCase {
     uri = DocumentURI(URL(fileURLWithPath: "/SemanticTokensTests/\(UUID()).swift"))
     connection = TestSourceKitServer()
     sk = connection.client
-    _ = try! sk.sendSync(InitializeRequest(
-      processId: nil,
-      rootPath: nil,
-      rootURI: nil,
-      initializationOptions: nil,
-      capabilities: ClientCapabilities(
-        workspace: .init(
-          semanticTokens: .init(
-            refreshSupport: true
+    _ = try! sk.sendSync(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(
+          workspace: .init(
+            semanticTokens: .init(
+              refreshSupport: true
+            )
+          ),
+          textDocument: .init(
+            semanticTokens: .init(
+              dynamicRegistration: true,
+              requests: .init(
+                range: .bool(true),
+                full: .bool(true)
+              ),
+              tokenTypes: Token.Kind.allCases.map(\._lspName),
+              tokenModifiers: Token.Modifiers.allModifiers.map { $0._lspName! },
+              formats: [.relative]
+            )
           )
         ),
-        textDocument: .init(
-          semanticTokens: .init(
-            dynamicRegistration: true,
-            requests: .init(
-              range: .bool(true),
-              full: .bool(true)
-            ),
-            tokenTypes: Token.Kind.allCases.map(\._lspName),
-            tokenModifiers: Token.Modifiers.allModifiers.map { $0._lspName! },
-            formats: [.relative]
-          )
-        )
-      ),
-      trace: .off,
-      workspaceFolders: nil
-    ))
+        trace: .off,
+        workspaceFolders: nil
+      )
+    )
   }
 
   private func expectSemanticTokensRefresh() -> XCTestExpectation {
@@ -84,9 +86,11 @@ final class SemanticTokensTests: XCTestCase {
     let registerCapabilityExpectation = expectation(description: "\(#function) - register semantic tokens capability")
     sk.appendOneShotRequestHandler { (req: Request<RegisterCapabilityRequest>) in
       let registrations = req.params.registrations
-      XCTAssert(registrations.contains { reg in
-        reg.method == SemanticTokensRegistrationOptions.method
-      })
+      XCTAssert(
+        registrations.contains { reg in
+          reg.method == SemanticTokensRegistrationOptions.method
+        }
+      )
       req.reply(VoidResponse())
       registerCapabilityExpectation.fulfill()
     }
@@ -95,12 +99,16 @@ final class SemanticTokensTests: XCTestCase {
 
     let refreshExpectation = expectSemanticTokensRefresh()
 
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: uri,
-      language: .swift,
-      version: version,
-      text: text
-    )))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: uri,
+          language: .swift,
+          version: version,
+          text: text
+        )
+      )
+    )
     version += 1
 
     wait(for: [registerCapabilityExpectation, refreshExpectation], timeout: defaultTimeout)
@@ -116,25 +124,30 @@ final class SemanticTokensTests: XCTestCase {
       expectations.append(expectSemanticTokensRefresh())
     }
 
-    sk.send(DidChangeTextDocumentNotification(
-      textDocument: VersionedTextDocumentIdentifier(
-        uri,
-        version: version
-      ),
-      contentChanges: changes
-    ))
+    sk.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(
+          uri,
+          version: version
+        ),
+        contentChanges: changes
+      )
+    )
     version += 1
 
     wait(for: expectations, timeout: defaultTimeout)
   }
 
   private func editDocument(range: Range<Position>, text: String, expectRefresh: Bool = true) {
-    editDocument(changes: [
-      TextDocumentContentChangeEvent(
-        range: range,
-        text: text
-      )
-    ], expectRefresh: expectRefresh)
+    editDocument(
+      changes: [
+        TextDocumentContentChangeEvent(
+          range: range,
+          text: text
+        )
+      ],
+      expectRefresh: expectRefresh
+    )
   }
 
   private func performSemanticTokensRequest(range: Range<Position>? = nil) throws -> [Token] {
@@ -170,19 +183,22 @@ final class SemanticTokensTests: XCTestCase {
     ]
 
     let encoded = tokens.lspEncoded
-    XCTAssertEqual(encoded, [
-      2, // line delta
-      3, // char delta
-      5, // length
-      Token.Kind.string.rawValue, // kind
-      0, // modifiers
+    XCTAssertEqual(
+      encoded,
+      [
+        2,  // line delta
+        3,  // char delta
+        5,  // length
+        Token.Kind.string.rawValue,  // kind
+        0,  // modifiers
 
-      2, // line delta
-      2, // char delta
-      1, // length
-      Token.Kind.interface.rawValue, // kind
-      Token.Modifiers.deprecated.rawValue | Token.Modifiers.definition.rawValue, // modifiers
-    ])
+        2,  // line delta
+        2,  // char delta
+        1,  // length
+        Token.Kind.interface.rawValue,  // kind
+        Token.Modifiers.deprecated.rawValue | Token.Modifiers.definition.rawValue,  // modifiers
+      ]
+    )
 
     let decoded = [Token](lspEncodedTokens: encoded)
     XCTAssertEqual(decoded, tokens)
@@ -190,13 +206,13 @@ final class SemanticTokensTests: XCTestCase {
 
   func testRangeSplitting() async {
     let text = """
-    struct X {
-      let x: Int
-      let y: String
+      struct X {
+        let x: Int
+        let y: String
 
 
-    }
-    """
+      }
+      """
     openDocument(text: text)
 
     guard let snapshot = await connection.server?._documentManager.latestSnapshot(uri) else {
@@ -207,16 +223,22 @@ final class SemanticTokensTests: XCTestCase {
     XCTAssertEqual(empty._splitToSingleLineRanges(in: snapshot), [])
 
     let multiLine = Position(line: 1, utf16index: 6)..<Position(line: 2, utf16index: 7)
-    XCTAssertEqual(multiLine._splitToSingleLineRanges(in: snapshot), [
-      Position(line: 1, utf16index: 6)..<Position(line: 1, utf16index: 12),
-      Position(line: 2, utf16index: 0)..<Position(line: 2, utf16index: 7),
-    ])
+    XCTAssertEqual(
+      multiLine._splitToSingleLineRanges(in: snapshot),
+      [
+        Position(line: 1, utf16index: 6)..<Position(line: 1, utf16index: 12),
+        Position(line: 2, utf16index: 0)..<Position(line: 2, utf16index: 7),
+      ]
+    )
 
     let emptyLines = Position(line: 2, utf16index: 14)..<Position(line: 5, utf16index: 1)
-    XCTAssertEqual(emptyLines._splitToSingleLineRanges(in: snapshot), [
-      Position(line: 2, utf16index: 14)..<Position(line: 2, utf16index: 15),
-      Position(line: 5, utf16index: 0)..<Position(line: 5, utf16index: 1),
-    ])
+    XCTAssertEqual(
+      emptyLines._splitToSingleLineRanges(in: snapshot),
+      [
+        Position(line: 2, utf16index: 14)..<Position(line: 2, utf16index: 15),
+        Position(line: 5, utf16index: 0)..<Position(line: 5, utf16index: 1),
+      ]
+    )
   }
 
   func testEmpty() throws {
@@ -227,265 +249,298 @@ final class SemanticTokensTests: XCTestCase {
 
   func testRanged() throws {
     let text = """
-    let x = 1
-    let test = 20
-    let abc = 333
-    let y = 4
-    """
+      let x = 1
+      let test = 20
+      let abc = 333
+      let y = 4
+      """
     let start = Position(line: 1, utf16index: 0)
     let end = Position(line: 2, utf16index: 5)
     let tokens = try openAndPerformSemanticTokensRequest(text: text, range: start..<end)
-    XCTAssertEqual(tokens, [
-      Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 1, utf16index: 4, length: 4, kind: .identifier),
-      Token(line: 1, utf16index: 11, length: 2, kind: .number),
-      Token(line: 2, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 2, utf16index: 4, length: 3, kind: .identifier),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 1, utf16index: 4, length: 4, kind: .identifier),
+        Token(line: 1, utf16index: 11, length: 2, kind: .number),
+        Token(line: 2, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 2, utf16index: 4, length: 3, kind: .identifier),
+      ]
+    )
   }
 
   func testLexicalTokens() throws {
     let text = """
-    let x = 3
-    var y = "test"
-    /* abc */ // 123
-    """
+      let x = 3
+      var y = "test"
+      /* abc */ // 123
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      // let x = 3
-      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 8, length: 1, kind: .number),
-      // var y = "test"
-      Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 1, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 1, utf16index: 8, length: 6, kind: .string),
-      // /* abc */ // 123
-      Token(line: 2, utf16index: 0, length: 9, kind: .comment),
-      Token(line: 2, utf16index: 10, length: 6, kind: .comment),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        // let x = 3
+        Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 8, length: 1, kind: .number),
+        // var y = "test"
+        Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 1, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 1, utf16index: 8, length: 6, kind: .string),
+        // /* abc */ // 123
+        Token(line: 2, utf16index: 0, length: 9, kind: .comment),
+        Token(line: 2, utf16index: 10, length: 6, kind: .comment),
+      ]
+    )
   }
 
   func testLexicalTokensForMultiLineComments() throws {
     let text = """
-    let x = 3 /*
-    let x = 12
-    */
-    """
+      let x = 3 /*
+      let x = 12
+      */
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 8, length: 1, kind: .number),
-      // Multi-line comments are split into single-line tokens
-      Token(line: 0, utf16index: 10, length: 2, kind: .comment),
-      Token(line: 1, utf16index: 0, length: 10, kind: .comment),
-      Token(line: 2, utf16index: 0, length: 2, kind: .comment),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 8, length: 1, kind: .number),
+        // Multi-line comments are split into single-line tokens
+        Token(line: 0, utf16index: 10, length: 2, kind: .comment),
+        Token(line: 1, utf16index: 0, length: 10, kind: .comment),
+        Token(line: 2, utf16index: 0, length: 2, kind: .comment),
+      ]
+    )
   }
 
   func testLexicalTokensForDocComments() throws {
     let text = """
-    /** abc */
-      /// def
-    """
+      /** abc */
+        /// def
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 10, kind: .comment, modifiers: [.documentation]),
-      Token(line: 1, utf16index: 2, length: 7, kind: .comment, modifiers: [.documentation]),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 10, kind: .comment, modifiers: [.documentation]),
+        Token(line: 1, utf16index: 2, length: 7, kind: .comment, modifiers: [.documentation]),
+      ]
+    )
   }
 
   func testLexicalTokensForBackticks() throws {
     let text = """
-    var `if` = 20
-    let `else` = 3
-    let `onLeft = ()
-    let onRight` = ()
-    """
+      var `if` = 20
+      let `else` = 3
+      let `onLeft = ()
+      let onRight` = ()
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      // var `if` = 20
-      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 0, utf16index: 4, length: 4, kind: .identifier),
-      Token(line: 0, utf16index: 11, length: 2, kind: .number),
-      // let `else` = 3
-      Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 1, utf16index: 4, length: 6, kind: .identifier),
-      Token(line: 1, utf16index: 13, length: 1, kind: .number),
-      // let `onLeft = ()
-      Token(line: 2, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 2, utf16index: 5, length: 6, kind: .identifier),
-      // let onRight` = ()
-      Token(line: 3, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 3, utf16index: 4, length: 7, kind: .identifier),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        // var `if` = 20
+        Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 0, utf16index: 4, length: 4, kind: .identifier),
+        Token(line: 0, utf16index: 11, length: 2, kind: .number),
+        // let `else` = 3
+        Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 1, utf16index: 4, length: 6, kind: .identifier),
+        Token(line: 1, utf16index: 13, length: 1, kind: .number),
+        // let `onLeft = ()
+        Token(line: 2, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 2, utf16index: 5, length: 6, kind: .identifier),
+        // let onRight` = ()
+        Token(line: 3, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 3, utf16index: 4, length: 7, kind: .identifier),
+      ]
+    )
   }
 
   func testSemanticTokens() throws {
     let text = """
-    struct X {}
+      struct X {}
 
-    let x = X()
-    let y = x + x
+      let x = X()
+      let y = x + x
 
-    func a() {}
-    let b = {}
+      func a() {}
+      let b = {}
 
-    a()
-    b()
-    """
+      a()
+      b()
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      // struct X {}
-      Token(line: 0, utf16index: 0, length: 6, kind: .keyword),
-      Token(line: 0, utf16index: 7, length: 1, kind: .identifier),
-      // let x = X()
-      Token(line: 2, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 2, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 2, utf16index: 8, length: 1, kind: .struct),
-      // let y = x + x
-      Token(line: 3, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 3, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 3, utf16index: 8, length: 1, kind: .variable),
-      Token(line: 3, utf16index: 10, length: 1, kind: .operator),
-      Token(line: 3, utf16index: 12, length: 1, kind: .variable),
-      // func a() {}
-      Token(line: 5, utf16index: 0, length: 4, kind: .keyword),
-      Token(line: 5, utf16index: 5, length: 1, kind: .identifier),
-      // let b = {}
-      Token(line: 6, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
-      // a()
-      Token(line: 8, utf16index: 0, length: 1, kind: .function),
-      // b()
-      Token(line: 9, utf16index: 0, length: 1, kind: .variable),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        // struct X {}
+        Token(line: 0, utf16index: 0, length: 6, kind: .keyword),
+        Token(line: 0, utf16index: 7, length: 1, kind: .identifier),
+        // let x = X()
+        Token(line: 2, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 2, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 2, utf16index: 8, length: 1, kind: .struct),
+        // let y = x + x
+        Token(line: 3, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 3, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 3, utf16index: 8, length: 1, kind: .variable),
+        Token(line: 3, utf16index: 10, length: 1, kind: .operator),
+        Token(line: 3, utf16index: 12, length: 1, kind: .variable),
+        // func a() {}
+        Token(line: 5, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 5, utf16index: 5, length: 1, kind: .identifier),
+        // let b = {}
+        Token(line: 6, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
+        // a()
+        Token(line: 8, utf16index: 0, length: 1, kind: .function),
+        // b()
+        Token(line: 9, utf16index: 0, length: 1, kind: .variable),
+      ]
+    )
   }
 
   func testSemanticTokensForProtocols() throws {
     let text = """
-    protocol X {}
-    class Y: X {}
+      protocol X {}
+      class Y: X {}
 
-    let y: Y = X()
+      let y: Y = X()
 
-    func f<T: X>() {}
-    """
+      func f<T: X>() {}
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      // protocol X {}
-      Token(line: 0, utf16index: 0, length: 8, kind: .keyword),
-      Token(line: 0, utf16index: 9, length: 1, kind: .identifier),
-      // class Y: X {}
-      Token(line: 1, utf16index: 0, length: 5, kind: .keyword),
-      Token(line: 1, utf16index: 6, length: 1, kind: .identifier),
-      Token(line: 1, utf16index: 9, length: 1, kind: .interface),
-      // let y: Y = X()
-      Token(line: 3, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 3, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 3, utf16index: 7, length: 1, kind: .class),
-      Token(line: 3, utf16index: 11, length: 1, kind: .interface),
-      // func f<T: X>() {}
-      Token(line: 5, utf16index: 0, length: 4, kind: .keyword),
-      Token(line: 5, utf16index: 5, length: 1, kind: .identifier),
-      Token(line: 5, utf16index: 7, length: 1, kind: .identifier),
-      Token(line: 5, utf16index: 10, length: 1, kind: .interface),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        // protocol X {}
+        Token(line: 0, utf16index: 0, length: 8, kind: .keyword),
+        Token(line: 0, utf16index: 9, length: 1, kind: .identifier),
+        // class Y: X {}
+        Token(line: 1, utf16index: 0, length: 5, kind: .keyword),
+        Token(line: 1, utf16index: 6, length: 1, kind: .identifier),
+        Token(line: 1, utf16index: 9, length: 1, kind: .interface),
+        // let y: Y = X()
+        Token(line: 3, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 3, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 3, utf16index: 7, length: 1, kind: .class),
+        Token(line: 3, utf16index: 11, length: 1, kind: .interface),
+        // func f<T: X>() {}
+        Token(line: 5, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 5, utf16index: 5, length: 1, kind: .identifier),
+        Token(line: 5, utf16index: 7, length: 1, kind: .identifier),
+        Token(line: 5, utf16index: 10, length: 1, kind: .interface),
+      ]
+    )
   }
 
   func testSemanticTokensForFunctionSignatures() throws {
     let text = "func f(x: Int, _ y: String) {}"
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
-      Token(line: 0, utf16index: 5, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 7, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 10, length: 3, kind: .struct, modifiers: .defaultLibrary),
-      Token(line: 0, utf16index: 17, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 20, length: 6, kind: .struct, modifiers: .defaultLibrary),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 0, utf16index: 5, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 7, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 10, length: 3, kind: .struct, modifiers: .defaultLibrary),
+        Token(line: 0, utf16index: 17, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 20, length: 6, kind: .struct, modifiers: .defaultLibrary),
+      ]
+    )
   }
 
   func testSemanticTokensForFunctionSignaturesWithEmoji() throws {
     let text = "func x👍y() {}"
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
-      Token(line: 0, utf16index: 5, length: 4, kind: .identifier),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 0, utf16index: 5, length: 4, kind: .identifier),
+      ]
+    )
   }
 
   func testSemanticTokensForStaticMethods() throws {
     let text = """
-    class X {
-      deinit {}
-      static func f() {}
-      class func g() {}
-    }
-    X.f()
-    X.g()
-    """
+      class X {
+        deinit {}
+        static func f() {}
+        class func g() {}
+      }
+      X.f()
+      X.g()
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      // class X
-      Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
-      Token(line: 0, utf16index: 6, length: 1, kind: .identifier),
-      // deinit {}
-      Token(line: 1, utf16index: 2, length: 6, kind: .keyword),
-      // static func f() {}
-      Token(line: 2, utf16index: 2, length: 6, kind: .keyword),
-      Token(line: 2, utf16index: 9, length: 4, kind: .keyword),
-      Token(line: 2, utf16index: 14, length: 1, kind: .identifier),
-      // class func g() {}
-      Token(line: 3, utf16index: 2, length: 5, kind: .keyword),
-      Token(line: 3, utf16index: 8, length: 4, kind: .keyword),
-      Token(line: 3, utf16index: 13, length: 1, kind: .identifier),
-      // X.f()
-      Token(line: 5, utf16index: 0, length: 1, kind: .class),
-      Token(line: 5, utf16index: 2, length: 1, kind: .method, modifiers: [.static]),
-      // X.g()
-      Token(line: 6, utf16index: 0, length: 1, kind: .class),
-      Token(line: 6, utf16index: 2, length: 1, kind: .method, modifiers: [.static]),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        // class X
+        Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
+        Token(line: 0, utf16index: 6, length: 1, kind: .identifier),
+        // deinit {}
+        Token(line: 1, utf16index: 2, length: 6, kind: .keyword),
+        // static func f() {}
+        Token(line: 2, utf16index: 2, length: 6, kind: .keyword),
+        Token(line: 2, utf16index: 9, length: 4, kind: .keyword),
+        Token(line: 2, utf16index: 14, length: 1, kind: .identifier),
+        // class func g() {}
+        Token(line: 3, utf16index: 2, length: 5, kind: .keyword),
+        Token(line: 3, utf16index: 8, length: 4, kind: .keyword),
+        Token(line: 3, utf16index: 13, length: 1, kind: .identifier),
+        // X.f()
+        Token(line: 5, utf16index: 0, length: 1, kind: .class),
+        Token(line: 5, utf16index: 2, length: 1, kind: .method, modifiers: [.static]),
+        // X.g()
+        Token(line: 6, utf16index: 0, length: 1, kind: .class),
+        Token(line: 6, utf16index: 2, length: 1, kind: .method, modifiers: [.static]),
+      ]
+    )
   }
 
   func testSemanticTokensForEnumMembers() throws {
     let text = """
-    enum Maybe<T> {
-      case none
-      case some(T)
-    }
+      enum Maybe<T> {
+        case none
+        case some(T)
+      }
 
-    let x = Maybe<String>.none
-    let y: Maybe = .some(42)
-    """
+      let x = Maybe<String>.none
+      let y: Maybe = .some(42)
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      // enum Maybe<T>
-      Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
-      Token(line: 0, utf16index: 5, length: 5, kind: .identifier),
-      Token(line: 0, utf16index: 11, length: 1, kind: .identifier),
-      // case none
-      Token(line: 1, utf16index: 2, length: 4, kind: .keyword),
-      Token(line: 1, utf16index: 7, length: 4, kind: .identifier),
-      // case some
-      Token(line: 2, utf16index: 2, length: 4, kind: .keyword),
-      Token(line: 2, utf16index: 7, length: 4, kind: .identifier),
-      Token(line: 2, utf16index: 12, length: 1, kind: .typeParameter),
-      // let x = Maybe<String>.none
-      Token(line: 5, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 5, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 5, utf16index: 8, length: 5, kind: .enum),
-      Token(line: 5, utf16index: 14, length: 6, kind: .struct, modifiers: .defaultLibrary),
-      Token(line: 5, utf16index: 22, length: 4, kind: .enumMember),
-      // let y: Maybe = .some(42)
-      Token(line: 6, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 6, utf16index: 7, length: 5, kind: .enum),
-      Token(line: 6, utf16index: 16, length: 4, kind: .enumMember),
-      Token(line: 6, utf16index: 21, length: 2, kind: .number),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        // enum Maybe<T>
+        Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 0, utf16index: 5, length: 5, kind: .identifier),
+        Token(line: 0, utf16index: 11, length: 1, kind: .identifier),
+        // case none
+        Token(line: 1, utf16index: 2, length: 4, kind: .keyword),
+        Token(line: 1, utf16index: 7, length: 4, kind: .identifier),
+        // case some
+        Token(line: 2, utf16index: 2, length: 4, kind: .keyword),
+        Token(line: 2, utf16index: 7, length: 4, kind: .identifier),
+        Token(line: 2, utf16index: 12, length: 1, kind: .typeParameter),
+        // let x = Maybe<String>.none
+        Token(line: 5, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 5, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 5, utf16index: 8, length: 5, kind: .enum),
+        Token(line: 5, utf16index: 14, length: 6, kind: .struct, modifiers: .defaultLibrary),
+        Token(line: 5, utf16index: 22, length: 4, kind: .enumMember),
+        // let y: Maybe = .some(42)
+        Token(line: 6, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 6, utf16index: 7, length: 5, kind: .enum),
+        Token(line: 6, utf16index: 16, length: 4, kind: .enumMember),
+        Token(line: 6, utf16index: 21, length: 2, kind: .number),
+      ]
+    )
   }
 
   func testRegexSemanticTokens() throws {
@@ -493,31 +548,37 @@ final class SemanticTokensTests: XCTestCase {
       let r = /a[bc]*/
       """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 8, length: 8, kind: .regexp),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 8, length: 8, kind: .regexp),
+      ]
+    )
   }
 
   func testOperatorDeclaration() throws {
     let text = """
-    infix operator ?= :ComparisonPrecedence
-    """
+      infix operator ?= :ComparisonPrecedence
+      """
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
-      Token(line: 0, utf16index: 6, length: 8, kind: .keyword),
-      Token(line: 0, utf16index: 15, length: 2, kind: .operator),
-      Token(line: 0, utf16index: 19, length: 20, kind: .identifier),
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
+        Token(line: 0, utf16index: 6, length: 8, kind: .keyword),
+        Token(line: 0, utf16index: 15, length: 2, kind: .operator),
+        Token(line: 0, utf16index: 19, length: 20, kind: .identifier),
+      ]
+    )
   }
 
   func testEmptyEdit() throws {
     let text = """
-    let x: String = "test"
-    var y = 123
-    """
+      let x: String = "test"
+      var y = 123
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
@@ -531,8 +592,8 @@ final class SemanticTokensTests: XCTestCase {
 
   func testReplaceUntilMiddleOfToken() throws {
     let text = """
-    var test = 4567
-    """
+      var test = 4567
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
@@ -540,54 +601,66 @@ final class SemanticTokensTests: XCTestCase {
       Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
       Token(line: 0, utf16index: 4, length: 4, kind: .identifier),
     ]
-    XCTAssertEqual(before, expectedLeading + [
-      Token(line: 0, utf16index: 11, length: 4, kind: .number),
-    ])
+    XCTAssertEqual(
+      before,
+      expectedLeading + [
+        Token(line: 0, utf16index: 11, length: 4, kind: .number)
+      ]
+    )
 
     let start = Position(line: 0, utf16index: 10)
     let end = Position(line: 0, utf16index: 13)
     editDocument(range: start..<end, text: " 1")
 
     let after = try performSemanticTokensRequest()
-    XCTAssertEqual(after, expectedLeading + [
-      Token(line: 0, utf16index: 11, length: 3, kind: .number),
-    ])
+    XCTAssertEqual(
+      after,
+      expectedLeading + [
+        Token(line: 0, utf16index: 11, length: 3, kind: .number)
+      ]
+    )
   }
 
   func testReplaceUntilEndOfToken() throws {
     let text = """
-    fatalError("xyz")
-    """
+      fatalError("xyz")
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
-    XCTAssertEqual(before, [
-      Token(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: .defaultLibrary),
-      Token(line: 0, utf16index: 11, length: 5, kind: .string),
-    ])
+    XCTAssertEqual(
+      before,
+      [
+        Token(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: .defaultLibrary),
+        Token(line: 0, utf16index: 11, length: 5, kind: .string),
+      ]
+    )
 
     let start = Position(line: 0, utf16index: 10)
     let end = Position(line: 0, utf16index: 16)
     editDocument(range: start..<end, text: "(\"test\"")
 
     let after = try performSemanticTokensRequest()
-    XCTAssertEqual(after, [
-      Token(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: .defaultLibrary),
-      Token(line: 0, utf16index: 11, length: 6, kind: .string),
-    ])
+    XCTAssertEqual(
+      after,
+      [
+        Token(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: .defaultLibrary),
+        Token(line: 0, utf16index: 11, length: 6, kind: .string),
+      ]
+    )
   }
 
   func testInsertSpaceBeforeToken() throws {
     let text = """
-    let x: String = "test"
-    """
+      let x: String = "test"
+      """
     openDocument(text: text)
 
     let expectedBefore = [
       SyntaxHighlightingToken(line: 0, utf16index: 0, length: 3, kind: .keyword),
       SyntaxHighlightingToken(line: 0, utf16index: 4, length: 1, kind: .identifier),
       SyntaxHighlightingToken(line: 0, utf16index: 7, length: 6, kind: .struct, modifiers: [.defaultLibrary]),
-      SyntaxHighlightingToken(line: 0, utf16index: 16, length: 6, kind: .string)
+      SyntaxHighlightingToken(line: 0, utf16index: 16, length: 6, kind: .string),
     ]
     let before = try performSemanticTokensRequest()
     XCTAssertEqual(before, expectedBefore)
@@ -601,15 +674,15 @@ final class SemanticTokensTests: XCTestCase {
       SyntaxHighlightingToken(line: 0, utf16index: 1, length: 3, kind: .keyword),
       SyntaxHighlightingToken(line: 0, utf16index: 5, length: 1, kind: .identifier),
       SyntaxHighlightingToken(line: 0, utf16index: 8, length: 6, kind: .struct, modifiers: [.defaultLibrary]),
-      SyntaxHighlightingToken(line: 0, utf16index: 17, length: 6, kind: .string)
+      SyntaxHighlightingToken(line: 0, utf16index: 17, length: 6, kind: .string),
     ]
     XCTAssertEqual(after, expectedAfter)
   }
 
   func testInsertSpaceAfterToken() throws {
     let text = """
-    var x = 0
-    """
+      var x = 0
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
@@ -624,13 +697,13 @@ final class SemanticTokensTests: XCTestCase {
 
   func testInsertNewline() throws {
     let text = """
-    fatalError("123")
-    """
+      fatalError("123")
+      """
     openDocument(text: text)
 
     let expectedBefore = [
       SyntaxHighlightingToken(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: [.defaultLibrary]),
-      SyntaxHighlightingToken(line: 0, utf16index: 11, length: 5, kind: .string)
+      SyntaxHighlightingToken(line: 0, utf16index: 11, length: 5, kind: .string),
     ]
     let before = try performSemanticTokensRequest()
     XCTAssertEqual(before, expectedBefore)
@@ -641,16 +714,16 @@ final class SemanticTokensTests: XCTestCase {
     let after = try performSemanticTokensRequest()
     let expectedAfter = [
       SyntaxHighlightingToken(line: 1, utf16index: 0, length: 10, kind: .function, modifiers: [.defaultLibrary]),
-      SyntaxHighlightingToken(line: 1, utf16index: 11, length: 5, kind: .string)
+      SyntaxHighlightingToken(line: 1, utf16index: 11, length: 5, kind: .string),
     ]
     XCTAssertEqual(after, expectedAfter)
   }
 
   func testRemoveNewline() throws {
     let text = """
-    let x =
-            "abc"
-    """
+      let x =
+              "abc"
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
@@ -676,9 +749,9 @@ final class SemanticTokensTests: XCTestCase {
 
   func testInsertTokens() throws {
     let text = """
-    let x =
-            "abc"
-    """
+      let x =
+              "abc"
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
@@ -706,69 +779,81 @@ final class SemanticTokensTests: XCTestCase {
 
   func testSemanticMultiEdit() throws {
     let text = """
-    let x = "abc"
-    let y = x
-    """
+      let x = "abc"
+      let y = x
+      """
     openDocument(text: text)
 
     let before = try performSemanticTokensRequest()
-    XCTAssertEqual(before, [
-      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 0, utf16index: 8, length: 5, kind: .string),
-      Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 1, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 1, utf16index: 8, length: 1, kind: .variable),
-    ])
+    XCTAssertEqual(
+      before,
+      [
+        Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 8, length: 5, kind: .string),
+        Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 1, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 1, utf16index: 8, length: 1, kind: .variable),
+      ]
+    )
 
     let newName = "renamed"
-    editDocument(changes: [
-      TextDocumentContentChangeEvent(
-        range: Position(line: 0, utf16index: 4)..<Position(line: 0, utf16index: 5),
-        text: newName
-      ),
-      TextDocumentContentChangeEvent(
-        range: Position(line: 1, utf16index: 8)..<Position(line: 1, utf16index: 9),
-        text: newName
-      ),
-    ], expectRefresh: true)
+    editDocument(
+      changes: [
+        TextDocumentContentChangeEvent(
+          range: Position(line: 0, utf16index: 4)..<Position(line: 0, utf16index: 5),
+          text: newName
+        ),
+        TextDocumentContentChangeEvent(
+          range: Position(line: 1, utf16index: 8)..<Position(line: 1, utf16index: 9),
+          text: newName
+        ),
+      ],
+      expectRefresh: true
+    )
 
     let after = try performSemanticTokensRequest()
-    XCTAssertEqual(after, [
-      Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 0, utf16index: 4, length: 7, kind: .identifier),
-      Token(line: 0, utf16index: 14, length: 5, kind: .string),
-      Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
-      Token(line: 1, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 1, utf16index: 8, length: 7, kind: .variable),
-    ])
+    XCTAssertEqual(
+      after,
+      [
+        Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 0, utf16index: 4, length: 7, kind: .identifier),
+        Token(line: 0, utf16index: 14, length: 5, kind: .string),
+        Token(line: 1, utf16index: 0, length: 3, kind: .keyword),
+        Token(line: 1, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 1, utf16index: 8, length: 7, kind: .variable),
+      ]
+    )
   }
-  
+
   func testActor() throws {
     let text = """
-    actor MyActor {}
+      actor MyActor {}
 
-    struct MyStruct {}
+      struct MyStruct {}
 
-    func t(
-        x: MyActor,
-        y: MyStruct
-    ) {}
-    """
+      func t(
+          x: MyActor,
+          y: MyStruct
+      ) {}
+      """
 
     let tokens = try openAndPerformSemanticTokensRequest(text: text)
-    XCTAssertEqual(tokens, [
-      Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
-      Token(line: 0, utf16index: 6, length: 7, kind: .identifier),
-      Token(line: 2, utf16index: 0, length: 6, kind: .keyword),
-      Token(line: 2, utf16index: 7, length: 8, kind: .identifier),
-      Token(line: 4, utf16index: 0, length: 4, kind: .keyword),
-      Token(line: 4, utf16index: 5, length: 1, kind: .identifier),
-      Token(line: 5, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 5, utf16index: 7, length: 7, kind: .actor),
-      Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
-      Token(line: 6, utf16index: 7, length: 8, kind: .struct)
-    ])
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 5, kind: .keyword),
+        Token(line: 0, utf16index: 6, length: 7, kind: .identifier),
+        Token(line: 2, utf16index: 0, length: 6, kind: .keyword),
+        Token(line: 2, utf16index: 7, length: 8, kind: .identifier),
+        Token(line: 4, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 4, utf16index: 5, length: 1, kind: .identifier),
+        Token(line: 5, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 5, utf16index: 7, length: 7, kind: .actor),
+        Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 6, utf16index: 7, length: 8, kind: .struct),
+      ]
+    )
   }
 }
 

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import ISDBTestSupport
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKCore
 import SKTestSupport
 import TSCBasic
@@ -22,56 +22,62 @@ public typealias URL = Foundation.URL
 
 final class SKTests: XCTestCase {
 
-    func testInitLocal() throws {
-      let c = TestSourceKitServer()
-      defer { withExtendedLifetime(c) {} } // Keep connection alive for callbacks.
+  func testInitLocal() throws {
+    let c = TestSourceKitServer()
+    defer { withExtendedLifetime(c) {} }  // Keep connection alive for callbacks.
 
-      let sk = c.client
+    let sk = c.client
 
-      let initResult = try sk.sendSync(InitializeRequest(
+    let initResult = try sk.sendSync(
+      InitializeRequest(
         processId: nil,
         rootPath: nil,
         rootURI: nil,
         initializationOptions: nil,
         capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
         trace: .off,
-        workspaceFolders: nil))
+        workspaceFolders: nil
+      )
+    )
 
-      guard case .options(let syncOptions) = initResult.capabilities.textDocumentSync else {
-        XCTFail("Unexpected textDocumentSync property")
-        return
-      }
-      XCTAssertEqual(syncOptions.openClose, true)
-      XCTAssertNotNil(initResult.capabilities.completionProvider)
+    guard case .options(let syncOptions) = initResult.capabilities.textDocumentSync else {
+      XCTFail("Unexpected textDocumentSync property")
+      return
     }
+    XCTAssertEqual(syncOptions.openClose, true)
+    XCTAssertNotNil(initResult.capabilities.completionProvider)
+  }
 
-    func testInitJSON() throws {
-      let c = TestSourceKitServer(connectionKind: .jsonrpc)
-      defer { withExtendedLifetime(c) {} } // Keep connection alive for callbacks.
+  func testInitJSON() throws {
+    let c = TestSourceKitServer(connectionKind: .jsonrpc)
+    defer { withExtendedLifetime(c) {} }  // Keep connection alive for callbacks.
 
-      let sk = c.client
+    let sk = c.client
 
-      let initResult = try sk.sendSync(InitializeRequest(
+    let initResult = try sk.sendSync(
+      InitializeRequest(
         processId: nil,
         rootPath: nil,
         rootURI: nil,
         initializationOptions: nil,
         capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
         trace: .off,
-        workspaceFolders: nil))
+        workspaceFolders: nil
+      )
+    )
 
-      guard case .options(let syncOptions) = initResult.capabilities.textDocumentSync else {
-        XCTFail("Unexpected textDocumentSync property")
-        return
-      }
-      XCTAssertEqual(syncOptions.openClose, true)
-      XCTAssertNotNil(initResult.capabilities.completionProvider)
+    guard case .options(let syncOptions) = initResult.capabilities.textDocumentSync else {
+      XCTFail("Unexpected textDocumentSync property")
+      return
     }
+    XCTAssertEqual(syncOptions.openClose, true)
+    XCTAssertNotNil(initResult.capabilities.completionProvider)
+  }
 
   func testIndexSwiftModules() async throws {
     guard let ws = try await staticSourceKitTibsWorkspace(name: "SwiftModules") else { return }
     try ws.buildAndIndex()
-    defer { withExtendedLifetime(ws) {} } // Keep workspace alive for callbacks.
+    defer { withExtendedLifetime(ws) {} }  // Keep workspace alive for callbacks.
 
     let locDef = ws.testLoc("aaa:def")
     let locRef = ws.testLoc("aaa:call:c")
@@ -81,9 +87,12 @@ final class SKTests: XCTestCase {
 
     // MARK: Jump to definition
 
-    let response = try ws.sk.sendSync(DefinitionRequest(
-      textDocument: locRef.docIdentifier,
-      position: locRef.position))
+    let response = try ws.sk.sendSync(
+      DefinitionRequest(
+        textDocument: locRef.docIdentifier,
+        position: locRef.position
+      )
+    )
     guard case .locations(let jump) = response else {
       XCTFail("Response is not locations")
       return
@@ -95,31 +104,62 @@ final class SKTests: XCTestCase {
 
     // MARK: Find references
 
-    let refs = try ws.sk.sendSync(ReferencesRequest(
-      textDocument: locDef.docIdentifier,
-      position: locDef.position,
-      context: ReferencesContext(includeDeclaration: true)))
+    let refs = try ws.sk.sendSync(
+      ReferencesRequest(
+        textDocument: locDef.docIdentifier,
+        position: locDef.position,
+        context: ReferencesContext(includeDeclaration: true)
+      )
+    )
 
     let call = ws.testLoc("aaa:call")
-    XCTAssertEqual(Set(refs), [
-      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: locDef.url.path)).pathString), line: locDef.line, utf8Column: locDef.utf8Column, utf16Column: locDef.utf16Column)),
-      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: locRef.url.path)).pathString), line: locRef.line, utf8Column: locRef.utf8Column, utf16Column: locRef.utf16Column)),
-      Location(TestLocation(url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: call.url.path)).pathString), line: call.line, utf8Column: call.utf8Column, utf16Column: call.utf16Column)),
-    ])
+    XCTAssertEqual(
+      Set(refs),
+      [
+        Location(
+          TestLocation(
+            url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: locDef.url.path)).pathString),
+            line: locDef.line,
+            utf8Column: locDef.utf8Column,
+            utf16Column: locDef.utf16Column
+          )
+        ),
+        Location(
+          TestLocation(
+            url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: locRef.url.path)).pathString),
+            line: locRef.line,
+            utf8Column: locRef.utf8Column,
+            utf16Column: locRef.utf16Column
+          )
+        ),
+        Location(
+          TestLocation(
+            url: URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: call.url.path)).pathString),
+            line: call.line,
+            utf8Column: call.utf8Column,
+            utf16Column: call.utf16Column
+          )
+        ),
+      ]
+    )
   }
 
   func testIndexShutdown() async throws {
 
     let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        .appendingPathComponent("sk-test-data/\(testDirectoryName)", isDirectory: true)
+      .appendingPathComponent("sk-test-data/\(testDirectoryName)", isDirectory: true)
 
     func listdir(_ url: URL) throws -> [URL] {
       try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
     }
 
     func checkRunningIndex(build: Bool) async throws -> URL? {
-      guard let ws = try await staticSourceKitTibsWorkspace(
-        name: "SwiftModules", tmpDir: tmpDir, removeTmpDir: false)
+      guard
+        let ws = try await staticSourceKitTibsWorkspace(
+          name: "SwiftModules",
+          tmpDir: tmpDir,
+          removeTmpDir: false
+        )
       else {
         return nil
       }
@@ -131,9 +171,12 @@ final class SKTests: XCTestCase {
       let locDef = ws.testLoc("aaa:def")
       let locRef = ws.testLoc("aaa:call:c")
       try ws.openDocument(locRef.url, language: .swift)
-      let response = try ws.sk.sendSync(DefinitionRequest(
-        textDocument: locRef.docIdentifier,
-        position: locRef.position))
+      let response = try ws.sk.sendSync(
+        DefinitionRequest(
+          textDocument: locRef.docIdentifier,
+          position: locRef.position
+        )
+      )
       guard case .locations(let jump) = response else {
         XCTFail("Response is not locations")
         return nil
@@ -174,35 +217,51 @@ final class SKTests: XCTestCase {
     let loc = ws.testLoc("cc:A")
     try ws.openDocument(loc.url, language: .swift)
 
-    let results = try withExtendedLifetime(ws) { try ws.sk.sendSync(
-      CompletionRequest(textDocument: loc.docIdentifier, position: loc.position))
+    let results = try withExtendedLifetime(ws) {
+      try ws.sk.sendSync(
+        CompletionRequest(textDocument: loc.docIdentifier, position: loc.position)
+      )
     }
 
-    XCTAssertEqual(results.items, [
-      CompletionItem(
-        label: "method(a: Int)",
-        kind: .method,
-        detail: "Void",
-        deprecated: false, sortText: nil,
-        filterText: "method(a:)",
-        insertText: "method(a: )",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "method(a: )"))),
-      CompletionItem(
-        label: "self",
-        kind: .keyword,
-        detail: "A",
-        deprecated: false, sortText: nil,
-        filterText: "self",
-        insertText: "self",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "self"))),
-    ])
+    XCTAssertEqual(
+      results.items,
+      [
+        CompletionItem(
+          label: "method(a: Int)",
+          kind: .method,
+          detail: "Void",
+          deprecated: false,
+          sortText: nil,
+          filterText: "method(a:)",
+          insertText: "method(a: )",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(
+              range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14),
+              newText: "method(a: )"
+            )
+          )
+        ),
+        CompletionItem(
+          label: "self",
+          kind: .keyword,
+          detail: "A",
+          deprecated: false,
+          sortText: nil,
+          filterText: "self",
+          insertText: "self",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(range: Position(line: 1, utf16index: 14)..<Position(line: 1, utf16index: 14), newText: "self")
+          )
+        ),
+      ]
+    )
   }
 
   func testDependenciesUpdatedSwiftTibs() async throws {
     guard let ws = try await mutableSourceKitTibsTestWorkspace(name: "SwiftModules") else { return }
-    defer { withExtendedLifetime(ws) {} } // Keep workspace alive for callbacks.
+    defer { withExtendedLifetime(ws) {} }  // Keep workspace alive for callbacks.
     guard let server = ws.testServer.server else {
       XCTFail("Unable to fetch SourceKitServer to notify for build system events.")
       return
@@ -216,12 +275,14 @@ final class SKTests: XCTestCase {
       XCTAssertEqual(note.params.diagnostics.count, 0)
       startExpectation.fulfill()
     }
-    ws.sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis: expect module import error.
       XCTAssertEqual(note.params.diagnostics.count, 1)
       if let diagnostic = note.params.diagnostics.first {
-        XCTAssert(diagnostic.message.contains("no such module"),
-                  "expected module import error but found \"\(diagnostic.message)\"")
+        XCTAssert(
+          diagnostic.message.contains("no such module"),
+          "expected module import error but found \"\(diagnostic.message)\""
+        )
       }
       startExpectation.fulfill()
     }
@@ -238,7 +299,7 @@ final class SKTests: XCTestCase {
       XCTAssertEqual(note.params.diagnostics.count, 1)
       finishExpectation.fulfill()
     }
-    ws.sk.appendOneShotNotificationHandler  { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis: no more errors expected, import should resolve since we built.
       XCTAssertEqual(note.params.diagnostics.count, 0)
       finishExpectation.fulfill()
@@ -250,7 +311,7 @@ final class SKTests: XCTestCase {
 
   func testDependenciesUpdatedCXXTibs() async throws {
     guard let ws = try await mutableSourceKitTibsTestWorkspace(name: "GeneratedHeader") else { return }
-    defer { withExtendedLifetime(ws) {} } // Keep workspace alive for callbacks.
+    defer { withExtendedLifetime(ws) {} }  // Keep workspace alive for callbacks.
     guard let server = ws.testServer.server else {
       XCTFail("Unable to fetch SourceKitServer to notify for build system events.")
       return
@@ -266,7 +327,7 @@ final class SKTests: XCTestCase {
     }
 
     let generatedHeaderURL = moduleRef.url.deletingLastPathComponent()
-        .appendingPathComponent("lib-generated.h", isDirectory: false)
+      .appendingPathComponent("lib-generated.h", isDirectory: false)
 
     // Write an empty header file first since clangd doesn't handle missing header
     // files without a recently upstreamed extension.
@@ -298,12 +359,14 @@ final class SKTests: XCTestCase {
     let mainLoc = ws.testLoc("Object:include:main")
     let expectedDoc = ws.testLoc("Object").docIdentifier.uri
     let includePosition =
-        Position(line: mainLoc.position.line, utf16index: mainLoc.utf16Column + 2)
+      Position(line: mainLoc.position.line, utf16index: mainLoc.utf16Column + 2)
 
     try ws.openDocument(mainLoc.url, language: .c)
 
     let goToInclude = DefinitionRequest(
-      textDocument: mainLoc.docIdentifier, position: includePosition)
+      textDocument: mainLoc.docIdentifier,
+      position: includePosition
+    )
     let resp = try withExtendedLifetime(ws) { try ws.sk.sendSync(goToInclude) }
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-#include")
@@ -332,7 +395,9 @@ final class SKTests: XCTestCase {
     try ws.openDocument(refLoc.url, language: .c)
 
     let goToDefinition = DefinitionRequest(
-      textDocument: refLoc.docIdentifier, position: refPos)
+      textDocument: refLoc.docIdentifier,
+      position: refPos
+    )
     let resp = try withExtendedLifetime(ws) { try ws.sk.sendSync(goToDefinition) }
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-definition")
@@ -357,12 +422,14 @@ final class SKTests: XCTestCase {
     let mainLoc = ws.testLoc("Object:ref:newObject")
     let expectedDoc = ws.testLoc("Object:decl:newObject").docIdentifier.uri
     let includePosition =
-        Position(line: mainLoc.position.line, utf16index: mainLoc.utf16Column + 2)
+      Position(line: mainLoc.position.line, utf16index: mainLoc.utf16Column + 2)
 
     try ws.openDocument(mainLoc.url, language: .c)
 
     let goToInclude = DeclarationRequest(
-      textDocument: mainLoc.docIdentifier, position: includePosition)
+      textDocument: mainLoc.docIdentifier,
+      position: includePosition
+    )
     let resp = try ws.sk.sendSync(goToInclude)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-declaration")

--- a/Tests/SourceKitLSPTests/SwiftCompileCommandsTest.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompileCommandsTest.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitLSP
 import SKCore
+import SourceKitLSP
 import XCTest
 
 final class SwiftCompileCommandsTest: XCTestCase {

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocol
 import LSPTestSupport
+import LanguageServerProtocol
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -70,19 +70,26 @@ final class SwiftCompletionTests: XCTestCase {
           "completion": .dictionary([
             "serverSideFiltering": .bool(options.serverSideFiltering),
             "maxResults": options.maxResults == nil ? .null : .int(options.maxResults!),
-          ]),
+          ])
         ]),
         capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
         trace: .off,
-        workspaceFolders: nil))
+        workspaceFolders: nil
+      )
+    )
   }
 
   func openDocument(text: String? = nil, url: URL) {
-    sk.send(DidOpenTextDocumentNotification(textDocument: TextDocumentItem(
-      uri: DocumentURI(url),
-      language: .swift,
-      version: 12,
-      text: text ?? self.text)))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: DocumentURI(url),
+          language: .swift,
+          version: 12,
+          text: text ?? self.text
+        )
+      )
+    )
   }
 
   func testCompletionClientFilter() throws {
@@ -102,9 +109,12 @@ final class SwiftCompletionTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(url: url)
 
-    let selfDot = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 5, utf16index: 9)))
+    let selfDot = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(url),
+        position: Position(line: 5, utf16index: 9)
+      )
+    )
 
     XCTAssertEqual(selfDot.isIncomplete, options.serverSideFiltering)
     XCTAssertGreaterThanOrEqual(selfDot.items.count, 2)
@@ -115,15 +125,21 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(abc.detail, "Int")
       XCTAssertEqual(abc.documentation, .markupContent(MarkupContent(kind: .markdown, value: "Documentation for abc.")))
       XCTAssertEqual(abc.filterText, "abc")
-      XCTAssertEqual(abc.textEdit, .textEdit(TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "abc")))
+      XCTAssertEqual(
+        abc.textEdit,
+        .textEdit(TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "abc"))
+      )
       XCTAssertEqual(abc.insertText, "abc")
       XCTAssertEqual(abc.insertTextFormat, .plain)
     }
 
     for col in 10...12 {
-      let inIdent = try sk.sendSync(CompletionRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 5, utf16index: col)))
+      let inIdent = try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 5, utf16index: col)
+        )
+      )
       guard let abc = inIdent.items.first(where: { $0.label == "abc" }) else {
         XCTFail("No completion item with label 'abc'")
         return
@@ -134,14 +150,22 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(abc.detail, "Int")
       XCTAssertEqual(abc.documentation, .markupContent(MarkupContent(kind: .markdown, value: "Documentation for abc.")))
       XCTAssertEqual(abc.filterText, "abc")
-      XCTAssertEqual(abc.textEdit, .textEdit(TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: col), newText: "abc")))
+      XCTAssertEqual(
+        abc.textEdit,
+        .textEdit(
+          TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: col), newText: "abc")
+        )
+      )
       XCTAssertEqual(abc.insertText, "abc")
       XCTAssertEqual(abc.insertTextFormat, .plain)
     }
 
-    let after = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 6, utf16index: 0)))
+    let after = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(url),
+        position: Position(line: 6, utf16index: 0)
+      )
+    )
     XCTAssertNotEqual(after, selfDot)
   }
 
@@ -154,9 +178,12 @@ final class SwiftCompletionTests: XCTestCase {
     openDocument(url: url)
 
     func getTestMethodCompletion(_ position: Position, label: String) throws -> CompletionItem? {
-      let selfDot = try sk.sendSync(CompletionRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: position))
+      let selfDot = try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: position
+        )
+      )
       return selfDot.items.first { $0.label == label }
     }
 
@@ -174,7 +201,15 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(a:)")
-      XCTAssertEqual(test.textEdit, .textEdit(TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "test(a: ${1:Int})")))
+      XCTAssertEqual(
+        test.textEdit,
+        .textEdit(
+          TextEdit(
+            range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9),
+            newText: "test(a: ${1:Int})"
+          )
+        )
+      )
       XCTAssertEqual(test.insertText, "test(a: ${1:Int})")
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
@@ -185,7 +220,15 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(:)")
-      XCTAssertEqual(test.textEdit, .textEdit(TextEdit(range: Position(line: 9, utf16index: 9)..<Position(line: 9, utf16index: 9), newText: "test(${1:b: Int})")))
+      XCTAssertEqual(
+        test.textEdit,
+        .textEdit(
+          TextEdit(
+            range: Position(line: 9, utf16index: 9)..<Position(line: 9, utf16index: 9),
+            newText: "test(${1:b: Int})"
+          )
+        )
+      )
       XCTAssertEqual(test.insertText, "test(${1:b: Int})")
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
@@ -201,7 +244,12 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(a:)")
-      XCTAssertEqual(test.textEdit, .textEdit(TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "test(a: )")))
+      XCTAssertEqual(
+        test.textEdit,
+        .textEdit(
+          TextEdit(range: Position(line: 5, utf16index: 9)..<Position(line: 5, utf16index: 9), newText: "test(a: )")
+        )
+      )
       XCTAssertEqual(test.insertText, "test(a: )")
       XCTAssertEqual(test.insertTextFormat, .plain)
     }
@@ -213,7 +261,12 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(:)")
       // FIXME:
-      XCTAssertEqual(test.textEdit, .textEdit(TextEdit(range: Position(line: 9, utf16index: 9)..<Position(line: 9, utf16index: 9), newText: "test()")))
+      XCTAssertEqual(
+        test.textEdit,
+        .textEdit(
+          TextEdit(range: Position(line: 9, utf16index: 9)..<Position(line: 9, utf16index: 9), newText: "test()")
+        )
+      )
       XCTAssertEqual(test.insertText, "test()")
       XCTAssertEqual(test.insertTextFormat, .plain)
     }
@@ -232,22 +285,31 @@ final class SwiftCompletionTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     openDocument(text: "foo", url: url)
 
-    for col in 0 ... 3 {
-      let inOrAfterFoo = try sk.sendSync(CompletionRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 0, utf16index: col)))
+    for col in 0...3 {
+      let inOrAfterFoo = try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 0, utf16index: col)
+        )
+      )
       XCTAssertEqual(inOrAfterFoo.isIncomplete, options.serverSideFiltering)
       XCTAssertFalse(inOrAfterFoo.items.isEmpty)
     }
 
-    let outOfRange1 = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 0, utf16index: 4)))
+    let outOfRange1 = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(url),
+        position: Position(line: 0, utf16index: 4)
+      )
+    )
     XCTAssertTrue(outOfRange1.isIncomplete)
 
-    let outOfRange2 = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 1, utf16index: 0)))
+    let outOfRange2 = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(url),
+        position: Position(line: 1, utf16index: 0)
+      )
+    )
     XCTAssertTrue(outOfRange2.isIncomplete)
   }
 
@@ -255,25 +317,33 @@ final class SwiftCompletionTests: XCTestCase {
     try initializeServer()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
-    struct Foo {
-      let bar: Int
-    }
-    let a: Foo? = Foo(bar: 1)
-    a.ba
-    """
+      struct Foo {
+        let bar: Int
+      }
+      let a: Foo? = Foo(bar: 1)
+      a.ba
+      """
     openDocument(text: text, url: url)
 
     for col in 2...4 {
-      let response = try sk.sendSync(CompletionRequest(
-        textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 4, utf16index: col)))
+      let response = try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 4, utf16index: col)
+        )
+      )
 
       guard let item = response.items.first(where: { $0.label.contains("bar") }) else {
         XCTFail("No completion item with label 'bar'")
         return
       }
       XCTAssertEqual(item.filterText, ".bar")
-      XCTAssertEqual(item.textEdit, .textEdit(TextEdit(range: Position(line: 4, utf16index: 1)..<Position(line: 4, utf16index: col), newText: "?.bar")))
+      XCTAssertEqual(
+        item.textEdit,
+        .textEdit(
+          TextEdit(range: Position(line: 4, utf16index: 1)..<Position(line: 4, utf16index: col), newText: "?.bar")
+        )
+      )
     }
   }
 
@@ -281,274 +351,512 @@ final class SwiftCompletionTests: XCTestCase {
     try initializeServer()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
-    class Base {
-      func foo() {}
-    }
-    class C: Base {
-      func    // don't delete trailing space in this file
-    }
-    """
+      class Base {
+        func foo() {}
+      }
+      class C: Base {
+        func    // don't delete trailing space in this file
+      }
+      """
     openDocument(text: text, url: url)
 
-    let response = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 4, utf16index: 7)))
+    let response = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(url),
+        position: Position(line: 4, utf16index: 7)
+      )
+    )
     guard let item = response.items.first(where: { $0.label == "foo()" }) else {
       XCTFail("No completion item with label 'foo()'")
       return
     }
     // FIXME: should be "foo()"
     XCTAssertEqual(item.filterText, "func foo()")
-    XCTAssertEqual(item.textEdit, .textEdit(TextEdit(range: Position(line: 4, utf16index: 2)..<Position(line: 4, utf16index: 7), newText: "override func foo() {\n\n}")))
+    XCTAssertEqual(
+      item.textEdit,
+      .textEdit(
+        TextEdit(
+          range: Position(line: 4, utf16index: 2)..<Position(line: 4, utf16index: 7),
+          newText: "override func foo() {\n\n}"
+        )
+      )
+    )
   }
 
   func testCompletionOverrideInNewLine() throws {
     try initializeServer()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let text = """
-    class Base {
-      func foo() {}
-    }
-    class C: Base {
-      func
-        // don't delete trailing space in this file
-    }
-    """
+      class Base {
+        func foo() {}
+      }
+      class C: Base {
+        func
+          // don't delete trailing space in this file
+      }
+      """
     openDocument(text: text, url: url)
 
-    let response = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 5, utf16index: 2)))
+    let response = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(url),
+        position: Position(line: 5, utf16index: 2)
+      )
+    )
     guard let item = response.items.first(where: { $0.label == "foo()" }) else {
       XCTFail("No completion item with label 'foo()'")
       return
     }
     // If the edit would cross multiple lines, we are currently not replacing any text. It's not technically correct but the best we can do.
     XCTAssertEqual(item.filterText, "foo()")
-    XCTAssertEqual(item.textEdit, .textEdit(TextEdit(range: Position(line: 5, utf16index: 2)..<Position(line: 5, utf16index: 2), newText: "override func foo() {\n\n}")))
+    XCTAssertEqual(
+      item.textEdit,
+      .textEdit(
+        TextEdit(
+          range: Position(line: 5, utf16index: 2)..<Position(line: 5, utf16index: 2),
+          newText: "override func foo() {\n\n}"
+        )
+      )
+    )
   }
 
   func testMaxResults() throws {
     try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
-    openDocument(text: """
-      struct S {
-        func f1() {}
-        func f2() {}
-        func f3() {}
-        func f4() {}
-        func f5() {}
-        func test() {
-          self.f
+    openDocument(
+      text: """
+        struct S {
+          func f1() {}
+          func f2() {}
+          func f3() {}
+          func f4() {}
+          func f5() {}
+          func test() {
+            self.f
+          }
         }
-      }
-      """, url: url)
+        """,
+      url: url
+    )
 
     // Server-wide option
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 9)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 9)
+          )
+        )
+      )
+    )
 
     // Explicit option
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 9),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: nil)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 9),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: nil
+              )
+          )
+        )
+      )
+    )
 
     // MARK: Limited
 
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 9),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: 1000)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 9),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: 1000
+              )
+          )
+        )
+      )
+    )
 
-    XCTAssertEqual(3, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 9),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: 3)))))
-    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 9),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: 1)))))
+    XCTAssertEqual(
+      3,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 9),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: 3
+              )
+          )
+        )
+      )
+    )
+    XCTAssertEqual(
+      1,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 9),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: 1
+              )
+          )
+        )
+      )
+    )
 
     // 0 also means unlimited
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 9),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: 0)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 9),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: 0
+              )
+          )
+        )
+      )
+    )
 
     // MARK: With filter='f'
 
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 10),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: nil)))))
-    XCTAssertEqual(3, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 10),
-                                                sourcekitlspOptions:
-                                                  SKCompletionOptions(
-                                                    serverSideFiltering: true,
-                                                    maxResults: 3)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 10),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: nil
+              )
+          )
+        )
+      )
+    )
+    XCTAssertEqual(
+      3,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 10),
+            sourcekitlspOptions:
+              SKCompletionOptions(
+                serverSideFiltering: true,
+                maxResults: 3
+              )
+          )
+        )
+      )
+    )
 
   }
 
   func testRefilterAfterIncompleteResults() throws {
     try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: 20))
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
-    openDocument(text: """
-      struct S {
-        func fooAbc() {}
-        func fooBcd() {}
-        func fooCde() {}
-        func fooDef() {}
-        func fooGoop() {}
-        func test() {
-          self.fcdez
+    openDocument(
+      text: """
+        struct S {
+          func fooAbc() {}
+          func fooBcd() {}
+          func fooCde() {}
+          func fooDef() {}
+          func fooGoop() {}
+          func test() {
+            self.fcdez
+          }
         }
-      }
-      """, url: url)
+        """,
+      url: url
+    )
 
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 10),
-                                                context:CompletionContext(triggerKind: .invoked)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 10),
+            context: CompletionContext(triggerKind: .invoked)
+          )
+        )
+      )
+    )
 
-    XCTAssertEqual(3, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 11),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(2, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 12),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 13),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(0, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 14),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
-    XCTAssertEqual(2, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 12),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertEqual(
+      3,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 11),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
+    XCTAssertEqual(
+      2,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 12),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
+    XCTAssertEqual(
+      1,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 13),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
+    XCTAssertEqual(
+      0,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 14),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
+    XCTAssertEqual(
+      2,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 12),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
 
     // Not valid for the current session.
     // We explicitly keep the session and fail any requests that don't match so that the editor
     // can rely on `.triggerFromIncompleteCompletions` always being fast.
-    XCTAssertThrowsError(try sk.sendSync(CompletionRequest(
-                                          textDocument: TextDocumentIdentifier(url),
-                                          position: Position(line: 7, utf16index: 0),
-                                          context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions))))
-    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 13),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertThrowsError(
+      try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 7, utf16index: 0),
+          context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+        )
+      )
+    )
+    XCTAssertEqual(
+      1,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 13),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
 
     // Trigger kind changed => OK (20 is maxResults since we're outside the member completion)
-    XCTAssertEqual(20, try sk.sendSync(CompletionRequest(
-                                        textDocument: TextDocumentIdentifier(url),
-                                        position: Position(line: 7, utf16index: 0),
-                                          context:CompletionContext(triggerKind: .invoked))).items.count)
+    XCTAssertEqual(
+      20,
+      try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 7, utf16index: 0),
+          context: CompletionContext(triggerKind: .invoked)
+        )
+      ).items.count
+    )
   }
 
   func testRefilterAfterIncompleteResultsWithEdits() throws {
     try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
-    openDocument(text: """
-      struct S {
-        func fooAbc() {}
-        func fooBcd() {}
-        func fooCde() {}
-        func fooDef() {}
-        func fooGoop() {}
-        func test() {
-          self.fz
+    openDocument(
+      text: """
+        struct S {
+          func fooAbc() {}
+          func fooBcd() {}
+          func fooCde() {}
+          func fooDef() {}
+          func fooGoop() {}
+          func test() {
+            self.fz
+          }
         }
-      }
-      """, url: url)
+        """,
+      url: url
+    )
 
     // 'f'
-    XCTAssertEqual(5, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 10),
-                                                context:CompletionContext(triggerKind: .invoked)))))
+    XCTAssertEqual(
+      5,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 10),
+            context: CompletionContext(triggerKind: .invoked)
+          )
+        )
+      )
+    )
 
     // 'fz'
-    XCTAssertEqual(0, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 11),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertEqual(
+      0,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 11),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
 
-    sk.send(DidChangeTextDocumentNotification(
-              textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
-              contentChanges: [
-                .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "A ")]))
+    sk.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
+        contentChanges: [
+          .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "A ")
+        ]
+      )
+    )
 
     // 'fA'
-    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 11),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertEqual(
+      1,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 11),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
 
     // 'fA '
-    XCTAssertThrowsError(try sk.sendSync(CompletionRequest(
-                                          textDocument: TextDocumentIdentifier(url),
-                                          position: Position(line: 7, utf16index: 12),
-                                          context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions))))
+    XCTAssertThrowsError(
+      try sk.sendSync(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(url),
+          position: Position(line: 7, utf16index: 12),
+          context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+        )
+      )
+    )
 
-    sk.send(DidChangeTextDocumentNotification(
-              textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
-              contentChanges: [
-                .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "Ab")]))
+    sk.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
+        contentChanges: [
+          .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "Ab")
+        ]
+      )
+    )
 
     // 'fAb'
-    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 11),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertEqual(
+      1,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 11),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
 
-    sk.send(DidChangeTextDocumentNotification(
-              textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
-              contentChanges: [
-                .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "")]))
+    sk.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
+        contentChanges: [
+          .init(range: Position(line: 7, utf16index: 10)..<Position(line: 7, utf16index: 11), text: "")
+        ]
+      )
+    )
 
     // 'fb'
-    XCTAssertEqual(2, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 11),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertEqual(
+      2,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 11),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
 
-    sk.send(DidChangeTextDocumentNotification(
-              textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
-              contentChanges: [
-                .init(range: Position(line: 7, utf16index: 11)..<Position(line: 7, utf16index: 11), text: "d")]))
+    sk.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(DocumentURI(url), version: 1),
+        contentChanges: [
+          .init(range: Position(line: 7, utf16index: 11)..<Position(line: 7, utf16index: 11), text: "d")
+        ]
+      )
+    )
 
     // 'fbd'
-    XCTAssertEqual(1, countFs(try sk.sendSync(CompletionRequest(
-                                                textDocument: TextDocumentIdentifier(url),
-                                                position: Position(line: 7, utf16index: 12),
-                                                context:CompletionContext(triggerKind: .triggerFromIncompleteCompletions)))))
+    XCTAssertEqual(
+      1,
+      countFs(
+        try sk.sendSync(
+          CompletionRequest(
+            textDocument: TextDocumentIdentifier(url),
+            position: Position(line: 7, utf16index: 12),
+            context: CompletionContext(triggerKind: .triggerFromIncompleteCompletions)
+          )
+        )
+      )
+    )
   }
 
   /// Regression test for https://bugs.swift.org/browse/SR-13561 to make sure the a session
@@ -556,28 +864,33 @@ final class SwiftCompletionTests: XCTestCase {
   func testSessionCloseWaitsforOpen() throws {
     try initializeServer(options: SKCompletionOptions(serverSideFiltering: true, maxResults: nil))
     let url = URL(fileURLWithPath: "/\(UUID())/file.swift")
-    openDocument(text: """
-      struct S {
-        func forSomethingCrazy() {}
-        func forSomethingCool() {}
-        func test() {
-          self.forSome
+    openDocument(
+      text: """
+        struct S {
+          func forSomethingCrazy() {}
+          func forSomethingCool() {}
+          func test() {
+            self.forSome
+          }
+          func print() {}
+          func anotherOne() {
+            self.prin
+          }
         }
-        func print() {}
-        func anotherOne() {
-          self.prin
-        }
-      }
-      """, url: url)
+        """,
+      url: url
+    )
 
     let forSomeComplete = CompletionRequest(
-          textDocument: TextDocumentIdentifier(url),
-        position: Position(line: 4, utf16index: 12), // forS^
-        context:CompletionContext(triggerKind: .invoked))
+      textDocument: TextDocumentIdentifier(url),
+      position: Position(line: 4, utf16index: 12),  // forS^
+      context: CompletionContext(triggerKind: .invoked)
+    )
     let printComplete = CompletionRequest(
-        textDocument: TextDocumentIdentifier(url),
-      position: Position(line: 8, utf16index: 12), // prin^
-      context:CompletionContext(triggerKind: .invoked))
+      textDocument: TextDocumentIdentifier(url),
+      position: Position(line: 8, utf16index: 12),  // prin^
+      context: CompletionContext(triggerKind: .invoked)
+    )
 
     // Code completion for "self.forSome"
     let forSomeExpectation = XCTestExpectation(description: "self.forSome code completion")
@@ -611,5 +924,5 @@ final class SwiftCompletionTests: XCTestCase {
 }
 
 private func countFs(_ response: CompletionList) -> Int {
-  return response.items.filter{$0.label.hasPrefix("f")}.count
+  return response.items.filter { $0.label.hasPrefix("f") }.count
 }

--- a/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
@@ -55,7 +55,7 @@ final class TypeHierarchyTests: XCTestCase {
 
     func testLoc(_ name: String) -> TestLocation {
       ws.testLoc(name)
-    }  
+    }
 
     func loc(_ name: String) -> Location {
       Location(badUTF16: ws.testLoc(name))
@@ -84,7 +84,12 @@ final class TypeHierarchyTests: XCTestCase {
       )
     }
 
-    func item(_ name: String, _ kind: SymbolKind, detail: String = "main", at locName: String) throws -> TypeHierarchyItem {
+    func item(
+      _ name: String,
+      _ kind: SymbolKind,
+      detail: String = "main",
+      at locName: String
+    ) throws -> TypeHierarchyItem {
       let location = loc(locName)
       return TypeHierarchyItem(
         name: name,
@@ -99,72 +104,123 @@ final class TypeHierarchyTests: XCTestCase {
 
     // Test type hierarchy preparation
 
-    assertEqualIgnoringData(try typeHierarchy(at: testLoc("P")), [
-      try item("P", .interface, at: "P"),
-    ])
-    assertEqualIgnoringData(try typeHierarchy(at: testLoc("A")), [
-      try item("A", .class, at: "A"),
-    ])
-    assertEqualIgnoringData(try typeHierarchy(at: testLoc("S")), [
-      try item("S", .struct, at: "S"),
-    ])
-    assertEqualIgnoringData(try typeHierarchy(at: testLoc("E")), [
-      try item("E", .enum, at: "E"),
-    ])
+    assertEqualIgnoringData(
+      try typeHierarchy(at: testLoc("P")),
+      [
+        try item("P", .interface, at: "P")
+      ]
+    )
+    assertEqualIgnoringData(
+      try typeHierarchy(at: testLoc("A")),
+      [
+        try item("A", .class, at: "A")
+      ]
+    )
+    assertEqualIgnoringData(
+      try typeHierarchy(at: testLoc("S")),
+      [
+        try item("S", .struct, at: "S")
+      ]
+    )
+    assertEqualIgnoringData(
+      try typeHierarchy(at: testLoc("E")),
+      [
+        try item("E", .enum, at: "E")
+      ]
+    )
 
     // Test supertype hierarchy
 
     assertEqualIgnoringData(try supertypes(at: testLoc("A")), [])
-    assertEqualIgnoringData(try supertypes(at: testLoc("B")), [
-      try item("A", .class, at: "A"),
-      try item("P", .interface, at: "P"),
-    ])
-    assertEqualIgnoringData(try supertypes(at: testLoc("C")), [
-      try item("B", .class, at: "B"),
-    ])
-    assertEqualIgnoringData(try supertypes(at: testLoc("D")), [
-      try item("A", .class, at: "A"),
-    ])
-    assertEqualIgnoringData(try supertypes(at: testLoc("S")), [
-      try item("P", .interface, at: "P"),
-      try item("X", .interface, at: "X"), // Retroactive conformance
-    ])
-    assertEqualIgnoringData(try supertypes(at: testLoc("E")), [
-      try item("P", .interface, at: "P"),
-      try item("Y", .interface, at: "Y"), // Retroactive conformance
-      try item("Z", .interface, at: "Z"), // Retroactive conformance
-    ])
+    assertEqualIgnoringData(
+      try supertypes(at: testLoc("B")),
+      [
+        try item("A", .class, at: "A"),
+        try item("P", .interface, at: "P"),
+      ]
+    )
+    assertEqualIgnoringData(
+      try supertypes(at: testLoc("C")),
+      [
+        try item("B", .class, at: "B")
+      ]
+    )
+    assertEqualIgnoringData(
+      try supertypes(at: testLoc("D")),
+      [
+        try item("A", .class, at: "A")
+      ]
+    )
+    assertEqualIgnoringData(
+      try supertypes(at: testLoc("S")),
+      [
+        try item("P", .interface, at: "P"),
+        try item("X", .interface, at: "X"),  // Retroactive conformance
+      ]
+    )
+    assertEqualIgnoringData(
+      try supertypes(at: testLoc("E")),
+      [
+        try item("P", .interface, at: "P"),
+        try item("Y", .interface, at: "Y"),  // Retroactive conformance
+        try item("Z", .interface, at: "Z"),  // Retroactive conformance
+      ]
+    )
 
     // Test subtype hierarchy (includes extensions)
 
-    assertEqualIgnoringData(try subtypes(at: testLoc("A")), [
-      try item("B", .class, at: "B"),
-      try item("D", .class, at: "D"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("B")), [
-      try item("C", .class, at: "C"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("P")), [
-      try item("B", .class, at: "B"),
-      try item("S", .struct, at: "S"),
-      try item("E", .enum, at: "E"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("E")), [
-      try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("S")), [
-      try item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
-      try item("S", .null, detail: "Extension at a.swift:16", at: "extS"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("X")), [
-      try item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("Y")), [
-      try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
-    ])
-    assertEqualIgnoringData(try subtypes(at: testLoc("Z")), [
-      try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z"),
-    ])
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("A")),
+      [
+        try item("B", .class, at: "B"),
+        try item("D", .class, at: "D"),
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("B")),
+      [
+        try item("C", .class, at: "C")
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("P")),
+      [
+        try item("B", .class, at: "B"),
+        try item("S", .struct, at: "S"),
+        try item("E", .enum, at: "E"),
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("E")),
+      [
+        try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z")
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("S")),
+      [
+        try item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X"),
+        try item("S", .null, detail: "Extension at a.swift:16", at: "extS"),
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("X")),
+      [
+        try item("S: X", .null, detail: "Extension at a.swift:15", at: "extS:X")
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("Y")),
+      [
+        try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z")
+      ]
+    )
+    assertEqualIgnoringData(
+      try subtypes(at: testLoc("Z")),
+      [
+        try item("E: Y, Z", .null, detail: "Extension at a.swift:19", at: "extE:Y,Z")
+      ]
+    )
 
     // Ensure that type hierarchies can be fetched from uses too
 

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import LanguageServerProtocol
 import LSPTestSupport
-import SourceKitLSP
+import LanguageServerProtocol
 import SKCore
 import SKTestSupport
+import SourceKitLSP
 import TSCBasic
 import XCTest
 
@@ -25,7 +25,8 @@ final class WorkspaceTests: XCTestCase {
     guard let ws = try await staticSourceKitSwiftPMWorkspace(name: "SwiftPMPackage") else { return }
     try ws.buildAndIndex()
 
-    guard let otherWs = try await staticSourceKitSwiftPMWorkspace(name: "OtherSwiftPMPackage", server: ws.testServer) else { return }
+    guard let otherWs = try await staticSourceKitSwiftPMWorkspace(name: "OtherSwiftPMPackage", server: ws.testServer)
+    else { return }
     try otherWs.buildAndIndex()
 
     assert(ws.testServer === otherWs.testServer, "Sanity check: The two workspaces should be opened in the same server")
@@ -36,64 +37,83 @@ final class WorkspaceTests: XCTestCase {
     try ws.openDocument(call.url, language: .swift)
 
     let completions = try withExtendedLifetime(ws) {
-        try ws.sk.sendSync(CompletionRequest(textDocument: call.docIdentifier, position: call.position))
+      try ws.sk.sendSync(CompletionRequest(textDocument: call.docIdentifier, position: call.position))
     }
 
-    XCTAssertEqual(completions.items, [
-      CompletionItem(
-        label: "foo()",
-        kind: .method,
-        detail: "Void",
-        deprecated: false,
-        sortText: nil,
-        filterText: "foo()",
-        insertText: "foo()",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "foo()"))),
-      CompletionItem(
-        label: "self",
-        kind: .keyword,
-        detail: "Lib",
-        deprecated: false,
-        sortText: nil,
-        filterText: "self",
-        insertText: "self",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "self"))),
-    ])
+    XCTAssertEqual(
+      completions.items,
+      [
+        CompletionItem(
+          label: "foo()",
+          kind: .method,
+          detail: "Void",
+          deprecated: false,
+          sortText: nil,
+          filterText: "foo()",
+          insertText: "foo()",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "foo()")
+          )
+        ),
+        CompletionItem(
+          label: "self",
+          kind: .keyword,
+          detail: "Lib",
+          deprecated: false,
+          sortText: nil,
+          filterText: "self",
+          insertText: "self",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(range: Position(line: 2, utf16index: 24)..<Position(line: 2, utf16index: 24), newText: "self")
+          )
+        ),
+      ]
+    )
 
     try ws.openDocument(otherCall.url, language: .swift)
 
     let otherCompletions = try withExtendedLifetime(ws) {
-        try ws.sk.sendSync(CompletionRequest(textDocument: otherCall.docIdentifier, position: otherCall.position))
+      try ws.sk.sendSync(CompletionRequest(textDocument: otherCall.docIdentifier, position: otherCall.position))
     }
 
-    XCTAssertEqual(otherCompletions.items, [
-      CompletionItem(
-        label: "sayHello()",
-        kind: .method,
-        detail: "Void",
-        documentation: nil,
-        deprecated: false,
-        sortText: nil,
-        filterText: "sayHello()",
-        insertText: "sayHello()",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(range: Position(line: 7, utf16index: 41)..<Position(line: 7, utf16index: 41), newText: "sayHello()"))
-      ),
-      CompletionItem(
-        label: "self",
-        kind: LanguageServerProtocol.CompletionItemKind(rawValue: 14),
-        detail: "FancyLib",
-        documentation: nil,
-        deprecated: false,
-        sortText: nil,
-        filterText: "self",
-        insertText: "self",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(range: Position(line: 7, utf16index: 41)..<Position(line: 7, utf16index: 41), newText: "self"))
-      ),
-    ])
+    XCTAssertEqual(
+      otherCompletions.items,
+      [
+        CompletionItem(
+          label: "sayHello()",
+          kind: .method,
+          detail: "Void",
+          documentation: nil,
+          deprecated: false,
+          sortText: nil,
+          filterText: "sayHello()",
+          insertText: "sayHello()",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(
+              range: Position(line: 7, utf16index: 41)..<Position(line: 7, utf16index: 41),
+              newText: "sayHello()"
+            )
+          )
+        ),
+        CompletionItem(
+          label: "self",
+          kind: LanguageServerProtocol.CompletionItemKind(rawValue: 14),
+          detail: "FancyLib",
+          documentation: nil,
+          deprecated: false,
+          sortText: nil,
+          filterText: "self",
+          insertText: "self",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(range: Position(line: 7, utf16index: 41)..<Position(line: 7, utf16index: 41), newText: "self")
+          )
+        ),
+      ]
+    )
   }
 
   func testMultipleClangdWorkspaces() async throws {
@@ -112,7 +132,10 @@ final class WorkspaceTests: XCTestCase {
 
     try await fulfillmentOfOrThrow([expectation])
 
-    let otherWs = try await staticSourceKitTibsWorkspace(name: "ClangCrashRecoveryBuildSettings", server: ws.testServer)!
+    let otherWs = try await staticSourceKitTibsWorkspace(
+      name: "ClangCrashRecoveryBuildSettings",
+      server: ws.testServer
+    )!
     assert(ws.testServer === otherWs.testServer, "Sanity check: The two workspaces should be opened in the same server")
     let otherLoc = otherWs.testLoc("loc")
 
@@ -122,10 +145,13 @@ final class WorkspaceTests: XCTestCase {
 
     let expectedHighlightResponse = [
       DocumentHighlight(range: Position(line: 3, utf16index: 5)..<Position(line: 3, utf16index: 8), kind: .text),
-      DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text)
+      DocumentHighlight(range: Position(line: 9, utf16index: 2)..<Position(line: 9, utf16index: 5), kind: .text),
     ]
 
-    let highlightRequest = DocumentHighlightRequest(textDocument: otherLoc.docIdentifier, position: Position(line: 9, utf16index: 3))
+    let highlightRequest = DocumentHighlightRequest(
+      textDocument: otherLoc.docIdentifier,
+      position: Position(line: 9, utf16index: 3)
+    )
     let highlightResponse = try otherWs.sk.sendSync(highlightRequest)
     XCTAssertEqual(highlightResponse, expectedHighlightResponse)
   }
@@ -134,7 +160,9 @@ final class WorkspaceTests: XCTestCase {
     guard let otherWs = try await staticSourceKitSwiftPMWorkspace(name: "OtherSwiftPMPackage") else { return }
     try otherWs.buildAndIndex()
 
-    guard let ws = try await staticSourceKitSwiftPMWorkspace(name: "SwiftPMPackage", server: otherWs.testServer) else { return }
+    guard let ws = try await staticSourceKitSwiftPMWorkspace(name: "SwiftPMPackage", server: otherWs.testServer) else {
+      return
+    }
     try ws.buildAndIndex()
 
     assert(ws.testServer === otherWs.testServer, "Sanity check: The two workspaces should be opened in the same server")
@@ -148,7 +176,10 @@ final class WorkspaceTests: XCTestCase {
     // SwiftPMPackage that hasn't been added to Package.swift yet) will belong
     // to OtherSwiftPMPackage by default (because it provides fallback build
     // settings for it).
-    assertEqual(await ws.testServer.server!.workspaceForDocument(uri: otherLib.docUri)?.rootUri, DocumentURI(otherWs.sources.rootDirectory))
+    assertEqual(
+      await ws.testServer.server!.workspaceForDocument(uri: otherLib.docUri)?.rootUri,
+      DocumentURI(otherWs.sources.rootDirectory)
+    )
 
     // Add the otherlib target to Package.swift
     _ = try ws.sources.edit { builder in
@@ -156,19 +187,24 @@ final class WorkspaceTests: XCTestCase {
         .appendingPathComponent("Package.swift")
       var packageManifestContents = try String(contentsOf: packageManifest, encoding: .utf8)
       let targetMarkerRange = packageManifestContents.range(of: "/*Package.swift:targets*/")!
-      packageManifestContents.replaceSubrange(targetMarkerRange, with: """
-        .target(
-           name: "otherlib",
-           dependencies: ["lib"]
-        ),
-        /*Package.swift:targets*/
-        """)
+      packageManifestContents.replaceSubrange(
+        targetMarkerRange,
+        with: """
+          .target(
+             name: "otherlib",
+             dependencies: ["lib"]
+          ),
+          /*Package.swift:targets*/
+          """
+      )
       builder.write(packageManifestContents, to: packageManifest)
     }
 
-    ws.sk.send(DidChangeWatchedFilesNotification(changes: [
-      FileEvent(uri: packageTargets.docUri, type: .changed)
-    ]))
+    ws.sk.send(
+      DidChangeWatchedFilesNotification(changes: [
+        FileEvent(uri: packageTargets.docUri, type: .changed)
+      ])
+    )
 
     // After updating Package.swift in SwiftPMPackage, SwiftPMPackage can
     // provide proper build settings for otherLib and thus workspace
@@ -179,7 +215,9 @@ final class WorkspaceTests: XCTestCase {
 
     // Updating the build settings takes a few seconds. Send code completion requests every second until we receive correct results.
     for _ in 0..<30 {
-      if await ws.testServer.server!.workspaceForDocument(uri: otherLib.docUri)?.rootUri == DocumentURI(ws.sources.rootDirectory) {
+      if await ws.testServer.server!.workspaceForDocument(uri: otherLib.docUri)?.rootUri
+        == DocumentURI(ws.sources.rootDirectory)
+      {
         didReceiveCorrectWorkspaceMembership = true
         break
       }
@@ -205,7 +243,7 @@ final class WorkspaceTests: XCTestCase {
       defer {
         receivedResponse.fulfill()
       }
-      guard case .success(_) = result else  {
+      guard case .success(_) = result else {
         XCTFail("Expected a successful response")
         return
       }
@@ -229,69 +267,95 @@ final class WorkspaceTests: XCTestCase {
 
     let testServer = TestSourceKitServer(connectionKind: .local)
     let sk = testServer.client
-    _ = try sk.sendSync(InitializeRequest(
-      rootURI: nil,
-      capabilities: ClientCapabilities(workspace: .init(workspaceFolders: true)),
-      workspaceFolders: [
-        WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory.deletingLastPathComponent()))
-      ]
-    ))
+    _ = try sk.sendSync(
+      InitializeRequest(
+        rootURI: nil,
+        capabilities: ClientCapabilities(workspace: .init(workspaceFolders: true)),
+        workspaceFolders: [
+          WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory.deletingLastPathComponent()))
+        ]
+      )
+    )
 
     let docString = try String(data: Data(contentsOf: otherPackLoc.url), encoding: .utf8)!
 
-    sk.send(DidOpenTextDocumentNotification(
-      textDocument: TextDocumentItem(
-      uri: otherPackLoc.docUri,
-      language: .swift,
-      version: 1,
-      text: docString)
-    ))
-
-    let preChangeWorkspaceResponse = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(otherPackLoc.docUri),
-      position: otherPackLoc.position
-    ))
-
-    XCTAssertEqual(preChangeWorkspaceResponse.items, [], "Did not expect to receive cross-module code completion results if we opened the parent directory of the package")
-
-    sk.send(DidChangeWorkspaceFoldersNotification(event: WorkspaceFoldersChangeEvent(added: [
-      WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory))
-    ])))
-
-    let postChangeWorkspaceResponse = try sk.sendSync(CompletionRequest(
-      textDocument: TextDocumentIdentifier(otherPackLoc.docUri),
-      position: otherPackLoc.position
-    ))
-
-    XCTAssertEqual(postChangeWorkspaceResponse.items, [
-      CompletionItem(
-        label: "helloWorld()",
-        kind: .method,
-        detail: "Void",
-        documentation: nil,
-        deprecated: false, sortText: nil,
-        filterText: "helloWorld()",
-        insertText: "helloWorld()",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(
-          range: otherPackLoc.position..<otherPackLoc.position,
-          newText: "helloWorld()"
-        ))
-      ),
-      CompletionItem(
-        label: "self",
-        kind: .keyword,
-        detail: "Package",
-        documentation: nil,
-        deprecated: false, sortText: nil,
-        filterText: "self",
-        insertText: "self",
-        insertTextFormat: .plain,
-        textEdit: .textEdit(TextEdit(
-          range: otherPackLoc.position..<otherPackLoc.position,
-          newText: "self"
-        ))
+    sk.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(
+          uri: otherPackLoc.docUri,
+          language: .swift,
+          version: 1,
+          text: docString
+        )
       )
-    ])
+    )
+
+    let preChangeWorkspaceResponse = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(otherPackLoc.docUri),
+        position: otherPackLoc.position
+      )
+    )
+
+    XCTAssertEqual(
+      preChangeWorkspaceResponse.items,
+      [],
+      "Did not expect to receive cross-module code completion results if we opened the parent directory of the package"
+    )
+
+    sk.send(
+      DidChangeWorkspaceFoldersNotification(
+        event: WorkspaceFoldersChangeEvent(added: [
+          WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory))
+        ])
+      )
+    )
+
+    let postChangeWorkspaceResponse = try sk.sendSync(
+      CompletionRequest(
+        textDocument: TextDocumentIdentifier(otherPackLoc.docUri),
+        position: otherPackLoc.position
+      )
+    )
+
+    XCTAssertEqual(
+      postChangeWorkspaceResponse.items,
+      [
+        CompletionItem(
+          label: "helloWorld()",
+          kind: .method,
+          detail: "Void",
+          documentation: nil,
+          deprecated: false,
+          sortText: nil,
+          filterText: "helloWorld()",
+          insertText: "helloWorld()",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(
+              range: otherPackLoc.position..<otherPackLoc.position,
+              newText: "helloWorld()"
+            )
+          )
+        ),
+        CompletionItem(
+          label: "self",
+          kind: .keyword,
+          detail: "Package",
+          documentation: nil,
+          deprecated: false,
+          sortText: nil,
+          filterText: "self",
+          insertText: "self",
+          insertTextFormat: .plain,
+          textEdit: .textEdit(
+            TextEdit(
+              range: otherPackLoc.position..<otherPackLoc.position,
+              newText: "self"
+            )
+          )
+        ),
+      ]
+    )
   }
 }


### PR DESCRIPTION
Add `.swift-format` to the repo and format the repo with `swift-format`.

This PR does not add any automation to enforce formatting of sourcekit-lsp in CI. The goal of the PR is to get the majority of source changes out of the way so that the diff of actually enforcing formatting will have fewer changes or conflicts.

I scanned through the changes, made a couple of improvements, like converting long function signatures to use `some` but other than that, all of the changes are mechanical.