### PR TITLE
Add cache to avoid requesting diagnostics from sourcekitd frequently.

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(SourceKitLSP PRIVATE
   Swift/CommentXML.swift
   Swift/CursorInfo.swift
   Swift/Diagnostic.swift
+  Swift/DiagnosticReportManager.swift
   Swift/DocumentSymbols.swift
   Swift/EditorPlaceholder.swift
   Swift/FoldingRange.swift

--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -1,0 +1,180 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPLogging
+import LanguageServerProtocol
+import SourceKitD
+import SwiftParserDiagnostics
+
+actor DiagnosticReportManager {
+  /// A task to produce diagnostics, either from a diagnostics request to `sourcektid` or by using the built-in swift-syntax.
+  private typealias ReportTask = Task<RelatedFullDocumentDiagnosticReport, Error>
+
+  private let sourcekitd: SourceKitD
+  private let syntaxTreeManager: SyntaxTreeManager
+  private let documentManager: DocumentManager
+  private let clientHasDiagnosticsCodeDescriptionSupport: Bool
+
+  private nonisolated var keys: sourcekitd_keys { return sourcekitd.keys }
+  private nonisolated var requests: sourcekitd_requests { return sourcekitd.requests }
+
+  /// The cache that stores reportTasks for snapshot id and buildSettings
+  ///
+  /// Conceptually, this is a dictionary. To prevent excessive memory usage we
+  /// only keep `cacheSize` entries within the array. Older entries are at the
+  /// end of the list, newer entries at the front.
+  private var reportTaskCache:
+    [(
+      snapshotID: DocumentSnapshot.ID,
+      buildSettings: SwiftCompileCommand?,
+      reportTask: ReportTask
+    )] = []
+
+  /// The number of reportTasks to keep
+  ///
+  /// - Note: This has been chosen without scientific measurements.
+  private let cacheSize = 5
+
+  init(
+    sourcekitd: SourceKitD,
+    syntaxTreeManager: SyntaxTreeManager,
+    documentManager: DocumentManager,
+    clientHasDiagnosticsCodeDescriptionSupport: Bool
+  ) {
+    self.sourcekitd = sourcekitd
+    self.syntaxTreeManager = syntaxTreeManager
+    self.documentManager = documentManager
+    self.clientHasDiagnosticsCodeDescriptionSupport = clientHasDiagnosticsCodeDescriptionSupport
+  }
+
+  func diagnosticReport(
+    for snapshot: DocumentSnapshot,
+    buildSettings: SwiftCompileCommand?
+  ) async throws -> RelatedFullDocumentDiagnosticReport {
+    if let reportTask = reportTask(for: snapshot.id, buildSettings: buildSettings) {
+      return try await reportTask.value
+    }
+    let reportTask: Task<RelatedFullDocumentDiagnosticReport, Error>
+    if let buildSettings, !buildSettings.isFallback {
+      reportTask = Task {
+        return try await requestReport(with: snapshot, compilerArgs: buildSettings.compilerArgs)
+      }
+    } else {
+      logger.log(
+        "Producing syntactic diagnostics from the built-in swift-syntax because we \(buildSettings != nil ? "have fallback build settings" : "don't have build settings", privacy: .public))"
+      )
+      // If we don't have build settings or we only have fallback build settings,
+      // sourcekitd won't be able to give us accurate semantic diagnostics.
+      // Fall back to providing syntactic diagnostics from the built-in
+      // swift-syntax. That's the best we can do for now.
+      reportTask = Task {
+        return try await requestFallbackReport(with: snapshot)
+      }
+    }
+    setReportTask(for: snapshot.id, buildSettings: buildSettings, reportTask: reportTask)
+    return try await reportTask.value
+  }
+
+  func removeItemsFromCache(with uri: DocumentURI) async {
+    for item in reportTaskCache {
+      if item.snapshotID.uri == uri {
+        item.reportTask.cancel()
+      }
+    }
+    reportTaskCache.removeAll(where: { $0.snapshotID.uri == uri })
+  }
+
+  private func requestReport(
+    with snapshot: DocumentSnapshot,
+    compilerArgs: [String]
+  ) async throws -> LanguageServerProtocol.RelatedFullDocumentDiagnosticReport {
+    try Task.checkCancellation()
+
+    let keys = self.keys
+
+    let skreq = sourcekitd.dictionary([
+      keys.request: requests.diagnostics,
+      keys.sourcefile: snapshot.uri.pseudoPath,
+      keys.compilerargs: compilerArgs as [SKDValue],
+    ])
+
+    let dict = try await self.sourcekitd.send(skreq, fileContents: snapshot.text)
+
+    try Task.checkCancellation()
+    guard (try? documentManager.latestSnapshot(snapshot.uri).id) == snapshot.id else {
+      // Check that the document wasn't modified while we were getting diagnostics. This could happen because we are
+      // calling `fullDocumentDiagnosticReport` from `publishDiagnosticsIfNeeded` outside of `messageHandlingQueue`
+      // and thus a concurrent edit is possible while we are waiting for the sourcekitd request to return a result.
+      throw ResponseError.unknown("Document was modified while loading diagnostics")
+    }
+
+    let diagnostics: [Diagnostic] =
+      dict[keys.diagnostics]?.compactMap({ diag in
+        Diagnostic(
+          diag,
+          in: snapshot,
+          useEducationalNoteAsCode: self.clientHasDiagnosticsCodeDescriptionSupport
+        )
+      }) ?? []
+
+    return RelatedFullDocumentDiagnosticReport(items: diagnostics)
+  }
+
+  private func requestFallbackReport(
+    with snapshot: DocumentSnapshot
+  ) async throws -> LanguageServerProtocol.RelatedFullDocumentDiagnosticReport {
+    // If we don't have build settings or we only have fallback build settings,
+    // sourcekitd won't be able to give us accurate semantic diagnostics.
+    // Fall back to providing syntactic diagnostics from the built-in
+    // swift-syntax. That's the best we can do for now.
+    let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    let swiftSyntaxDiagnostics = ParseDiagnosticsGenerator.diagnostics(for: syntaxTree)
+    let diagnostics = swiftSyntaxDiagnostics.compactMap { (diag) -> Diagnostic? in
+      if diag.diagnosticID == StaticTokenError.editorPlaceholder.diagnosticID {
+        // Ignore errors about editor placeholders in the source file, similar to how sourcekitd ignores them.
+        return nil
+      }
+      return Diagnostic(diag, in: snapshot)
+    }
+    return RelatedFullDocumentDiagnosticReport(items: diagnostics)
+  }
+
+  /// The reportTask for the given document snapshot and buildSettings.
+  private func reportTask(
+    for snapshotID: DocumentSnapshot.ID,
+    buildSettings: SwiftCompileCommand?
+  ) -> ReportTask? {
+    return reportTaskCache.first(where: { $0.snapshotID == snapshotID && $0.buildSettings == buildSettings })?
+      .reportTask
+  }
+
+  /// Set the reportTask for the given document snapshot and buildSettings.
+  ///
+  /// If we are already storing `cacheSize` many reports, the oldest one
+  /// will get discarded.
+  private func setReportTask(
+    for snapshotID: DocumentSnapshot.ID,
+    buildSettings: SwiftCompileCommand?,
+    reportTask: ReportTask
+  ) {
+    reportTaskCache.insert((snapshotID, buildSettings, reportTask), at: 0)
+
+    // Remove any reportTasks for old versions of this document.
+    reportTaskCache.removeAll(where: { $0.snapshotID < snapshotID })
+
+    // If we still have more than `cacheSize` reportTasks, delete the ones that
+    // were produced last. We can always re-request them on-demand.
+    while reportTaskCache.count > cacheSize {
+      reportTaskCache.removeLast()
+    }
+  }
+}

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -139,6 +139,8 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
 
   private var stateChangeHandlers: [(_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void] = []
 
+  private let diagnosticReportManager: DiagnosticReportManager
+
   /// Creates a language server for the given client using the sourcekitd dylib specified in `toolchain`.
   /// `reopenDocuments` is a closure that will be called if sourcekitd crashes and the `SwiftLanguageServer` asks its parent server to reopen all of its documents.
   /// Returns `nil` if `sourcektid` couldn't be found.
@@ -157,6 +159,12 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
     self.state = .connected
     self.generatedInterfacesPath = options.generatedInterfacesPath.asURL
     try FileManager.default.createDirectory(at: generatedInterfacesPath, withIntermediateDirectories: true)
+    self.diagnosticReportManager = DiagnosticReportManager(
+      sourcekitd: self.sourcekitd,
+      syntaxTreeManager: syntaxTreeManager,
+      documentManager: documentManager,
+      clientHasDiagnosticsCodeDescriptionSupport: capabilityRegistry.clientHasDiagnosticsCodeDescriptionSupport
+    )
   }
 
   /// - Important: For testing only
@@ -270,6 +278,7 @@ extension SwiftLanguageServer {
 
   private func reopenDocument(_ snapshot: DocumentSnapshot, _ compileCmd: SwiftCompileCommand?) async {
     cancelInFlightPublishDiagnosticsTask(for: snapshot.uri)
+    await diagnosticReportManager.removeItemsFromCache(with: snapshot.id.uri)
 
     let keys = self.keys
     let path = snapshot.uri.pseudoPath
@@ -317,6 +326,7 @@ extension SwiftLanguageServer {
 
   public func openDocument(_ note: DidOpenTextDocumentNotification) async {
     cancelInFlightPublishDiagnosticsTask(for: note.textDocument.uri)
+    await diagnosticReportManager.removeItemsFromCache(with: note.textDocument.uri)
 
     let keys = self.keys
 
@@ -340,6 +350,7 @@ extension SwiftLanguageServer {
   public func closeDocument(_ note: DidCloseTextDocumentNotification) async {
     cancelInFlightPublishDiagnosticsTask(for: note.textDocument.uri)
     inFlightPublishDiagnosticsTasks[note.textDocument.uri] = nil
+    await diagnosticReportManager.removeItemsFromCache(with: note.textDocument.uri)
 
     let keys = self.keys
 
@@ -394,8 +405,11 @@ extension SwiftLanguageServer {
         return
       }
       do {
-        let diagnosticReport = try await self.fullDocumentDiagnosticReport(
-          DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(document))
+        let snapshot = try await documentManager.latestSnapshot(document)
+        let buildSettings = await self.buildSettings(for: document)
+        let diagnosticReport = try await self.diagnosticReportManager.diagnosticReport(
+          for: snapshot,
+          buildSettings: buildSettings
         )
 
         await sourceKitServer.sendNotificationToClient(
@@ -697,10 +711,11 @@ extension SwiftLanguageServer {
   }
 
   func retrieveQuickFixCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {
-    let diagnosticReport = try await self.fullDocumentDiagnosticReport(
-      DocumentDiagnosticsRequest(
-        textDocument: params.textDocument
-      )
+    let snapshot = try documentManager.latestSnapshot(params.textDocument.uri)
+    let buildSettings = await self.buildSettings(for: params.textDocument.uri)
+    let diagnosticReport = try await self.diagnosticReportManager.diagnosticReport(
+      for: snapshot,
+      buildSettings: buildSettings
     )
 
     let codeActions = diagnosticReport.items.flatMap { (diag) -> [CodeAction] in
@@ -775,24 +790,15 @@ extension SwiftLanguageServer {
     return Array(hints)
   }
 
-  public func syntacticDiagnosticFromBuiltInSwiftSyntax(
-    for snapshot: DocumentSnapshot
-  ) async throws -> RelatedFullDocumentDiagnosticReport {
-    let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
-    let swiftSyntaxDiagnostics = ParseDiagnosticsGenerator.diagnostics(for: syntaxTree)
-    let diagnostics = swiftSyntaxDiagnostics.compactMap { (diag) -> Diagnostic? in
-      if diag.diagnosticID == StaticTokenError.editorPlaceholder.diagnosticID {
-        // Ignore errors about editor placeholders in the source file, similar to how sourcekitd ignores them.
-        return nil
-      }
-      return Diagnostic(diag, in: snapshot)
-    }
-    return RelatedFullDocumentDiagnosticReport(items: diagnostics)
-  }
-
   public func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport {
+    let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
+    let buildSettings = await self.buildSettings(for: req.textDocument.uri)
+    let diagnosticReport = try await self.diagnosticReportManager.diagnosticReport(
+      for: snapshot,
+      buildSettings: buildSettings
+    )
     do {
-      return try await .full(fullDocumentDiagnosticReport(req))
+      return try await .full(diagnosticReport)
     } catch {
       // VS Code does not request diagnostics again for a document if the diagnostics request failed.
       // Since sourcekit-lsp usually recovers from failures (e.g. after sourcekitd crashes), this is undesirable.
@@ -805,53 +811,6 @@ extension SwiftLanguageServer {
       )
       return .full(RelatedFullDocumentDiagnosticReport(items: []))
     }
-  }
-
-  private func fullDocumentDiagnosticReport(
-    _ req: DocumentDiagnosticsRequest
-  ) async throws -> RelatedFullDocumentDiagnosticReport {
-    let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
-    guard let buildSettings = await self.buildSettings(for: req.textDocument.uri), !buildSettings.isFallback else {
-      logger.log(
-        "Producing syntactic diagnostics from the built-in swift-syntax because we have fallback arguments"
-      )
-      // If we don't have build settings or we only have fallback build settings,
-      // sourcekitd won't be able to give us accurate semantic diagnostics.
-      // Fall back to providing syntactic diagnostics from the built-in
-      // swift-syntax. That's the best we can do for now.
-      return try await syntacticDiagnosticFromBuiltInSwiftSyntax(for: snapshot)
-    }
-
-    try Task.checkCancellation()
-
-    let keys = self.keys
-
-    let skreq = sourcekitd.dictionary([
-      keys.request: requests.diagnostics,
-      keys.sourcefile: snapshot.uri.pseudoPath,
-      keys.compilerargs: buildSettings.compilerArgs as [SKDValue],
-    ])
-
-    let dict = try await self.sourcekitd.send(skreq, fileContents: snapshot.text)
-
-    try Task.checkCancellation()
-    guard (try? documentManager.latestSnapshot(req.textDocument.uri).id) == snapshot.id else {
-      // Check that the document wasn't modified while we were getting diagnostics. This could happen because we are
-      // calling `fullDocumentDiagnosticReport` from `publishDiagnosticsIfNeeded` outside of `messageHandlingQueue`
-      // and thus a concurrent edit is possible while we are waiting for the sourcekitd request to return a result.
-      throw ResponseError.unknown("Document was modified while loading document")
-    }
-
-    let supportsCodeDescription = capabilityRegistry.clientHasDiagnosticsCodeDescriptionSupport
-    var diagnostics: [Diagnostic] = []
-    dict[keys.diagnostics]?.forEach { _, diag in
-      if let diag = Diagnostic(diag, in: snapshot, useEducationalNoteAsCode: supportsCodeDescription) {
-        diagnostics.append(diag)
-      }
-      return true
-    }
-
-    return RelatedFullDocumentDiagnosticReport(items: diagnostics)
   }
 
   public func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -86,7 +86,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(
       DidChangeTextDocumentNotification(
-        textDocument: .init(uri, version: 14),
+        textDocument: .init(uri, version: 15),
         contentChanges: [
           .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "foo")
         ]
@@ -105,7 +105,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(
       DidChangeTextDocumentNotification(
-        textDocument: .init(uri, version: 15),
+        textDocument: .init(uri, version: 16),
         contentChanges: [
           .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "fooTypo")
         ]
@@ -128,7 +128,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(
       DidChangeTextDocumentNotification(
-        textDocument: .init(uri, version: 16),
+        textDocument: .init(uri, version: 17),
         contentChanges: [
           .init(
             range: nil,
@@ -210,7 +210,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(
       DidChangeTextDocumentNotification(
-        textDocument: .init(uri, version: 14),
+        textDocument: .init(uri, version: 15),
         contentChanges: [
           .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "foo")
         ]
@@ -229,7 +229,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(
       DidChangeTextDocumentNotification(
-        textDocument: .init(uri, version: 15),
+        textDocument: .init(uri, version: 16),
         contentChanges: [
           .init(range: Position(line: 1, utf16index: 0)..<Position(line: 1, utf16index: 3), text: "fooTypo")
         ]
@@ -251,7 +251,7 @@ final class LocalSwiftTests: XCTestCase {
 
     testClient.send(
       DidChangeTextDocumentNotification(
-        textDocument: .init(uri, version: 16),
+        textDocument: .init(uri, version: 17),
         contentChanges: [
           .init(
             range: nil,


### PR DESCRIPTION
I'm following the way we cached computations in SyntaxTreeManager.
https://github.com/apple/sourcekit-lsp/issues/922#issuecomment-1783343524