### PR TITLE
Add support for a compile database file not at the root of a workspace

### DIFF
--- a/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKSwiftPMTestWorkspace.swift
@@ -55,7 +55,7 @@ public final class SKSwiftPMTestWorkspace {
   /// Connection to the language server.
   public let testClient: TestSourceKitLSPClient
 
-  /// When `testServer` is not `nil`, the workspace will be opened in that server, otherwise a new server will be created for the workspace
+  /// When `testClient` is not `nil`, the workspace will be opened in that client's server, otherwise a new client will be created for the workspace
   public init(
     projectDir: URL,
     tmpDir: URL,

--- a/Sources/SKTestSupport/SKTibsTestWorkspace.swift
+++ b/Sources/SKTestSupport/SKTibsTestWorkspace.swift
@@ -24,6 +24,7 @@ import XCTest
 import enum PackageLoading.Platform
 import struct PackageModel.BuildFlags
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 
 public typealias URL = Foundation.URL
 
@@ -83,7 +84,10 @@ public final class SKTibsTestWorkspace {
 
   func initWorkspace(clientCapabilities: ClientCapabilities) async throws {
     let buildPath = try AbsolutePath(validating: builder.buildRoot.path)
-    let buildSystem = CompilationDatabaseBuildSystem(projectRoot: buildPath)
+    let buildSystem = CompilationDatabaseBuildSystem(
+      projectRoot: buildPath,
+      searchPaths: try [RelativePath(validating: ".")]
+    )
     let indexDelegate = SourceKitIndexDelegate()
     tibsWorkspace.delegate = indexDelegate
 

--- a/Sources/SourceKitLSP/SourceKitServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitServer+Options.swift
@@ -16,6 +16,7 @@ import SKCore
 import SKSupport
 
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 
 extension SourceKitServer {
 
@@ -28,6 +29,9 @@ extension SourceKitServer {
 
     /// Additional arguments to pass to `clangd` on the command-line.
     public var clangdOptions: [String]
+
+    /// Additional paths to search for a compilation database, relative to a workspace root.
+    public var compilationDatabaseSearchPaths: [RelativePath]
 
     /// Additional options for the index.
     public var indexOptions: IndexOptions
@@ -48,6 +52,7 @@ extension SourceKitServer {
     public init(
       buildSetup: BuildSetup = .default,
       clangdOptions: [String] = [],
+      compilationDatabaseSearchPaths: [RelativePath] = [],
       indexOptions: IndexOptions = .init(),
       completionOptions: SKCompletionOptions = .init(),
       generatedInterfacesPath: AbsolutePath = defaultDirectoryForGeneratedInterfaces,
@@ -55,6 +60,7 @@ extension SourceKitServer {
     ) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
+      self.compilationDatabaseSearchPaths = compilationDatabaseSearchPaths
       self.indexOptions = indexOptions
       self.completionOptions = completionOptions
       self.generatedInterfacesPath = generatedInterfacesPath

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -597,7 +597,7 @@ private var notificationIDForLogging: Int = 0
 
 /// On every call, returns a new unique number that can be used to identify a notification.
 ///
-/// This is needed so we can consistently refer to a notification using the `category` of the logger. 
+/// This is needed so we can consistently refer to a notification using the `category` of the logger.
 /// Requests don't need this since they already have a unique ID in the LSP protocol.
 private func getNextNotificationIDForLogging() -> Int {
   return notificationIDForLoggingLock.withLock {
@@ -648,7 +648,7 @@ extension SourceKitServer: MessageHandler {
       await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.willSaveDocument)
     case let notification as DidSaveTextDocumentNotification:
       await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.didSaveDocument)
-      // IMPORTANT: When adding a new entry to this switch, also add it to the `TaskMetadata` initializer.
+    // IMPORTANT: When adding a new entry to this switch, also add it to the `TaskMetadata` initializer.
     default:
       break
     }
@@ -771,7 +771,7 @@ extension SourceKitServer: MessageHandler {
         requestHandler: self.documentDiagnostic,
         fallback: .full(.init(items: []))
       )
-      // IMPORTANT: When adding a new entry to this switch, also add it to the `TaskMetadata` initializer.
+    // IMPORTANT: When adding a new entry to this switch, also add it to the `TaskMetadata` initializer.
     default:
       reply(.failure(ResponseError.methodNotFound(R.method)))
     }
@@ -860,6 +860,7 @@ extension SourceKitServer {
       capabilityRegistry: capabilityRegistry,
       toolchainRegistry: self.toolchainRegistry,
       buildSetup: self.options.buildSetup,
+      compilationDatabaseSearchPaths: self.options.compilationDatabaseSearchPaths,
       indexOptions: self.options.indexOptions,
       reloadPackageStatusCallback: { status in
         guard capabilityRegistry.clientCapabilities.window?.workDoneProgress ?? false else {

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -18,6 +18,7 @@ import SKSupport
 import SKSwiftPMWorkspace
 
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 
 /// Same as `??` but allows the right-hand side of the operator to 'await'.
 fileprivate func firstNonNil<T>(_ optional: T?, _ defaultValue: @autoclosure () async throws -> T) async rethrows -> T {
@@ -102,6 +103,7 @@ public final class Workspace {
     capabilityRegistry: CapabilityRegistry,
     toolchainRegistry: ToolchainRegistry,
     buildSetup: BuildSetup,
+    compilationDatabaseSearchPaths: [RelativePath],
     indexOptions: IndexOptions = IndexOptions(),
     reloadPackageStatusCallback: @escaping (ReloadPackageStatus) async -> Void
   ) async throws {
@@ -117,7 +119,7 @@ public final class Workspace {
       ) {
         buildSystem = swiftpm
       } else {
-        buildSystem = CompilationDatabaseBuildSystem(projectRoot: rootPath)
+        buildSystem = CompilationDatabaseBuildSystem(projectRoot: rootPath, searchPaths: compilationDatabaseSearchPaths)
       }
     } else {
       // We assume that workspaces are directories. This is only true for URLs not for URIs in general.

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -22,6 +22,7 @@ import SKSupport
 import SourceKitLSP
 
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 import var TSCBasic.localFileSystem
 
 extension AbsolutePath: ExpressibleByArgument {
@@ -45,6 +46,18 @@ extension AbsolutePath: ExpressibleByArgument {
     // This type is most commonly used to select a directory, not a file.
     // Specify '.file()' in an argument declaration when necessary.
     .directory
+  }
+}
+
+extension RelativePath: ExpressibleByArgument {
+  public init?(argument: String) {
+    let path = try? RelativePath(validating: argument)
+
+    guard let path = path else {
+      return nil
+    }
+
+    self = path
   }
 }
 
@@ -138,6 +151,14 @@ struct SourceKitLSP: ParsableCommand {
   var indexPrefixMappings = [PathPrefixMapping]()
 
   @Option(
+    name: .customLong("compilation-db-search-path"),
+    parsing: .singleValue,
+    help:
+      "Specify a relative path where sourcekit-lsp should search for `compile_commands.json` or `compile_flags.txt` relative to the root of a workspace. Multiple search paths may be specified by repeating this option."
+  )
+  var compilationDatabaseSearchPaths = [RelativePath]()
+
+  @Option(
     help: "Specify the directory where generated interfaces will be stored"
   )
   var generatedInterfacesPath = defaultDirectoryForGeneratedInterfaces
@@ -157,6 +178,7 @@ struct SourceKitLSP: ParsableCommand {
     serverOptions.buildSetup.flags.linkerFlags = buildFlagsLinker
     serverOptions.buildSetup.flags.swiftCompilerFlags = buildFlagsSwift
     serverOptions.clangdOptions = clangdOptions
+    serverOptions.compilationDatabaseSearchPaths = compilationDatabaseSearchPaths
     serverOptions.indexOptions.indexStorePath = indexStorePath
     serverOptions.indexOptions.indexDatabasePath = indexDatabasePath
     serverOptions.indexOptions.indexPrefixMappings = indexPrefixMappings

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -43,7 +43,11 @@ final class CompilationDatabaseTests: XCTestCase {
     let compilationDatabaseUrl = ws.builder.buildRoot.appendingPathComponent("compile_commands.json")
 
     _ = try ws.sources.edit({ builder in
-      let compilationDatabase = try JSONCompilationDatabase(file: AbsolutePath(validating: compilationDatabaseUrl.path))
+      let compilationDatabase = try XCTUnwrap(
+        JSONCompilationDatabase(
+          file: AbsolutePath(validating: compilationDatabaseUrl.path)
+        )
+      )
       let newCommands = compilationDatabase.allCommands.map {
         (command: CompilationDatabaseCompileCommand) -> CompilationDatabaseCompileCommand in
         var command = command


### PR DESCRIPTION
Introduce a new command-line flag (`--compile-db-search-path`) to `sourcekit-lsp`, which can be used to specify which subdirectories in a workspace should be searched for a clangd-style compile database (`compile_commands.json` or `compile_flags.txt`). Originally, I was going to add a `clangd`-like `--compile-commands-dir` flag, but upon further investigation decided this wasn't a good approach, as sourcekit-lsp supports multiple workspaces and `clangd` [does not](https://github.com/clangd/clangd/issues/1549). In a world with multiple workspaces it does not make sense to specify a single absolute path to a compile-database, so instead I opted for a set of relative search paths, which apply to all databases managed by a particular instance of `sourcekit-lsp`.