### PR TITLE
Rename note to notification throughout the codebase

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -95,11 +95,11 @@ public final class TestClient: MessageHandler {
   public var allowUnexpectedNotification: Bool = true
 
   public func appendOneShotNotificationHandler<N>(_ handler: @escaping (Notification<N>) -> Void) {
-    oneShotNotificationHandlers.append({ anyNote in
-      guard let note = anyNote as? Notification<N> else {
-        fatalError("received notification of the wrong type \(anyNote); expected \(N.self)")
+    oneShotNotificationHandlers.append({ anyNotification in
+      guard let notification = anyNotification as? Notification<N> else {
+        fatalError("received notification of the wrong type \(anyNotification); expected \(N.self)")
       }
-      handler(note)
+      handler(notification)
     })
   }
 
@@ -171,15 +171,15 @@ extension TestClient: Connection {
 
   /// Send a notification and expect a notification in reply synchronously.
   /// For testing notifications that behave like requests  - e.g. didChange & publishDiagnostics.
-  public func sendNoteSync<NReply>(
+  public func sendnotificationSync<NReply>(
     _ notification: some NotificationType,
     _ handler: @escaping (Notification<NReply>) -> Void
   ) {
 
-    let expectation = XCTestExpectation(description: "sendNoteSync - note received")
+    let expectation = XCTestExpectation(description: "sendnotificationSync - notification received")
 
-    handleNextNotification { (note: Notification<NReply>) in
-      handler(note)
+    handleNextNotification { (notification: Notification<NReply>) in
+      handler(notification)
       expectation.fulfill()
     }
 
@@ -194,21 +194,21 @@ extension TestClient: Connection {
 
   /// Send a notification and expect two notifications in reply synchronously.
   /// For testing notifications that behave like requests  - e.g. didChange & publishDiagnostics.
-  public func sendNoteSync<NSend, NReply1, NReply2>(
+  public func sendnotificationSync<NSend, NReply1, NReply2>(
     _ notification: NSend,
     _ handler1: @escaping (Notification<NReply1>) -> Void,
     _ handler2: @escaping (Notification<NReply2>) -> Void
   ) where NSend: NotificationType {
 
-    let expectation = XCTestExpectation(description: "sendNoteSync - note received")
+    let expectation = XCTestExpectation(description: "sendnotificationSync - notification received")
     expectation.expectedFulfillmentCount = 2
 
-    handleNextNotification { (note: Notification<NReply1>) in
-      handler1(note)
+    handleNextNotification { (notification: Notification<NReply1>) in
+      handler1(notification)
       expectation.fulfill()
     }
-    appendOneShotNotificationHandler { (note: Notification<NReply2>) in
-      handler2(note)
+    appendOneShotNotificationHandler { (notification: Notification<NReply2>) in
+      handler2(notification)
       expectation.fulfill()
     }
 
@@ -230,9 +230,9 @@ public final class TestServer: MessageHandler {
   }
 
   public func handle<N: NotificationType>(_ params: N, from clientID: ObjectIdentifier) {
-    let note = Notification(params, clientID: clientID)
+    let notification = Notification(params, clientID: clientID)
     if params is EchoNotification {
-      self.client.send(note.params)
+      self.client.send(notification.params)
     } else {
       fatalError("Unhandled notification")
     }
@@ -312,7 +312,7 @@ public struct EchoError: RequestType {
 }
 
 public struct EchoNotification: NotificationType {
-  public static var method: String = "test_server/echo_note"
+  public static var method: String = "test_server/echo_notification"
 
   public var string: String
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -24,7 +24,7 @@ import WinSDK
 #endif
 
 extension NSLock {
-  /// notification: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
+  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
   fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
     lock()
     defer { unlock() }

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -200,17 +200,17 @@ extension DocumentManager {
 
   /// Convenience wrapper for `open(_:language:version:text:)` that logs on failure.
   @discardableResult
-  func open(_ note: DidOpenTextDocumentNotification) -> DocumentSnapshot? {
-    let doc = note.textDocument
+  func open(_ notification: DidOpenTextDocumentNotification) -> DocumentSnapshot? {
+    let doc = notification.textDocument
     return orLog("failed to open document", level: .error) {
       try open(doc.uri, language: doc.language, version: doc.version, text: doc.text)
     }
   }
 
   /// Convenience wrapper for `close(_:)` that logs on failure.
-  func close(_ note: DidCloseTextDocumentNotification) {
+  func close(_ notification: DidCloseTextDocumentNotification) {
     orLog("failed to close document", level: .error) {
-      try close(note.textDocument.uri)
+      try close(notification.textDocument.uri)
     }
   }
 
@@ -218,14 +218,14 @@ extension DocumentManager {
   /// that logs on failure.
   @discardableResult
   func edit(
-    _ note: DidChangeTextDocumentNotification,
+    _ notification: DidChangeTextDocumentNotification,
     willEditDocument: ((_ before: LineTable, TextDocumentContentChangeEvent) -> Void)? = nil
   ) -> (preEditSnapshot: DocumentSnapshot, postEditSnapshot: DocumentSnapshot)? {
     return orLog("failed to edit document", level: .error) {
       return try edit(
-        note.textDocument.uri,
-        newVersion: note.textDocument.version,
-        edits: note.contentChanges,
+        notification.textDocument.uri,
+        newVersion: notification.textDocument.version,
+        edits: notification.contentChanges,
         willEditDocument: willEditDocument
       )
     }

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1033,12 +1033,12 @@ extension SourceKitServer {
     await openDocument(notification, workspace: workspace)
   }
 
-  private func openDocument(_ note: DidOpenTextDocumentNotification, workspace: Workspace) async {
+  private func openDocument(_ notification: DidOpenTextDocumentNotification, workspace: Workspace) async {
     // Immediately open the document even if the build system isn't ready. This is important since
     // we check that the document is open when we receive messages from the build system.
-    documentManager.open(note)
+    documentManager.open(notification)
 
-    let textDocument = note.textDocument
+    let textDocument = notification.textDocument
     let uri = textDocument.uri
     let language = textDocument.language
 
@@ -1050,7 +1050,7 @@ extension SourceKitServer {
     await workspace.buildSystemManager.registerForChangeNotifications(for: uri, language: language)
 
     // If the document is ready, we can immediately send the notification.
-    await service.openDocument(note)
+    await service.openDocument(notification)
   }
 
   func closeDocument(_ notification: DidCloseTextDocumentNotification) async {
@@ -1062,16 +1062,16 @@ extension SourceKitServer {
     await self.closeDocument(notification, workspace: workspace)
   }
 
-  func closeDocument(_ note: DidCloseTextDocumentNotification, workspace: Workspace) async {
+  func closeDocument(_ notification: DidCloseTextDocumentNotification, workspace: Workspace) async {
     // Immediately close the document. We need to be sure to clear our pending work queue in case
     // the build system still isn't ready.
-    documentManager.close(note)
+    documentManager.close(notification)
 
-    let uri = note.textDocument.uri
+    let uri = notification.textDocument.uri
 
     await workspace.buildSystemManager.unregisterForChangeNotifications(for: uri)
 
-    await workspace.documentService[uri]?.closeDocument(note)
+    await workspace.documentService[uri]?.closeDocument(notification)
   }
 
   func changeDocument(_ notification: DidChangeTextDocumentNotification) async {
@@ -1098,10 +1098,10 @@ extension SourceKitServer {
   }
 
   func didSaveDocument(
-    _ note: DidSaveTextDocumentNotification,
+    _ notification: DidSaveTextDocumentNotification,
     languageService: ToolchainLanguageServer
   ) async {
-    await languageService.didSaveDocument(note)
+    await languageService.didSaveDocument(notification)
   }
 
   func didChangeWorkspaceFolders(_ notification: DidChangeWorkspaceFoldersNotification) async {

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -19,8 +19,8 @@ extension CodeAction {
 
   /// Creates a CodeAction from a list for sourcekit fixits.
   ///
-  /// If this is from a note, the note's description should be passed as `fromNote`.
-  init?(fixits: SKDResponseArray, in snapshot: DocumentSnapshot, fromNote: String?) {
+  /// If this is from a notification, the notification's description should be passed as `fromNotification`.
+  init?(fixits: SKDResponseArray, in snapshot: DocumentSnapshot, fromNotification: String?) {
     var edits: [TextEdit] = []
     let editsMapped = fixits.forEach { (_, skfixit) -> Bool in
       if let edit = TextEdit(fixit: skfixit, in: snapshot) {
@@ -40,8 +40,8 @@ extension CodeAction {
     }
 
     let title: String
-    if let fromNote = fromNote {
-      title = fromNote
+    if let fromNotification = fromNotification {
+      title = fromNotification
     } else {
       guard let startIndex = snapshot.index(of: edits[0].range.lowerBound),
         let endIndex = snapshot.index(of: edits[0].range.upperBound),
@@ -123,7 +123,7 @@ extension Diagnostic {
   init?(
     _ diag: SKDResponseDictionary,
     in snapshot: DocumentSnapshot,
-    useEducationalNoteAsCode: Bool
+    useEducationalNotificationAsCode: Bool
   ) {
     // FIXME: this assumes that the diagnostics are all in the same file.
 
@@ -175,14 +175,14 @@ extension Diagnostic {
 
     var code: DiagnosticCode? = nil
     var codeDescription: CodeDescription? = nil
-    // If this diagnostic has one or more educational notes, the first one is
+    // If this diagnostic has one or more educational notifications, the first one is
     // treated as primary and used to fill in the diagnostic code and
-    // description. `useEducationalNoteAsCode` ensures a note name is only used
+    // description. `useEducationalNotificationAsCode` ensures a notification name is only used
     // as a code if the cline supports an extended code description.
-    if useEducationalNoteAsCode,
-      let educationalNotePaths: SKDResponseArray = diag[keys.educational_note_paths],
-      educationalNotePaths.count > 0,
-      let primaryPath = educationalNotePaths[0]
+    if useEducationalNotificationAsCode,
+      let educationalNotificationPaths: SKDResponseArray = diag[keys.educational_notification_paths],
+      educationalNotificationPaths.count > 0,
+      let primaryPath = educationalNotificationPaths[0]
     {
       let url = URL(fileURLWithPath: primaryPath)
       let name = url.deletingPathExtension().lastPathComponent
@@ -192,17 +192,17 @@ extension Diagnostic {
 
     var actions: [CodeAction]? = nil
     if let skfixits: SKDResponseArray = diag[keys.fixits],
-      let action = CodeAction(fixits: skfixits, in: snapshot, fromNote: nil)
+      let action = CodeAction(fixits: skfixits, in: snapshot, fromNotification: nil)
     {
       actions = [action]
     }
 
-    var notes: [DiagnosticRelatedInformation]? = nil
-    if let sknotes: SKDResponseArray = diag[keys.diagnostics] {
-      notes = []
-      sknotes.forEach { (_, sknote) -> Bool in
-        guard let note = DiagnosticRelatedInformation(sknote, in: snapshot) else { return true }
-        notes?.append(note)
+    var notifications: [DiagnosticRelatedInformation]? = nil
+    if let sknotifications: SKDResponseArray = diag[keys.diagnostics] {
+      notifications = []
+      sknotifications.forEach { (_, sknotification) -> Bool in
+        guard let notification = DiagnosticRelatedInformation(sknotification, in: snapshot) else { return true }
+        notifications?.append(notification)
         return true
       }
     }
@@ -230,7 +230,7 @@ extension Diagnostic {
       source: "sourcekitd",
       message: message,
       tags: tags,
-      relatedInformation: notes,
+      relatedInformation: notifications,
       codeActions: actions
     )
   }
@@ -238,7 +238,7 @@ extension Diagnostic {
 
 extension DiagnosticRelatedInformation {
 
-  /// Creates related information from a sourcekitd note response dictionary.
+  /// Creates related information from a sourcekitd notification response dictionary.
   init?(_ diag: SKDResponseDictionary, in snapshot: DocumentSnapshot) {
     let keys = diag.sourcekitd.keys
 
@@ -260,7 +260,7 @@ extension DiagnosticRelatedInformation {
 
     var actions: [CodeAction]? = nil
     if let skfixits: SKDResponseArray = diag[keys.fixits],
-      let action = CodeAction(fixits: skfixits, in: snapshot, fromNote: message)
+      let action = CodeAction(fixits: skfixits, in: snapshot, fromNotification: message)
     {
       actions = [action]
     }
@@ -297,14 +297,14 @@ extension CachedDiagnostic {
   init?(
     _ diag: SKDResponseDictionary,
     in snapshot: DocumentSnapshot,
-    useEducationalNoteAsCode: Bool
+    useEducationalNotificationAsCode: Bool
   ) {
     let sk = diag.sourcekitd
     guard
       let diagnostic = Diagnostic(
         diag,
         in: snapshot,
-        useEducationalNoteAsCode: useEducationalNoteAsCode
+        useEducationalNotificationAsCode: useEducationalNotificationAsCode
       )
     else {
       return nil

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -58,37 +58,37 @@ class ConnectionTests: XCTestCase {
   func testMessageBuffer() throws {
     let client = connection.client
     let clientConnection = connection.clientConnection
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
-      XCTAssertEqual(note.params.string, "hello!")
+    client.handleNextNotification { (notification: Notification<EchoNotification>) in
+      XCTAssertEqual(notification.params.string, "hello!")
       expectation.fulfill()
     }
 
-    let note1 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
-    let note2 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
+    let notification1 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
+    let notification2 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
 
-    let note1Str: String = "Content-Length: \(note1.count)\r\n\r\n\(String(data: note1, encoding: .utf8)!)"
-    let note2Str: String = "Content-Length: \(note2.count)\r\n\r\n\(String(data: note2, encoding: .utf8)!)"
+    let notification1Str: String = "Content-Length: \(notification1.count)\r\n\r\n\(String(data: notification1, encoding: .utf8)!)"
+    let notification2Str: String = "Content-Length: \(notification2.count)\r\n\r\n\(String(data: notification2, encoding: .utf8)!)"
 
-    for b in note1Str.utf8.dropLast() {
+    for b in notification1Str.utf8.dropLast() {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })
     }
 
     clientConnection.send(
-      _rawData: [note1Str.utf8.last!, note2Str.utf8.first!].withUnsafeBytes { DispatchData(bytes: $0) }
+      _rawData: [notification1Str.utf8.last!, notification2Str.utf8.first!].withUnsafeBytes { DispatchData(bytes: $0) }
     )
 
     waitForExpectations(timeout: defaultTimeout)
 
-    let expectation2 = self.expectation(description: "note received")
+    let expectation2 = self.expectation(description: "notification received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
-      XCTAssertEqual(note.params.string, "no way!")
+    client.handleNextNotification { (notification: Notification<EchoNotification>) in
+      XCTAssertEqual(notification.params.string, "no way!")
       expectation2.fulfill()
     }
 
-    for b in note2Str.utf8.dropFirst() {
+    for b in notification2Str.utf8.dropFirst() {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })
     }
 
@@ -121,12 +121,12 @@ class ConnectionTests: XCTestCase {
     waitForExpectations(timeout: defaultTimeout)
   }
 
-  func testEchoNote() {
+  func testEchoNotification() {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
-      XCTAssertEqual(note.params.string, "hello!")
+    client.handleNextNotification { (notification: Notification<EchoNotification>) in
+      XCTAssertEqual(notification.params.string, "hello!")
       expectation.fulfill()
     }
 
@@ -154,13 +154,13 @@ class ConnectionTests: XCTestCase {
 
   func testUnknownNotification() {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    struct UnknownNote: NotificationType {
+    struct UnknownNotification: NotificationType {
       static let method: String = "unknown"
     }
 
-    client.send(UnknownNote())
+    client.send(UnknownNotification())
 
     // Nothing bad should happen; check that the next request works.
 
@@ -195,7 +195,7 @@ class ConnectionTests: XCTestCase {
 
   func testSendAfterClose() {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
     connection.clientConnection.close()
 
@@ -218,7 +218,7 @@ class ConnectionTests: XCTestCase {
     let server = connection.server
 
     let expectation = self.expectation(description: "received notification")
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.handleNextNotification { (notification: Notification<EchoNotification>) in
       expectation.fulfill()
     }
 
@@ -232,7 +232,7 @@ class ConnectionTests: XCTestCase {
     let client = connection.client
 
     let expectation = self.expectation(description: "received notification")
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.handleNextNotification { (notification: Notification<EchoNotification>) in
       expectation.fulfill()
     }
     let notification = EchoNotification(string: "about to close!")

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -64,12 +64,12 @@ class ConnectionTests: XCTestCase {
     waitForExpectations(timeout: defaultTimeout)
   }
 
-  func testEchoNote() {
+  func testEchoNotification() {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
-      XCTAssertEqual(note.params.string, "hello!")
+    client.handleNextNotification { (notification: Notification<EchoNotification>) in
+      XCTAssertEqual(notification.params.string, "hello!")
       expectation.fulfill()
     }
 

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -55,12 +55,12 @@ final class CrashRecoveryTests: XCTestCase {
 
     let documentOpened = self.expectation(description: "documentOpened")
     documentOpened.expectedFulfillmentCount = 2
-    ws.sk.handleNextNotification({ (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification({ (notification: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
       log("Received diagnostics for open - syntactic")
       documentOpened.fulfill()
     })
     ws.sk.appendOneShotNotificationHandler({
-      (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
+      (notification: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
       log("Received diagnostics for open - semantic")
       documentOpened.fulfill()
     })
@@ -79,15 +79,15 @@ final class CrashRecoveryTests: XCTestCase {
         }
         """
     )
-    ws.sk.sendNoteSync(
+    ws.sk.sendNotificationSync(
       DidChangeTextDocumentNotification(
         textDocument: VersionedTextDocumentIdentifier(loc.docUri, version: 2),
         contentChanges: [addFuncChange]
       ),
-      { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
+      { (notification: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
         log("Received diagnostics for text edit - syntactic")
       },
-      { (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
+      { (notification: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) -> Void in
         log("Received diagnostics for text edit - semantic")
       }
     )

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -169,7 +169,7 @@ final class BuildSystemTests: XCTestCase {
 
     let documentManager = await self.testServer.server!._documentManager
 
-    sk.sendNoteSync(
+    sk.sendNotificationSync(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -178,8 +178,8 @@ final class BuildSystemTests: XCTestCase {
           text: text
         )
       ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        XCTAssertEqual(note.params.diagnostics.count, 1)
+      { (notification: Notification<PublishDiagnosticsNotification>) in
+        XCTAssertEqual(notification.params.diagnostics.count, 1)
         XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
       }
     )
@@ -190,8 +190,8 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.buildSettingsByFile[doc] = newSettings
 
     let expectation = XCTestExpectation(description: "refresh")
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+    sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
       expectation.fulfill()
     }
@@ -220,7 +220,7 @@ final class BuildSystemTests: XCTestCase {
 
     let documentManager = await self.testServer.server!._documentManager
 
-    sk.sendNoteSync(
+    sk.sendNotificationSync(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -229,14 +229,14 @@ final class BuildSystemTests: XCTestCase {
           text: text
         )
       ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
+      { (notification: Notification<PublishDiagnosticsNotification>) in
         // Syntactic analysis - no expected errors here.
-        XCTAssertEqual(note.params.diagnostics.count, 0)
+        XCTAssertEqual(notification.params.diagnostics.count, 0)
         XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
       },
-      { (note: Notification<PublishDiagnosticsNotification>) in
+      { (notification: Notification<PublishDiagnosticsNotification>) in
         // Semantic analysis - expect one error here.
-        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(notification.params.diagnostics.count, 1)
       }
     )
 
@@ -247,14 +247,14 @@ final class BuildSystemTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "refresh")
     expectation.expectedFulfillmentCount = 2
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis - SourceKit currently caches diagnostics so we still see an error.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       expectation.fulfill()
     }
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis - no expected errors here because we fixed the settings.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       expectation.fulfill()
     }
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
@@ -287,7 +287,7 @@ final class BuildSystemTests: XCTestCase {
 
     let documentManager = await self.testServer.server!._documentManager
 
-    sk.sendNoteSync(
+    sk.sendNotificationSync(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -296,9 +296,9 @@ final class BuildSystemTests: XCTestCase {
           text: text
         )
       ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
+      { (notification: Notification<PublishDiagnosticsNotification>) in
         // Expect diagnostics to be withheld.
-        XCTAssertEqual(note.params.diagnostics.count, 0)
+        XCTAssertEqual(notification.params.diagnostics.count, 0)
         XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
       }
     )
@@ -309,8 +309,8 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.buildSettingsByFile[doc] = newSettings
 
     let expectation = XCTestExpectation(description: "refresh due to fallback --> primary")
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+    sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
       expectation.fulfill()
     }
@@ -341,7 +341,7 @@ final class BuildSystemTests: XCTestCase {
 
     let documentManager = await self.testServer.server!._documentManager
 
-    sk.sendNoteSync(
+    sk.sendNotificationSync(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -350,14 +350,14 @@ final class BuildSystemTests: XCTestCase {
           text: text
         )
       ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
+      { (notification: Notification<PublishDiagnosticsNotification>) in
         // Syntactic analysis - one expected errors here (for `func`).
-        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(notification.params.diagnostics.count, 1)
         XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
       },
-      { (note: Notification<PublishDiagnosticsNotification>) in
+      { (notification: Notification<PublishDiagnosticsNotification>) in
         // Should be the same syntactic analysis since we are using fallback arguments
-        XCTAssertEqual(note.params.diagnostics.count, 1)
+        XCTAssertEqual(notification.params.diagnostics.count, 1)
       }
     )
 
@@ -365,14 +365,14 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.buildSettingsByFile[doc] = primarySettings
     let expectation = XCTestExpectation(description: "refresh due to fallback --> primary")
     expectation.expectedFulfillmentCount = 2
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Syntactic analysis with new args - one expected errors here (for `func`).
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       expectation.fulfill()
     }
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis - two errors since `-DFOO` was not passed.
-      XCTAssertEqual(note.params.diagnostics.count, 2)
+      XCTAssertEqual(notification.params.diagnostics.count, 2)
       expectation.fulfill()
     }
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
@@ -389,9 +389,9 @@ final class BuildSystemTests: XCTestCase {
     ws.testServer.client.allowUnexpectedNotification = false
 
     let expectation = self.expectation(description: "initial")
-    ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.testServer.client.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Should withhold diagnostics since we should be using fallback arguments.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       expectation.fulfill()
     }
 
@@ -399,9 +399,9 @@ final class BuildSystemTests: XCTestCase {
     try await fulfillmentOfOrThrow([expectation])
 
     let use_d = self.expectation(description: "update settings to d.cpp")
-    ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      if let diag = note.params.diagnostics.first {
+    ws.testServer.client.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
+      if let diag = notification.params.diagnostics.first {
         XCTAssertEqual(diag.severity, .warning)
         XCTAssertEqual(diag.message, "UNIQUE_INCLUDED_FROM_D")
       }
@@ -412,9 +412,9 @@ final class BuildSystemTests: XCTestCase {
     try await fulfillmentOfOrThrow([use_d])
 
     let use_c = self.expectation(description: "update settings to c.cpp")
-    ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      if let diag = note.params.diagnostics.first {
+    ws.testServer.client.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
+      if let diag = notification.params.diagnostics.first {
         XCTAssertEqual(diag.severity, .warning)
         XCTAssertEqual(diag.message, "UNIQUE_INCLUDED_FROM_C")
       }

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -301,19 +301,19 @@ final class CodeActionTests: XCTestCase {
     let syntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics received")
     let semanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics received")
 
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // syntactic diagnostics
-      XCTAssertEqual(note.params.uri, def.docUri)
-      XCTAssertEqual(note.params.diagnostics, [])
+      XCTAssertEqual(notification.params.uri, def.docUri)
+      XCTAssertEqual(notification.params.diagnostics, [])
       syntacticDiagnosticsReceived.fulfill()
     }
 
     var diags: [Diagnostic]! = nil
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // semantic diagnostics
-      XCTAssertEqual(note.params.uri, def.docUri)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      diags = note.params.diagnostics
+      XCTAssertEqual(notification.params.uri, def.docUri)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
+      diags = notification.params.diagnostics
       semanticDiagnosticsReceived.fulfill()
     }
 

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -233,8 +233,8 @@ final class LocalClangTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "diagnostics")
 
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      let diagnostics = note.params.diagnostics
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      let diagnostics = notification.params.diagnostics
       // It seems we either get no diagnostics or a `-Wswitch` warning. Either is fine
       // as long as our code action works properly.
       XCTAssert(
@@ -291,15 +291,15 @@ final class LocalClangTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "diagnostics")
 
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Don't use exact equality because of differences in recent clang.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(loc)..<Position(ws.testLoc("unused_b:end"))
       )
-      XCTAssertEqual(note.params.diagnostics.first?.severity, .warning)
-      XCTAssertEqual(note.params.diagnostics.first?.message, "Unused variable 'b'")
+      XCTAssertEqual(notification.params.diagnostics.first?.severity, .warning)
+      XCTAssertEqual(notification.params.diagnostics.first?.message, "Unused variable 'b'")
       expectation.fulfill()
     }
 
@@ -316,8 +316,8 @@ final class LocalClangTests: XCTestCase {
 
     let expectation = self.expectation(description: "diagnostics")
 
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       expectation.fulfill()
     }
 
@@ -335,9 +335,9 @@ final class LocalClangTests: XCTestCase {
     let mainLoc = ws.testLoc("Object:include:main")
 
     let diagnostics = self.expectation(description: "diagnostics")
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       diagnostics.fulfill()
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
     }
 
     try ws.openDocument(mainLoc.url, language: .c)
@@ -365,8 +365,8 @@ final class LocalClangTests: XCTestCase {
 
     // Initially the workspace should build fine.
     let documentOpened = self.expectation(description: "documentOpened")
-    ws.sk.handleNextNotification({ (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
-      XCTAssert(note.params.diagnostics.isEmpty)
+    ws.sk.handleNextNotification({ (notification: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
+      XCTAssert(notification.params.diagnostics.isEmpty)
       documentOpened.fulfill()
     })
 
@@ -385,8 +385,8 @@ final class LocalClangTests: XCTestCase {
 
     // Now we should get a diagnostic in main.c file because `Object` is no longer defined.
     let updatedNotificationsReceived = self.expectation(description: "updatedNotificationsReceived")
-    ws.sk.handleNextNotification({ (note: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
-      XCTAssertFalse(note.params.diagnostics.isEmpty)
+    ws.sk.handleNextNotification({ (notification: LanguageServerProtocol.Notification<PublishDiagnosticsNotification>) in
+      XCTAssertFalse(notification.params.diagnostics.isEmpty)
       updatedNotificationsReceived.fulfill()
     })
 

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -80,16 +80,16 @@ final class PublishDiagnosticsTests: XCTestCase {
     let syntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics received")
     let semanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics received")
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Unresolved identifier is not a syntactic diagnostic.
-      XCTAssertEqual(note.params.diagnostics, [])
+      XCTAssertEqual(notification.params.diagnostics, [])
       syntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
       )
       semanticDiagnosticsReceived.fulfill()
@@ -112,16 +112,16 @@ final class PublishDiagnosticsTests: XCTestCase {
     )
     let initialSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after open received")
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Unresolved identifier is not a syntactic diagnostic.
-      XCTAssertEqual(note.params.diagnostics, [])
+      XCTAssertEqual(notification.params.diagnostics, [])
       initialSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
       )
       initialSemanticDiagnosticsReceived.fulfill()
@@ -142,20 +142,20 @@ final class PublishDiagnosticsTests: XCTestCase {
     )
     let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // We should report the semantic diagnostic reported by the edit range-shifted
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9)
       )
       editedSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9)
       )
       editedSemanticDiagnosticsReceived.fulfill()
@@ -178,16 +178,16 @@ final class PublishDiagnosticsTests: XCTestCase {
     )
     let initialSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after open received")
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Unresolved identifier is not a syntactic diagnostic.
-      XCTAssertEqual(note.params.diagnostics, [])
+      XCTAssertEqual(notification.params.diagnostics, [])
       initialSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 2, utf16index: 2)..<Position(line: 2, utf16index: 9)
       )
       initialSemanticDiagnosticsReceived.fulfill()
@@ -209,20 +209,20 @@ final class PublishDiagnosticsTests: XCTestCase {
     )
     let editedSemanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics after edit received")
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // We should report the semantic diagnostic reported by the edit range-shifted
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
       )
       editedSyntacticDiagnosticsReceived.fulfill()
     }
 
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+    sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       XCTAssertEqual(
-        note.params.diagnostics.first?.range,
+        notification.params.diagnostics.first?.range,
         Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9)
       )
       editedSemanticDiagnosticsReceived.fulfill()

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -109,19 +109,19 @@ final class PullDiagnosticsTests: XCTestCase {
     XCTAssertEqual(diagnostics.count, 1)
     let diagnostic = try XCTUnwrap(diagnostics.first)
     XCTAssertEqual(diagnostic.range, Position(line: 4, utf16index: 7)..<Position(line: 4, utf16index: 7))
-    let note = try XCTUnwrap(diagnostic.relatedInformation?.first)
-    XCTAssertEqual(note.location.range, Position(line: 4, utf16index: 7)..<Position(line: 4, utf16index: 7))
-    XCTAssertEqual(note.codeActions?.count ?? 0, 1)
+    let notification = try XCTUnwrap(diagnostic.relatedInformation?.first)
+    XCTAssertEqual(notification.location.range, Position(line: 4, utf16index: 7)..<Position(line: 4, utf16index: 7))
+    XCTAssertEqual(notification.codeActions?.count ?? 0, 1)
 
     let response = try sk.sendSync(
       CodeActionRequest(
-        range: note.location.range,
+        range: notification.location.range,
         context: CodeActionContext(
           diagnostics: diagnostics,
           only: [.quickFix],
           triggerKind: .invoked
         ),
-        textDocument: TextDocumentIdentifier(note.location.uri)
+        textDocument: TextDocumentIdentifier(notification.location.uri)
       )
     )
 

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -270,15 +270,15 @@ final class SKTests: XCTestCase {
     let moduleRef = ws.testLoc("aaa:call:c")
     let startExpectation = XCTestExpectation(description: "initial diagnostics")
     startExpectation.expectedFulfillmentCount = 2
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis: no errors expected here.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       startExpectation.fulfill()
     }
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis: expect module import error.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      if let diagnostic = note.params.diagnostics.first {
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
+      if let diagnostic = notification.params.diagnostics.first {
         XCTAssert(
           diagnostic.message.contains("no such module"),
           "expected module import error but found \"\(diagnostic.message)\""
@@ -294,14 +294,14 @@ final class SKTests: XCTestCase {
 
     let finishExpectation = XCTestExpectation(description: "post-build diagnostics")
     finishExpectation.expectedFulfillmentCount = 2
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis - SourceKit currently caches diagnostics so we still see an error.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       finishExpectation.fulfill()
     }
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.appendOneShotNotificationHandler { (notification: Notification<PublishDiagnosticsNotification>) in
       // Semantic analysis: no more errors expected, import should resolve since we built.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       finishExpectation.fulfill()
     }
     await server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
@@ -319,10 +319,10 @@ final class SKTests: XCTestCase {
 
     let moduleRef = ws.testLoc("libX:call:main")
     let startExpectation = XCTestExpectation(description: "initial diagnostics")
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // Expect one error:
       // - Implicit declaration of function invalid
-      XCTAssertEqual(note.params.diagnostics.count, 1)
+      XCTAssertEqual(notification.params.diagnostics.count, 1)
       startExpectation.fulfill()
     }
 
@@ -341,10 +341,10 @@ final class SKTests: XCTestCase {
     try ws.buildAndIndex()
 
     let finishExpectation = XCTestExpectation(description: "post-build diagnostics")
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
       // No more errors expected, import should resolve since we the generated header file
       // now has the proper contents.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       finishExpectation.fulfill()
     }
     await server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -123,8 +123,8 @@ final class WorkspaceTests: XCTestCase {
 
     let expectation = self.expectation(description: "diagnostics")
 
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 0)
+    ws.sk.handleNextNotification { (notification: Notification<PublishDiagnosticsNotification>) in
+      XCTAssertEqual(notification.params.diagnostics.count, 0)
       expectation.fulfill()
     }
 


### PR DESCRIPTION
Fixes #865

- Replaced occurrences of `note` with `notification`.
- Updated related comments and documentation.

Originated from feedback by @ahoppen regarding terminology confusion. This change aims to maintain clarity across the codebase.

Reference: Apple’s issue tracker rdar://116703667

Please review.