### PR TITLE
Remove `Connection.sendSync`

### DIFF
--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -17,29 +17,13 @@ import SKSupport
 public protocol Connection: AnyObject {
 
   /// Send a notification without a reply.
-  func send<Notification>(_: Notification) where Notification: NotificationType
+  func send(_ notification: some NotificationType)
 
   /// Send a request and (asynchronously) receive a reply.
   func send<Request: RequestType>(
     _: Request,
     reply: @escaping (LSPResult<Request.Response>) -> Void
   ) -> RequestID
-
-  /// Send a request synchronously. **Use wisely**.
-  func sendSync<Request>(_: Request) throws -> Request.Response where Request: RequestType
-}
-
-extension Connection {
-  public func sendSync<Request>(_ request: Request) throws -> Request.Response where Request: RequestType {
-    var result: LSPResult<Request.Response>? = nil
-    let semaphore = DispatchSemaphore(value: 0)
-    _ = send(request) { _result in
-      result = _result
-      semaphore.signal()
-    }
-    semaphore.wait()
-    return try result!.get()
-  }
 }
 
 /// An abstract message handler, such as a language server or client.

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -102,7 +102,7 @@ public actor BuildServerBuildSystem: MessageHandler {
     self.buildFolder = buildFolder
     self.projectRoot = projectRoot
     self.serverConfig = config
-    try self.initializeBuildServer()
+    try await self.initializeBuildServer()
   }
 
   /// Creates a build system using the Build Server Protocol config.
@@ -134,7 +134,7 @@ public actor BuildServerBuildSystem: MessageHandler {
     }
   }
 
-  private func initializeBuildServer() throws {
+  private func initializeBuildServer() async throws {
     var serverPath = try AbsolutePath(validating: serverConfig.argv[0], relativeTo: projectRoot)
     var flags = Array(serverConfig.argv[1...])
     if serverPath.suffix == ".py" {
@@ -172,7 +172,7 @@ public actor BuildServerBuildSystem: MessageHandler {
     )
 
     let buildServer = try makeJSONRPCBuildServer(client: self, serverPath: serverPath, serverFlags: flags)
-    let response = try buildServer.sendSync(initializeRequest)
+    let response = try await buildServer.send(initializeRequest)
     buildServer.send(InitializedBuildNotification())
     logger.log("initialized build server \(response.displayName)")
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -516,7 +516,7 @@ public actor SourceKitServer {
       }
 
       let pid = Int(ProcessInfo.processInfo.processIdentifier)
-      let resp = try await service.initializeSync(
+      let resp = try await service.initialize(
         InitializeRequest(
           processId: pid,
           rootPath: nil,

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -196,7 +196,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
 
 extension SwiftLanguageServer {
 
-  public func initializeSync(_ initialize: InitializeRequest) throws -> InitializeResult {
+  public func initialize(_ initialize: InitializeRequest) throws -> InitializeResult {
     sourcekitd.addNotificationHandler(self)
 
     return InitializeResult(

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -43,7 +43,7 @@ public protocol ToolchainLanguageServer: AnyObject {
 
   // MARK: - Lifetime
 
-  func initializeSync(_ initialize: InitializeRequest) async throws -> InitializeResult
+  func initialize(_ initialize: InitializeRequest) async throws -> InitializeResult
   func clientInitialized(_ initialized: InitializedNotification) async
 
   /// Shut the server down and return once the server has finished shutting down


### PR DESCRIPTION
All callers should call the async version `Connection.send`.