### PR TITLE
Use NonDarwinLogger when running tests instead of os_log

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -22,7 +22,7 @@ import Foundation
 /// The subsystem that should be used for any logging by default.
 public let subsystem = "org.swift.sourcekit-lsp"
 
-#if canImport(os)
+#if canImport(os) && !SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
 import os  // os_log
 
 public typealias LogLevel = os.OSLogType

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -202,6 +202,16 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
+    # 'swift test' doesn't print os_log output to the command line. Use the 
+    # `NonDarwinLogger` that prints to stderr so we can view the log output in CI test 
+    # runs.
+    additional_env['SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER'] = '1'
+
+    # CI doesn't contain any sensitive information. Log everything.
+    additional_env['SOURCEKITLSP_LOG_PRIVACY_LEVEL'] = 'sensitive'
+
+    # Log with the highest log level to simplify debugging of CI failures.
+    additional_env['SOURCEKITLSP_LOG_LEVEL'] = 'debug'
 
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, additional_env=additional_env)
     tests = os.path.join(bin_path, 'sk-tests')


### PR DESCRIPTION
'swift test' doesn't print os_log output to the command line. Use the  `NonDarwinLogger` that prints to stderr so we can view the log output in CI test runs.