### PR TITLE
Add support for different arguments per workspace

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
@@ -10,6 +10,53 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// The configuration to build a workspace in.
+///
+/// **(LSP Extension)**
+public enum BuildConfiguration: Hashable, Codable {
+  case debug
+  case release
+}
+
+/// Build settings that should be used for a workspace.
+///
+/// **(LSP Extension)**
+public struct WorkspaceBuildSetup: Hashable, Codable {
+  /// The configuration that the workspace should be built in.
+  public let buildConfiguration: BuildConfiguration?
+
+  /// The build directory for the workspace.
+  public let scratchPath: DocumentURI?
+
+  /// Arguments to be passed to any C compiler invocations.
+  public let cFlags: [String]?
+
+  /// Arguments to be passed to any C++ compiler invocations.
+  public let cxxFlags: [String]?
+
+  /// Arguments to be passed to any linker invocations.
+  public let linkerFlags: [String]?
+
+  /// Arguments to be passed to any Swift compiler invocations.
+  public let swiftFlags: [String]?
+
+  public init(
+    buildConfiguration: BuildConfiguration? = nil,
+    scratchPath: DocumentURI? = nil,
+    cFlags: [String]? = nil,
+    cxxFlags: [String]? = nil,
+    linkerFlags: [String]? = nil,
+    swiftFlags: [String]? = nil
+  ) {
+    self.buildConfiguration = buildConfiguration
+    self.scratchPath = scratchPath
+    self.cFlags = cFlags
+    self.cxxFlags = cxxFlags
+    self.linkerFlags = linkerFlags
+    self.swiftFlags = swiftFlags
+  }
+}
+
 /// Unique identifier for a document.
 public struct WorkspaceFolder: ResponseType, Hashable, Codable {
 
@@ -19,7 +66,20 @@ public struct WorkspaceFolder: ResponseType, Hashable, Codable {
   /// The name of the workspace (default: basename of url).
   public var name: String
 
-  public init(uri: DocumentURI, name: String? = nil) {
+  /// Build settings that should be used for this workspace.
+  ///
+  /// For arguments that have a single value (like the build configuration), this takes precedence over the global
+  /// options set when launching sourcekit-lsp. For all other options, the values specified in the workspace-specific
+  /// build setup are appended to the global options.
+  ///
+  /// **(LSP Extension)**
+  public var buildSetup: WorkspaceBuildSetup?
+
+  public init(
+    uri: DocumentURI,
+    name: String? = nil,
+    buildSetup: WorkspaceBuildSetup? = nil
+  ) {
     self.uri = uri
 
     self.name = name ?? uri.fileURL?.lastPathComponent ?? "unknown_workspace"
@@ -27,5 +87,6 @@ public struct WorkspaceFolder: ResponseType, Hashable, Codable {
     if self.name.isEmpty {
       self.name = "unknown_workspace"
     }
+    self.buildSetup = buildSetup
   }
 }

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -20,23 +20,37 @@ public struct BuildSetup {
 
   /// Default configuration
   public static let `default` = BuildSetup(
-    configuration: .debug,
+    configuration: nil,
     path: nil,
     flags: BuildFlags()
   )
 
   /// Build configuration (debug|release).
-  public var configuration: BuildConfiguration
+  public var configuration: BuildConfiguration?
 
-  /// Build artefacts directory path. If nil, the build system may choose a default value.
+  /// Build artifacts directory path. If nil, the build system may choose a default value.
   public var path: AbsolutePath?
 
   /// Additional build flags
   public var flags: BuildFlags
 
-  public init(configuration: BuildConfiguration, path: AbsolutePath?, flags: BuildFlags) {
+  public init(configuration: BuildConfiguration?, path: AbsolutePath?, flags: BuildFlags) {
     self.configuration = configuration
     self.path = path
     self.flags = flags
+  }
+
+  /// Create a new `BuildSetup` merging this and `other`.
+  ///
+  /// For any option that only takes a single value (like `configuration`), `other` takes precedence. For all array
+  /// arguments, `other` is appended to the options provided by this setup.
+  public func merging(_ other: BuildSetup) -> BuildSetup {
+    var flags = self.flags
+    flags = flags.merging(other.flags)
+    return BuildSetup(
+      configuration: other.configuration ?? self.configuration,
+      path: other.path ?? self.path,
+      flags: flags
+    )
   }
 }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -136,7 +136,7 @@ public actor SwiftPMWorkspace {
 
     let buildConfiguration: PackageModel.BuildConfiguration
     switch buildSetup.configuration {
-    case .debug:
+    case .debug, nil:
       buildConfiguration = .debug
     case .release:
       buildConfiguration = .release

--- a/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
@@ -38,6 +38,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
   public init(
     files: [RelativeFileLocation: String],
     manifest: String = SwiftPMTestWorkspace.defaultPackageManifest,
+    workspaces: (URL) -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
     build: Bool = false,
     testName: String = #function
   ) async throws {
@@ -56,6 +57,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
     filesByPath["Package.swift"] = manifest
     try await super.init(
       files: filesByPath,
+      workspaces: workspaces,
       testName: testName
     )
 

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -87,9 +87,9 @@ extension PathPrefixMapping: @retroactive ExpressibleByArgument {}
 #endif
 
 #if swift(<5.10)
-extension BuildConfiguration: ExpressibleByArgument {}
+extension SKSupport.BuildConfiguration: ExpressibleByArgument {}
 #else
-extension BuildConfiguration: @retroactive ExpressibleByArgument {}
+extension SKSupport.BuildConfiguration: @retroactive ExpressibleByArgument {}
 #endif
 
 @main

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -739,5 +739,5 @@ private func buildPath(
   platform: String
 ) -> AbsolutePath {
   let buildPath = config.path ?? root.appending(component: ".build")
-  return buildPath.appending(components: platform, "\(config.configuration)")
+  return buildPath.appending(components: platform, "\(config.configuration ?? .debug)")
 }


### PR DESCRIPTION
Fixes #663
rdar://101815704

@adam-fowler Do you think these new options on `WorkspaceFolder` would work for you? You should be able to specify them on both the `initialize` and the `workspace/didChangeWorkspaceFolders` request.