### PR TITLE
Convert ManualMainFilesProvider and BSMDelegate to be actors

### DIFF
--- a/Sources/SKCore/MainFilesProvider.swift
+++ b/Sources/SKCore/MainFilesProvider.swift
@@ -23,7 +23,7 @@ public protocol MainFilesProvider: AnyObject {
   /// mainFilesContainingFile("foo.cpp") == Set(["foo.cpp"])
   /// mainFilesContainingFile("foo.h") == Set(["foo.cpp", "bar.cpp"])
   /// ```
-  func mainFilesContainingFile(_: DocumentURI) -> Set<DocumentURI>
+  func mainFilesContainingFile(_: DocumentURI) async -> Set<DocumentURI>
 }
 
 /// Delegate that responds to possible main file changes.

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -473,7 +473,6 @@ private actor BSMDelegate: BuildSystemDelegate {
     uri: DocumentURI, expectation: XCTestExpectation, file: StaticString, line: UInt
   )
 
-  let queue: DispatchQueue = DispatchQueue(label: "\(BSMDelegate.self)")
   unowned let bsm: BuildSystemManager
   var expected: [ExpectedBuildSettingChangedCall] = []
 


### PR DESCRIPTION
issue: https://github.com/apple/sourcekit-lsp/issues/868

- Convert ManualMainFilesProvider to be an actor
- Remove an unused queue from BSMDelegate