### PR TITLE
Make logs less noisy

### DIFF
--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -73,12 +73,16 @@ public actor CompilationDatabaseBuildSystem {
     return nil
   }
 
-  public init(projectRoot: AbsolutePath? = nil, searchPaths: [RelativePath], fileSystem: FileSystem = localFileSystem) {
+  public init?(projectRoot: AbsolutePath? = nil, searchPaths: [RelativePath], fileSystem: FileSystem = localFileSystem) {
     self.fileSystem = fileSystem
     self.projectRoot = projectRoot
     self.searchPaths = searchPaths
-    if let path = projectRoot {
-      self.compdb = tryLoadCompilationDatabase(directory: path, additionalSearchPaths: searchPaths, fileSystem)
+    if let path = projectRoot,
+      let compdb = tryLoadCompilationDatabase(directory: path, additionalSearchPaths: searchPaths, fileSystem)
+    {
+      self.compdb = compdb
+    } else {
+      return nil
     }
   }
 }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -554,7 +554,7 @@ private func findPackageDirectory(
 extension Basics.Diagnostic.Severity {
   var asLogLevel: LogLevel {
     switch self {
-    case .error, .warning: return .error
+    case .error, .warning: return .default
     case .info: return .info
     case .debug: return .debug
     }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -118,8 +118,16 @@ public final class Workspace {
         reloadPackageStatusCallback: reloadPackageStatusCallback
       ) {
         buildSystem = swiftpm
+      } else if let compdb = CompilationDatabaseBuildSystem(
+        projectRoot: rootPath,
+        searchPaths: compilationDatabaseSearchPaths
+      ) {
+        buildSystem = compdb
       } else {
-        buildSystem = CompilationDatabaseBuildSystem(projectRoot: rootPath, searchPaths: compilationDatabaseSearchPaths)
+        logger.error(
+          "Could not set up a build system for workspace at '\(rootUri.forLogging)'"
+        )
+        buildSystem = nil
       }
     } else {
       // We assume that workspaces are directories. This is only true for URLs not for URIs in general.

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -453,5 +453,5 @@ private func checkCompilationDatabaseBuildSystem(
     searchPaths: try [RelativePath(validating: ".")],
     fileSystem: fs
   )
-  try await block(buildSystem)
+  try await block(XCTUnwrap(buildSystem))
 }


### PR DESCRIPTION
Make logs less noisy in two ways:

- Set the build system to `nil` if no compilation database can be loaded
  - When we couldn’t start a build server or find a SwiftPM package, we currently always create a `CompilationDatabaseBuildSystem`, even if no `compile_commands.json` or `compile_flags.txt` exits. Every request for build settings would then log an error that the compilation database can’t be opened, which was very spammy. Instead, if the compilation database can’t be loaded, just set the build system to `nil` and log a single error message.
- Reduce SwiftPM log message to be at most at the `default` level
  - SwiftPM would output warnings for every compilation warning it hits while building the package manifest, which usually doesn’t affect sourcekit-lsp. Logging these at the `error` level is very noisy. Reduce the log level to `default`.