### PR TITLE
Add more fine grained dependency tracking to `AsyncQueue`

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -58,7 +58,7 @@ public actor BuildServerBuildSystem: MessageHandler {
   /// This ensures that messages from the build server are handled in the order
   /// they were received. Swift concurrency does not guarentee in-order
   /// execution of tasks.
-  public let bspMessageHandlingQueue = AsyncQueue(.serial)
+  public let bspMessageHandlingQueue = AsyncQueue<Serial>()
 
   let searchPaths: [AbsolutePath]
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -49,7 +49,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// Since we are blindly forwarding requests from clangd to the editor, we
   /// cannot allow concurrent requests. This should be fine since the number of
   /// requests and notifications sent from clangd to the client is quite small.
-  public let clangdMessageHandlingQueue = AsyncQueue(.serial)
+  public let clangdMessageHandlingQueue = AsyncQueue<Serial>()
 
   /// The ``SourceKitServer`` instance that created this `ClangLanguageServerShim`.
   ///

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -40,7 +40,7 @@ class CodeCompletionSession {
   /// But it's rare to open multiple sourcekitd instances simultaneously and
   /// even rarer to interact with them at the same time, so we have a global
   /// queue for now to simplify the implementation.
-  private static let completionQueue = AsyncQueue(.serial)
+  private static let completionQueue = AsyncQueue<Serial>()
 
   /// The code completion session for each sourcekitd instance.
   ///

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -94,7 +94,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
 
   /// Queue on which notifications from sourcekitd are handled to ensure we are
   /// handling them in-order.
-  let sourcekitdNotificationHandlingQueue = AsyncQueue(.serial)
+  let sourcekitdNotificationHandlingQueue = AsyncQueue<Serial>()
 
   let capabilityRegistry: CapabilityRegistry
 


### PR DESCRIPTION
Instead of just having barriers and non-barriers, this allows `AsyncQueue` to track dependencies between tasks at a more fine-grained level.

For example, we can now specify that requests that affect one document only depend on edits to that same document and are not blocked by edits to any other document. As a consequence, a busy `sourcekitd` will not block requests from `clangd` to be executed and vice versa.


Resolves #875
rdar://116705652