### PR TITLE
build: correct dependencies for SKSupport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(LLBuild QUIET)
 find_package(ArgumentParser CONFIG REQUIRED)
 find_package(SwiftCollections QUIET)
 find_package(SwiftSystem CONFIG REQUIRED)
-find_package(SwiftSyntax CONFIG REQUIRED) 
+find_package(SwiftSyntax CONFIG REQUIRED)
 find_package(SwiftCrypto CONFIG REQUIRED)
 
 include(SwiftSupport)

--- a/Sources/LSPLogging/CMakeLists.txt
+++ b/Sources/LSPLogging/CMakeLists.txt
@@ -5,14 +5,10 @@ add_library(LSPLogging STATIC
   LoggingScope.swift
   NonDarwinLogging.swift
   OrLog.swift
-  SplitLogMessage.swift
-)
+  SplitLogMessage.swift)
 set_target_properties(LSPLogging PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(LSPLogging PRIVATE
-  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
-)
-
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 target_link_libraries(LSPLogging PUBLIC
-  Crypto
-)
+  Crypto)

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -136,8 +136,5 @@ add_library(LanguageServerProtocol STATIC
 set_target_properties(LanguageServerProtocol PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(LanguageServerProtocol PUBLIC
-  LSPLogging
-  SKSupport
-  TSCBasic
   $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftDispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -20,6 +20,8 @@ target_link_libraries(SKCore PRIVATE
   BuildServerProtocol
   LanguageServerProtocol
   LanguageServerProtocolJSONRPC
-  PackageModel
+  LSPLogging
   SKSupport
-  SourceKitD)
+  SourceKitD
+  PackageModel
+  TSCBasic)

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -16,5 +16,7 @@ add_library(SKSupport STATIC
 set_target_properties(SKSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SKSupport PRIVATE
+  LanguageServerProtocol
+  LSPLogging
   TSCBasic
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/SKSwiftPMWorkspace/CMakeLists.txt
+++ b/Sources/SKSwiftPMWorkspace/CMakeLists.txt
@@ -6,6 +6,8 @@ set_target_properties(SKSwiftPMWorkspace PROPERTIES
 target_link_libraries(SKSwiftPMWorkspace PRIVATE
   BuildServerProtocol
   LanguageServerProtocol
-  SKCore)
+  LSPLogging
+  SKCore
+  TSCBasic)
 target_link_libraries(SKSwiftPMWorkspace PUBLIC
   Build)

--- a/Sources/SourceKitD/CMakeLists.txt
+++ b/Sources/SourceKitD/CMakeLists.txt
@@ -12,8 +12,9 @@ add_library(SourceKitD STATIC
   sourcekitd_uids.swift)
 set_target_properties(SourceKitD PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(SourceKitD PUBLIC
+  Csourcekitd)
 target_link_libraries(SourceKitD PRIVATE
-  Csourcekitd
   LSPLogging
   SKSupport
   TSCBasic

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -38,21 +38,21 @@ set_target_properties(SourceKitLSP PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 # TODO(compnerd) reduce the exposure here, why is everything PUBLIC-ly linked?
 target_link_libraries(SourceKitLSP PUBLIC
-  Csourcekitd
   BuildServerProtocol
-  IndexStoreDB
   LanguageServerProtocol
   LanguageServerProtocolJSONRPC
+  LSPLogging
   SKCore
+  SKSupport
   SKSwiftPMWorkspace
   SourceKitD
+  IndexStoreDB
   SwiftSyntax::SwiftBasicFormat
   SwiftSyntax::SwiftDiagnostics
   SwiftSyntax::SwiftIDEUtils
   SwiftSyntax::SwiftParser
   SwiftSyntax::SwiftParserDiagnostics
-  SwiftSyntax::SwiftSyntax
-)
+  SwiftSyntax::SwiftSyntax)
 target_link_libraries(SourceKitLSP PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -2,10 +2,13 @@
 add_executable(sourcekit-lsp
   SourceKitLSP.swift)
 target_link_libraries(sourcekit-lsp PRIVATE
-  ArgumentParser
+  LanguageServerProtocol
   LanguageServerProtocolJSONRPC
   SKCore
-  SourceKitLSP)
+  SKSupport
+  SourceKitLSP
+  ArgumentParser
+  TSCBasic)
 target_compile_options(sourcekit-lsp PRIVATE
   -parse-as-library)
 target_link_libraries(sourcekit-lsp PRIVATE


### PR DESCRIPTION
The changes in #945 changed the dependencies but did not correct them in the CMakeLists.txt resulting in a broken build.