### PR TITLE
Improve test scratch directory creation

### DIFF
--- a/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
@@ -38,7 +38,7 @@ public struct IndexedSingleSwiftFileWorkspace {
     _ markedText: String,
     indexSystemModules: Bool = false,
     workspaceDirectory: URL? = nil,
-    cleanUp: Bool = true,
+    cleanUp: Bool = cleanScratchDirectories,
     testName: String = #function
   ) async throws {
     let testWorkspaceDirectory = try workspaceDirectory ?? testScratchDir(testName: testName)

--- a/Sources/SKTestSupport/MultiFileTestWorkspace.swift
+++ b/Sources/SKTestSupport/MultiFileTestWorkspace.swift
@@ -105,7 +105,9 @@ public class MultiFileTestWorkspace {
     self.testClient = try await TestSourceKitLSPClient(
       workspaceFolders: workspaces(scratchDirectory),
       cleanUp: { [scratchDirectory] in
-        try? FileManager.default.removeItem(at: scratchDirectory)
+        if cleanScratchDirectories {
+          try? FileManager.default.removeItem(at: scratchDirectory)
+        }
       }
     )
   }

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -44,15 +44,20 @@ extension DocumentURI {
   }
 }
 
+public let cleanScratchDirectories = (ProcessInfo.processInfo.environment["SOURCEKITLSP_KEEP_TEST_SCRATCH_DIR"] == nil)
+
 /// An empty directory in which a test with `#function` name `testName` can store temporary data.
 public func testScratchDir(testName: String = #function) throws -> URL {
   let testBaseName = testName.prefix(while: \.isLetter)
 
+  var uuid = UUID().uuidString[...]
+  if let firstDash = uuid.firstIndex(of: "-") {
+    uuid = uuid[..<firstDash]
+  }
   let url = FileManager.default.temporaryDirectory
     .realpath
     .appendingPathComponent("sourcekit-lsp-test-scratch")
-    .appendingPathComponent(UUID().uuidString)
-    .appendingPathComponent(String(testBaseName))
+    .appendingPathComponent("\(testBaseName)-\(uuid)")
   try? FileManager.default.removeItem(at: url)
   try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
   return url


### PR DESCRIPTION
Addresses the comments in #929 

> - We should shorten the name of the directory by not including a full UUID, a few characters should be sufficient to ensure there are no conflicts
> - Instead of having a `<UUID>/<testName>` sub-directory structure we should have a single folder `<testName>-<UUID>`. That also ensures that the UUID directories don’t stay around after clean-up.
> - Add an environment variable to not clean up the test directories.

Resolves #929
rdar://117547610