### PR TITLE
Rename `qualifiedDeclName` to `declName` in document symbols

### DIFF
--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -121,7 +121,7 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
 
     return record(
       node: node,
-      name: node.qualifiedDeclName,
+      name: node.declName,
       symbolKind: .enumMember,
       range: node.name.positionAfterSkippingLeadingTrivia..<rangeEnd,
       selection: node.name.positionAfterSkippingLeadingTrivia..<rangeEnd
@@ -148,7 +148,7 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
     }
     return record(
       node: node,
-      name: node.qualifiedDeclName,
+      name: node.declName,
       symbolKind: kind,
       range: node.rangeWithoutTrivia,
       selection: node.name
@@ -199,7 +199,7 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
 // MARK: - Syntax Utilities
 
 fileprivate extension EnumCaseElementSyntax {
-  var qualifiedDeclName: String {
+  var declName: String {
     var result = self.name.text
     if let parameterClause {
       result += "("
@@ -213,7 +213,7 @@ fileprivate extension EnumCaseElementSyntax {
 }
 
 fileprivate extension FunctionDeclSyntax {
-  var qualifiedDeclName: String {
+  var declName: String {
     var result = self.name.text
     result += "("
     for parameter in self.signature.parameterClause.parameters {


### PR DESCRIPTION
`qualifiedDeclName` wasn’t the correct term here.