### PR TITLE
Sort the JSON keys when logging a request

### DIFF
--- a/Sources/LanguageServerProtocol/Request.swift
+++ b/Sources/LanguageServerProtocol/Request.swift
@@ -96,6 +96,7 @@ public final class Notification<N: NotificationType> {
 fileprivate extension Encodable {
   var prettyPrintJSON: String {
     let encoder = JSONEncoder()
+    encoder.outputFormatting.insert(.sortedKeys)
     encoder.outputFormatting.insert(.prettyPrinted)
     guard let data = try? encoder.encode(self) else {
       return "\(self)"


### PR DESCRIPTION
Otherwise, we get non-deterministic ordering of keys, which makes it harder to compare requests