### PR TITLE
Capture stderr from clangd and forward it to the logger

### DIFF
--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -32,6 +32,26 @@ extension NSLock {
   }
 }
 
+/// Gathers data from clangd's stderr pipe. When it has accumulated a full line, writes the the line to the logger.
+fileprivate class ClangdStderrLogForwarder {
+  private var buffer = Data()
+
+  func handle(_ newData: Data) {
+    self.buffer += newData
+    while let newlineIndex = self.buffer.firstIndex(of: UInt8(ascii: "\n")) {
+      // Output a separate log message for every line in clangd's stderr.
+      // The reason why we don't output multiple lines in a single log message is that 
+      //  a) os_log truncates log messages at about 1000 bytes. The assumption is that a single line is usually less
+      //     than 1000 bytes long but if we merge multiple lines into one message, we might easily exceed this limit.
+      //  b) It might be confusing why sometimes a single log message contains one line while sometimes it contains 
+      //     multiple.
+      let logger = Logger(subsystem: subsystem, category: "clangd-stderr")
+      logger.info("\(String(data: self.buffer[...newlineIndex], encoding: .utf8) ?? "<invalid UTF-8>")")
+      buffer = buffer[buffer.index(after: newlineIndex)...]
+    }
+  }
+}
+
 /// A thin wrapper over a connection to a clangd server providing build setting handling.
 ///
 /// In addition, it also intercepts notifications and replies from clangd in order to do things
@@ -203,6 +223,17 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
 
     process.standardOutput = clangdToUs
     process.standardInput = usToClangd
+    let logForwarder = ClangdStderrLogForwarder()
+    let stderrHandler = Pipe()
+    stderrHandler.fileHandleForReading.readabilityHandler = { fileHandle in
+      let newData = fileHandle.availableData
+      if newData.count == 0 {
+        stderrHandler.fileHandleForReading.readabilityHandler = nil
+      } else {
+        logForwarder.handle(newData)
+      }
+    }
+    process.standardError = stderrHandler
     process.terminationHandler = { [weak self] process in
       logger.log(
         level: process.terminationReason == .exit ? .default : .error,


### PR DESCRIPTION
Previously, we were forwarding clangd’s stderr to sourcekit-lsp’s stderr. We should pipe it through the logger so that it ends up in OSLog on Darwin.