### PR TITLE
Always require a prefix for `orLog` calls

### DIFF
--- a/Sources/LSPLogging/OrLog.swift
+++ b/Sources/LSPLogging/OrLog.swift
@@ -23,7 +23,7 @@ private func logError(prefix: String, error: Error, level: LogLevel) {
 
 /// Like `try?`, but logs the error on failure.
 public func orLog<R>(
-  _ prefix: String = "",
+  _ prefix: String,
   level: LogLevel = .error,
   _ block: () throws -> R?
 ) -> R? {
@@ -39,7 +39,7 @@ public func orLog<R>(
 ///
 /// - SeeAlso: ``orLog(_:level:_:)-66i2z``
 public func orLog<R>(
-  _ prefix: String = "",
+  _ prefix: String,
   level: LogLevel = .error,
   _ block: () async throws -> R?
 ) async -> R? {

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -348,7 +348,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 
   public func filesDidChange(_ events: [FileEvent]) async {
     if events.contains(where: { self.fileEventShouldTriggerPackageReload(event: $0) }) {
-      await orLog {
+      await orLog("Reloading package") {
         // TODO: It should not be necessary to reload the entire package just to get build settings for one file.
         try await self.reloadPackage()
       }

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -52,7 +52,7 @@ extension SwiftLanguageServer {
     in range: Range<Position>? = nil
   ) async -> [SyntaxHighlightingToken] {
     async let tree = syntaxTreeManager.syntaxTree(for: snapshot)
-    async let semanticTokens = await orLog { try await semanticHighlightingTokens(for: snapshot) }
+    async let semanticTokens = await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
 
     let range =
       if let range = range.flatMap({ $0.byteSourceRange(in: snapshot) }) {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -528,12 +528,12 @@ extension SwiftLanguageServer {
     if let doc = cursorInfo.documentationXML {
       result += """
 
-        \(orLog { try xmlDocumentationToMarkdown(doc) } ?? doc)
+        \(orLog("Convert XML to Markdown") { try xmlDocumentationToMarkdown(doc) } ?? doc)
         """
     } else if let annotated: String = cursorInfo.annotatedDeclaration {
       result += """
 
-        \(orLog { try xmlDocumentationToMarkdown(annotated) } ?? annotated)
+        \(orLog("Convert XML to Markdown") { try xmlDocumentationToMarkdown(annotated) } ?? annotated)
         """
     }
 


### PR DESCRIPTION
Otherwise it’s very easy to end up with log messages like `requestCancelled` for which it’s not clear where they are coming from.