### PR TITLE
Fix typo in `SemanticRefactoringError` doc comment

### DIFF
--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -78,7 +78,7 @@ struct SemanticRefactoring {
   }
 }
 
-/// An error from a cursor info request.
+/// An error from a semantic refactoring request.
 enum SemanticRefactoringError: Error {
 
   /// The given URL is not a known document.


### PR DESCRIPTION
This fixes a minor typo.