### PR TITLE
Emit signposts for request handling

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -27,9 +27,17 @@ import os  // os_log
 
 public typealias LogLevel = os.OSLogType
 public typealias Logger = os.Logger
+public typealias Signposter = OSSignposter
+
+extension os.Logger {
+  public func makeSignposter() -> Signposter {
+    return OSSignposter(logger: self)
+  }
+}
 #else
 public typealias LogLevel = NonDarwinLogLevel
 public typealias Logger = NonDarwinLogger
+public typealias Signposter = NonDarwinSignposter
 #endif
 
 /// The logger that is used to log any messages.

--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -330,4 +330,35 @@ public struct NonDarwinLogger {
   public static func flush() {
     loggingQueue.sync {}
   }
+
+  public func makeSignposter() -> NonDarwinSignposter {
+    return NonDarwinSignposter()
+  }
+}
+
+// MARK: - Signposter
+
+public struct NonDarwinSignpostID {}
+
+public struct NonDarwinSignpostIntervalState {}
+
+/// A type that is API-compatible to `OSLogMessage` for all uses within sourcekit-lsp.
+///
+/// Since non-Darwin platforms don't have signposts, the type just has no-op operations.
+public struct NonDarwinSignposter {
+  public func makeSignpostID() -> NonDarwinSignpostID {
+    return NonDarwinSignpostID()
+  }
+
+  public func beginInterval(
+    _ name: StaticString,
+    id: NonDarwinSignpostID,
+    _ message: NonDarwinLogMessage
+  ) -> NonDarwinSignpostIntervalState {
+    return NonDarwinSignpostIntervalState()
+  }
+
+  public func emitEvent(_ name: StaticString, id: NonDarwinSignpostID, _ message: NonDarwinLogMessage = "") {}
+
+  public func endInterval(_ name: StaticString, _ state: NonDarwinSignpostIntervalState, _ message: StaticString) {}
 }


### PR DESCRIPTION
This allows you to trace sourcekit-lsp in Instruments to get a feeling for how long requests take to be handled. I’m not sure how useful this will be in practice but we can’t really know until we have it in a build that we see an issue with, so I’d propose we put it in and if we never use it in the next year or two, we can rip it back out again.