### PR TITLE
Make the `LanguageServerProtocol` module dependency-free

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,10 +101,7 @@ let package = Package(
     // The core LSP types, suitable for any LSP implementation.
     .target(
       name: "LanguageServerProtocol",
-      dependencies: [
-        "SKSupport",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
+      dependencies: [],
       exclude: ["CMakeLists.txt"]
     ),
 
@@ -200,7 +197,9 @@ let package = Package(
     .target(
       name: "SKSupport",
       dependencies: [
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+        "LanguageServerProtocol",
+        "LSPLogging"
       ],
       exclude: ["CMakeLists.txt"]
     ),

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(LanguageServerProtocol STATIC
-  AsyncQueue.swift
   Connection.swift
   CustomCodable.swift
   Error.swift

--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import SKSupport
 
 /// An abstract connection, allow messages to be sent to a (potentially remote) `MessageHandler`.
 public protocol Connection: AnyObject {
@@ -127,25 +126,5 @@ extension LocalConnection: Connection {
     }
 
     return id
-  }
-}
-
-extension Connection {
-  /// Send the given request to the connection and await its result.
-  ///
-  /// This method automatically sends a `CancelRequestNotification` to the
-  /// connection if the task it is executing in is being cancelled.
-  ///
-  /// - Warning: Because this message is `async`, it does not provide any ordering
-  ///   guarantees. If you need to gurantee that messages are sent in-order
-  ///   use the version with a completion handler.
-  public func send<R: RequestType>(_ request: R) async throws -> R.Response {
-    return try await withCancellableCheckedThrowingContinuation { continuation in
-      return self.send(request) { result in
-        continuation.resume(with: result)
-      }
-    } cancel: { requestID in
-      self.send(CancelRequestNotification(id: requestID))
-    }
   }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -11,27 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import LSPLogging
 
-import struct TSCBasic.AbsolutePath
-import func TSCBasic.resolveSymlinks
-
-public struct DocumentURI: Codable, Hashable, CustomLogStringConvertible {
+public struct DocumentURI: Codable, Hashable {
   /// The URL that store the URIs value
   private let storage: URL
 
   public var description: String {
     return storage.description
-  }
-
-  public var redactedDescription: String {
-    return "<DocumentURI length=\(storage.description.count) hash=\(description.hashForLogging)>"
-  }
-
-  public var nativeURI: Self {
-    get throws {
-      DocumentURI(URL(fileURLWithPath: try resolveSymlinks(AbsolutePath(validating: self.pseudoPath)).pathString))
-    }
   }
 
   public var fileURL: URL? {

--- a/Sources/SKSupport/AsyncQueue.swift
+++ b/Sources/SKSupport/AsyncQueue.swift
@@ -24,7 +24,7 @@ extension Task: AnyTask {
   }
 }
 
-extension NSLock {
+fileprivate extension NSLock {
   /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
   func withLock<T>(_ body: () throws -> T) rethrows -> T {
     lock()
@@ -48,7 +48,7 @@ public struct Serial: DependencyTracker {
   }
 }
 
-/// A queue that allows the execution of asyncronous blocks of code.
+/// A queue that allows the execution of asynchronous blocks of code.
 public final class AsyncQueue<TaskMetadata: DependencyTracker> {
   private struct PendingTask {
     /// The task that is pending.
@@ -109,7 +109,7 @@ public final class AsyncQueue<TaskMetadata: DependencyTracker> {
     let id = UUID()
 
     return pendingTasksLock.withLock {
-      // Build the list of tasks that need to finishe exeuction before this one
+      // Build the list of tasks that need to finished execution before this one
       // can be executed
       let dependencies: [PendingTask] = pendingTasks.filter { $0.metadata.isDependency(of: metadata) }
 

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -1,11 +1,14 @@
 
 add_library(SKSupport STATIC
+  AsyncQueue.swift
   AsyncUtils.swift
   BuildConfiguration.swift
   ByteString.swift
+  Connection+Send.swift
   dlopen.swift
   FileSystem.swift
   LineTable.swift
+  LoggableMessageTypes.swift
   Random.swift
   Result.swift
   ThreadSafeBox.swift

--- a/Sources/SKSupport/Connection+Send.swift
+++ b/Sources/SKSupport/Connection+Send.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+extension Connection {
+  /// Send the given request to the connection and await its result.
+  ///
+  /// This method automatically sends a `CancelRequestNotification` to the
+  /// connection if the task it is executing in is being cancelled.
+  ///
+  /// - Warning: Because this message is `async`, it does not provide any ordering
+  ///   guarantees. If you need to guarantee that messages are sent in-order
+  ///   use the version with a completion handler.
+  public func send<R: RequestType>(_ request: R) async throws -> R.Response {
+    return try await withCancellableCheckedThrowingContinuation { continuation in
+      return self.send(request) { result in
+        continuation.resume(with: result)
+      }
+    } cancel: { requestID in
+      self.send(CancelRequestNotification(id: requestID))
+    }
+  }
+}

--- a/Sources/SKSupport/LoggableMessageTypes.swift
+++ b/Sources/SKSupport/LoggableMessageTypes.swift
@@ -31,6 +31,16 @@ fileprivate extension Encodable {
   }
 }
 
+// MARK: - DocumentURI
+
+extension DocumentURI: CustomLogStringConvertible {
+  public var redactedDescription: String {
+    return "<DocumentURI length=\(description.count) hash=\(description.hashForLogging)>"
+  }
+}
+
+// MARK: - RequestType
+
 fileprivate struct AnyRequestType: CustomLogStringConvertible {
   let request: any RequestType
 
@@ -52,6 +62,8 @@ extension RequestType {
   }
 }
 
+// MARK: - NotificationType
+
 fileprivate struct AnyNotificationType: CustomLogStringConvertible {
   let notification: any NotificationType
 
@@ -72,6 +84,8 @@ extension NotificationType {
     return AnyNotificationType(notification: self).forLogging
   }
 }
+
+// MARK: - ResponseType
 
 fileprivate struct AnyResponseType: CustomLogStringConvertible {
   let response: any ResponseType

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(SourceKitLSP STATIC
   CapabilityRegistry.swift
   DocumentManager.swift
   IndexStoreDB+MainFilesProvider.swift
-  LoggableMessageTypes.swift
   ResponseError+Init.swift
   Sequence+AsyncMap.swift
   SourceKitIndexDelegate.swift

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -14,6 +14,7 @@ import Dispatch
 import LSPLogging
 import LanguageServerProtocol
 import SourceKitD
+import SKSupport
 
 /// Represents a code-completion session for a given source location that can be efficiently
 /// re-filtered by calling `update()`.


### PR DESCRIPTION
Shuffle a few types around so that the `LanguageServerProtocol` has no more dependencies.

Fixes #938
rdar://117565087