### PR TITLE
Minor improvements to SwiftLanguageServer.swift

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -389,12 +389,16 @@ extension SwiftLanguageServer {
         // Sleep for a little bit until triggering the diagnostic generation. This effectively de-bounces diagnostic
         // generation since any later edit will cancel the previous in-flight task, which will thus never go on to send
         // the `DocumentDiagnosticsRequest`.
-        try await Task.sleep(nanoseconds: UInt64(sourceKitServer.options.swiftPublishDiagnosticsDebounceDuration * 1_000_000_000))
+        try await Task.sleep(
+          nanoseconds: UInt64(sourceKitServer.options.swiftPublishDiagnosticsDebounceDuration * 1_000_000_000)
+        )
       } catch {
         return
       }
       do {
-        let diagnosticReport = try await self.fullDocumentDiagnosticReport(DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(document)))
+        let diagnosticReport = try await self.fullDocumentDiagnosticReport(
+          DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(document))
+        )
 
         await sourceKitServer.sendNotificationToClient(
           PublishDiagnosticsNotification(
@@ -404,10 +408,12 @@ extension SwiftLanguageServer {
         )
       } catch is CancellationError {
       } catch {
-        logger.fault("""
+        logger.fault(
+          """
           Failed to get diagnostics
           \(error.forLogging)
-          """)
+          """
+        )
       }
     }
   }
@@ -1178,7 +1184,9 @@ extension SwiftLanguageServer {
     return try await .full(fullDocumentDiagnosticReport(req))
   }
 
-  private func fullDocumentDiagnosticReport(_ req: DocumentDiagnosticsRequest) async throws -> RelatedFullDocumentDiagnosticReport {
+  private func fullDocumentDiagnosticReport(
+    _ req: DocumentDiagnosticsRequest
+  ) async throws -> RelatedFullDocumentDiagnosticReport {
     guard let snapshot = documentManager.latestSnapshot(req.textDocument.uri) else {
       throw ResponseError.unknown("failed to find snapshot for url \(req.textDocument.uri.forLogging)")
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -367,6 +367,12 @@ extension SwiftLanguageServer {
   /// If the client doesn't support pull diagnostics, compute diagnostics for the latest version of the given document
   /// and send a `PublishDiagnosticsNotification` to the client for it.
   private func publishDiagnosticsIfNeeded(for document: DocumentURI) {
+    withLoggingScope("publish-diagnostics") {
+      publishDiagnosticsIfNeededImpl(for: document)
+    }
+  }
+
+  private func publishDiagnosticsIfNeededImpl(for document: DocumentURI) {
     guard enablePublishDiagnostics else {
       return
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -402,6 +402,7 @@ extension SwiftLanguageServer {
             diagnostics: diagnosticReport.items
           )
         )
+      } catch is CancellationError {
       } catch {
         logger.fault("""
           Failed to get diagnostics


### PR DESCRIPTION
- Introduce a new sub-logging scope for the implicitly triggered publish diagnostics notification
  - Just makes it clearer why some logs are being triggered if you know that it’s for the publish diagnostics notification.
- Don’t log a fault if the publish diagnostics notification is cancelled
  - Cancelling the publish diagnostics notificaiton because there was an edit is totally normal and nothing to be logged at the `fault` level.
- Format SwiftLanguageServer.swift