### PR TITLE
Output a `---` marker to mark the end of a log message in `NonDarwinLogger`

### DIFF
--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -291,6 +291,7 @@ public struct NonDarwinLogger {
         """
         [\(subsystem):\(category)] \(level) \(dateFormatter.string(from: date))
         \(message().value.string(for: self.privacyLevel))
+        ---
         """
       )
     }

--- a/Tests/LSPLoggingTests/LoggingTests.swift
+++ b/Tests/LSPLoggingTests/LoggingTests.swift
@@ -57,7 +57,11 @@ fileprivate func assertLogging(
       )
       continue
     }
-    let messageContent = String(message[message.index(after: firstNewline)...])
+    guard message.hasSuffix("\n---") else {
+      XCTFail("Message is expected to end with `---`", file: file, line: line)
+      return
+    }
+    let messageContent = String(message[message.index(after: firstNewline)...].dropLast(4))
     XCTAssertEqual(messageContent, expected, "Message does not match expected", file: file, line: line)
   }
 
@@ -82,7 +86,7 @@ final class LoggingTests: XCTestCase {
       message.starts(with: "[org.swift.sourcekit-lsp:test] error"),
       "Message did not have expected header. Received \n\(message)"
     )
-    XCTAssert(message.hasSuffix("\nmy message"), "Message did not have expected body. Received \n\(message)")
+    XCTAssert(message.hasSuffix("\nmy message\n---"), "Message did not have expected body. Received \n\(message)")
   }
 
   func testLoggingBasic() {


### PR DESCRIPTION
Figuring out where one log message ends and the next one starts is a little tricky. A `---` marker helped me a lot to find the boundary between two log messages.