### PR TITLE
Reduce logging level for unknown notifications or requests

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/DocumentLinkRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentLinkRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The document links request is sent from the client to the server to request the location of links in a document.
-public struct DocumentLinkRequest: RequestType {
+public struct DocumentLinkRequest: TextDocumentRequest {
   public static let method: String = "textDocument/documentLink"
   public typealias Response = [DocumentLink]?
 

--- a/Sources/LanguageServerProtocol/Requests/InlineValueRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlineValueRefreshRequest.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct InlineValueRefreshRequest: RequestType {
-  static var method: String = "workspace/inlineValue/refresh"
-  typealias Response = VoidResponse
+public struct InlineValueRefreshRequest: RequestType {
+  public static var method: String = "workspace/inlineValue/refresh"
+  public typealias Response = VoidResponse
 
   public init() {}
 }

--- a/Sources/LanguageServerProtocol/Requests/WillSaveWaitUntilTextDocumentRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WillSaveWaitUntilTextDocumentRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The document will save request is sent from the client to the server before the document is actually saved. The request can return an array of TextEdits which will be applied to the text document before it is saved. Please note that clients might drop results if computing the text edits took too long or if a server constantly fails on this request. This is done to keep the save fast and reliable. If a server has registered for open / close events clients should ensure that the document is open before a willSaveWaitUntil notification is sent since clients can’t change the content of a file without ownership transferal.
-public struct WillSaveWaitUntilTextDocumentRequest: RequestType {
+public struct WillSaveWaitUntilTextDocumentRequest: TextDocumentRequest {
   public static let method: String = "textDocument/willSaveWaitUntil"
   public typealias Response = [TextEdit]?
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -176,26 +176,56 @@ fileprivate enum TaskMetadata: DependencyTracker {
 
   init(_ notification: any NotificationType) {
     switch notification {
-    case is InitializedNotification:
-      self = .globalConfigurationChange
-    case is CancelRequestNotification:
+    case is CancelRequestNotification: 
       self = .freestanding
-    case is ExitNotification:
-      self = .globalConfigurationChange
-    case let notification as DidOpenTextDocumentNotification:
-      self = .documentUpdate(notification.textDocument.uri)
-    case let notification as DidCloseTextDocumentNotification:
-      self = .documentUpdate(notification.textDocument.uri)
-    case let notification as DidChangeTextDocumentNotification:
-      self = .documentUpdate(notification.textDocument.uri)
-    case is DidChangeWorkspaceFoldersNotification:
-      self = .globalConfigurationChange
-    case is DidChangeWatchedFilesNotification:
+    case is CancelWorkDoneProgressNotification: 
       self = .freestanding
-    case let notification as WillSaveTextDocumentNotification:
+    case is DidChangeConfigurationNotification: 
+      self = .globalConfigurationChange
+    case let notification as DidChangeNotebookDocumentNotification: 
+      self = .documentUpdate(notification.notebookDocument.uri)
+    case let notification as DidChangeTextDocumentNotification: 
       self = .documentUpdate(notification.textDocument.uri)
-    case let notification as DidSaveTextDocumentNotification:
+    case is DidChangeWatchedFilesNotification: 
+      self = .freestanding
+    case is DidChangeWorkspaceFoldersNotification: 
+      self = .globalConfigurationChange
+    case let notification as DidCloseNotebookDocumentNotification: 
+      self = .documentUpdate(notification.notebookDocument.uri)
+    case let notification as DidCloseTextDocumentNotification: 
       self = .documentUpdate(notification.textDocument.uri)
+    case is DidCreateFilesNotification: 
+      self = .freestanding
+    case is DidDeleteFilesNotification: 
+      self = .freestanding
+    case let notification as DidOpenNotebookDocumentNotification: 
+      self = .documentUpdate(notification.notebookDocument.uri)
+    case let notification as DidOpenTextDocumentNotification: 
+      self = .documentUpdate(notification.textDocument.uri)
+    case is DidRenameFilesNotification: 
+      self = .freestanding
+    case let notification as DidSaveNotebookDocumentNotification: 
+      self = .documentUpdate(notification.notebookDocument.uri)
+    case let notification as DidSaveTextDocumentNotification: 
+      self = .documentUpdate(notification.textDocument.uri)
+    case is ExitNotification: 
+      self = .globalConfigurationChange
+    case is InitializedNotification: 
+      self = .globalConfigurationChange
+    case is LogMessageNotification: 
+      self = .freestanding
+    case is LogTraceNotification: 
+      self = .freestanding
+    case is PublishDiagnosticsNotification: 
+      self = .freestanding
+    case is SetTraceNotification: 
+      self = .globalConfigurationChange
+    case is ShowMessageNotification: 
+      self = .freestanding
+    case let notification as WillSaveTextDocumentNotification: 
+      self = .documentUpdate(notification.textDocument.uri)
+    case is WorkDoneProgress: 
+      self = .freestanding
     default:
       logger.error(
         """
@@ -209,32 +239,73 @@ fileprivate enum TaskMetadata: DependencyTracker {
 
   init(_ request: any RequestType) {
     switch request {
-    case is InitializeRequest:
-      self = .globalConfigurationChange
-    case is ShutdownRequest:
-      self = .globalConfigurationChange
-    case is WorkspaceSymbolsRequest:
+    case let request as any TextDocumentRequest: self = .documentRequest(request.textDocument.uri)
+    case is ApplyEditRequest: 
       self = .freestanding
-    case is BarrierRequest:
+    case is BarrierRequest: 
       self = .globalConfigurationChange
-    case is PollIndexRequest:
-      self = .globalConfigurationChange
-    case let request as ExecuteCommandRequest:
+    case is CallHierarchyIncomingCallsRequest: 
+      self = .freestanding
+    case is CallHierarchyOutgoingCallsRequest: 
+      self = .freestanding
+    case is CodeActionResolveRequest: 
+      self = .freestanding
+    case is CodeLensRefreshRequest: 
+      self = .freestanding
+    case is CodeLensResolveRequest: 
+      self = .freestanding
+    case is CompletionItemResolveRequest: 
+      self = .freestanding
+    case is CreateWorkDoneProgressRequest: 
+      self = .freestanding
+    case is DiagnosticsRefreshRequest: 
+      self = .freestanding
+    case is DocumentLinkResolveRequest: 
+      self = .freestanding
+    case let request as ExecuteCommandRequest: 
       if let uri = request.textDocument?.uri {
         self = .documentRequest(uri)
       } else {
         self = .freestanding
       }
-    case is CallHierarchyIncomingCallsRequest:
+    case is InitializeRequest: 
+      self = .globalConfigurationChange
+    case is InlayHintRefreshRequest: 
       self = .freestanding
-    case is CallHierarchyOutgoingCallsRequest:
+    case is InlayHintResolveRequest: 
       self = .freestanding
-    case is TypeHierarchySupertypesRequest:
+    case is InlineValueRefreshRequest: 
       self = .freestanding
-    case is TypeHierarchySubtypesRequest:
+    case is PollIndexRequest: 
+      self = .globalConfigurationChange
+    case is RegisterCapabilityRequest: 
+      self = .globalConfigurationChange
+    case is ShowMessageRequest: 
       self = .freestanding
-    case let request as any TextDocumentRequest:
-      self = .documentRequest(request.textDocument.uri)
+    case is ShutdownRequest: 
+      self = .globalConfigurationChange
+    case is TypeHierarchySubtypesRequest: 
+      self = .freestanding
+    case is TypeHierarchySupertypesRequest: 
+      self = .freestanding
+    case is UnregisterCapabilityRequest: 
+      self = .globalConfigurationChange
+    case is WillCreateFilesRequest: 
+      self = .freestanding
+    case is WillDeleteFilesRequest: 
+      self = .freestanding
+    case is WillRenameFilesRequest: 
+      self = .freestanding
+    case is WorkspaceDiagnosticsRequest: 
+      self = .freestanding
+    case is WorkspaceFoldersRequest: 
+      self = .freestanding
+    case is WorkspaceSemanticTokensRefreshRequest: 
+      self = .freestanding
+    case is WorkspaceSymbolResolveRequest: 
+      self = .freestanding
+    case is WorkspaceSymbolsRequest: 
+      self = .freestanding
     default:
       logger.error(
         """


### PR DESCRIPTION
We are, for example, ignoring the `setTrace` notification that VS Code sends to use. That’s a totally valid thing to do and we shouldn’t log an error for that.