### PR TITLE
Fix issue that `SOURCEKITLSP_LOG_LEVEL` environment variable was not honored

### DIFF
--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -17,10 +17,15 @@ import Foundation
 public enum LogConfig {
   /// The globally set log level
   fileprivate static let logLevel: NonDarwinLogLevel = {
-    guard let envVar = ProcessInfo.processInfo.environment["SOURCEKITLSP_LOG_LEVEL"] else {
-      return .default
+    if let envVar = ProcessInfo.processInfo.environment["SOURCEKITLSP_LOG_LEVEL"],
+      let logLevel = NonDarwinLogLevel(envVar) {
+      return logLevel
     }
-    return NonDarwinLogLevel(envVar) ?? .default
+    #if DEBUG
+    return .debug
+    #else
+    return .default
+    #endif
   }()
 
   /// The globally set privacy level

--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -53,19 +53,24 @@ public enum NonDarwinLogLevel: Comparable, CustomStringConvertible {
     case "default": self = .`default`
     case "error": self = .error
     case "fault": self = .fault
-    default: break
+    default:
+      if let int = Int(value) {
+        self.init(int)
+      } else {
+        return nil
+      }
     }
+  }
 
-    switch Int(value) {
+  public init?(_ value: Int) {
+    switch value {
     case 0: self = .fault
     case 1: self = .error
     case 2: self = .default
     case 3: self = .info
     case 4: self = .debug
-    default: break
+    default: return nil
     }
-
-    return nil
   }
 
   public var description: String {


### PR DESCRIPTION
The initializer of `NonDarwinLogLevel` always returned `nil`, even if a valid value was passed. Thus, the log level was always `default`, independent of the value passed to `SOURCEKITLSP_LOG_LEVEL`.

While at it, change the default log level to be `debug` (opposed to `default`) when sourcekit-lsp is built in debug mode. That way you get full log output when running tests on Linux by default, which makes debugging easier.