### PR TITLE
Validate ClangWorkspaceSettings before preferring it over unknown WorkspaceSettingsChanges

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceSettings.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceSettings.swift
@@ -19,10 +19,7 @@ public enum WorkspaceSettingsChange: Codable, Hashable {
   case unknown(LSPAny)
 
   public init(from decoder: Decoder) throws {
-    // FIXME: doing trial deserialization only works if we have at least one non-optional unique
-    // key, which we don't yet.  For now, assume that if we add another kind of workspace settings
-    // it will rectify this issue.
-    if let settings = try? ClangWorkspaceSettings(from: decoder) {
+    if let settings = try? ClangWorkspaceSettings(from: decoder), settings.isValid {
       self = .clangd(settings)
     } else {
       let settings = try LSPAny(from: decoder)
@@ -58,6 +55,13 @@ public struct ClangWorkspaceSettings: Codable, Hashable {
   ) {
     self.compilationDatabasePath = compilationDatabasePath
     self.compilationDatabaseChanges = compilationDatabaseChanges
+  }
+
+  var isValid: Bool {
+    switch (compilationDatabasePath, compilationDatabaseChanges) {
+      case (nil, .some), (.some, nil): return true
+      default: return false
+    }
   }
 }
 

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -174,10 +174,6 @@ final class CodingTests: XCTestCase {
     )
 
     checkCoding(
-      WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: nil)),
-      json: "{\n\n}"
-    )
-    checkCoding(
       WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: "foo")),
       json: """
         {
@@ -186,14 +182,13 @@ final class CodingTests: XCTestCase {
         """
     )
 
-    // FIXME: should probably be "unknown"; see comment in WorkspaceSettingsChange decoder.
     checkDecoding(
       json: """
         {
           "hi": "there"
         }
         """,
-      expected: WorkspaceSettingsChange.clangd(ClangWorkspaceSettings(compilationDatabasePath: nil))
+      expected: WorkspaceSettingsChange.unknown(LSPAny.dictionary(["hi": LSPAny.string("there")]))
     )
 
     // experimental can be anything


### PR DESCRIPTION
Basically everything will be decoded as ClangWorkspaceSettings, even if it has nothing to do wit hit, yielding for example:
```
clangd(LanguageServerProtocol.ClangWorkspaceSettings(compilationDatabasePath: nil, compilationDatabaseChanges: nil))
```
This breaks at least my case of using WorkspaceSettingsChange. This patch adds a - maybe bandaid - fix for that.

Furthermore I removed one test, as it - AFAIU - broke the invariant that none of the attributes of ClangWorkspaceSettings may be nil.

I'm not sure whether there would be a better solution, but this patch works for my use.