### PR TITLE
Remove `SourceKitD.sendSync`

### DIFF
--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -65,21 +65,6 @@ extension SourceKitD {
 
   // MARK: - Convenience API for requests.
 
-  /// Send the given request and synchronously receive a reply dictionary (or error).
-  public func sendSync(_ req: SKDRequestDictionary) throws -> SKDResponseDictionary {
-    logRequest(req)
-
-    let resp = SKDResponse(api.send_request_sync(req.dict), sourcekitd: self)
-
-    logResponse(resp)
-
-    guard let dict = resp.value else {
-      throw resp.error!
-    }
-
-    return dict
-  }
-
   public func send(_ req: SKDRequestDictionary) async throws -> SKDResponseDictionary {
     logRequest(req)
 

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -120,7 +120,7 @@ class CodeCompletionSession {
         }
         // The sessions aren't compatible. Close the existing session and open
         // a new one below.
-        session.close()
+        await session.close()
       }
       if mustReuse {
         logger.error("triggerFromIncompleteCompletions with no existing completion session")
@@ -264,7 +264,7 @@ class CodeCompletionSession {
     return dict
   }
 
-  private func close() {
+  private func close() async {
     switch self.state {
     case .closed:
       // Already closed, nothing to do.
@@ -275,7 +275,7 @@ class CodeCompletionSession {
       req[keys.offset] = self.utf8StartOffset
       req[keys.name] = self.snapshot.uri.pseudoPath
       logger.info("Closing code completion session: \(self, privacy: .private)")
-      _ = try? sourcekitd.sendSync(req)
+      _ = try? await sourcekitd.send(req)
       self.state = .closed
     }
   }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -259,10 +259,10 @@ extension SwiftLanguageServer {
   }
 
   /// Tell sourcekitd to crash itself. For testing purposes only.
-  public func _crash() {
+  public func _crash() async {
     let req = SKDRequestDictionary(sourcekitd: sourcekitd)
     req[sourcekitd.keys.request] = sourcekitd.requests.crash_exit
-    _ = try? sourcekitd.sendSync(req)
+    _ = try? await sourcekitd.send(req)
   }
 
   // MARK: - Build System Integration
@@ -276,7 +276,7 @@ extension SwiftLanguageServer {
     let closeReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
     closeReq[keys.request] = self.requests.editor_close
     closeReq[keys.name] = path
-    _ = try? self.sourcekitd.sendSync(closeReq)
+    _ = try? await self.sourcekitd.send(closeReq)
 
     let openReq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
     openReq[keys.request] = self.requests.editor_open
@@ -286,7 +286,7 @@ extension SwiftLanguageServer {
       openReq[keys.compilerargs] = compileCmd.compilerArgs
     }
 
-    _ = try? self.sourcekitd.sendSync(openReq)
+    _ = try? await self.sourcekitd.send(openReq)
 
     publishDiagnosticsIfNeeded(for: snapshot.uri)
   }
@@ -336,7 +336,7 @@ extension SwiftLanguageServer {
       req[keys.compilerargs] = compilerArgs
     }
 
-    _ = try? self.sourcekitd.sendSync(req)
+    _ = try? await self.sourcekitd.send(req)
     publishDiagnosticsIfNeeded(for: note.textDocument.uri)
   }
 
@@ -354,7 +354,7 @@ extension SwiftLanguageServer {
     req[keys.request] = self.requests.editor_close
     req[keys.name] = uri.pseudoPath
 
-    _ = try? self.sourcekitd.sendSync(req)
+    _ = try? await self.sourcekitd.send(req)
   }
 
   /// Cancels any in-flight tasks to send a `PublishedDiagnosticsNotification` after edits.

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -36,7 +36,7 @@ final class SourceKitDTests: XCTestCase {
       .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
-  func testMultipleNotificationHandlers() throws {
+  func testMultipleNotificationHandlers() async throws {
     let sourcekitd = try SourceKitDImpl.getOrCreate(dylibPath: SourceKitDTests.sourcekitdPath)
     let keys = sourcekitd.keys
     let path = DocumentURI.for(.swift).pseudoPath
@@ -88,14 +88,14 @@ final class SourceKitDTests: XCTestCase {
     args.append(path)
     req[keys.compilerargs] = args
 
-    _ = try sourcekitd.sendSync(req)
+    _ = try await sourcekitd.send(req)
 
-    waitForExpectations(timeout: defaultTimeout)
+    try await fulfillmentOfOrThrow([expectation1, expectation2])
 
     let close = SKDRequestDictionary(sourcekitd: sourcekitd)
     close[keys.request] = sourcekitd.requests.editor_close
     close[keys.name] = path
-    _ = try sourcekitd.sendSync(close)
+    _ = try await sourcekitd.send(close)
   }
 }
 


### PR DESCRIPTION
Everybody should be calling the `async` version of `send`. Most callers could be migrated easily. `SwiftLanguageServer.changeDocument` was a little bit more tricky because the callback of `DocumentManager.edit` can’t be async but that’s easily fixed by gathering the edits in an array and sending them to `sourcekitd` outside after the document manager is done.

Resolves https://github.com/apple/sourcekit-lsp/issues/869
rdar://116703689