### PR TITLE
Use new SwiftPM flag to remove `$ORIGIN` from installed sourcekit-lsp ELF executable runpath

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -124,6 +124,8 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace) -> List[str]:
             '-Xcxx', '-I', '-Xcxx',
             os.path.join(args.toolchain, 'lib', 'swift', 'Block'),
         ]
+        if args.action == 'install':
+            swiftpm_args += ['--disable-local-rpath']
 
     if '-android' in build_target:
         swiftpm_args += [
@@ -181,6 +183,9 @@ def get_swiftpm_environment_variables(swift_exec: str, args: argparse.Namespace)
     if args.action == 'test' and args.skip_long_tests:
         env['SKIP_LONG_TESTS'] = '1'
 
+    if args.action == 'install':
+        env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
+
     return env
 
 
@@ -190,8 +195,6 @@ def build_single_product(product: str, swift_exec: str, args: argparse.Namespace
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
-    if args.action == 'install':
-      additional_env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
     cmd = [swift_exec, 'build', '--product', product] + swiftpm_args
     check_call(cmd, additional_env=additional_env, verbose=args.verbose)
 


### PR DESCRIPTION
Also, move installation-only environment variable into `get_swiftpm_environment_variables()`.

One of the latest trunk snapshot toolchains shows five executables built by SwiftPM that incorrectly have this runpath, including `sourcekit-lsp` from this repo:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/*|ag "File:|runpath"|ag "ORIGIN[^/]" -B1
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/docc
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/sourcekit-lsp
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-build-sdk-interfaces
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-driver
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-help
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
```
This will remove that unneeded runpath, as I just did for `swift-package` in apple/swift-package-manager#6947. I limited this to non-Darwin installs because I have no idea if this would be useful on Darwin too.