### PR TITLE
Reduce log level in CI to info

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -214,7 +214,7 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
     additional_env['SOURCEKITLSP_LOG_PRIVACY_LEVEL'] = 'sensitive'
 
     # Log with the highest log level to simplify debugging of CI failures.
-    additional_env['SOURCEKITLSP_LOG_LEVEL'] = 'debug'
+    additional_env['SOURCEKITLSP_LOG_LEVEL'] = 'info'
 
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, additional_env=additional_env)
     tests = os.path.join(bin_path, 'sk-tests')


### PR DESCRIPTION
This reduced the CI log generated by sourcekit-lsp tests from 76MB to 2.7MB