### PR TITLE
Increase log level for request responses

### DIFF
--- a/Sources/LanguageServerProtocol/Request.swift
+++ b/Sources/LanguageServerProtocol/Request.swift
@@ -129,3 +129,26 @@ extension Notification: CustomStringConvertible, CustomLogStringConvertible {
     return "Notification<\(N.method)>"
   }
 }
+
+fileprivate struct AnyResponseType: CustomLogStringConvertible {
+  let response: any ResponseType
+
+  var description: String {
+    return """
+      \(type(of: response))
+      \(response.prettyPrintJSON)
+      """
+  }
+
+  var redactedDescription: String {
+    return """
+      \(type(of: response))
+      """
+  }
+}
+
+extension ResponseType {
+  public var forLogging: CustomLogStringConvertibleWrapper {
+    return AnyResponseType(response: self).forLogging
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -713,14 +713,24 @@ extension SourceKitServer: MessageHandler {
         reply(result)
         let endDate = Date()
         Task {
-          logger.debug(
-            """
-            Sending response (took \(endDate.timeIntervalSince(startDate) * 1000, privacy: .public)ms)
-            Response<\(R.method, privacy: .public)(\(id, privacy: .public))>(
-              \(String(describing: result))
+          switch result {
+          case .success(let response):
+            logger.log(
+              """
+              Succeeded (took \(endDate.timeIntervalSince(startDate) * 1000, privacy: .public)ms)
+              \(R.method, privacy: .public)
+              \(response.forLogging)
+              """
             )
-            """
-          )
+          case .failure(let error):
+             logger.log(
+              """
+              Failed (took \(endDate.timeIntervalSince(startDate) * 1000, privacy: .public)ms)
+              \(R.method, privacy: .public)(\(id, privacy: .public))
+              \(error.forLogging, privacy: .private)
+              """
+            ) 
+          }
         }
       }
     )


### PR DESCRIPTION
The request responses are interesting to see to diagnose issues. Log them at the `log` instead of `debug` level instead.