### PR TITLE
A couple of logging improvements

### DIFF
--- a/Sources/LanguageServerProtocol/Request.swift
+++ b/Sources/LanguageServerProtocol/Request.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LSPLogging
 
 /// A request object, wrapping the parameters of a `RequestType` and tracking its state.
@@ -92,14 +93,27 @@ public final class Notification<N: NotificationType> {
   }
 }
 
+fileprivate extension Encodable {
+  var prettyPrintJSON: String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting.insert(.prettyPrinted)
+    guard let data = try? encoder.encode(self) else {
+      return "\(self)"
+    }
+    guard let string = String(data: data, encoding: .utf8) else {
+      return "\(self)"
+    }
+    // Don't escape '/'. Most JSON readers don't need it escaped and it makes
+    // paths a lot easier to read and copy-paste.
+    return string.replacingOccurrences(of: "\\/", with: "/")
+  }
+}
+
 extension Request: CustomStringConvertible, CustomLogStringConvertible {
   public var description: String {
     return """
-      Request<\(R.method)>(
-        id: \(id),
-        clientID: \(clientID),
-        params: \(params)
-      )
+      \(R.method)
+      \(params.prettyPrintJSON)
       """
   }
 
@@ -112,10 +126,8 @@ extension Request: CustomStringConvertible, CustomLogStringConvertible {
 extension Notification: CustomStringConvertible, CustomLogStringConvertible {
   public var description: String {
     return """
-      Notification<\(N.method)>(
-        clientID: \(clientID),
-        params: \(params)
-      )
+      \(N.method)
+      \(params.prettyPrintJSON)
       """
   }
 

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -76,10 +76,13 @@ public actor BuildSystemManager {
 ///
 /// The intended use case for this is to split compiler arguments into multiple chunks so that each chunk doesn't exceed
 /// the maximum message length of `os_log` and thus won't get truncated.
+///
+///  - Note: This will only split along newline boundary. If a single line is longer than `maxChunkSize`, it won't be
+///    split. This is fine for compiler argument splitting since a single argument is rarely longer than 800 characters.
 private func splitLongMultilineMessage(message: String, maxChunkSize: Int) -> [String] {
-  var chunks: [String] = [""]
+  var chunks: [String] = []
   for line in message.split(separator: "\n", omittingEmptySubsequences: false) {
-    if chunks.last!.utf8.count + line.utf8.count < maxChunkSize {
+    if let lastChunk = chunks.last, lastChunk.utf8.count + line.utf8.count < maxChunkSize {
       chunks[chunks.count - 1] += "\n" + line
     } else {
       chunks.append(String(line))

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -420,10 +420,9 @@ extension ClangLanguageServerShim {
 
   public func shutdown() async {
     await withCheckedContinuation { continuation in
-      _ = clangd.send(ShutdownRequest()) { [weak self] _ in
-        guard let self else { return }
+      _ = clangd.send(ShutdownRequest()) { _ in
         Task {
-          await self.clangd.send(ExitNotification())
+          self.clangd.send(ExitNotification())
           continuation.resume()
         }
       }

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -667,6 +667,8 @@ extension SourceKitServer: MessageHandler {
     from clientID: ObjectIdentifier,
     reply: @escaping (LSPResult<R.Response>) -> Void
   ) async {
+    let startDate = Date()
+
     let cancellationToken = CancellationToken()
 
     let request = Request(
@@ -676,6 +678,7 @@ extension SourceKitServer: MessageHandler {
       cancellation: cancellationToken,
       reply: { [weak self] result in
         reply(result)
+        logger.log("Replied. Took \(-startDate.timeIntervalSinceNow * 1000)ms")
         if let self {
           Task {
             await self._logResponse(result, id: id, method: R.method)


### PR DESCRIPTION
The key changes here are:
- Set the request ID as the category for all log messages created while handling it (using `withLoggingScope`)
- Pretty-print requests and notifications as JSON
- Log build settings. If they are too long to be logged in a single log message, split them over multiple messages.