### PR TITLE
Bump swift-crypto to 3.0.0 in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -270,7 +270,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: relatedDependenciesBranch),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
     .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
To address the error
```
Dependencies could not be resolved because root depends on 'swift-crypto' 2.5.0..<3.0.0 and 'swift-package-manager' 
depends on 'swift-crypto' 3.0.0..<3.1.0. 
```
related issue: https://github.com/apple/sourcekit-lsp/issues/903