### PR TITLE
Don't cancel cursor info and related identifiers requests on subsequent requests

### DIFF
--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -20,6 +20,7 @@ public struct sourcekitd_keys {
   public let associated_usrs: sourcekitd_uid_t
   public let bodylength: sourcekitd_uid_t
   public let bodyoffset: sourcekitd_uid_t
+  public let cancelOnSubsequentRequest: sourcekitd_uid_t
   public let categories: sourcekitd_uid_t
   public let categorizededits: sourcekitd_uid_t
   public let column: sourcekitd_uid_t
@@ -97,6 +98,7 @@ public struct sourcekitd_keys {
     associated_usrs = api.uid_get_from_cstr("key.associated_usrs")!
     bodylength = api.uid_get_from_cstr("key.bodylength")!
     bodyoffset = api.uid_get_from_cstr("key.bodyoffset")!
+    cancelOnSubsequentRequest = api.uid_get_from_cstr("key.cancel_on_subsequent_request")!
     categories = api.uid_get_from_cstr("key.categories")!
     categorizededits = api.uid_get_from_cstr("key.categorizededits")!
     column = api.uid_get_from_cstr("key.column")!

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -94,6 +94,7 @@ extension SwiftLanguageServer {
 
     let skreq = SKDRequestDictionary(sourcekitd: sourcekitd)
     skreq[keys.request] = requests.cursorinfo
+    skreq[keys.cancelOnSubsequentRequest] = 0
     skreq[keys.offset] = offsetRange.lowerBound
     if offsetRange.upperBound != offsetRange.lowerBound {
       skreq[keys.length] = offsetRange.count

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -631,6 +631,7 @@ extension SwiftLanguageServer {
 
     let skreq = SKDRequestDictionary(sourcekitd: self.sourcekitd)
     skreq[keys.request] = self.requests.relatedidents
+    skreq[keys.cancelOnSubsequentRequest] = 0
     skreq[keys.offset] = offset
     skreq[keys.sourcefile] = snapshot.uri.pseudoPath
 


### PR DESCRIPTION
SourceKit-LSP supports explicit cancellation and thus we don’t need to do the implicit cancellation of cursor info and related identifiers on subsequent requests.