### PR TITLE
Automatically initialize the SourceKit-LSP server when creating a `TestSourceKitLSPClient`

### DIFF
--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -62,7 +62,14 @@ public final class SKSwiftPMTestWorkspace {
     toolchain: Toolchain,
     testClient: TestSourceKitLSPClient? = nil
   ) async throws {
-    self.testClient = testClient ?? TestSourceKitLSPClient()
+    self.testClient =
+      if let testClient {
+        testClient
+      } else {
+        // Don't initialize the LSP server because we wire up all the properties that `InitializeRequest` would set
+        // manually below.
+        try await TestSourceKitLSPClient(initialize: false)
+      }
 
     self.projectDir = URL(
       fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: projectDir.path)).pathString

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -51,7 +51,14 @@ public final class SKTibsTestWorkspace {
     clientCapabilities: ClientCapabilities,
     testClient: TestSourceKitLSPClient? = nil
   ) async throws {
-    self.testClient = testClient ?? TestSourceKitLSPClient()
+    self.testClient =
+      if let testClient {
+        testClient
+      } else {
+        // Don't initialize the LSP server because we wire up all the properties that `InitializeRequest` would set
+        // manually below.
+        try await TestSourceKitLSPClient(initialize: false)
+      }
     self.tibsWorkspace = try TibsTestWorkspace(
       immutableProjectDir: immutableProjectDir,
       persistentBuildDir: persistentBuildDir,
@@ -70,7 +77,14 @@ public final class SKTibsTestWorkspace {
     clientCapabilities: ClientCapabilities,
     testClient: TestSourceKitLSPClient? = nil
   ) async throws {
-    self.testClient = testClient ?? TestSourceKitLSPClient()
+    self.testClient =
+      if let testClient {
+        testClient
+      } else {
+        // Don't initialize the LSP server because we wire up all the properties that `InitializeRequest` would set
+        // manually below.
+        try await TestSourceKitLSPClient(initialize: false)
+      }
 
     self.tibsWorkspace = try TibsTestWorkspace(
       projectDir: projectDir,

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -94,7 +94,7 @@ final class BuildSystemTests: XCTestCase {
 
   override func setUp() async throws {
     haveClangd = ToolchainRegistry.shared.toolchains.contains { $0.clangd != nil }
-    testClient = TestSourceKitLSPClient()
+    testClient = try await TestSourceKitLSPClient()
     buildSystem = TestBuildSystem()
 
     let server = testClient.server
@@ -112,18 +112,6 @@ final class BuildSystemTests: XCTestCase {
 
     await server.setWorkspaces([workspace])
     await workspace.buildSystemManager.setDelegate(server)
-
-    _ = try await testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
   }
 
   override func tearDown() {

--- a/Tests/SourceKitLSPTests/DocumentColorTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentColorTests.swift
@@ -17,34 +17,11 @@ import SourceKitLSP
 import XCTest
 
 final class DocumentColorTests: XCTestCase {
-  /// The mock client used to communicate with the SourceKit-LSP server.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  override func setUp() async throws {
-    testClient = TestSourceKitLSPClient()
-    let documentCapabilities = TextDocumentClientCapabilities()
-    _ = try await testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
-  }
-
-  override func tearDown() {
-    testClient = nil
-  }
-
   // MARK: - Helpers
 
   private func performDocumentColorRequest(text: String) async throws -> [ColorInformation] {
+    let testClient = try await TestSourceKitLSPClient()
+
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(text, uri: uri)
@@ -58,6 +35,8 @@ final class DocumentColorTests: XCTestCase {
     color: Color,
     range: Range<Position>
   ) async throws -> [ColorPresentation] {
+    let testClient = try await TestSourceKitLSPClient()
+
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(text, uri: uri)

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -17,37 +17,10 @@ import SourceKitLSP
 import XCTest
 
 final class DocumentSymbolTests: XCTestCase {
-  typealias DocumentSymbolCapabilities = TextDocumentClientCapabilities.DocumentSymbol
-
-  /// The mock client used to communicate with the SourceKit-LSP server.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  override func setUp() async throws {
-    testClient = TestSourceKitLSPClient()
-    var documentCapabilities = TextDocumentClientCapabilities()
-    documentCapabilities.documentSymbol = DocumentSymbolCapabilities()
-    _ = try await testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil, textDocument: documentCapabilities),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
-  }
-
-  override func tearDown() {
-    testClient = nil
-  }
-
   // MARK: - Helpers
 
   private func performDocumentSymbolRequest(text: String) async throws -> DocumentSymbolResponse {
+    let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(text, uri: uri)

--- a/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
@@ -17,33 +17,6 @@ import SourceKitLSP
 import XCTest
 
 final class ExecuteCommandTests: XCTestCase {
-
-  /// The mock client used to communicate with the SourceKit-LSP server.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  override func tearDown() {
-    testClient = nil
-  }
-
-  override func setUp() async throws {
-    testClient = TestSourceKitLSPClient()
-    _ = try await self.testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
-  }
-
-  // MARK: - Tests
-
   func testLocationSemanticRefactoring() async throws {
     guard let ws = try await staticSourceKitTibsWorkspace(name: "SemanticRefactor") else { return }
     let loc = ws.testLoc("sr:string")

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -17,33 +17,10 @@ import SourceKitLSP
 import XCTest
 
 final class InlayHintTests: XCTestCase {
-  /// The mock client used to communicate with the SourceKit-LSP server.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  override func setUp() async throws {
-    testClient = TestSourceKitLSPClient()
-    _ = try await testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(workspace: nil, textDocument: nil),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
-  }
-
-  override func tearDown() {
-    testClient = nil
-  }
-
   // MARK: - Helpers
 
   func performInlayHintRequest(text: String, range: Range<Position>? = nil) async throws -> [InlayHint] {
+    let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(text, uri: uri)

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -24,44 +24,20 @@ import XCTest
 typealias Notification = LanguageServerProtocol.Notification
 
 final class LocalSwiftTests: XCTestCase {
-
-  /// The mock client used to communicate with the SourceKit-LSP server.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  override func setUp() async throws {
-    testClient = TestSourceKitLSPClient()
-    _ = try await self.testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(
-          workspace: nil,
-          textDocument: TextDocumentClientCapabilities(
-            codeAction: .init(
-              codeActionLiteralSupport: .init(
-                codeActionKind: .init(valueSet: [.quickFix])
-              )
-            ),
-            publishDiagnostics: .init(codeDescriptionSupport: true)
-          )
-        ),
-        trace: .off,
-        workspaceFolders: nil
+  private let quickFixCapabilities = ClientCapabilities(
+    textDocument: TextDocumentClientCapabilities(
+      codeAction: .init(
+        codeActionLiteralSupport: .init(
+          codeActionKind: .init(valueSet: [.quickFix])
+        )
       )
     )
-  }
-
-  override func tearDown() {
-    testClient = nil
-  }
+  )
 
   // MARK: - Tests
 
   func testEditing() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 
     let documentManager = await testClient.server._documentManager
@@ -184,6 +160,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEditingNonURL() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(string: "urn:uuid:A1B08909-E791-469E-BF0F-F5790977E051")
 
     let documentManager = await testClient.server._documentManager
@@ -307,6 +284,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testExcludedDocumentSchemeDiagnostics() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let includedURL = URL(fileURLWithPath: "/a.swift")
     let includedURI = DocumentURI(includedURL)
 
@@ -322,6 +300,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testCrossFileDiagnostics() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let urlB = URL(fileURLWithPath: "/\(UUID())/b.swift")
     let uriA = DocumentURI(urlA)
@@ -359,6 +338,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDiagnosticsReopen() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uriA = DocumentURI(urlA)
 
@@ -384,6 +364,13 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEducationalNotesAreUsedAsDiagnosticCodes() async throws {
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(
+        textDocument: TextDocumentClientCapabilities(
+          publishDiagnostics: .init(codeDescriptionSupport: true)
+        )
+      )
+    )
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -397,6 +384,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnostics() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -434,6 +422,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnosticsNotes() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -497,6 +486,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitInsert() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -540,6 +530,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActions() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -597,6 +588,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActionsNotes() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -655,6 +647,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionPrimary() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -701,6 +694,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1172,6 +1166,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testSymbolInfo() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1277,6 +1272,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHover() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1338,6 +1334,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testHoverNameEscaping() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(
@@ -1414,6 +1411,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDocumentSymbolHighlight() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1557,6 +1555,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testIncrementalParse() async throws {
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1613,10 +1612,7 @@ final class LocalSwiftTests: XCTestCase {
     serverOptions.swiftPublishDiagnosticsDebounceDuration = 1 /* 1s */
 
     // Construct our own  `TestSourceKitLSPClient` instead of the one from set up because we want a higher debounce interval.
-    let testClient = TestSourceKitLSPClient(serverOptions: serverOptions)
-    _ = try await testClient.send(
-      InitializeRequest(rootURI: nil, capabilities: ClientCapabilities(), workspaceFolders: nil)
-    )
+    let testClient = try await TestSourceKitLSPClient(serverOptions: serverOptions)
 
     let uri = DocumentURI(URL(fileURLWithPath: "/\(UUID())/a.swift"))
     testClient.openDocument("foo", uri: uri)

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -38,34 +38,25 @@ final class SemanticTokensTests: XCTestCase {
   override func setUp() async throws {
     version = 0
     uri = DocumentURI(URL(fileURLWithPath: "/SemanticTokensTests/\(UUID()).swift"))
-    testClient = TestSourceKitLSPClient()
-    _ = try await self.testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(
-          workspace: .init(
-            semanticTokens: .init(
-              refreshSupport: true
-            )
-          ),
-          textDocument: .init(
-            semanticTokens: .init(
-              dynamicRegistration: true,
-              requests: .init(
-                range: .bool(true),
-                full: .bool(true)
-              ),
-              tokenTypes: Token.Kind.allCases.map(\._lspName),
-              tokenModifiers: Token.Modifiers.allModifiers.map { $0._lspName! },
-              formats: [.relative]
-            )
+    testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(
+        workspace: .init(
+          semanticTokens: .init(
+            refreshSupport: true
           )
         ),
-        trace: .off,
-        workspaceFolders: nil
+        textDocument: .init(
+          semanticTokens: .init(
+            dynamicRegistration: true,
+            requests: .init(
+              range: .bool(true),
+              full: .bool(true)
+            ),
+            tokenTypes: Token.Kind.allCases.map(\._lspName),
+            tokenModifiers: Token.Modifiers.allModifiers.map { $0._lspName! },
+            formats: [.relative]
+          )
+        )
       )
     )
   }

--- a/Tests/SourceKitLSPTests/SourceKitTests.swift
+++ b/Tests/SourceKitLSPTests/SourceKitTests.swift
@@ -23,7 +23,7 @@ public typealias URL = Foundation.URL
 final class SKTests: XCTestCase {
 
   func testInitLocal() async throws {
-    let testClient = TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(initialize: false)
 
     let initResult = try await testClient.send(
       InitializeRequest(

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -21,49 +21,13 @@ import SourceKitLSP
 import XCTest
 
 final class SwiftInterfaceTests: XCTestCase {
-
-  /// The mock client used to communicate with the SourceKit-LSP server.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  override func setUp() async throws {
+  func testSystemModuleInterface() async throws {
     // This is the only test that references modules from the SDK (Foundation).
     // `testSystemModuleInterface` has been flaky for a long while and a
     // hypothesis is that it was failing because of a malformed global module
     // cache that might still be present from previous CI runs. If we use a
     // local module cache, we define away that source of bugs.
-    testClient = TestSourceKitLSPClient(useGlobalModuleCache: false)
-    _ = try await testClient.send(
-      InitializeRequest(
-        processId: nil,
-        rootPath: nil,
-        rootURI: nil,
-        initializationOptions: nil,
-        capabilities: ClientCapabilities(
-          workspace: nil,
-          textDocument: TextDocumentClientCapabilities(
-            codeAction: .init(
-              codeActionLiteralSupport: .init(
-                codeActionKind: .init(valueSet: [.quickFix])
-              )
-            ),
-            publishDiagnostics: .init(codeDescriptionSupport: true)
-          )
-        ),
-        trace: .off,
-        workspaceFolders: nil
-      )
-    )
-  }
-
-  override func tearDown() {
-    testClient = nil
-  }
-
-  // MARK: - Tests
-
-  func testSystemModuleInterface() async throws {
+    let testClient = try await TestSourceKitLSPClient(useGlobalModuleCache: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -251,15 +251,11 @@ final class WorkspaceTests: XCTestCase {
 
     let otherPackLoc = ws.testLoc("otherPackage:call")
 
-    let testClient = TestSourceKitLSPClient()
-    _ = try await testClient.send(
-      InitializeRequest(
-        rootURI: nil,
-        capabilities: ClientCapabilities(workspace: .init(workspaceFolders: true)),
-        workspaceFolders: [
-          WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory.deletingLastPathComponent()))
-        ]
-      )
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(
+        workspace: .init(workspaceFolders: true)
+      ),
+      workspaceFolders: [WorkspaceFolder(uri: DocumentURI(ws.sources.rootDirectory.deletingLastPathComponent()))]
     )
 
     let docString = try String(data: Data(contentsOf: otherPackLoc.url), encoding: .utf8)!


### PR DESCRIPTION
Sending the `InitializeRequest` was always unnecessarily verbose. If we automatically initialize the server when creating the test client, the code becomes sufficiently concise that we can set up the client + server in the test method itself and no longer need the `setUp` methods, making the tests easier to read.