### PR TITLE
[5.10] Use new SwiftPM flag to remove `$ORIGIN` from installed sourcekit-lsp ELF executable runpath

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -124,6 +124,8 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace) -> List[str]:
             '-Xcxx', '-I', '-Xcxx',
             os.path.join(args.toolchain, 'lib', 'swift', 'Block'),
         ]
+        if args.action == 'install':
+            swiftpm_args += ['--disable-local-rpath']
 
     if '-android' in build_target:
         swiftpm_args += [
@@ -181,6 +183,9 @@ def get_swiftpm_environment_variables(swift_exec: str, args: argparse.Namespace)
     if args.action == 'test' and not args.skip_long_tests:
         env['SOURCEKIT_LSP_ENABLE_LONG_TESTS'] = '1'
 
+    if args.action == 'install':
+        env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
+
     return env
 
 
@@ -190,8 +195,6 @@ def build_single_product(product: str, swift_exec: str, args: argparse.Namespace
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
-    if args.action == 'install':
-      additional_env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
     cmd = [swift_exec, 'build', '--product', product] + swiftpm_args
     check_call(cmd, additional_env=additional_env, verbose=args.verbose)
 


### PR DESCRIPTION
Cherrypick of #894

__Explanation:__ Without this flag, `sourcekit-lsp` looks in `usr/bin/` first for shared libraries, but there are none in that executable directory.

__Scope:__ installed executable runpath

__Issue:__ none

__Risk:__ none, there were no shared libraries there

__Testing:__ SwiftPM merged using this flag into trunk and 5.10 last week, no problems with `swift-package` itself so far.

__Reviewer:__ @ahoppen