### PR TITLE
Simplify tests 

### DIFF
--- a/Sources/LSPTestSupport/Assertions.swift
+++ b/Sources/LSPTestSupport/Assertions.swift
@@ -130,28 +130,4 @@ extension XCTestCase {
       throw ExpectationNotFulfilledError(expecatations: expectations)
     }
   }
-
-  /// Execute the given asynchronous `operation` and block execution until it
-  /// finishes.
-  ///
-  /// - Important: Only use this in context where execution of async functions
-  ///   is necessary but the context doesn't allow it, like `XCTestCase.setUp`
-  public func awaitTask(
-    description: String,
-    _ operation: () async throws -> Void,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) {
-    let completed = self.expectation(description: description)
-    withoutActuallyEscaping(operation) { operation in
-      Task(priority: .userInitiated) {
-        await assertNoThrow<Void>(operation, "", file: file, line: line)
-        completed.fulfill()
-      }
-      let started = XCTWaiter.wait(for: [completed], timeout: defaultTimeout)
-      if started != .completed {
-        XCTFail("Task '\(description)' did not finish within timeout", file: file, line: line)
-      }
-    }
-  }
 }

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -55,11 +55,9 @@ public final class SKSwiftPMTestWorkspace {
   /// Connection to the language server.
   public let testServer: TestSourceKitServer
 
-  public var sk: TestClient { testServer.client }
-
   /// When `testServer` is not `nil`, the workspace will be opened in that server, otherwise a new server will be created for the workspace
   public init(projectDir: URL, tmpDir: URL, toolchain: Toolchain, testServer: TestSourceKitServer? = nil) async throws {
-    self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
+    self.testServer = testServer ?? TestSourceKitServer()
 
     self.projectDir = URL(
       fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: projectDir.path)).pathString
@@ -105,7 +103,7 @@ public final class SKSwiftPMTestWorkspace {
       listenToUnitEvents: false
     )
 
-    let server = self.testServer.server!
+    let server = self.testServer.server
     let workspace = await Workspace(
       documentManager: DocumentManager(),
       rootUri: DocumentURI(sources.rootDirectory),
@@ -153,7 +151,7 @@ extension SKSwiftPMTestWorkspace {
 
 extension SKSwiftPMTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    sk.send(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: DocumentURI(url),
@@ -166,7 +164,7 @@ extension SKSwiftPMTestWorkspace {
   }
 
   public func closeDocument(_ url: URL) {
-    sk.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(DocumentURI(url))))
+    testServer.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(DocumentURI(url))))
   }
 }
 

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -41,7 +41,6 @@ public final class SKTibsTestWorkspace {
   public var index: IndexStoreDB { tibsWorkspace.index }
   public var builder: TibsBuilder { tibsWorkspace.builder }
   public var sources: TestSources { tibsWorkspace.sources }
-  public var sk: TestClient { testServer.client }
 
   public init(
     immutableProjectDir: URL,
@@ -52,7 +51,7 @@ public final class SKTibsTestWorkspace {
     clientCapabilities: ClientCapabilities,
     testServer: TestSourceKitServer? = nil
   ) async throws {
-    self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
+    self.testServer = testServer ?? TestSourceKitServer()
     self.tibsWorkspace = try TibsTestWorkspace(
       immutableProjectDir: immutableProjectDir,
       persistentBuildDir: persistentBuildDir,
@@ -71,7 +70,7 @@ public final class SKTibsTestWorkspace {
     clientCapabilities: ClientCapabilities,
     testServer: TestSourceKitServer? = nil
   ) async throws {
-    self.testServer = testServer ?? TestSourceKitServer(connectionKind: .local)
+    self.testServer = testServer ?? TestSourceKitServer()
 
     self.tibsWorkspace = try TibsTestWorkspace(
       projectDir: projectDir,
@@ -99,8 +98,8 @@ public final class SKTibsTestWorkspace {
       indexDelegate: indexDelegate
     )
 
-    await workspace.buildSystemManager.setDelegate(testServer.server!)
-    await testServer.server!.setWorkspaces([workspace])
+    await workspace.buildSystemManager.setDelegate(testServer.server)
+    await testServer.server.setWorkspaces([workspace])
   }
 }
 
@@ -123,7 +122,7 @@ extension SKTibsTestWorkspace {
 
 extension SKTibsTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    sk.send(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: DocumentURI(url),

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -36,7 +36,7 @@ fileprivate extension SourceKitServer {
 public final class SKTibsTestWorkspace {
 
   public let tibsWorkspace: TibsTestWorkspace
-  public let testServer: TestSourceKitServer
+  public let testClient: TestSourceKitLSPClient
 
   public var index: IndexStoreDB { tibsWorkspace.index }
   public var builder: TibsBuilder { tibsWorkspace.builder }
@@ -49,9 +49,9 @@ public final class SKTibsTestWorkspace {
     removeTmpDir: Bool,
     toolchain: Toolchain,
     clientCapabilities: ClientCapabilities,
-    testServer: TestSourceKitServer? = nil
+    testClient: TestSourceKitLSPClient? = nil
   ) async throws {
-    self.testServer = testServer ?? TestSourceKitServer()
+    self.testClient = testClient ?? TestSourceKitLSPClient()
     self.tibsWorkspace = try TibsTestWorkspace(
       immutableProjectDir: immutableProjectDir,
       persistentBuildDir: persistentBuildDir,
@@ -68,9 +68,9 @@ public final class SKTibsTestWorkspace {
     tmpDir: URL,
     toolchain: Toolchain,
     clientCapabilities: ClientCapabilities,
-    testServer: TestSourceKitServer? = nil
+    testClient: TestSourceKitLSPClient? = nil
   ) async throws {
-    self.testServer = testServer ?? TestSourceKitServer()
+    self.testClient = testClient ?? TestSourceKitLSPClient()
 
     self.tibsWorkspace = try TibsTestWorkspace(
       projectDir: projectDir,
@@ -98,8 +98,8 @@ public final class SKTibsTestWorkspace {
       indexDelegate: indexDelegate
     )
 
-    await workspace.buildSystemManager.setDelegate(testServer.server)
-    await testServer.server.setWorkspaces([workspace])
+    await workspace.buildSystemManager.setDelegate(testClient.server)
+    await testClient.server.setWorkspaces([workspace])
   }
 }
 
@@ -122,7 +122,7 @@ extension SKTibsTestWorkspace {
 
 extension SKTibsTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    testServer.send(
+    testClient.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: DocumentURI(url),
@@ -142,7 +142,7 @@ extension XCTestCase {
     clientCapabilities: ClientCapabilities = .init(),
     tmpDir: URL? = nil,
     removeTmpDir: Bool = true,
-    server: TestSourceKitServer? = nil
+    testClient: TestSourceKitLSPClient? = nil
   ) async throws -> SKTibsTestWorkspace? {
     let testDirName = testDirectoryName
     let workspace = try await SKTibsTestWorkspace(
@@ -156,7 +156,7 @@ extension XCTestCase {
       removeTmpDir: removeTmpDir,
       toolchain: ToolchainRegistry.shared.default!,
       clientCapabilities: clientCapabilities,
-      testServer: server
+      testClient: testClient
     )
 
     if workspace.builder.targets.contains(where: { target in !target.clangTUs.isEmpty })

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -19,6 +19,11 @@ import SKSupport
 import SourceKitLSP
 import XCTest
 
+extension SourceKitServer.Options {
+  /// The default SourceKitServer options for testing.
+  public static var testDefault = Self()
+}
+
 /// A mock SourceKit-LSP client (aka. a mock editor) that behaves like an editor
 /// for testing purposes.
 ///
@@ -27,8 +32,6 @@ import XCTest
 public final class TestSourceKitLSPClient: MessageHandler {
   /// A function that takes a request and returns the request's response.
   public typealias RequestHandler<Request: RequestType> = (Request) -> Request.Response
-
-  public static let serverOptions: SourceKitServer.Options = SourceKitServer.Options()
 
   /// The ID that should be assigned to the next request sent to the `server`.
   private var nextRequestID: Int = 0
@@ -66,7 +69,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
     } else {
       moduleCache = nil
     }
-    var serverOptions = Self.serverOptions
+    var serverOptions = SourceKitServer.Options.testDefault
     if let moduleCache {
       serverOptions.buildSetup.flags.swiftCompilerFlags += ["-module-cache-path", moduleCache.path]
     }

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -535,7 +535,11 @@ extension SourceKitServer: MessageHandler {
     //    completion session but it only makes sense for the client to request
     //    more results for this completion session after it has received the
     //    initial results.
-    messageHandlingQueue.async(barrier: false) {
+    // FIXME: (async) We need more granular request handling. Completion requests
+    // to the same file depend on each other because we only have one global
+    // code completion session in sourcekitd but they don't need to be full
+    // barriers to any other request.
+    messageHandlingQueue.async(barrier: R.self is CompletionRequest.Type) {
       let cancellationToken = CancellationToken()
 
       let request = Request(

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -60,7 +60,7 @@ class ConnectionTests: XCTestCase {
     let clientConnection = connection.clientConnection
     let expectation = self.expectation(description: "note received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.appendOneShotNotificationHandler { (note: Notification<EchoNotification>) in
       XCTAssertEqual(note.params.string, "hello!")
       expectation.fulfill()
     }
@@ -83,7 +83,7 @@ class ConnectionTests: XCTestCase {
 
     let expectation2 = self.expectation(description: "note received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.appendOneShotNotificationHandler { (note: Notification<EchoNotification>) in
       XCTAssertEqual(note.params.string, "no way!")
       expectation2.fulfill()
     }
@@ -125,7 +125,7 @@ class ConnectionTests: XCTestCase {
     let client = connection.client
     let expectation = self.expectation(description: "note received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.appendOneShotNotificationHandler { (note: Notification<EchoNotification>) in
       XCTAssertEqual(note.params.string, "hello!")
       expectation.fulfill()
     }
@@ -218,7 +218,7 @@ class ConnectionTests: XCTestCase {
     let server = connection.server
 
     let expectation = self.expectation(description: "received notification")
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.appendOneShotNotificationHandler { (note: Notification<EchoNotification>) in
       expectation.fulfill()
     }
 
@@ -232,7 +232,7 @@ class ConnectionTests: XCTestCase {
     let client = connection.client
 
     let expectation = self.expectation(description: "received notification")
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.appendOneShotNotificationHandler { (note: Notification<EchoNotification>) in
       expectation.fulfill()
     }
     let notification = EchoNotification(string: "about to close!")

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -68,7 +68,7 @@ class ConnectionTests: XCTestCase {
     let client = connection.client
     let expectation = self.expectation(description: "note received")
 
-    client.handleNextNotification { (note: Notification<EchoNotification>) in
+    client.appendOneShotNotificationHandler { (note: Notification<EchoNotification>) in
       XCTAssertEqual(note.params.string, "hello!")
       expectation.fulfill()
     }

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -17,6 +17,7 @@ import PackageModel
 import SKCore
 import SKSwiftPMWorkspace
 import SKTestSupport
+import SourceKitLSP
 import TSCBasic
 import XCTest
 
@@ -44,7 +45,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
-          buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+          buildSetup: SourceKitServer.Options.testDefault.buildSetup
         )
       )
     }
@@ -71,7 +72,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
-          buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+          buildSetup: SourceKitServer.Options.testDefault.buildSetup
         )
       )
     }
@@ -98,7 +99,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: ToolchainRegistry(),
           fileSystem: fs,
-          buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+          buildSetup: SourceKitServer.Options.testDefault.buildSetup
         )
       )
     }
@@ -126,7 +127,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -231,7 +232,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
@@ -265,7 +266,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -309,7 +310,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
@@ -371,7 +372,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
@@ -407,7 +408,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
@@ -499,7 +500,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.shared,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -547,7 +548,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift1 = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -606,7 +607,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
@@ -651,7 +652,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -687,7 +688,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
 
       assertEqual(await ws._packageRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
@@ -734,7 +735,7 @@ private func check(
 
 private func buildPath(
   root: AbsolutePath,
-  config: BuildSetup = TestSourceKitLSPClient.serverOptions.buildSetup,
+  config: BuildSetup = SourceKitServer.Options.testDefault.buildSetup,
   platform: String
 ) -> AbsolutePath {
   let buildPath = config.path ?? root.appending(component: ".build")

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -44,7 +44,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
-          buildSetup: TestSourceKitServer.serverOptions.buildSetup
+          buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
         )
       )
     }
@@ -71,7 +71,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
-          buildSetup: TestSourceKitServer.serverOptions.buildSetup
+          buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
         )
       )
     }
@@ -98,7 +98,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: ToolchainRegistry(),
           fileSystem: fs,
-          buildSetup: TestSourceKitServer.serverOptions.buildSetup
+          buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
         )
       )
     }
@@ -126,7 +126,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -231,7 +231,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
@@ -265,7 +265,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -309,7 +309,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
@@ -371,7 +371,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
@@ -407,7 +407,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
@@ -499,7 +499,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.shared,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -547,7 +547,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift1 = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -606,7 +606,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
@@ -651,7 +651,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -687,7 +687,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: TestSourceKitServer.serverOptions.buildSetup
+        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup
       )
 
       assertEqual(await ws._packageRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
@@ -734,7 +734,7 @@ private func check(
 
 private func buildPath(
   root: AbsolutePath,
-  config: BuildSetup = TestSourceKitServer.serverOptions.buildSetup,
+  config: BuildSetup = TestSourceKitLSPClient.serverOptions.buildSetup,
   platform: String
 ) -> AbsolutePath {
   let buildPath = config.path ?? root.appending(component: ".build")

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -75,9 +75,6 @@ final class BuildSystemTests: XCTestCase {
   /// Connection and lifetime management for the service.
   var testServer: TestSourceKitServer! = nil
 
-  /// The primary interface to make requests to the SourceKitServer.
-  var sk: TestClient! = nil
-
   /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
   var workspace: Workspace! = nil
 
@@ -88,17 +85,12 @@ final class BuildSystemTests: XCTestCase {
   var haveClangd: Bool = false
 
   override func setUp() {
-    // XCTestCase.setUp cannot be async, so unfortunately we need to do some
-    // hackery to synchronously wait for a task to finish. This is very much an
-    // anti-pattern because it can easily lead to priority inversions and should
-    // thus not be copied to any non-test code.
-    let setUpCompleted = XCTestExpectation(description: "Waiting for set up")
-    Task {
+    awaitTask(description: "Setup complete") {
       haveClangd = ToolchainRegistry.shared.toolchains.contains { $0.clangd != nil }
       testServer = TestSourceKitServer()
       buildSystem = TestBuildSystem()
 
-      let server = testServer.server!
+      let server = testServer.server
 
       self.workspace = await Workspace(
         documentManager: DocumentManager(),
@@ -114,8 +106,7 @@ final class BuildSystemTests: XCTestCase {
       await server.setWorkspaces([workspace])
       await workspace.buildSystemManager.setDelegate(server)
 
-      sk = testServer.client
-      _ = try! sk.sendSync(
+      _ = try await testServer.send(
         InitializeRequest(
           processId: nil,
           rootPath: nil,
@@ -126,17 +117,12 @@ final class BuildSystemTests: XCTestCase {
           workspaceFolders: nil
         )
       )
-      setUpCompleted.fulfill()
-    }
-    if XCTWaiter.wait(for: [setUpCompleted], timeout: defaultTimeout) != .completed {
-      XCTFail("Set up failed to complete")
     }
   }
 
   override func tearDown() {
     buildSystem = nil
     workspace = nil
-    sk = nil
     testServer = nil
   }
 
@@ -165,11 +151,9 @@ final class BuildSystemTests: XCTestCase {
 
     buildSystem.buildSettingsByFile[doc] = FileBuildSettings(compilerArguments: args)
 
-    sk.allowUnexpectedNotification = false
+    let documentManager = await self.testServer.server._documentManager
 
-    let documentManager = await self.testServer.server!._documentManager
-
-    sk.sendNoteSync(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -177,12 +161,11 @@ final class BuildSystemTests: XCTestCase {
           version: 12,
           text: text
         )
-      ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        XCTAssertEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
-      }
+      )
     )
+    let diags = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(diags.diagnostics.count, 1)
+    XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
 
     // Modify the build settings and inform the delegate.
     // This should trigger a new publish diagnostics and we should no longer have errors.
@@ -190,11 +173,9 @@ final class BuildSystemTests: XCTestCase {
     buildSystem.buildSettingsByFile[doc] = newSettings
 
     let expectation = XCTestExpectation(description: "refresh")
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
-      expectation.fulfill()
-    }
+    let refreshedDiags = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(refreshedDiags.diagnostics.count, 0)
+    XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
 
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
@@ -216,11 +197,9 @@ final class BuildSystemTests: XCTestCase {
       foo()
       """
 
-    sk.allowUnexpectedNotification = false
+    let documentManager = await self.testServer.server._documentManager
 
-    let documentManager = await self.testServer.server!._documentManager
-
-    sk.sendNoteSync(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -228,38 +207,29 @@ final class BuildSystemTests: XCTestCase {
           version: 12,
           text: text
         )
-      ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        // Syntactic analysis - no expected errors here.
-        XCTAssertEqual(note.params.diagnostics.count, 0)
-        XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
-      },
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        // Semantic analysis - expect one error here.
-        XCTAssertEqual(note.params.diagnostics.count, 1)
-      }
+      )
     )
+    let syntacticDiags1 = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(syntacticDiags1.diagnostics.count, 0)
+    XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
+
+    let semanticDiags1 = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(semanticDiags1.diagnostics.count, 1)
 
     // Modify the build settings and inform the delegate.
     // This should trigger a new publish diagnostics and we should no longer have errors.
     let newSettings = FileBuildSettings(compilerArguments: args + ["-DFOO"])
     buildSystem.buildSettingsByFile[doc] = newSettings
 
-    let expectation = XCTestExpectation(description: "refresh")
-    expectation.expectedFulfillmentCount = 2
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis - SourceKit currently caches diagnostics so we still see an error.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      expectation.fulfill()
-    }
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis - no expected errors here because we fixed the settings.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      expectation.fulfill()
-    }
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
-    try await fulfillmentOfOrThrow([expectation])
+    let syntacticDiags2 = try await testServer.nextDiagnosticsNotification()
+    // Semantic analysis - SourceKit currently caches diagnostics so we still see an error.
+    XCTAssertEqual(syntacticDiags2.diagnostics.count, 1)
+
+    let semanticDiags2 = try await testServer.nextDiagnosticsNotification()
+    // Semantic analysis - no expected errors here because we fixed the settings.
+    XCTAssertEqual(semanticDiags2.diagnostics.count, 0)
   }
 
   func testClangdDocumentFallbackWithholdsDiagnostics() async throws {
@@ -283,11 +253,9 @@ final class BuildSystemTests: XCTestCase {
         }
       """
 
-    sk.allowUnexpectedNotification = false
+    let documentManager = await self.testServer.server._documentManager
 
-    let documentManager = await self.testServer.server!._documentManager
-
-    sk.sendNoteSync(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -295,29 +263,23 @@ final class BuildSystemTests: XCTestCase {
           version: 12,
           text: text
         )
-      ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        // Expect diagnostics to be withheld.
-        XCTAssertEqual(note.params.diagnostics.count, 0)
-        XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
-      }
+      )
     )
+    let openDiags = try await testServer.nextDiagnosticsNotification()
+    // Expect diagnostics to be withheld.
+    XCTAssertEqual(openDiags.diagnostics.count, 0)
+    XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
 
     // Modify the build settings and inform the delegate.
     // This should trigger a new publish diagnostics and we should see a diagnostic.
     let newSettings = FileBuildSettings(compilerArguments: args)
     buildSystem.buildSettingsByFile[doc] = newSettings
 
-    let expectation = XCTestExpectation(description: "refresh due to fallback --> primary")
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
-      expectation.fulfill()
-    }
-
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
-    try await fulfillmentOfOrThrow([expectation])
+    let refreshedDiags = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(refreshedDiags.diagnostics.count, 1)
+    XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
   }
 
   func testSwiftDocumentFallbackWithholdsSemanticDiagnostics() async throws {
@@ -337,11 +299,9 @@ final class BuildSystemTests: XCTestCase {
         func
       """
 
-    sk.allowUnexpectedNotification = false
+    let documentManager = await self.testServer.server._documentManager
 
-    let documentManager = await self.testServer.server!._documentManager
-
-    sk.sendNoteSync(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: doc,
@@ -349,35 +309,28 @@ final class BuildSystemTests: XCTestCase {
           version: 12,
           text: text
         )
-      ),
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        // Syntactic analysis - one expected errors here (for `func`).
-        XCTAssertEqual(note.params.diagnostics.count, 1)
-        XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
-      },
-      { (note: Notification<PublishDiagnosticsNotification>) in
-        // Should be the same syntactic analysis since we are using fallback arguments
-        XCTAssertEqual(note.params.diagnostics.count, 1)
-      }
+      )
     )
+    let openSyntacticDiags = try await testServer.nextDiagnosticsNotification()
+    // Syntactic analysis - one expected errors here (for `func`).
+    XCTAssertEqual(openSyntacticDiags.diagnostics.count, 1)
+    XCTAssertEqual(text, documentManager.latestSnapshot(doc)!.text)
+    let openSemanticDiags = try await testServer.nextDiagnosticsNotification()
+    // Should be the same syntactic analysis since we are using fallback arguments
+    XCTAssertEqual(openSemanticDiags.diagnostics.count, 1)
 
     // Swap from fallback settings to primary build system settings.
     buildSystem.buildSettingsByFile[doc] = primarySettings
-    let expectation = XCTestExpectation(description: "refresh due to fallback --> primary")
-    expectation.expectedFulfillmentCount = 2
-    sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // Syntactic analysis with new args - one expected errors here (for `func`).
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      expectation.fulfill()
-    }
-    sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis - two errors since `-DFOO` was not passed.
-      XCTAssertEqual(note.params.diagnostics.count, 2)
-      expectation.fulfill()
-    }
+
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
-    try await fulfillmentOfOrThrow([expectation])
+    let refreshedSyntacticDiags = try await testServer.nextDiagnosticsNotification()
+    // Syntactic analysis with new args - one expected errors here (for `func`).
+    XCTAssertEqual(refreshedSyntacticDiags.diagnostics.count, 1)
+
+    let refreshedSemanticDiags = try await testServer.nextDiagnosticsNotification()
+    // Semantic analysis - two errors since `-DFOO` was not passed.
+    XCTAssertEqual(refreshedSemanticDiags.diagnostics.count, 2)
   }
 
   func testMainFilesChanged() async throws {
@@ -386,40 +339,17 @@ final class BuildSystemTests: XCTestCase {
     let ws = try await mutableSourceKitTibsTestWorkspace(name: "MainFiles")!
     let unique_h = ws.testLoc("unique").docIdentifier.uri
 
-    ws.testServer.client.allowUnexpectedNotification = false
-
-    let expectation = self.expectation(description: "initial")
-    ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // Should withhold diagnostics since we should be using fallback arguments.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      expectation.fulfill()
-    }
-
     try ws.openDocument(unique_h.fileURL!, language: .cpp)
-    try await fulfillmentOfOrThrow([expectation])
 
-    let use_d = self.expectation(description: "update settings to d.cpp")
-    ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      if let diag = note.params.diagnostics.first {
-        XCTAssertEqual(diag.severity, .warning)
-        XCTAssertEqual(diag.message, "UNIQUE_INCLUDED_FROM_D")
-      }
-      use_d.fulfill()
-    }
+    let openSyntacticDiags = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(openSyntacticDiags.diagnostics.count, 0)
 
     try ws.buildAndIndex()
-    try await fulfillmentOfOrThrow([use_d])
-
-    let use_c = self.expectation(description: "update settings to c.cpp")
-    ws.testServer.client.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      if let diag = note.params.diagnostics.first {
-        XCTAssertEqual(diag.severity, .warning)
-        XCTAssertEqual(diag.message, "UNIQUE_INCLUDED_FROM_C")
-      }
-      use_c.fulfill()
-    }
+    let diagsFromD = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(diagsFromD.diagnostics.count, 1)
+    let diagFromD = try XCTUnwrap(diagsFromD.diagnostics.first)
+    XCTAssertEqual(diagFromD.severity, .warning)
+    XCTAssertEqual(diagFromD.message, "UNIQUE_INCLUDED_FROM_D")
 
     try ws.edit(rebuild: true) { (changes, _) in
       changes.write(
@@ -436,7 +366,11 @@ final class BuildSystemTests: XCTestCase {
       )
     }
 
-    try await fulfillmentOfOrThrow([use_c])
+    let diagsFromC = try await testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(diagsFromC.diagnostics.count, 1)
+    let diagFromC = try XCTUnwrap(diagsFromC.diagnostics.first)
+    XCTAssertEqual(diagFromC.severity, .warning)
+    XCTAssertEqual(diagFromC.message, "UNIQUE_INCLUDED_FROM_C")
   }
 
   private func clangBuildSettings(for uri: DocumentURI) -> FileBuildSettings {

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -105,7 +105,7 @@ final class BuildSystemTests: XCTestCase {
         rootUri: nil,
         capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
         toolchainRegistry: ToolchainRegistry.shared,
-        buildSetup: TestSourceKitLSPClient.serverOptions.buildSetup,
+        buildSetup: SourceKitServer.Options.testDefault.buildSetup,
         underlyingBuildSystem: buildSystem,
         index: nil,
         indexDelegate: nil

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -28,7 +28,7 @@ final class CallHierarchyTests: XCTestCase {
     func callHierarchy(at testLoc: TestLocation) async throws -> [CallHierarchyItem] {
       let textDocument = testLoc.docIdentifier
       let request = CallHierarchyPrepareRequest(textDocument: textDocument, position: Position(testLoc))
-      return try await ws.testServer.send(request) ?? []
+      return try await ws.testClient.send(request) ?? []
     }
 
     func incomingCalls(at testLoc: TestLocation) async throws -> [CallHierarchyIncomingCall] {
@@ -37,7 +37,7 @@ final class CallHierarchyTests: XCTestCase {
         return []
       }
       let request = CallHierarchyIncomingCallsRequest(item: item)
-      return try await ws.testServer.send(request) ?? []
+      return try await ws.testClient.send(request) ?? []
     }
 
     func outgoingCalls(at testLoc: TestLocation) async throws -> [CallHierarchyOutgoingCall] {
@@ -46,7 +46,7 @@ final class CallHierarchyTests: XCTestCase {
         return []
       }
       let request = CallHierarchyOutgoingCallsRequest(item: item)
-      return try await ws.testServer.send(request) ?? []
+      return try await ws.testClient.send(request) ?? []
     }
 
     func usr(at testLoc: TestLocation) async throws -> String {

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ISDBTestSupport
+import LSPTestSupport
 import LanguageServerProtocol
 import TSCBasic
 import XCTest
@@ -24,35 +25,32 @@ final class CallHierarchyTests: XCTestCase {
 
     // Requests
 
-    func callHierarchy(at testLoc: TestLocation) throws -> [CallHierarchyItem] {
+    func callHierarchy(at testLoc: TestLocation) async throws -> [CallHierarchyItem] {
       let textDocument = testLoc.docIdentifier
       let request = CallHierarchyPrepareRequest(textDocument: textDocument, position: Position(testLoc))
-      let items = try ws.sk.sendSync(request)
-      return items ?? []
+      return try await ws.testServer.send(request) ?? []
     }
 
-    func incomingCalls(at testLoc: TestLocation) throws -> [CallHierarchyIncomingCall] {
-      guard let item = try callHierarchy(at: testLoc).first else {
+    func incomingCalls(at testLoc: TestLocation) async throws -> [CallHierarchyIncomingCall] {
+      guard let item = try await callHierarchy(at: testLoc).first else {
         XCTFail("call hierarchy at \(testLoc) was empty")
         return []
       }
       let request = CallHierarchyIncomingCallsRequest(item: item)
-      let calls = try ws.sk.sendSync(request)
-      return calls ?? []
+      return try await ws.testServer.send(request) ?? []
     }
 
-    func outgoingCalls(at testLoc: TestLocation) throws -> [CallHierarchyOutgoingCall] {
-      guard let item = try callHierarchy(at: testLoc).first else {
+    func outgoingCalls(at testLoc: TestLocation) async throws -> [CallHierarchyOutgoingCall] {
+      guard let item = try await callHierarchy(at: testLoc).first else {
         XCTFail("call hierarchy at \(testLoc) was empty")
         return []
       }
       let request = CallHierarchyOutgoingCallsRequest(item: item)
-      let calls = try ws.sk.sendSync(request)
-      return calls ?? []
+      return try await ws.testServer.send(request) ?? []
     }
 
-    func usr(at testLoc: TestLocation) throws -> String {
-      guard let item = try callHierarchy(at: testLoc).first else {
+    func usr(at testLoc: TestLocation) async throws -> String {
+      guard let item = try await callHierarchy(at: testLoc).first else {
         XCTFail("call hierarchy at \(testLoc) was empty")
         return ""
       }
@@ -112,24 +110,24 @@ final class CallHierarchyTests: XCTestCase {
       )
     }
 
-    let aUsr = try usr(at: testLoc("a"))
-    let bUsr = try usr(at: testLoc("b"))
-    let cUsr = try usr(at: testLoc("c"))
-    let dUsr = try usr(at: testLoc("d"))
+    let aUsr = try await usr(at: testLoc("a"))
+    let bUsr = try await usr(at: testLoc("b"))
+    let cUsr = try await usr(at: testLoc("c"))
+    let dUsr = try await usr(at: testLoc("d"))
 
     // Test outgoing call hierarchy
 
-    XCTAssertEqual(try outgoingCalls(at: testLoc("a")), [])
-    XCTAssertEqual(
-      try outgoingCalls(at: testLoc("b")),
+    assertEqual(try await outgoingCalls(at: testLoc("a")), [])
+    assertEqual(
+      try await outgoingCalls(at: testLoc("b")),
       [
         outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "b->a"),
         outCall(try item("c()", .function, usr: cUsr, at: "c"), at: "b->c"),
         outCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b"),
       ]
     )
-    XCTAssertEqual(
-      try outgoingCalls(at: testLoc("c")),
+    assertEqual(
+      try await outgoingCalls(at: testLoc("c")),
       [
         outCall(try item("a()", .function, usr: aUsr, at: "a"), at: "c->a"),
         outCall(try item("d()", .function, usr: dUsr, at: "d"), at: "c->d"),
@@ -139,21 +137,21 @@ final class CallHierarchyTests: XCTestCase {
 
     // Test incoming call hierarchy
 
-    XCTAssertEqual(
-      try incomingCalls(at: testLoc("a")),
+    assertEqual(
+      try await incomingCalls(at: testLoc("a")),
       [
         inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->a"),
         inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->a"),
       ]
     )
-    XCTAssertEqual(
-      try incomingCalls(at: testLoc("b")),
+    assertEqual(
+      try await incomingCalls(at: testLoc("b")),
       [
         inCall(try item("b(x:)", .function, usr: bUsr, at: "b"), at: "b->b")
       ]
     )
-    XCTAssertEqual(
-      try incomingCalls(at: testLoc("d")),
+    assertEqual(
+      try await incomingCalls(at: testLoc("d")),
       [
         inCall(try item("c()", .function, usr: cUsr, at: "c"), at: "c->d")
       ]

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -203,10 +203,8 @@ final class CodeActionTests: XCTestCase {
     let textDocument = TextDocumentIdentifier(loc.url)
     let start = Position(line: 2, utf16index: 0)
     let request = CodeActionRequest(range: start..<start, context: .init(), textDocument: textDocument)
-    try withExtendedLifetime(ws) {
-      let result = try ws.sk.sendSync(request)
-      XCTAssertEqual(result, .codeActions([]))
-    }
+    let result = try await ws.testServer.send(request)
+    XCTAssertEqual(result, .codeActions([]))
   }
 
   func testSemanticRefactorLocalRenameResult() async throws {
@@ -216,10 +214,8 @@ final class CodeActionTests: XCTestCase {
 
     let textDocument = TextDocumentIdentifier(loc.url)
     let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
-    try withExtendedLifetime(ws) {
-      let result = try ws.sk.sendSync(request)
-      XCTAssertEqual(result, .codeActions([]))
-    }
+    let result = try await ws.testServer.send(request)
+    XCTAssertEqual(result, .codeActions([]))
   }
 
   func testSemanticRefactorLocationCodeActionResult() async throws {
@@ -229,7 +225,7 @@ final class CodeActionTests: XCTestCase {
 
     let textDocument = TextDocumentIdentifier(loc.url)
     let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
-    let result = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let result = try await ws.testServer.send(request)
 
     let expectedCommandArgs: LSPAny = [
       "actionString": "source.refactoring.kind.localize.string",
@@ -267,7 +263,7 @@ final class CodeActionTests: XCTestCase {
       context: .init(),
       textDocument: textDocument
     )
-    let result = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let result = try await ws.testServer.send(request)
 
     let expectedCommandArgs: LSPAny = [
       "actionString": "source.refactoring.kind.extract.function",
@@ -298,34 +294,21 @@ final class CodeActionTests: XCTestCase {
 
     try ws.openDocument(def.url, language: .swift)
 
-    let syntacticDiagnosticsReceived = self.expectation(description: "Syntactic diagnotistics received")
-    let semanticDiagnosticsReceived = self.expectation(description: "Semantic diagnotistics received")
+    let syntacticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(syntacticDiags.uri, def.docUri)
+    XCTAssertEqual(syntacticDiags.diagnostics, [])
 
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      // syntactic diagnostics
-      XCTAssertEqual(note.params.uri, def.docUri)
-      XCTAssertEqual(note.params.diagnostics, [])
-      syntacticDiagnosticsReceived.fulfill()
-    }
-
-    var diags: [Diagnostic]! = nil
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      // semantic diagnostics
-      XCTAssertEqual(note.params.uri, def.docUri)
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      diags = note.params.diagnostics
-      semanticDiagnosticsReceived.fulfill()
-    }
-
-    try await fulfillmentOfOrThrow([syntacticDiagnosticsReceived, semanticDiagnosticsReceived])
+    let semanticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(semanticDiags.uri, def.docUri)
+    XCTAssertEqual(semanticDiags.diagnostics.count, 1)
 
     let textDocument = TextDocumentIdentifier(def.url)
     let actionsRequest = CodeActionRequest(
       range: def.position..<def.position,
-      context: .init(diagnostics: diags),
+      context: .init(diagnostics: semanticDiags.diagnostics),
       textDocument: textDocument
     )
-    let actionResult = try ws.sk.sendSync(actionsRequest)
+    let actionResult = try await ws.testServer.send(actionsRequest)
 
     guard case .codeActions(let codeActions) = actionResult else {
       return XCTFail("Expected code actions, not commands as a response")
@@ -360,12 +343,13 @@ final class CodeActionTests: XCTestCase {
 
     let editReceived = self.expectation(description: "Received ApplyEdit request")
 
-    ws.sk.appendOneShotRequestHandler { (request: Request<ApplyEditRequest>) in
+    ws.testServer.handleNextRequest { (request: ApplyEditRequest) -> ApplyEditResponse in
       defer {
         editReceived.fulfill()
       }
-      guard let change = request.params.edit.changes?[def.docUri]?.spm_only else {
-        return XCTFail("Expected exactly one edit")
+      guard let change = request.edit.changes?[def.docUri]?.spm_only else {
+        XCTFail("Expected exactly one edit")
+        return ApplyEditResponse(applied: false, failureReason: "Expected exactly one edit")
       }
       XCTAssertEqual(
         change.newText.trimmingTrailingWhitespace(),
@@ -377,9 +361,9 @@ final class CodeActionTests: XCTestCase {
 
         """
       )
-      request.reply(ApplyEditResponse(applied: true, failureReason: nil))
+      return ApplyEditResponse(applied: true, failureReason: nil)
     }
-    _ = try ws.sk.sendSync(ExecuteCommandRequest(command: command.command, arguments: command.arguments))
+    _ = try await ws.testServer.send(ExecuteCommandRequest(command: command.command, arguments: command.arguments))
 
     try await fulfillmentOfOrThrow([editReceived])
   }

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -203,7 +203,7 @@ final class CodeActionTests: XCTestCase {
     let textDocument = TextDocumentIdentifier(loc.url)
     let start = Position(line: 2, utf16index: 0)
     let request = CodeActionRequest(range: start..<start, context: .init(), textDocument: textDocument)
-    let result = try await ws.testServer.send(request)
+    let result = try await ws.testClient.send(request)
     XCTAssertEqual(result, .codeActions([]))
   }
 
@@ -214,7 +214,7 @@ final class CodeActionTests: XCTestCase {
 
     let textDocument = TextDocumentIdentifier(loc.url)
     let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
-    let result = try await ws.testServer.send(request)
+    let result = try await ws.testClient.send(request)
     XCTAssertEqual(result, .codeActions([]))
   }
 
@@ -225,7 +225,7 @@ final class CodeActionTests: XCTestCase {
 
     let textDocument = TextDocumentIdentifier(loc.url)
     let request = CodeActionRequest(range: loc.position..<loc.position, context: .init(), textDocument: textDocument)
-    let result = try await ws.testServer.send(request)
+    let result = try await ws.testClient.send(request)
 
     let expectedCommandArgs: LSPAny = [
       "actionString": "source.refactoring.kind.localize.string",
@@ -263,7 +263,7 @@ final class CodeActionTests: XCTestCase {
       context: .init(),
       textDocument: textDocument
     )
-    let result = try await ws.testServer.send(request)
+    let result = try await ws.testClient.send(request)
 
     let expectedCommandArgs: LSPAny = [
       "actionString": "source.refactoring.kind.extract.function",
@@ -294,11 +294,11 @@ final class CodeActionTests: XCTestCase {
 
     try ws.openDocument(def.url, language: .swift)
 
-    let syntacticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    let syntacticDiags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(syntacticDiags.uri, def.docUri)
     XCTAssertEqual(syntacticDiags.diagnostics, [])
 
-    let semanticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    let semanticDiags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(semanticDiags.uri, def.docUri)
     XCTAssertEqual(semanticDiags.diagnostics.count, 1)
 
@@ -308,7 +308,7 @@ final class CodeActionTests: XCTestCase {
       context: .init(diagnostics: semanticDiags.diagnostics),
       textDocument: textDocument
     )
-    let actionResult = try await ws.testServer.send(actionsRequest)
+    let actionResult = try await ws.testClient.send(actionsRequest)
 
     guard case .codeActions(let codeActions) = actionResult else {
       return XCTFail("Expected code actions, not commands as a response")
@@ -343,7 +343,7 @@ final class CodeActionTests: XCTestCase {
 
     let editReceived = self.expectation(description: "Received ApplyEdit request")
 
-    ws.testServer.handleNextRequest { (request: ApplyEditRequest) -> ApplyEditResponse in
+    ws.testClient.handleNextRequest { (request: ApplyEditRequest) -> ApplyEditResponse in
       defer {
         editReceived.fulfill()
       }
@@ -363,7 +363,7 @@ final class CodeActionTests: XCTestCase {
       )
       return ApplyEditResponse(applied: true, failureReason: nil)
     }
-    _ = try await ws.testServer.send(ExecuteCommandRequest(command: command.command, arguments: command.arguments))
+    _ = try await ws.testClient.send(ExecuteCommandRequest(command: command.command, arguments: command.arguments))
 
     try await fulfillmentOfOrThrow([editReceived])
   }

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -29,7 +29,7 @@ final class CompilationDatabaseTests: XCTestCase {
       textDocument: loc.docIdentifier,
       position: Position(line: 9, utf16index: 3)
     )
-    let preChangeHighlightResponse = try await ws.testServer.send(highlightRequest)
+    let preChangeHighlightResponse = try await ws.testClient.send(highlightRequest)
     XCTAssertEqual(
       preChangeHighlightResponse,
       [
@@ -56,7 +56,7 @@ final class CompilationDatabaseTests: XCTestCase {
       builder.write(newCompilationDatabaseStr, to: compilationDatabaseUrl)
     })
 
-    ws.testServer.send(
+    ws.testClient.send(
       DidChangeWatchedFilesNotification(changes: [
         FileEvent(uri: DocumentURI(compilationDatabaseUrl), type: .changed)
       ])
@@ -74,7 +74,7 @@ final class CompilationDatabaseTests: XCTestCase {
     // Updating the build settings takes a few seconds.
     // Send highlight requests every second until we receive correct results.
     for _ in 0..<30 {
-      let postChangeHighlightResponse = try await ws.testServer.send(highlightRequest)
+      let postChangeHighlightResponse = try await ws.testClient.send(highlightRequest)
 
       if postChangeHighlightResponse == expectedPostEditHighlight {
         didReceiveCorrectHighlight = true

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -29,7 +29,7 @@ final class CompilationDatabaseTests: XCTestCase {
       textDocument: loc.docIdentifier,
       position: Position(line: 9, utf16index: 3)
     )
-    let preChangeHighlightResponse = try ws.sk.sendSync(highlightRequest)
+    let preChangeHighlightResponse = try await ws.testServer.send(highlightRequest)
     XCTAssertEqual(
       preChangeHighlightResponse,
       [
@@ -56,7 +56,7 @@ final class CompilationDatabaseTests: XCTestCase {
       builder.write(newCompilationDatabaseStr, to: compilationDatabaseUrl)
     })
 
-    ws.sk.send(
+    ws.testServer.send(
       DidChangeWatchedFilesNotification(changes: [
         FileEvent(uri: DocumentURI(compilationDatabaseUrl), type: .changed)
       ])
@@ -74,7 +74,7 @@ final class CompilationDatabaseTests: XCTestCase {
     // Updating the build settings takes a few seconds.
     // Send highlight requests every second until we receive correct results.
     for _ in 0..<30 {
-      let postChangeHighlightResponse = try ws.sk.sendSync(highlightRequest)
+      let postChangeHighlightResponse = try await ws.testServer.send(highlightRequest)
 
       if postChangeHighlightResponse == expectedPostEditHighlight {
         didReceiveCorrectHighlight = true

--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -44,7 +44,7 @@ final class FoldingRangeTests: XCTestCase {
     }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
-    let ranges = try await ws.testServer.send(request)
+    let ranges = try await ws.testClient.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 1, endUTF16Index: 18, kind: .comment),
@@ -73,7 +73,7 @@ final class FoldingRangeTests: XCTestCase {
     }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
-    let ranges = try await ws.testServer.send(request)
+    let ranges = try await ws.testClient.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, endLine: 1, kind: .comment),
@@ -99,7 +99,7 @@ final class FoldingRangeTests: XCTestCase {
         return
       }
       let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-      let ranges = try await ws.testServer.send(request)
+      let ranges = try await ws.testClient.send(request)
       XCTAssertEqual(ranges?.count, expectedRanges, "Failed rangeLimit test at line \(line)")
     }
 
@@ -118,7 +118,7 @@ final class FoldingRangeTests: XCTestCase {
     }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-    let ranges = try await ws.testServer.send(request)
+    let ranges = try await ws.testClient.send(request)
 
     XCTAssertEqual(ranges?.count, 0)
   }
@@ -136,7 +136,7 @@ final class FoldingRangeTests: XCTestCase {
     else { return }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-    let ranges = try await ws.testServer.send(request)
+    let ranges = try await ws.testClient.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 2, endUTF16Index: 65, kind: .comment),
@@ -159,7 +159,7 @@ final class FoldingRangeTests: XCTestCase {
     else { return }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-    let ranges = try await ws.testServer.send(request)
+    let ranges = try await ws.testClient.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 12, endLine: 2, endUTF16Index: 0, kind: nil),

--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -44,7 +44,7 @@ final class FoldingRangeTests: XCTestCase {
     }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
-    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let ranges = try await ws.testServer.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 1, endUTF16Index: 18, kind: .comment),
@@ -73,7 +73,7 @@ final class FoldingRangeTests: XCTestCase {
     }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))
-    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let ranges = try await ws.testServer.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, endLine: 1, kind: .comment),
@@ -99,7 +99,7 @@ final class FoldingRangeTests: XCTestCase {
         return
       }
       let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-      let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+      let ranges = try await ws.testServer.send(request)
       XCTAssertEqual(ranges?.count, expectedRanges, "Failed rangeLimit test at line \(line)")
     }
 
@@ -118,7 +118,7 @@ final class FoldingRangeTests: XCTestCase {
     }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let ranges = try await ws.testServer.send(request)
 
     XCTAssertEqual(ranges?.count, 0)
   }
@@ -136,7 +136,7 @@ final class FoldingRangeTests: XCTestCase {
     else { return }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let ranges = try await ws.testServer.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 0, endLine: 2, endUTF16Index: 65, kind: .comment),
@@ -159,7 +159,7 @@ final class FoldingRangeTests: XCTestCase {
     else { return }
 
     let request = FoldingRangeRequest(textDocument: TextDocumentIdentifier(url))
-    let ranges = try withExtendedLifetime(ws) { try ws.sk.sendSync(request) }
+    let ranges = try await ws.testServer.send(request)
 
     let expected = [
       FoldingRange(startLine: 0, startUTF16Index: 12, endLine: 2, endUTF16Index: 0, kind: nil),

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -27,7 +27,7 @@ final class ImplementationTests: XCTestCase {
     func impls(at testLoc: TestLocation) async throws -> Set<Location> {
       let textDocument = testLoc.docIdentifier
       let request = ImplementationRequest(textDocument: textDocument, position: Position(testLoc))
-      let response = try await ws.testServer.send(request)
+      let response = try await ws.testClient.send(request)
       guard case .locations(let implementations) = response else {
         XCTFail("Response was not locations")
         return []

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ISDBTestSupport
+import LSPTestSupport
 import LanguageServerProtocol
 import TSCBasic
 import XCTest
@@ -23,10 +24,10 @@ final class ImplementationTests: XCTestCase {
     try ws.openDocument(ws.testLoc("a.swift").url, language: .swift)
     try ws.openDocument(ws.testLoc("b.swift").url, language: .swift)
 
-    func impls(at testLoc: TestLocation) throws -> Set<Location> {
+    func impls(at testLoc: TestLocation) async throws -> Set<Location> {
       let textDocument = testLoc.docIdentifier
       let request = ImplementationRequest(textDocument: textDocument, position: Position(testLoc))
-      let response = try ws.sk.sendSync(request)
+      let response = try await ws.testServer.send(request)
       guard case .locations(let implementations) = response else {
         XCTFail("Response was not locations")
         return []
@@ -48,31 +49,31 @@ final class ImplementationTests: XCTestCase {
       )
     }
 
-    try XCTAssertEqual(impls(at: testLoc("Protocol")), [loc("StructConformance")])
-    try XCTAssertEqual(impls(at: testLoc("ProtocolStaticVar")), [loc("StructStaticVar")])
-    try XCTAssertEqual(impls(at: testLoc("ProtocolStaticFunction")), [loc("StructStaticFunction")])
-    try XCTAssertEqual(impls(at: testLoc("ProtocolVariable")), [loc("StructVariable")])
-    try XCTAssertEqual(impls(at: testLoc("ProtocolFunction")), [loc("StructFunction")])
-    try XCTAssertEqual(impls(at: testLoc("Class")), [loc("SubclassConformance")])
-    try XCTAssertEqual(impls(at: testLoc("ClassClassVar")), [loc("SubclassClassVar")])
-    try XCTAssertEqual(impls(at: testLoc("ClassClassFunction")), [loc("SubclassClassFunction")])
-    try XCTAssertEqual(impls(at: testLoc("ClassVariable")), [loc("SubclassVariable")])
-    try XCTAssertEqual(impls(at: testLoc("ClassFunction")), [loc("SubclassFunction")])
+    try assertEqual(await impls(at: testLoc("Protocol")), [loc("StructConformance")])
+    try assertEqual(await impls(at: testLoc("ProtocolStaticVar")), [loc("StructStaticVar")])
+    try assertEqual(await impls(at: testLoc("ProtocolStaticFunction")), [loc("StructStaticFunction")])
+    try assertEqual(await impls(at: testLoc("ProtocolVariable")), [loc("StructVariable")])
+    try assertEqual(await impls(at: testLoc("ProtocolFunction")), [loc("StructFunction")])
+    try assertEqual(await impls(at: testLoc("Class")), [loc("SubclassConformance")])
+    try assertEqual(await impls(at: testLoc("ClassClassVar")), [loc("SubclassClassVar")])
+    try assertEqual(await impls(at: testLoc("ClassClassFunction")), [loc("SubclassClassFunction")])
+    try assertEqual(await impls(at: testLoc("ClassVariable")), [loc("SubclassVariable")])
+    try assertEqual(await impls(at: testLoc("ClassFunction")), [loc("SubclassFunction")])
 
-    try XCTAssertEqual(
-      impls(at: testLoc("Sepulcidae")),
+    try assertEqual(
+      await impls(at: testLoc("Sepulcidae")),
       [loc("ParapamphiliinaeConformance"), loc("XyelulinaeConformance"), loc("TrematothoracinaeConformance")]
     )
-    try XCTAssertEqual(
-      impls(at: testLoc("Parapamphiliinae")),
+    try assertEqual(
+      await impls(at: testLoc("Parapamphiliinae")),
       [loc("MicramphiliusConformance"), loc("PamparaphiliusConformance")]
     )
-    try XCTAssertEqual(impls(at: testLoc("Xyelulinae")), [loc("XyelulaConformance")])
-    try XCTAssertEqual(impls(at: testLoc("Trematothoracinae")), [])
+    try assertEqual(await impls(at: testLoc("Xyelulinae")), [loc("XyelulaConformance")])
+    try assertEqual(await impls(at: testLoc("Trematothoracinae")), [])
 
-    try XCTAssertEqual(impls(at: testLoc("Prozaiczne")), [loc("MurkwiaConformance2"), loc("SepulkaConformance1")])
-    try XCTAssertEqual(
-      impls(at: testLoc("Sepulkowate")),
+    try assertEqual(await impls(at: testLoc("Prozaiczne")), [loc("MurkwiaConformance2"), loc("SepulkaConformance1")])
+    try assertEqual(
+      await impls(at: testLoc("Sepulkowate")),
       [
         loc("MurkwiaConformance1"), loc("SepulkaConformance2"), loc("PćmaŁagodnaConformance"),
         loc("PćmaZwyczajnaConformance"),
@@ -80,13 +81,13 @@ final class ImplementationTests: XCTestCase {
     )
     // FIXME: sourcekit returns wrong locations for the function (subclasses that don't override it, and extensions that don't implement it)
     // try XCTAssertEqual(impls(at: testLoc("rozpocznijSepulenie")), [loc("MurkwiaFunc"), loc("SepulkaFunc"), loc("PćmaŁagodnaFunc"), loc("PćmaZwyczajnaFunc")])
-    try XCTAssertEqual(impls(at: testLoc("Murkwia")), [])
-    try XCTAssertEqual(impls(at: testLoc("MurkwiaFunc")), [])
-    try XCTAssertEqual(
-      impls(at: testLoc("Sepulka")),
+    try assertEqual(await impls(at: testLoc("Murkwia")), [])
+    try assertEqual(await impls(at: testLoc("MurkwiaFunc")), [])
+    try assertEqual(
+      await impls(at: testLoc("Sepulka")),
       [loc("SepulkaDwuusznaConformance"), loc("SepulkaPrzechylnaConformance")]
     )
-    try XCTAssertEqual(impls(at: testLoc("SepulkaVar")), [loc("SepulkaDwuusznaVar"), loc("SepulkaPrzechylnaVar")])
-    try XCTAssertEqual(impls(at: testLoc("SepulkaFunc")), [])
+    try assertEqual(await impls(at: testLoc("SepulkaVar")), [loc("SepulkaDwuusznaVar"), loc("SepulkaPrzechylnaVar")])
+    try assertEqual(await impls(at: testLoc("SepulkaFunc")), [])
   }
 }

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -19,47 +19,51 @@ import XCTest
 final class LocalClangTests: XCTestCase {
 
   /// Whether to fail tests if clangd cannot be found.
-  static let requireClangd: Bool = false  // Note: Swift CI doesn't build clangd on all jobs
+  ///
+  /// - Note: Swift CI doesn't build clangd on all jobs
+  private static let requireClangd: Bool = false
 
   /// Whether clangd exists in the toolchain.
-  var haveClangd: Bool = false
+  ///
+  /// - Note: Set before each test run in `setUp`.
+  private var haveClangd: Bool = false
 
-  /// Connection and lifetime management for the service.
-  var connection: TestSourceKitServer! = nil
+  /// The mock client used to communicate with the SourceKit-LSP server.
+  ///
+  /// - Note: Set before each test run in `setUp`.
+  private var testClient: TestSourceKitLSPClient! = nil
 
-  override func setUp() {
+  override func setUp() async throws {
     haveClangd = ToolchainRegistry.shared.toolchains.contains { $0.clangd != nil }
     if LocalClangTests.requireClangd && !haveClangd {
       XCTFail("cannot find clangd in toolchain")
     }
 
-    connection = TestSourceKitServer()
+    testClient = TestSourceKitLSPClient()
     let documentSymbol = TextDocumentClientCapabilities.DocumentSymbol(
       dynamicRegistration: nil,
       symbolKind: nil,
       hierarchicalDocumentSymbolSupport: true
     )
     let textDocument = TextDocumentClientCapabilities(documentSymbol: documentSymbol)
-    self.awaitTask(description: "Initialized") {
-      _ = try await self.connection.send(
-        InitializeRequest(
-          processId: nil,
-          rootPath: nil,
-          rootURI: nil,
-          initializationOptions: nil,
-          capabilities: ClientCapabilities(workspace: nil, textDocument: textDocument),
-          trace: .off,
-          workspaceFolders: nil
-        )
+    _ = try await self.testClient.send(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: textDocument),
+        trace: .off,
+        workspaceFolders: nil
       )
-    }
+    )
   }
 
   override func tearDown() {
-    connection = nil
+    testClient = nil
   }
 
-  // MARK: Tests
+  // MARK: - Tests
 
   func testSymbolInfo() async throws {
     guard haveClangd else { return }
@@ -69,7 +73,7 @@ final class LocalClangTests: XCTestCase {
     let url = URL(fileURLWithPath: "/a.cpp")
     #endif
 
-    connection.send(
+    testClient.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: DocumentURI(url),
@@ -87,7 +91,7 @@ final class LocalClangTests: XCTestCase {
     )
 
     do {
-      let resp = try await connection.send(
+      let resp = try await testClient.send(
         SymbolInfoRequest(
           textDocument: TextDocumentIdentifier(url),
           position: Position(line: 0, utf16index: 7)
@@ -103,7 +107,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try await connection.send(
+      let resp = try await testClient.send(
         SymbolInfoRequest(
           textDocument: TextDocumentIdentifier(url),
           position: Position(line: 1, utf16index: 7)
@@ -119,7 +123,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try await connection.send(
+      let resp = try await testClient.send(
         SymbolInfoRequest(
           textDocument: TextDocumentIdentifier(url),
           position: Position(line: 2, utf16index: 8)
@@ -135,7 +139,7 @@ final class LocalClangTests: XCTestCase {
     }
 
     do {
-      let resp = try await connection.send(
+      let resp = try await testClient.send(
         SymbolInfoRequest(
           textDocument: TextDocumentIdentifier(url),
           position: Position(line: 3, utf16index: 0)
@@ -154,7 +158,7 @@ final class LocalClangTests: XCTestCase {
     let url = URL(fileURLWithPath: "/a.cpp")
     #endif
 
-    connection.send(
+    testClient.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: DocumentURI(url),
@@ -171,7 +175,7 @@ final class LocalClangTests: XCTestCase {
       )
     )
 
-    let resp = try await connection.send(FoldingRangeRequest(textDocument: TextDocumentIdentifier(url)))
+    let resp = try await testClient.send(FoldingRangeRequest(textDocument: TextDocumentIdentifier(url)))
     if let resp = resp {
       XCTAssertEqual(
         resp,
@@ -191,7 +195,7 @@ final class LocalClangTests: XCTestCase {
     let url = URL(fileURLWithPath: "/a.cpp")
     #endif
 
-    connection.send(
+    testClient.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: DocumentURI(url),
@@ -208,7 +212,7 @@ final class LocalClangTests: XCTestCase {
       )
     )
 
-    guard let resp = try await connection.send(DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))) else {
+    guard let resp = try await testClient.send(DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))) else {
       XCTFail("Invalid document symbol response")
       return
     }
@@ -230,7 +234,7 @@ final class LocalClangTests: XCTestCase {
 
     try ws.openDocument(loc.url, language: .cpp)
 
-    let diagsNotification = try await ws.testServer.nextDiagnosticsNotification()
+    let diagsNotification = try await ws.testClient.nextDiagnosticsNotification()
     let diagnostics = diagsNotification.diagnostics
     // It seems we either get no diagnostics or a `-Wswitch` warning. Either is fine
     // as long as our code action works properly.
@@ -244,7 +248,7 @@ final class LocalClangTests: XCTestCase {
       context: CodeActionContext(),
       textDocument: loc.docIdentifier
     )
-    guard let reply = try await ws.testServer.send(codeAction) else {
+    guard let reply = try await ws.testClient.send(codeAction) else {
       XCTFail("CodeActionRequest had nil reply")
       return
     }
@@ -259,7 +263,7 @@ final class LocalClangTests: XCTestCase {
     XCTAssertEqual(command.command, "clangd.applyTweak")
 
     let applyEdit = XCTestExpectation(description: "applyEdit")
-    ws.testServer.handleNextRequest { (request: ApplyEditRequest) -> ApplyEditResponse in
+    ws.testClient.handleNextRequest { (request: ApplyEditRequest) -> ApplyEditResponse in
       XCTAssertNotNil(request.edit.changes)
       applyEdit.fulfill()
       return ApplyEditResponse(applied: true, failureReason: nil)
@@ -269,7 +273,7 @@ final class LocalClangTests: XCTestCase {
       command: command.command,
       arguments: command.arguments
     )
-    _ = try await ws.testServer.send(executeCommand)
+    _ = try await ws.testClient.send(executeCommand)
 
     try await fulfillmentOfOrThrow([applyEdit])
   }
@@ -282,7 +286,7 @@ final class LocalClangTests: XCTestCase {
 
     try ws.openDocument(loc.url, language: .cpp)
 
-    let diags = try await ws.testServer.nextDiagnosticsNotification()
+    let diags = try await ws.testClient.nextDiagnosticsNotification()
     // Don't use exact equality because of differences in recent clang.
     XCTAssertEqual(diags.diagnostics.count, 1)
     XCTAssertEqual(
@@ -301,7 +305,7 @@ final class LocalClangTests: XCTestCase {
 
     try ws.openDocument(loc.url, language: .objective_c)
 
-    let diags = try await ws.testServer.nextDiagnosticsNotification()
+    let diags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 0)
   }
 
@@ -314,12 +318,12 @@ final class LocalClangTests: XCTestCase {
 
     try ws.openDocument(mainLoc.url, language: .c)
 
-    let diags = try await ws.testServer.nextDiagnosticsNotification()
+    let diags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 0)
 
     let request = DocumentSemanticTokensRequest(textDocument: mainLoc.docIdentifier)
     do {
-      let reply = try await ws.testServer.send(request)
+      let reply = try await ws.testClient.send(request)
       XCTAssertNotNil(reply)
     } catch let e {
       if let error = e as? ResponseError {
@@ -340,7 +344,7 @@ final class LocalClangTests: XCTestCase {
     try ws.openDocument(cFileLoc.url, language: .cpp)
 
     // Initially the workspace should build fine.
-    let initialDiags = try await ws.testServer.nextDiagnosticsNotification()
+    let initialDiags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssert(initialDiags.diagnostics.isEmpty)
 
     // We rename Object to MyObject in the header.
@@ -352,16 +356,16 @@ final class LocalClangTests: XCTestCase {
       builder.write(headerFile, to: headerFilePath)
     }
 
-    let clangdServer = await ws.testServer.server._languageService(
+    let clangdServer = await ws.testClient.server._languageService(
       for: cFileLoc.docUri,
       .cpp,
-      in: ws.testServer.server.workspaceForDocument(uri: cFileLoc.docUri)!
+      in: ws.testClient.server.workspaceForDocument(uri: cFileLoc.docUri)!
     )!
 
     await clangdServer.documentDependenciesUpdated(cFileLoc.docUri)
 
     // Now we should get a diagnostic in main.c file because `Object` is no longer defined.
-    let editedDiags = try await ws.testServer.nextDiagnosticsNotification()
+    let editedDiags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssertFalse(editedDiags.diagnostics.isEmpty)
   }
 }

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -32,24 +32,22 @@ final class PublishDiagnosticsTests: XCTestCase {
   ///   `openDocument` and `editDocument`.
   private var version: Int!
 
-  override func setUp() {
+  override func setUp() async throws {
     version = 0
     uri = DocumentURI(URL(fileURLWithPath: "/PublishDiagnosticsTests/\(UUID()).swift"))
     testClient = TestSourceKitLSPClient()
     let documentCapabilities = TextDocumentClientCapabilities()
-    awaitTask(description: "Initialized") {
-      _ = try await self.testClient.send(
-        InitializeRequest(
-          processId: nil,
-          rootPath: nil,
-          rootURI: nil,
-          initializationOptions: nil,
-          capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
-          trace: .off,
-          workspaceFolders: nil
-        )
+    _ = try await self.testClient.send(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
+        trace: .off,
+        workspaceFolders: nil
       )
-    }
+    )
   }
 
   override func tearDown() {

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -22,16 +22,12 @@ final class SemanticTokensTests: XCTestCase {
   /// Connection and lifetime management for the service.
   private var connection: TestSourceKitServer! = nil
 
-  /// The primary interface to make requests to the SourceKitServer.
-  private var sk: TestClient! = nil
-
   private var version: Int = 0
 
   private var uri: DocumentURI!
   private var textDocument: TextDocumentIdentifier { TextDocumentIdentifier(uri) }
 
   override func tearDown() {
-    sk = nil
     connection = nil
   }
 
@@ -39,43 +35,44 @@ final class SemanticTokensTests: XCTestCase {
     version = 0
     uri = DocumentURI(URL(fileURLWithPath: "/SemanticTokensTests/\(UUID()).swift"))
     connection = TestSourceKitServer()
-    sk = connection.client
-    _ = try! sk.sendSync(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(
-          workspace: .init(
-            semanticTokens: .init(
-              refreshSupport: true
+    awaitTask(description: "Initialize") {
+      _ = try await self.connection.send(
+        InitializeRequest(
+          processId: nil,
+          rootPath: nil,
+          rootURI: nil,
+          initializationOptions: nil,
+          capabilities: ClientCapabilities(
+            workspace: .init(
+              semanticTokens: .init(
+                refreshSupport: true
+              )
+            ),
+            textDocument: .init(
+              semanticTokens: .init(
+                dynamicRegistration: true,
+                requests: .init(
+                  range: .bool(true),
+                  full: .bool(true)
+                ),
+                tokenTypes: Token.Kind.allCases.map(\._lspName),
+                tokenModifiers: Token.Modifiers.allModifiers.map { $0._lspName! },
+                formats: [.relative]
+              )
             )
           ),
-          textDocument: .init(
-            semanticTokens: .init(
-              dynamicRegistration: true,
-              requests: .init(
-                range: .bool(true),
-                full: .bool(true)
-              ),
-              tokenTypes: Token.Kind.allCases.map(\._lspName),
-              tokenModifiers: Token.Modifiers.allModifiers.map { $0._lspName! },
-              formats: [.relative]
-            )
-          )
-        ),
-        trace: .off,
-        workspaceFolders: nil
+          trace: .off,
+          workspaceFolders: nil
+        )
       )
-    )
+    }
   }
 
   private func expectSemanticTokensRefresh() -> XCTestExpectation {
     let refreshExpectation = expectation(description: "\(#function) - refresh received")
-    sk.appendOneShotRequestHandler { (req: Request<WorkspaceSemanticTokensRefreshRequest>) in
-      req.reply(VoidResponse())
+    connection.handleNextRequest { (req: WorkspaceSemanticTokensRefreshRequest) -> VoidResponse in
       refreshExpectation.fulfill()
+      return VoidResponse()
     }
     return refreshExpectation
   }
@@ -84,22 +81,21 @@ final class SemanticTokensTests: XCTestCase {
     // We will wait for the server to dynamically register semantic tokens
 
     let registerCapabilityExpectation = expectation(description: "\(#function) - register semantic tokens capability")
-    sk.appendOneShotRequestHandler { (req: Request<RegisterCapabilityRequest>) in
-      let registrations = req.params.registrations
+    connection.handleNextRequest { (req: RegisterCapabilityRequest) -> VoidResponse in
       XCTAssert(
-        registrations.contains { reg in
+        req.registrations.contains { reg in
           reg.method == SemanticTokensRegistrationOptions.method
         }
       )
-      req.reply(VoidResponse())
       registerCapabilityExpectation.fulfill()
+      return VoidResponse()
     }
 
     // We will wait for the first refresh request to make sure that the semantic tokens are ready
 
     let refreshExpectation = expectSemanticTokensRefresh()
 
-    sk.send(
+    connection.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: uri,
@@ -124,7 +120,7 @@ final class SemanticTokensTests: XCTestCase {
       expectations.append(expectSemanticTokensRefresh())
     }
 
-    sk.send(
+    connection.send(
       DidChangeTextDocumentNotification(
         textDocument: VersionedTextDocumentIdentifier(
           uri,
@@ -150,21 +146,24 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  private func performSemanticTokensRequest(range: Range<Position>? = nil) throws -> [Token] {
+  private func performSemanticTokensRequest(range: Range<Position>? = nil) async throws -> [Token] {
     let response: DocumentSemanticTokensResponse!
 
     if let range = range {
-      response = try sk.sendSync(DocumentSemanticTokensRangeRequest(textDocument: textDocument, range: range))
+      response = try await connection.send(DocumentSemanticTokensRangeRequest(textDocument: textDocument, range: range))
     } else {
-      response = try sk.sendSync(DocumentSemanticTokensRequest(textDocument: textDocument))
+      response = try await connection.send(DocumentSemanticTokensRequest(textDocument: textDocument))
     }
 
     return [Token](lspEncodedTokens: response.data)
   }
 
-  private func openAndPerformSemanticTokensRequest(text: String, range: Range<Position>? = nil) throws -> [Token] {
+  private func openAndPerformSemanticTokensRequest(
+    text: String,
+    range: Range<Position>? = nil
+  ) async throws -> [Token] {
     openDocument(text: text)
-    return try performSemanticTokensRequest(range: range)
+    return try await performSemanticTokensRequest(range: range)
   }
 
   func testIntArrayCoding() {
@@ -215,7 +214,7 @@ final class SemanticTokensTests: XCTestCase {
       """
     openDocument(text: text)
 
-    guard let snapshot = await connection.server?._documentManager.latestSnapshot(uri) else {
+    guard let snapshot = await connection.server._documentManager.latestSnapshot(uri) else {
       fatalError("Could not fetch document snapshot for \(#function)")
     }
 
@@ -241,13 +240,13 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testEmpty() throws {
+  func testEmpty() async throws {
     let text = ""
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(tokens, [])
   }
 
-  func testRanged() throws {
+  func testRanged() async throws {
     let text = """
       let x = 1
       let test = 20
@@ -256,7 +255,7 @@ final class SemanticTokensTests: XCTestCase {
       """
     let start = Position(line: 1, utf16index: 0)
     let end = Position(line: 2, utf16index: 5)
-    let tokens = try openAndPerformSemanticTokensRequest(text: text, range: start..<end)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text, range: start..<end)
     XCTAssertEqual(
       tokens,
       [
@@ -269,13 +268,13 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testLexicalTokens() throws {
+  func testLexicalTokens() async throws {
     let text = """
       let x = 3
       var y = "test"
       /* abc */ // 123
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -294,13 +293,13 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testLexicalTokensForMultiLineComments() throws {
+  func testLexicalTokensForMultiLineComments() async throws {
     let text = """
       let x = 3 /*
       let x = 12
       */
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -315,12 +314,12 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testLexicalTokensForDocComments() throws {
+  func testLexicalTokensForDocComments() async throws {
     let text = """
       /** abc */
         /// def
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -330,14 +329,14 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testLexicalTokensForBackticks() throws {
+  func testLexicalTokensForBackticks() async throws {
     let text = """
       var `if` = 20
       let `else` = 3
       let `onLeft = ()
       let onRight` = ()
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -359,7 +358,7 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testSemanticTokens() throws {
+  func testSemanticTokens() async throws {
     let text = """
       struct X {}
 
@@ -372,7 +371,7 @@ final class SemanticTokensTests: XCTestCase {
       a()
       b()
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -403,7 +402,7 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testSemanticTokensForProtocols() throws {
+  func testSemanticTokensForProtocols() async throws {
     let text = """
       protocol X {}
       class Y: X {}
@@ -412,7 +411,7 @@ final class SemanticTokensTests: XCTestCase {
 
       func f<T: X>() {}
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -437,9 +436,9 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testSemanticTokensForFunctionSignatures() throws {
+  func testSemanticTokensForFunctionSignatures() async throws {
     let text = "func f(x: Int, _ y: String) {}"
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -453,9 +452,9 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testSemanticTokensForFunctionSignaturesWithEmoji() throws {
+  func testSemanticTokensForFunctionSignaturesWithEmoji() async throws {
     let text = "func x👍y() {}"
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -465,7 +464,7 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testSemanticTokensForStaticMethods() throws {
+  func testSemanticTokensForStaticMethods() async throws {
     let text = """
       class X {
         deinit {}
@@ -475,7 +474,7 @@ final class SemanticTokensTests: XCTestCase {
       X.f()
       X.g()
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -502,7 +501,7 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testSemanticTokensForEnumMembers() throws {
+  func testSemanticTokensForEnumMembers() async throws {
     let text = """
       enum Maybe<T> {
         case none
@@ -512,7 +511,7 @@ final class SemanticTokensTests: XCTestCase {
       let x = Maybe<String>.none
       let y: Maybe = .some(42)
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -543,11 +542,11 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testRegexSemanticTokens() throws {
+  func testRegexSemanticTokens() async throws {
     let text = """
       let r = /a[bc]*/
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -558,11 +557,11 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testOperatorDeclaration() throws {
+  func testOperatorDeclaration() async throws {
     let text = """
       infix operator ?= :ComparisonPrecedence
       """
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [
@@ -574,29 +573,29 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testEmptyEdit() throws {
+  func testEmptyEdit() async throws {
     let text = """
       let x: String = "test"
       var y = 123
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
 
     let pos = Position(line: 0, utf16index: 1)
     editDocument(range: pos..<pos, text: "", expectRefresh: false)
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     XCTAssertEqual(before, after)
   }
 
-  func testReplaceUntilMiddleOfToken() throws {
+  func testReplaceUntilMiddleOfToken() async throws {
     let text = """
       var test = 4567
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     let expectedLeading = [
       Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
       Token(line: 0, utf16index: 4, length: 4, kind: .identifier),
@@ -612,7 +611,7 @@ final class SemanticTokensTests: XCTestCase {
     let end = Position(line: 0, utf16index: 13)
     editDocument(range: start..<end, text: " 1")
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     XCTAssertEqual(
       after,
       expectedLeading + [
@@ -621,13 +620,13 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testReplaceUntilEndOfToken() throws {
+  func testReplaceUntilEndOfToken() async throws {
     let text = """
       fatalError("xyz")
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     XCTAssertEqual(
       before,
       [
@@ -640,7 +639,7 @@ final class SemanticTokensTests: XCTestCase {
     let end = Position(line: 0, utf16index: 16)
     editDocument(range: start..<end, text: "(\"test\"")
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     XCTAssertEqual(
       after,
       [
@@ -650,7 +649,7 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testInsertSpaceBeforeToken() throws {
+  func testInsertSpaceBeforeToken() async throws {
     let text = """
       let x: String = "test"
       """
@@ -662,14 +661,14 @@ final class SemanticTokensTests: XCTestCase {
       SyntaxHighlightingToken(line: 0, utf16index: 7, length: 6, kind: .struct, modifiers: [.defaultLibrary]),
       SyntaxHighlightingToken(line: 0, utf16index: 16, length: 6, kind: .string),
     ]
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     XCTAssertEqual(before, expectedBefore)
 
     let pos = Position(line: 0, utf16index: 0)
     let editText = " "
     editDocument(range: pos..<pos, text: editText, expectRefresh: false)
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     let expectedAfter = [
       SyntaxHighlightingToken(line: 0, utf16index: 1, length: 3, kind: .keyword),
       SyntaxHighlightingToken(line: 0, utf16index: 5, length: 1, kind: .identifier),
@@ -679,23 +678,23 @@ final class SemanticTokensTests: XCTestCase {
     XCTAssertEqual(after, expectedAfter)
   }
 
-  func testInsertSpaceAfterToken() throws {
+  func testInsertSpaceAfterToken() async throws {
     let text = """
       var x = 0
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
 
     let pos = Position(line: 0, utf16index: 9)
     let editText = " "
     editDocument(range: pos..<pos, text: editText, expectRefresh: false)
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     XCTAssertEqual(before, after)
   }
 
-  func testInsertNewline() throws {
+  func testInsertNewline() async throws {
     let text = """
       fatalError("123")
       """
@@ -705,13 +704,13 @@ final class SemanticTokensTests: XCTestCase {
       SyntaxHighlightingToken(line: 0, utf16index: 0, length: 10, kind: .function, modifiers: [.defaultLibrary]),
       SyntaxHighlightingToken(line: 0, utf16index: 11, length: 5, kind: .string),
     ]
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     XCTAssertEqual(before, expectedBefore)
 
     let pos = Position(line: 0, utf16index: 0)
     editDocument(range: pos..<pos, text: "\n", expectRefresh: false)
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     let expectedAfter = [
       SyntaxHighlightingToken(line: 1, utf16index: 0, length: 10, kind: .function, modifiers: [.defaultLibrary]),
       SyntaxHighlightingToken(line: 1, utf16index: 11, length: 5, kind: .string),
@@ -719,14 +718,14 @@ final class SemanticTokensTests: XCTestCase {
     XCTAssertEqual(after, expectedAfter)
   }
 
-  func testRemoveNewline() throws {
+  func testRemoveNewline() async throws {
     let text = """
       let x =
               "abc"
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     let expectedBefore = [
       Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
       Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
@@ -738,7 +737,7 @@ final class SemanticTokensTests: XCTestCase {
     let end = Position(line: 1, utf16index: 7)
     editDocument(range: start..<end, text: "", expectRefresh: false)
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     let expectedAfter = [
       Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
       Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
@@ -747,14 +746,14 @@ final class SemanticTokensTests: XCTestCase {
     XCTAssertEqual(after, expectedAfter)
   }
 
-  func testInsertTokens() throws {
+  func testInsertTokens() async throws {
     let text = """
       let x =
               "abc"
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     let expectedBefore = [
       Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
       Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
@@ -766,7 +765,7 @@ final class SemanticTokensTests: XCTestCase {
     let end = Position(line: 1, utf16index: 7)
     editDocument(range: start..<end, text: " \"test\" +", expectRefresh: true)
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     let expectedAfter: [Token] = [
       Token(line: 0, utf16index: 0, length: 3, kind: .keyword),
       Token(line: 0, utf16index: 4, length: 1, kind: .identifier),
@@ -777,14 +776,14 @@ final class SemanticTokensTests: XCTestCase {
     XCTAssertEqual(after, expectedAfter)
   }
 
-  func testSemanticMultiEdit() throws {
+  func testSemanticMultiEdit() async throws {
     let text = """
       let x = "abc"
       let y = x
       """
     openDocument(text: text)
 
-    let before = try performSemanticTokensRequest()
+    let before = try await performSemanticTokensRequest()
     XCTAssertEqual(
       before,
       [
@@ -812,7 +811,7 @@ final class SemanticTokensTests: XCTestCase {
       expectRefresh: true
     )
 
-    let after = try performSemanticTokensRequest()
+    let after = try await performSemanticTokensRequest()
     XCTAssertEqual(
       after,
       [
@@ -826,7 +825,7 @@ final class SemanticTokensTests: XCTestCase {
     )
   }
 
-  func testActor() throws {
+  func testActor() async throws {
     let text = """
       actor MyActor {}
 
@@ -838,7 +837,7 @@ final class SemanticTokensTests: XCTestCase {
       ) {}
       """
 
-    let tokens = try openAndPerformSemanticTokensRequest(text: text)
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
     XCTAssertEqual(
       tokens,
       [

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -22,39 +22,11 @@ public typealias URL = Foundation.URL
 
 final class SKTests: XCTestCase {
 
-  func testInitLocal() throws {
+  func testInitLocal() async throws {
     let c = TestSourceKitServer()
     defer { withExtendedLifetime(c) {} }  // Keep connection alive for callbacks.
 
-    let sk = c.client
-
-    let initResult = try sk.sendSync(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
-
-    guard case .options(let syncOptions) = initResult.capabilities.textDocumentSync else {
-      XCTFail("Unexpected textDocumentSync property")
-      return
-    }
-    XCTAssertEqual(syncOptions.openClose, true)
-    XCTAssertNotNil(initResult.capabilities.completionProvider)
-  }
-
-  func testInitJSON() throws {
-    let c = TestSourceKitServer(connectionKind: .jsonrpc)
-    defer { withExtendedLifetime(c) {} }  // Keep connection alive for callbacks.
-
-    let sk = c.client
-
-    let initResult = try sk.sendSync(
+    let initResult = try await c.send(
       InitializeRequest(
         processId: nil,
         rootPath: nil,
@@ -87,7 +59,7 @@ final class SKTests: XCTestCase {
 
     // MARK: Jump to definition
 
-    let response = try ws.sk.sendSync(
+    let response = try await ws.testServer.send(
       DefinitionRequest(
         textDocument: locRef.docIdentifier,
         position: locRef.position
@@ -104,7 +76,7 @@ final class SKTests: XCTestCase {
 
     // MARK: Find references
 
-    let refs = try ws.sk.sendSync(
+    let refs = try await ws.testServer.send(
       ReferencesRequest(
         textDocument: locDef.docIdentifier,
         position: locDef.position,
@@ -171,7 +143,7 @@ final class SKTests: XCTestCase {
       let locDef = ws.testLoc("aaa:def")
       let locRef = ws.testLoc("aaa:call:c")
       try ws.openDocument(locRef.url, language: .swift)
-      let response = try ws.sk.sendSync(
+      let response = try await ws.testServer.send(
         DefinitionRequest(
           textDocument: locRef.docIdentifier,
           position: locRef.position
@@ -195,9 +167,7 @@ final class SKTests: XCTestCase {
       XCTAssertEqual(versionContentsBefore.count, 1)
       XCTAssert(versionContentsBefore.first?.lastPathComponent.starts(with: "p") ?? false)
 
-      try withExtendedLifetime(ws) {
-        _ = try ws.sk.sendSync(ShutdownRequest())
-      }
+      _ = try await ws.testServer.send(ShutdownRequest())
       return versionedPath
     }
 
@@ -217,11 +187,9 @@ final class SKTests: XCTestCase {
     let loc = ws.testLoc("cc:A")
     try ws.openDocument(loc.url, language: .swift)
 
-    let results = try withExtendedLifetime(ws) {
-      try ws.sk.sendSync(
-        CompletionRequest(textDocument: loc.docIdentifier, position: loc.position)
-      )
-    }
+    let results = try await ws.testServer.send(
+      CompletionRequest(textDocument: loc.docIdentifier, position: loc.position)
+    )
 
     XCTAssertEqual(
       results.items,
@@ -262,69 +230,43 @@ final class SKTests: XCTestCase {
   func testDependenciesUpdatedSwiftTibs() async throws {
     guard let ws = try await mutableSourceKitTibsTestWorkspace(name: "SwiftModules") else { return }
     defer { withExtendedLifetime(ws) {} }  // Keep workspace alive for callbacks.
-    guard let server = ws.testServer.server else {
-      XCTFail("Unable to fetch SourceKitServer to notify for build system events.")
-      return
-    }
 
     let moduleRef = ws.testLoc("aaa:call:c")
-    let startExpectation = XCTestExpectation(description: "initial diagnostics")
-    startExpectation.expectedFulfillmentCount = 2
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis: no errors expected here.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      startExpectation.fulfill()
-    }
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis: expect module import error.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      if let diagnostic = note.params.diagnostics.first {
-        XCTAssert(
-          diagnostic.message.contains("no such module"),
-          "expected module import error but found \"\(diagnostic.message)\""
-        )
-      }
-      startExpectation.fulfill()
-    }
 
     try ws.openDocument(moduleRef.url, language: .swift)
-    try await fulfillmentOfOrThrow([startExpectation])
+
+    let initialSyntacticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    // Semantic analysis: no errors expected here.
+    XCTAssertEqual(initialSyntacticDiags.diagnostics.count, 0)
+
+    let initialSemanticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    // Semantic analysis: expect module import error.
+    XCTAssertEqual(initialSemanticDiags.diagnostics.count, 1)
+    if let diagnostic = initialSemanticDiags.diagnostics.first {
+      XCTAssert(
+        diagnostic.message.contains("no such module"),
+        "expected module import error but found \"\(diagnostic.message)\""
+      )
+    }
 
     try ws.buildAndIndex()
 
-    let finishExpectation = XCTestExpectation(description: "post-build diagnostics")
-    finishExpectation.expectedFulfillmentCount = 2
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis - SourceKit currently caches diagnostics so we still see an error.
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      finishExpectation.fulfill()
-    }
-    ws.sk.appendOneShotNotificationHandler { (note: Notification<PublishDiagnosticsNotification>) in
-      // Semantic analysis: no more errors expected, import should resolve since we built.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      finishExpectation.fulfill()
-    }
-    await server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
+    await ws.testServer.server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
-    try await fulfillmentOfOrThrow([finishExpectation])
+    let updatedSyntacticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    // Semantic analysis - SourceKit currently caches diagnostics so we still see an error.
+    XCTAssertEqual(updatedSyntacticDiags.diagnostics.count, 1)
+
+    let updatedSemanticDiags = try await ws.testServer.nextDiagnosticsNotification()
+    // Semantic analysis: no more errors expected, import should resolve since we built.
+    XCTAssertEqual(updatedSemanticDiags.diagnostics.count, 0)
   }
 
   func testDependenciesUpdatedCXXTibs() async throws {
     guard let ws = try await mutableSourceKitTibsTestWorkspace(name: "GeneratedHeader") else { return }
     defer { withExtendedLifetime(ws) {} }  // Keep workspace alive for callbacks.
-    guard let server = ws.testServer.server else {
-      XCTFail("Unable to fetch SourceKitServer to notify for build system events.")
-      return
-    }
 
     let moduleRef = ws.testLoc("libX:call:main")
-    let startExpectation = XCTestExpectation(description: "initial diagnostics")
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // Expect one error:
-      // - Implicit declaration of function invalid
-      XCTAssertEqual(note.params.diagnostics.count, 1)
-      startExpectation.fulfill()
-    }
 
     let generatedHeaderURL = moduleRef.url.deletingLastPathComponent()
       .appendingPathComponent("lib-generated.h", isDirectory: false)
@@ -333,23 +275,23 @@ final class SKTests: XCTestCase {
     // files without a recently upstreamed extension.
     try "".write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
     try ws.openDocument(moduleRef.url, language: .c)
-    try await fulfillmentOfOrThrow([startExpectation])
+
+    let openDiags = try await ws.testServer.nextDiagnosticsNotification()
+    // Expect one error:
+    // - Implicit declaration of function invalid
+    XCTAssertEqual(openDiags.diagnostics.count, 1)
 
     // Update the header file to have the proper contents for our code to build.
     let contents = "int libX(int value);"
     try contents.write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
     try ws.buildAndIndex()
 
-    let finishExpectation = XCTestExpectation(description: "post-build diagnostics")
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      // No more errors expected, import should resolve since we the generated header file
-      // now has the proper contents.
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      finishExpectation.fulfill()
-    }
-    await server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
+    await ws.testServer.server.filesDependenciesUpdated([DocumentURI(moduleRef.url)])
 
-    try await fulfillmentOfOrThrow([finishExpectation])
+    let updatedDiags = try await ws.testServer.nextDiagnosticsNotification()
+    // No more errors expected, import should resolve since we the generated header file
+    // now has the proper contents.
+    XCTAssertEqual(updatedDiags.diagnostics.count, 0)
   }
 
   func testClangdGoToInclude() async throws {
@@ -367,7 +309,7 @@ final class SKTests: XCTestCase {
       textDocument: mainLoc.docIdentifier,
       position: includePosition
     )
-    let resp = try withExtendedLifetime(ws) { try ws.sk.sendSync(goToInclude) }
+    let resp = try await ws.testServer.send(goToInclude)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-#include")
     switch locationsOrLinks {
@@ -398,7 +340,7 @@ final class SKTests: XCTestCase {
       textDocument: refLoc.docIdentifier,
       position: refPos
     )
-    let resp = try withExtendedLifetime(ws) { try ws.sk.sendSync(goToDefinition) }
+    let resp = try await ws.testServer.send(goToDefinition)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-definition")
     switch locationsOrLinks {
@@ -430,7 +372,7 @@ final class SKTests: XCTestCase {
       textDocument: mainLoc.docIdentifier,
       position: includePosition
     )
-    let resp = try ws.sk.sendSync(goToInclude)
+    let resp = try await ws.testServer.send(goToInclude)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-declaration")
     switch locationsOrLinks {

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -27,36 +27,34 @@ final class SwiftInterfaceTests: XCTestCase {
   /// - Note: Set before each test run in `setUp`.
   private var testClient: TestSourceKitLSPClient! = nil
 
-  override func setUp() {
+  override func setUp() async throws {
     // This is the only test that references modules from the SDK (Foundation).
     // `testSystemModuleInterface` has been flaky for a long while and a
     // hypothesis is that it was failing because of a malformed global module
     // cache that might still be present from previous CI runs. If we use a
     // local module cache, we define away that source of bugs.
     testClient = TestSourceKitLSPClient(useGlobalModuleCache: false)
-    awaitTask(description: "Initialize") {
-      _ = try await testClient.send(
-        InitializeRequest(
-          processId: nil,
-          rootPath: nil,
-          rootURI: nil,
-          initializationOptions: nil,
-          capabilities: ClientCapabilities(
-            workspace: nil,
-            textDocument: TextDocumentClientCapabilities(
-              codeAction: .init(
-                codeActionLiteralSupport: .init(
-                  codeActionKind: .init(valueSet: [.quickFix])
-                )
-              ),
-              publishDiagnostics: .init(codeDescriptionSupport: true)
-            )
-          ),
-          trace: .off,
-          workspaceFolders: nil
-        )
+    _ = try await testClient.send(
+      InitializeRequest(
+        processId: nil,
+        rootPath: nil,
+        rootURI: nil,
+        initializationOptions: nil,
+        capabilities: ClientCapabilities(
+          workspace: nil,
+          textDocument: TextDocumentClientCapabilities(
+            codeAction: .init(
+              codeActionLiteralSupport: .init(
+                codeActionKind: .init(valueSet: [.quickFix])
+              )
+            ),
+            publishDiagnostics: .init(codeDescriptionSupport: true)
+          )
+        ),
+        trace: .off,
+        workspaceFolders: nil
       )
-    }
+    )
   }
 
   override func tearDown() {

--- a/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
@@ -27,7 +27,7 @@ final class TypeHierarchyTests: XCTestCase {
     func typeHierarchy(at testLoc: TestLocation) async throws -> [TypeHierarchyItem] {
       let textDocument = testLoc.docIdentifier
       let request = TypeHierarchyPrepareRequest(textDocument: textDocument, position: Position(testLoc))
-      let items = try await ws.testServer.send(request)
+      let items = try await ws.testClient.send(request)
       return items ?? []
     }
 
@@ -37,7 +37,7 @@ final class TypeHierarchyTests: XCTestCase {
         return []
       }
       let request = TypeHierarchySupertypesRequest(item: item)
-      let types = try await ws.testServer.send(request)
+      let types = try await ws.testClient.send(request)
       return types ?? []
     }
 
@@ -47,7 +47,7 @@ final class TypeHierarchyTests: XCTestCase {
         return []
       }
       let request = TypeHierarchySubtypesRequest(item: item)
-      let types = try await ws.testServer.send(request)
+      let types = try await ws.testClient.send(request)
       return types ?? []
     }
 

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -36,9 +36,9 @@ final class WorkspaceTests: XCTestCase {
 
     try ws.openDocument(call.url, language: .swift)
 
-    let completions = try withExtendedLifetime(ws) {
-      try ws.sk.sendSync(CompletionRequest(textDocument: call.docIdentifier, position: call.position))
-    }
+    let completions = try await ws.testServer.send(
+      CompletionRequest(textDocument: call.docIdentifier, position: call.position)
+    )
 
     XCTAssertEqual(
       completions.items,
@@ -74,9 +74,9 @@ final class WorkspaceTests: XCTestCase {
 
     try ws.openDocument(otherCall.url, language: .swift)
 
-    let otherCompletions = try withExtendedLifetime(ws) {
-      try ws.sk.sendSync(CompletionRequest(textDocument: otherCall.docIdentifier, position: otherCall.position))
-    }
+    let otherCompletions = try await ws.testServer.send(
+      CompletionRequest(textDocument: otherCall.docIdentifier, position: otherCall.position)
+    )
 
     XCTAssertEqual(
       otherCompletions.items,
@@ -121,16 +121,10 @@ final class WorkspaceTests: XCTestCase {
 
     let loc = ws.testLoc("main_file")
 
-    let expectation = self.expectation(description: "diagnostics")
-
-    ws.sk.handleNextNotification { (note: Notification<PublishDiagnosticsNotification>) in
-      XCTAssertEqual(note.params.diagnostics.count, 0)
-      expectation.fulfill()
-    }
-
     try ws.openDocument(loc.url, language: .objective_c)
 
-    try await fulfillmentOfOrThrow([expectation])
+    let diags = try await ws.testServer.nextDiagnosticsNotification()
+    XCTAssertEqual(diags.diagnostics.count, 0)
 
     let otherWs = try await staticSourceKitTibsWorkspace(
       name: "ClangCrashRecoveryBuildSettings",
@@ -152,7 +146,7 @@ final class WorkspaceTests: XCTestCase {
       textDocument: otherLoc.docIdentifier,
       position: Position(line: 9, utf16index: 3)
     )
-    let highlightResponse = try otherWs.sk.sendSync(highlightRequest)
+    let highlightResponse = try await otherWs.testServer.send(highlightRequest)
     XCTAssertEqual(highlightResponse, expectedHighlightResponse)
   }
 
@@ -177,7 +171,7 @@ final class WorkspaceTests: XCTestCase {
     // to OtherSwiftPMPackage by default (because it provides fallback build
     // settings for it).
     assertEqual(
-      await ws.testServer.server!.workspaceForDocument(uri: otherLib.docUri)?.rootUri,
+      await ws.testServer.server.workspaceForDocument(uri: otherLib.docUri)?.rootUri,
       DocumentURI(otherWs.sources.rootDirectory)
     )
 
@@ -200,7 +194,7 @@ final class WorkspaceTests: XCTestCase {
       builder.write(packageManifestContents, to: packageManifest)
     }
 
-    ws.sk.send(
+    ws.testServer.send(
       DidChangeWatchedFilesNotification(changes: [
         FileEvent(uri: packageTargets.docUri, type: .changed)
       ])
@@ -215,7 +209,7 @@ final class WorkspaceTests: XCTestCase {
 
     // Updating the build settings takes a few seconds. Send code completion requests every second until we receive correct results.
     for _ in 0..<30 {
-      if await ws.testServer.server!.workspaceForDocument(uri: otherLib.docUri)?.rootUri
+      if await ws.testServer.server.workspaceForDocument(uri: otherLib.docUri)?.rootUri
         == DocumentURI(ws.sources.rootDirectory)
       {
         didReceiveCorrectWorkspaceMembership = true
@@ -237,19 +231,9 @@ final class WorkspaceTests: XCTestCase {
     try ws.openDocument(swiftLoc.url, language: .swift)
     try ws.openDocument(cLoc.url, language: .c)
 
-    let receivedResponse = self.expectation(description: "Received completion response")
-
-    _ = ws.sk.send(CompletionRequest(textDocument: cLoc.docIdentifier, position: cLoc.position)) { result in
-      defer {
-        receivedResponse.fulfill()
-      }
-      guard case .success(_) = result else {
-        XCTFail("Expected a successful response")
-        return
-      }
+    await assertNoThrow {
+      _ = try await ws.testServer.send(CompletionRequest(textDocument: cLoc.docIdentifier, position: cLoc.position))
     }
-
-    try await fulfillmentOfOrThrow([receivedResponse])
   }
 
   func testChangeWorkspaceFolders() async throws {
@@ -265,9 +249,8 @@ final class WorkspaceTests: XCTestCase {
 
     let otherPackLoc = ws.testLoc("otherPackage:call")
 
-    let testServer = TestSourceKitServer(connectionKind: .local)
-    let sk = testServer.client
-    _ = try sk.sendSync(
+    let testServer = TestSourceKitServer()
+    _ = try await testServer.send(
       InitializeRequest(
         rootURI: nil,
         capabilities: ClientCapabilities(workspace: .init(workspaceFolders: true)),
@@ -279,7 +262,7 @@ final class WorkspaceTests: XCTestCase {
 
     let docString = try String(data: Data(contentsOf: otherPackLoc.url), encoding: .utf8)!
 
-    sk.send(
+    testServer.send(
       DidOpenTextDocumentNotification(
         textDocument: TextDocumentItem(
           uri: otherPackLoc.docUri,
@@ -290,7 +273,7 @@ final class WorkspaceTests: XCTestCase {
       )
     )
 
-    let preChangeWorkspaceResponse = try sk.sendSync(
+    let preChangeWorkspaceResponse = try await testServer.send(
       CompletionRequest(
         textDocument: TextDocumentIdentifier(otherPackLoc.docUri),
         position: otherPackLoc.position
@@ -303,7 +286,7 @@ final class WorkspaceTests: XCTestCase {
       "Did not expect to receive cross-module code completion results if we opened the parent directory of the package"
     )
 
-    sk.send(
+    testServer.send(
       DidChangeWorkspaceFoldersNotification(
         event: WorkspaceFoldersChangeEvent(added: [
           WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory))
@@ -311,7 +294,7 @@ final class WorkspaceTests: XCTestCase {
       )
     )
 
-    let postChangeWorkspaceResponse = try sk.sendSync(
+    let postChangeWorkspaceResponse = try await testServer.send(
       CompletionRequest(
         textDocument: TextDocumentIdentifier(otherPackLoc.docUri),
         position: otherPackLoc.position


### PR DESCRIPTION
Apologies for the large diff but all the changes are fairly straightforward and intertwined so it doesn’t make too much sense to split them up. 

The goal of this PR is to simplify the API of `TestSourceKitServer`

- Send requests and notifications to `SourceKitServer` by directly calling into `SourceKitServer.handle` instead of going through a `Connection`. This makes the code a lot easier to understand statically
- Make `TestSourceKitServer` conform to `MessageHandler` instead of going through `TestClient`
  - IMO this centralizes all the handling and makes it a lot easier to follow. `TestClient` didn’t do a whole bunch anyway.
- Change `sendSync` function that sends a request and returns the result to be `async`
- Allow async awaiting of next notifications instead of having to register a `handleNextNotification` handler before expecting the notification to be emitted.
  - This allows us to remove quite a few `XCTExpectation`s in test cases
- Remove the JSONRPC connection kind between `TestSourceKitServer` and `SourceKitServer`
  - It wasn’t actually used and the connection abstraction just made things more complicated than they needed to be
- And finally rename `TestSourceKitServer` to `TestSourceKitClient` because really, it’s mocking an LSP client and isn’t modeling a server.

While doing this refactoring, I discovered a race condition where two code completion requests could be executed concurrently, causing conflicts because `sourcekitd` only has a single, global code completion session. I hot-fixed this for now by making code completion requests barriers in the message handling queue. The real fix is https://github.com/apple/sourcekit-lsp/pull/899.