### PR TITLE
Open documents using `testClient.openDocument` instead of constructing a `DidOpenDocumentNotification`

### DIFF
--- a/Sources/SKTestSupport/LocationMarkers.swift
+++ b/Sources/SKTestSupport/LocationMarkers.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Finds all marked ranges in the given text, see `Marker`.
+fileprivate func findMarkedRanges(text: String) -> [Marker] {
+  var markers = [Marker]()
+  while let marker = nextMarkedRange(text: text, from: markers.last?.range.upperBound ?? text.startIndex) {
+    markers.append(marker)
+  }
+  return markers
+}
+
+extension Character {
+  var isMarkerEmoji: Bool {
+    switch self {
+    case "0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟", "ℹ️":
+      return true
+    default: return false
+    }
+  }
+}
+
+fileprivate func nextMarkedRange(text: String, from: String.Index) -> Marker? {
+  guard let start = text[from...].firstIndex(where: { $0.isMarkerEmoji }) else {
+    return nil
+  }
+  let end = text.index(after: start)
+
+  let markerRange = start..<end
+  let name = text[start..<end]
+
+  return Marker(name: name, range: markerRange)
+}
+
+fileprivate struct Marker {
+  /// The name of the marker.
+  let name: Substring
+  /// The range of the marker.
+  ///
+  /// If the marker contains all the non-whitespace characters on the line,
+  /// this is the range of the entire line. Otherwise it's the range of the
+  /// marker itself.
+  let range: Range<String.Index>
+}
+
+public func extractMarkers(_ markedText: String) -> (markers: [String: Int], textWithoutMarkers: String) {
+  var text = ""
+  var markers = [String: Int]()
+  var lastIndex = markedText.startIndex
+  for marker in findMarkedRanges(text: markedText) {
+    text += markedText[lastIndex..<marker.range.lowerBound]
+    lastIndex = marker.range.upperBound
+
+    assert(markers[String(marker.name)] == nil, "Marker names must be unique")
+    markers[String(marker.name)] = text.utf8.count
+  }
+  text += markedText[lastIndex..<markedText.endIndex]
+
+  return (markers, text)
+}

--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -156,15 +156,10 @@ extension SKSwiftPMTestWorkspace {
 
 extension SKSwiftPMTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: language,
-          version: 1,
-          text: try sources.sourceCache.get(url)
-        )
-      )
+    testClient.openDocument(
+      try sources.sourceCache.get(url),
+      uri: DocumentURI(url),
+      language: language
     )
   }
 

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -122,15 +122,10 @@ extension SKTibsTestWorkspace {
 
 extension SKTibsTestWorkspace {
   public func openDocument(_ url: URL, language: Language) throws {
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: language,
-          version: 1,
-          text: try sources.sourceCache.get(url)
-        )
-      )
+    testClient.openDocument(
+      try sources.sourceCache.get(url),
+      uri: DocumentURI(url),
+      language: language
     )
   }
 }

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LanguageServerProtocol
+
+extension Language {
+  var fileExtension: String {
+    switch self {
+    case .objective_c: return "m"
+    default: return self.rawValue
+    }
+  }
+
+  init?(fileExtension: String) {
+    switch fileExtension {
+    case "m": self = .objective_c
+    default: self.init(rawValue: fileExtension)
+    }
+  }
+}
+
+extension DocumentURI {
+  /// Create a unique URI for a document of the given language.
+  public static func `for`(_ language: Language, testName: String = #function) -> DocumentURI {
+    let testBaseName = testName.prefix(while: \.isLetter)
+
+    #if os(Windows)
+    let url = URL(fileURLWithPath: "C:/\(testBaseName)/\(UUID())/test.\(language.fileExtension)")
+    #else
+    let url = URL(fileURLWithPath: "/\(testBaseName)/\(UUID())/test.\(language.fileExtension)")
+    #endif
+    return DocumentURI(url)
+  }
+}

--- a/Tests/SourceKitLSPTests/DocumentColorTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentColorTests.swift
@@ -45,20 +45,11 @@ final class DocumentColorTests: XCTestCase {
   // MARK: - Helpers
 
   private func performDocumentColorRequest(text: String) async throws -> [ColorInformation] {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let uri = DocumentURI.for(.swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: .swift,
-          version: 12,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument(text, uri: uri)
 
-    let request = DocumentColorRequest(textDocument: TextDocumentIdentifier(url))
+    let request = DocumentColorRequest(textDocument: TextDocumentIdentifier(uri))
     return try await testClient.send(request)
   }
 
@@ -67,21 +58,12 @@ final class DocumentColorTests: XCTestCase {
     color: Color,
     range: Range<Position>
   ) async throws -> [ColorPresentation] {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let uri = DocumentURI.for(.swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: .swift,
-          version: 12,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument(text, uri: uri)
 
     let request = ColorPresentationRequest(
-      textDocument: TextDocumentIdentifier(url),
+      textDocument: TextDocumentIdentifier(uri),
       color: color,
       range: range
     )

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -48,20 +48,11 @@ final class DocumentSymbolTests: XCTestCase {
   // MARK: - Helpers
 
   private func performDocumentSymbolRequest(text: String) async throws -> DocumentSymbolResponse {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let uri = DocumentURI.for(.swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: .swift,
-          version: 17,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument(text, uri: uri)
 
-    let request = DocumentSymbolRequest(textDocument: TextDocumentIdentifier(url))
+    let request = DocumentSymbolRequest(textDocument: TextDocumentIdentifier(uri))
     return try await testClient.send(request)!
   }
 

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -44,20 +44,11 @@ final class InlayHintTests: XCTestCase {
   // MARK: - Helpers
 
   func performInlayHintRequest(text: String, range: Range<Position>? = nil) async throws -> [InlayHint] {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let uri = DocumentURI.for(.swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: .swift,
-          version: 17,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument(text, uri: uri)
 
-    let request = InlayHintRequest(textDocument: TextDocumentIdentifier(url), range: range)
+    let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: range)
 
     do {
       return try await testClient.send(request)

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -62,23 +62,11 @@ final class LocalSwiftTests: XCTestCase {
   // MARK: - Tests
 
   func testEditing() async throws {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
-    let uri = DocumentURI(url)
+    let uri = DocumentURI.for(.swift)
 
     let documentManager = await testClient.server._documentManager
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func
-            """
-        )
-      )
-    )
+    testClient.openDocument("func", uri: uri, version: 12)
 
     let openDiags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openDiags.diagnostics.count, 1)
@@ -200,18 +188,7 @@ final class LocalSwiftTests: XCTestCase {
 
     let documentManager = await testClient.server._documentManager
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func
-            """
-        )
-      )
-    )
+    testClient.openDocument("func", uri: uri, language: .swift)
 
     let openDiags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openDiags.diagnostics.count, 1)
@@ -335,33 +312,11 @@ final class LocalSwiftTests: XCTestCase {
 
     let excludedURI = DocumentURI(string: "git:/a.swift")
 
-    let text = """
-      func
-      """
-
     // Open the excluded URI first so our later notification handlers can confirm
     // that no diagnostics were emitted for this excluded URI.
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: excludedURI,
-          language: .swift,
-          version: 1,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument("func", uri: excludedURI, language: .swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: includedURI,
-          language: .swift,
-          version: 1,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument("func", uri: includedURI, language: .swift)
     let diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.uri, includedURI)
   }
@@ -372,18 +327,7 @@ final class LocalSwiftTests: XCTestCase {
     let uriA = DocumentURI(urlA)
     let uriB = DocumentURI(urlB)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uriA,
-          language: .swift,
-          version: 12,
-          text: """
-            foo()
-            """
-        )
-      )
-    )
+    testClient.openDocument("foo()", uri: uriA)
 
     let openADiags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openADiags.diagnostics.count, 1)
@@ -392,18 +336,7 @@ final class LocalSwiftTests: XCTestCase {
       Position(line: 0, utf16index: 0)
     )
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uriB,
-          language: .swift,
-          version: 12,
-          text: """
-            bar()
-            """
-        )
-      )
-    )
+    testClient.openDocument("bar()", uri: uriB)
 
     let openBDiags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openBDiags.diagnostics.count, 1)
@@ -429,18 +362,7 @@ final class LocalSwiftTests: XCTestCase {
     let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uriA = DocumentURI(urlA)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uriA,
-          language: .swift,
-          version: 12,
-          text: """
-            foo()
-            """
-        )
-      )
-    )
+    testClient.openDocument("foo()", uri: uriA)
 
     let open1Diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(open1Diags.diagnostics.count, 1)
@@ -451,18 +373,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(DidCloseTextDocumentNotification(textDocument: .init(urlA)))
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uriA,
-          language: .swift,
-          version: 13,
-          text: """
-            var
-            """
-        )
-      )
-    )
+    testClient.openDocument("var", uri: uriA)
 
     let open2Diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(open2Diags.diagnostics.count, 1)
@@ -476,16 +387,7 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: "@propertyWrapper struct Bar {}"
-        )
-      )
-    )
+    testClient.openDocument("@propertyWrapper struct Bar {}", uri: uri)
 
     let diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 1)
@@ -498,19 +400,13 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func foo() {
-              let a = 2
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func foo() {
+        let a = 2
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
@@ -541,19 +437,13 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func foo(a: Int?) {
-              _ = a.bigEndian
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func foo(a: Int?) {
+        _ = a.bigEndian
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
@@ -610,19 +500,13 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func foo() {
-              print("")print("")
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func foo() {
+        print("")print("")
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
@@ -659,25 +543,18 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    var diagnostic: Diagnostic? = nil
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func foo() {
-              let a = 2
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func foo() {
+        let a = 2
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 1)
-    diagnostic = diags.diagnostics.first
+    let diagnostic = diags.diagnostics.first
 
     let request = CodeActionRequest(
       range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 11),
@@ -723,25 +600,18 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    var diagnostic: Diagnostic?
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            func foo(a: Int?) {
-              _ = a.bigEndian
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func foo(a: Int?) {
+        _ = a.bigEndian
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 1)
-    diagnostic = diags.diagnostics.first
+    let diagnostic = diags.diagnostics.first
 
     let request = CodeActionRequest(
       range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 11),
@@ -788,24 +658,17 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    var diagnostic: Diagnostic?
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            @available(*, introduced: 10, deprecated: 11)
-            func foo() {}
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      @available(*, introduced: 10, deprecated: 11)
+      func foo() {}
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 1)
-    diagnostic = diags.diagnostics.first
+    let diagnostic = diags.diagnostics.first
 
     let request = CodeActionRequest(
       range: Position(line: 0, utf16index: 1)..<Position(line: 0, utf16index: 10),
@@ -841,27 +704,20 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    var diagnostic: Diagnostic?
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 12,
-          text: """
-            @available(*, deprecated, renamed: "new(_:hotness:)")
-            func old(and: Int, busted: Int) {}
-            func test() {
-              old(and: 1, busted: 2)
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      @available(*, deprecated, renamed: "new(_:hotness:)")
+      func old(and: Int, busted: Int) {}
+      func test() {
+        old(and: 1, busted: 2)
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 1)
-    diagnostic = diags.diagnostics.first!
+    let diagnostic = diags.diagnostics.first!
 
     let request = CodeActionRequest(
       range: Position(line: 3, utf16index: 2)..<Position(line: 3, utf16index: 2),
@@ -1319,22 +1175,16 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 1,
-          text: """
-            import Foundation
-            struct S {
-              func foo() {
-                var local = 1
-              }
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      import Foundation
+      struct S {
+        func foo() {
+          var local = 1
+        }
+      }
+      """,
+      uri: uri
     )
 
     do {
@@ -1430,20 +1280,14 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 1,
-          text: """
-            /// This is a doc comment for S.
-            ///
-            /// Details.
-            struct S {}
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      /// This is a doc comment for S.
+      ///
+      /// Details.
+      struct S {}
+      """,
+      uri: uri
     )
 
     do {
@@ -1494,28 +1338,22 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHoverNameEscaping() async throws {
-    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let uri = DocumentURI.for(.swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: .swift,
-          version: 1,
-          text: """
-            /// this is **bold** documentation
-            func test(_ a: Int, _ b: Int) { }
-            /// this is *italic* documentation
-            func *%*(lhs: String, rhs: String) { }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      /// this is **bold** documentation
+      func test(_ a: Int, _ b: Int) { }
+      /// this is *italic* documentation
+      func *%*(lhs: String, rhs: String) { }
+      """,
+      uri: uri
     )
 
     do {
       let resp = try await testClient.send(
         HoverRequest(
-          textDocument: TextDocumentIdentifier(url),
+          textDocument: TextDocumentIdentifier(uri),
           position: Position(line: 1, utf16index: 7)
         )
       )
@@ -1546,7 +1384,7 @@ final class LocalSwiftTests: XCTestCase {
     do {
       let resp = try await testClient.send(
         HoverRequest(
-          textDocument: TextDocumentIdentifier(url),
+          textDocument: TextDocumentIdentifier(uri),
           position: Position(line: 3, utf16index: 7)
         )
       )
@@ -1579,23 +1417,17 @@ final class LocalSwiftTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 1,
-          text: """
-            func test() {
-              let a = 1
-              let b = 2
-              let ccc = 3
-              _ = b
-              _ = ccc + ccc
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func test() {
+        let a = 1
+        let b = 2
+        let ccc = 3
+        _ = b
+        _ = ccc + ccc
+      }
+      """,
+      uri: uri
     )
 
     do {
@@ -1738,20 +1570,14 @@ final class LocalSwiftTests: XCTestCase {
       reusedNodeCallback.fulfill()
     }
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 0,
-          text: """
-            func foo() {
-            }
-            class bar {
-            }
-            """
-        )
-      )
+    testClient.openDocument(
+      """
+      func foo() {
+      }
+      class bar {
+      }
+      """,
+      uri: uri
     )
 
     // Send a request that triggers a syntax tree to be built.
@@ -1793,18 +1619,7 @@ final class LocalSwiftTests: XCTestCase {
     )
 
     let uri = DocumentURI(URL(fileURLWithPath: "/\(UUID())/a.swift"))
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 0,
-          text: """
-            foo
-            """
-        )
-      )
-    )
+    testClient.openDocument("foo", uri: uri)
 
     let edit = TextDocumentContentChangeEvent(
       range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 3),

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -56,20 +56,6 @@ final class PublishDiagnosticsTests: XCTestCase {
 
   // MARK: - Helpers
 
-  private func openDocument(text: String) {
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: version,
-          text: text
-        )
-      )
-    )
-    version += 1
-  }
-
   private func editDocument(changes: [TextDocumentContentChangeEvent]) {
     testClient.send(
       DidChangeTextDocumentNotification(
@@ -86,12 +72,13 @@ final class PublishDiagnosticsTests: XCTestCase {
   // MARK: - Tests
 
   func testUnknownIdentifierDiagnostic() async throws {
-    openDocument(
-      text: """
-        func foo() {
-          invalid
-        }
-        """
+    testClient.openDocument(
+      """
+      func foo() {
+        invalid
+      }
+      """,
+      uri: uri
     )
 
     let diags = try await testClient.nextDiagnosticsNotification()
@@ -103,12 +90,13 @@ final class PublishDiagnosticsTests: XCTestCase {
   }
 
   func testRangeShiftAfterNewlineAdded() async throws {
-    openDocument(
-      text: """
-        func foo() {
-          invalid
-        }
-        """
+    testClient.openDocument(
+      """
+      func foo() {
+        invalid
+      }
+      """,
+      uri: uri
     )
 
     let openDiags = try await testClient.nextDiagnosticsNotification()
@@ -135,13 +123,14 @@ final class PublishDiagnosticsTests: XCTestCase {
   }
 
   func testRangeShiftAfterNewlineRemoved() async throws {
-    openDocument(
-      text: """
+    testClient.openDocument(
+      """
 
-        func foo() {
-          invalid
-        }
-        """
+      func foo() {
+        invalid
+      }
+      """,
+      uri: uri
     )
 
     let openDiags = try await testClient.nextDiagnosticsNotification()

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -52,20 +52,11 @@ final class PullDiagnosticsTests: XCTestCase {
   // MARK: - Tests
 
   func performDiagnosticRequest(text: String) async throws -> [Diagnostic] {
-    let url = URL(fileURLWithPath: "/PullDiagnostics/\(UUID()).swift")
+    let uri = DocumentURI.for(.swift)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: DocumentURI(url),
-          language: .swift,
-          version: 17,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument(text, uri: uri)
 
-    let request = DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(url))
+    let request = DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
 
     let report: DocumentDiagnosticReport
     do {

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -101,16 +101,7 @@ final class SemanticTokensTests: XCTestCase {
 
     let refreshExpectation = expectSemanticTokensRefresh()
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: version,
-          text: text
-        )
-      )
-    )
+    testClient.openDocument(text, uri: uri)
     version += 1
 
     wait(for: [registerCapabilityExpectation, refreshExpectation], timeout: defaultTimeout)

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -67,18 +67,7 @@ final class SwiftInterfaceTests: XCTestCase {
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(
-          uri: uri,
-          language: .swift,
-          version: 1,
-          text: """
-            import Foundation
-            """
-        )
-      )
-    )
+    testClient.openDocument("import Foundation", uri: uri)
 
     let _resp = try await testClient.send(
       DefinitionRequest(


### PR DESCRIPTION
Instead of constructing a `DidOpenTextDocumentNotification` inside the tests, add a `TestSourceKitLSPClient.openDocument` method that opens a document. In addition to being shorter to write than the `DidOpenTextDocumentNotification`, it does two smart things: 
- It infers the language of the test file from its file extension
- It removes location markers (like `1️⃣`) and returns their positions, which means that we don’t need to write fragile line-column based positions in the test files. Migrating all the tests from line-column based `Position` initializers to use location markers is quite a big change and not part of this PR.