### PR TITLE
Add LSP extension request for retrieving macro expansions

### DIFF
--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(LanguageServerProtocol STATIC
   Requests/InlineValueRefreshRequest.swift
   Requests/InlineValueRequest.swift
   Requests/LinkedEditingRangeRequest.swift
+  Requests/MacroExpansionRequest.swift
   Requests/MonikersRequest.swift
   Requests/OpenInterfaceRequest.swift
   Requests/PollIndexRequest.swift
@@ -107,6 +108,7 @@ add_library(LanguageServerProtocol STATIC
   SupportTypes/LocationLink.swift
   SupportTypes/LocationsOrLocationLinksResponse.swift
   SupportTypes/LSPAny.swift
+  SupportTypes/MacroExpansion.swift
   SupportTypes/MarkupContent.swift
   SupportTypes/NotebookCellTextDocumentFilter.swift
   SupportTypes/NotebookDocument.swift

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -107,6 +107,11 @@ extension ResponseError {
     message: "request cancelled by server"
   )
 
+  public static var unsupportedMethod: ResponseError = ResponseError(
+    code: .unknownErrorCode,
+    message: "unsupported method"
+  )
+
   public static func workspaceNotOpen(_ uri: DocumentURI) -> ResponseError {
     return ResponseError(code: .workspaceNotOpen, message: "No workspace containing '\(uri)' found")
   }

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -55,6 +55,7 @@ public let builtinRequests: [_RequestType.Type] = [
   InlineValueRefreshRequest.self,
   InlineValueRequest.self,
   LinkedEditingRangeRequest.self,
+  MacroExpansionRequest.self,
   MonikersRequest.self,
   OpenInterfaceRequest.self,
   PollIndexRequest.self,

--- a/Sources/LanguageServerProtocol/Requests/MacroExpansionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/MacroExpansionRequest.swift
@@ -15,7 +15,7 @@
 ///
 /// - Parameters:
 ///   - textDocument: The document in which the macro is used.
-///   - position: The position at which the macro is used.
+///   - range: The range at which the macro is used.
 ///
 /// - Returns: The macro expansion.
 public struct MacroExpansionRequest: TextDocumentRequest, Hashable {
@@ -26,13 +26,14 @@ public struct MacroExpansionRequest: TextDocumentRequest, Hashable {
   public var textDocument: TextDocumentIdentifier
 
   /// The position at which the macro is used.
-  public var position: Position
+  @CustomCodable<PositionRange>
+  public var range: Range<Position>
 
   public init(
     textDocument: TextDocumentIdentifier,
-    position: Position
+    range: Range<Position>
   ) {
     self.textDocument = textDocument
-    self.position = position
+    self._range = CustomCodable(wrappedValue: range)
   }
 }

--- a/Sources/LanguageServerProtocol/Requests/MacroExpansionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/MacroExpansionRequest.swift
@@ -20,7 +20,7 @@
 /// - Returns: The macro expansion.
 public struct MacroExpansionRequest: TextDocumentRequest, Hashable {
   public static let method: String = "sourcekit-lsp/macroExpansion"
-  public typealias Response = MacroExpansion?
+  public typealias Response = [MacroExpansion]
 
   /// The document in which the macro is used.
   public var textDocument: TextDocumentIdentifier

--- a/Sources/LanguageServerProtocol/Requests/MacroExpansionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/MacroExpansionRequest.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request the expansion of the macro at a given use site.
+/// **LSP Extension**.
+///
+/// - Parameters:
+///   - textDocument: The document in which the macro is used.
+///   - position: The position at which the macro is used.
+///
+/// - Returns: The macro expansion.
+public struct MacroExpansionRequest: TextDocumentRequest, Hashable {
+  public static let method: String = "sourcekit-lsp/macroExpansion"
+  public typealias Response = MacroExpansion?
+
+  /// The document in which the macro is used.
+  public var textDocument: TextDocumentIdentifier
+
+  /// The position at which the macro is used.
+  public var position: Position
+
+  public init(
+    textDocument: TextDocumentIdentifier,
+    position: Position
+  ) {
+    self.textDocument = textDocument
+    self.position = position
+  }
+}

--- a/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The expansion of a macro in a source file.
+public struct MacroExpansion: ResponseType, Hashable {
+  /// The Swift code that the macro expands to.
+  public let expansion: String
+}

--- a/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
@@ -13,5 +13,5 @@
 /// The expansion of a macro in a source file.
 public struct MacroExpansion: ResponseType, Hashable {
   /// The Swift code that the macro expands to.
-  public let expansion: String
+  public let sourceText: String
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
@@ -14,4 +14,8 @@
 public struct MacroExpansion: ResponseType, Hashable {
   /// The Swift code that the macro expands to.
   public let sourceText: String
+
+  public init(sourceText: String) {
+    self.sourceText = sourceText
+  }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/MacroExpansion.swift
@@ -12,10 +12,14 @@
 
 /// The expansion of a macro in a source file.
 public struct MacroExpansion: ResponseType, Hashable {
+  /// The position in the source file where the expansion would be inserted.
+  public let position: Position
+
   /// The Swift code that the macro expands to.
   public let sourceText: String
 
-  public init(sourceText: String) {
+  public init(position: Position, sourceText: String) {
+    self.position = position
     self.sourceText = sourceText
   }
 }

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -572,7 +572,7 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
-  func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion? {
+  func macroExpansion(_ req: MacroExpansionRequest) async throws -> [MacroExpansion] {
     throw ResponseError.unsupportedMethod
   }
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -573,7 +573,7 @@ extension ClangLanguageServerShim {
   }
 
   func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion? {
-    return nil
+    throw ResponseError.unsupportedMethod
   }
 
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]? {

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -572,6 +572,10 @@ extension ClangLanguageServerShim {
     return try await forwardRequestToClangd(req)
   }
 
+  func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion? {
+    return nil
+  }
+
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]? {
     guard self.capabilities?.foldingRangeProvider?.isSupported ?? false else {
       return nil

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -584,7 +584,7 @@ extension ClangLanguageServerShim {
   }
 
   func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails? {
-    throw ResponseError.unknown("unsupported method")
+    throw ResponseError.unsupportedMethod
   }
 
   // MARK: - Other

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -624,6 +624,8 @@ extension SourceKitServer: MessageHandler {
           requestHandler: self.documentDiagnostic,
           fallback: .full(.init(items: []))
         )
+      case let request as Request<MacroExpansionRequest>:
+        await self.handleRequest(for: request, requestHandler: self.macroExpansion, fallback: nil)
       default:
         reply(.failure(ResponseError.methodNotFound(R.method)))
       }
@@ -1384,6 +1386,14 @@ extension SourceKitServer {
     languageService: ToolchainLanguageServer
   ) async throws -> DocumentDiagnosticReport {
     return try await languageService.documentDiagnostic(req)
+  }
+
+  func macroExpansion(
+    _ request: MacroExpansionRequest,
+    workspace: Workspace,
+    languageService: ToolchainLanguageServer
+  ) async throws -> MacroExpansion? {
+    return try await languageService.macroExpansion(request)
   }
 
   /// Converts a location from the symbol index to an LSP location.

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -625,7 +625,7 @@ extension SourceKitServer: MessageHandler {
           fallback: .full(.init(items: []))
         )
       case let request as Request<MacroExpansionRequest>:
-        await self.handleRequest(for: request, requestHandler: self.macroExpansion, fallback: nil)
+        await self.handleRequest(for: request, requestHandler: self.macroExpansion, fallback: [])
       default:
         reply(.failure(ResponseError.methodNotFound(R.method)))
       }
@@ -1392,7 +1392,7 @@ extension SourceKitServer {
     _ request: MacroExpansionRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async throws -> MacroExpansion? {
+  ) async throws -> [MacroExpansion] {
     return try await languageService.macroExpansion(request)
   }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1299,6 +1299,11 @@ extension SwiftLanguageServer {
     return .full(RelatedFullDocumentDiagnosticReport(items: diagnostics))
   }
 
+  public func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion? {
+    // TODO
+    return nil
+  }
+
   public func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
     // TODO: If there's support for several types of commands, we might need to structure this similarly to the code actions request.
     guard let sourceKitServer else {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1300,7 +1300,20 @@ extension SwiftLanguageServer {
   }
 
   public func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion? {
-    // TODO
+    guard let snapshot = documentManager.latestSnapshot(req.textDocument.uri) else {
+      let msg = "failed to find snapshot for url \(req.textDocument.uri)"
+      log(msg)
+      throw ResponseError.unknown(msg)
+    }
+
+    let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
+
+    // TODO: Traverse syntax tree, extract the moduleName, typeName and roles
+    // for the macro at the position given in the request. Use these to
+    // construct `ExpansionSpecifier`s and pass them to SourceKitD via
+    // the `syntacticMacroExpansion` function. Extract the text edits from the
+    // result and wrap them in `MacroExpansion`.
+
     return nil
   }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -577,11 +577,11 @@ extension SwiftLanguageServer {
 
   /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
   public func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
-    throw ResponseError.unknown("unsupported method")
+    throw ResponseError.unsupportedMethod
   }
 
   public func declaration(_ request: DeclarationRequest) async throws -> LocationsOrLocationLinksResponse? {
-    throw ResponseError.unknown("unsupported method")
+    throw ResponseError.unsupportedMethod
   }
 
   public func hover(_ req: HoverRequest) async throws -> HoverResponse? {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1318,7 +1318,7 @@ extension SwiftLanguageServer {
         position: edit.range.lowerBound,
         sourceText: edit.newText
       )
-    } catch SemanticRefactoringError.noEditsNeeded(_) {
+    } catch SemanticRefactoringError.noEditsNeeded {
       return nil
     }
   }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1307,13 +1307,17 @@ extension SwiftLanguageServer {
       textDocument: req.textDocument
     )
     
-    let refactor = try await semanticRefactoring(command)
+    do {
+      let refactor = try await semanticRefactoring(command)
 
-    guard let newText = refactor.edit.changes?[req.textDocument.uri]?.first?.newText else {
+      guard let newText = refactor.edit.changes?[req.textDocument.uri]?.first?.newText else {
+        return nil
+      }
+
+      return MacroExpansion(sourceText: newText)
+    } catch SemanticRefactoringError.noEditsNeeded(_) {
       return nil
     }
-
-    return MacroExpansion(sourceText: newText)
   }
 
   public func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1303,7 +1303,7 @@ extension SwiftLanguageServer {
     let command = SemanticRefactorCommand(
       title: "Expand Macro",
       actionString: "source.refactoring.kind.expand.macro",
-      positionRange: req.position..<req.position,
+      positionRange: req.range,
       textDocument: req.textDocument
     )
     

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1299,7 +1299,7 @@ extension SwiftLanguageServer {
     return .full(RelatedFullDocumentDiagnosticReport(items: diagnostics))
   }
 
-  public func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion? {
+  public func macroExpansion(_ req: MacroExpansionRequest) async throws -> [MacroExpansion] {
     let command = SemanticRefactorCommand(
       title: "Expand Macro",
       actionString: "source.refactoring.kind.expand.macro",
@@ -1310,16 +1310,18 @@ extension SwiftLanguageServer {
     do {
       let refactor = try await semanticRefactoring(command)
 
-      guard let edit = refactor.edit.changes?[req.textDocument.uri]?.first else {
-        return nil
+      guard let edits = refactor.edit.changes?[req.textDocument.uri] else {
+        return []
       }
 
-      return MacroExpansion(
-        position: edit.range.lowerBound,
-        sourceText: edit.newText
-      )
+      return edits.map { edit in
+        MacroExpansion(
+          position: edit.range.lowerBound,
+          sourceText: edit.newText
+        )
+      }
     } catch SemanticRefactoringError.noEditsNeeded {
-      return nil
+      return []
     }
   }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1310,11 +1310,14 @@ extension SwiftLanguageServer {
     do {
       let refactor = try await semanticRefactoring(command)
 
-      guard let newText = refactor.edit.changes?[req.textDocument.uri]?.first?.newText else {
+      guard let edit = refactor.edit.changes?[req.textDocument.uri]?.first else {
         return nil
       }
 
-      return MacroExpansion(sourceText: newText)
+      return MacroExpansion(
+        position: edit.range.lowerBound,
+        sourceText: edit.newText
+      )
     } catch SemanticRefactoringError.noEditsNeeded(_) {
       return nil
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1308,10 +1308,10 @@ extension SwiftLanguageServer {
 
     let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
 
-    // TODO: Traverse syntax tree, extract the moduleName, typeName and roles
-    // for the macro at the position given in the request. Use these to
-    // construct `ExpansionSpecifier`s and pass them to SourceKitD via
-    // the `syntacticMacroExpansion` function. Extract the text edits from the
+    // TODO: Find the moduleName, typeName and roles for the macro at the
+    // position given in the request somehow. Use these to construct
+    // `ExpansionSpecifier`s and pass them to SourceKitD via the
+    // `syntacticMacroExpansion` function. Extract the text edits from the
     // result and wrap them in `MacroExpansion`.
 
     return nil

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -104,6 +104,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint]
   func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport
+  func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion?
 
   // MARK: - Other
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -104,7 +104,7 @@ public protocol ToolchainLanguageServer: AnyObject {
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
   func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint]
   func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport
-  func macroExpansion(_ req: MacroExpansionRequest) async throws -> MacroExpansion?
+  func macroExpansion(_ req: MacroExpansionRequest) async throws -> [MacroExpansion]
 
   // MARK: - Other
 


### PR DESCRIPTION
This implements #755 by introducing a new, non-standard request for fetching macro expansions, wrapping the corresponding SourceKitD request, [`SyntacticMacroExpansion`](https://github.com/apple/swift/blob/fad02e3737c547acc5b2d489487316d83bc12a46/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp#L1871-L1888).

### Motivation

- There is precedent in [`rust-analyzer`](https://github.com/rust-lang/rust-analyzer) for such a request, see [this document](https://github.com/rust-lang/rust-analyzer/blob/8a2331450a2fa269aa60818b224a2beaef7d7198/docs/dev/lsp-extensions.md?plain=1#L628-L648)
- Using a dedicated request for this reduces the impedance mismatch between SourceKitD and the LSP layer
- Not imposing any particular presentation (as e.g. including it in hovers would) gives LSP clients freedom to present the expansion in a custom way.
  - In VSCode, for example, I would imagine that a read-only inline code editor, akin to the one shown when browsing references/definitions, might look nice:
    <img width="400" alt="Screenshot 2023-10-11 at 02 50 13" src="https://github.com/apple/sourcekit-lsp/assets/30873659/a3a0ad37-05c1-41f6-b38b-8d766efe19d3">

Similar to what we did with inlay hints last year (#465), my hope is that a macro expansion request could eventually be upstreamed to LSP, given that such a request might be more generally useful to other languages too, as evidenced by the `rust-analyzer` implementation. This would then give clients full flexibility to implement a tailored UI too.

Feel free to leave some thoughts on whether this is the right approach to go with or alternative suggestions.

### To do

- [x] Add an LSP request (`sourcekit-lsp/macroExpansion`) and support structures
  - Specifics are up for discussion, currently the request only takes a single position and returns a single expansion, should we support batch expansions, like SourceKitD does?
- [x] Add the SourceKit request `SyntacticMacroExpansion`
- [x] Add boilerplate to `ToolchainLanguageServer` and its implementations to support the request
- [x] Implement the actual request handler (`SwiftLanguageServer.macroExpansion`)
- [ ] Support nested expansions (perhaps customizable via a boolean flag in the request, e.g. `nested: Bool` or `recursive: Bool`?)
- [ ] Add unit tests (might require some more machinery to generate the macro plugin, similar to the [upstream tests in SourceKit](https://github.com/apple/swift/blob/4d8c0c8ca5eb04a1ef0f2e09388e7e2108fd5607/test/SourceKit/Macros/syntactic_expansion.swift)

### See also

- **SourceKit/upstream:**
  - [The `SyntacticMacroExpansion` test](https://github.com/apple/swift/blob/main/test/SourceKit/Macros/syntactic_expansion.swift)
  - [The `SyntacticMacroExpansion` implementation](https://github.com/apple/swift/blob/fad02e3737c547acc5b2d489487316d83bc12a46/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp#L1871-L1888)
  - https://github.com/apple/swift/pull/66295
- **VSCode:**
  - https://github.com/swift-server/vscode-swift/pull/621