### PR TITLE
Show overriden functions when performing jump-to-definition on a dynamic call

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/SymbolInfoRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SymbolInfoRequest.swift
@@ -81,17 +81,25 @@ public struct SymbolDetails: ResponseType, Hashable {
   /// The kind of the symbol
   public var kind: SymbolKind?
 
+  /// Whether the symbol is a dynamic call for which it isn't known which method will be invoked at runtime. This is
+  /// the case for protocol methods and class functions.
+  ///
+  /// Optional because `clangd` does not return whether a symbol is dynamic.
+  public var isDynamic: Bool?
+
   public init(
     name: String?,
-    containerName: String? = nil,
+    containerName: String?,
     usr: String?,
-    bestLocalDeclaration: Location? = nil,
-    kind: SymbolKind? = nil
+    bestLocalDeclaration: Location?,
+    kind: SymbolKind?,
+    isDynamic: Bool
   ) {
     self.name = name
     self.containerName = containerName
     self.usr = usr
     self.bestLocalDeclaration = bestLocalDeclaration
     self.kind = kind
+    self.isDynamic = isDynamic
   }
 }

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -55,6 +55,27 @@ public final class SKDResponseArray {
     return true
   }
 
+  public func map<T>(_ transform: (SKDResponseDictionary) -> T) -> [T] {
+    var result: [T] = []
+    result.reserveCapacity(self.count)
+    self.forEach { _, element in
+      result.append(transform(element))
+      return true
+    }
+    return result
+  }
+
+  public func compactMap<T>(_ transform: (SKDResponseDictionary) -> T?) -> [T] {
+    var result: [T] = []
+    self.forEach { _, element in
+      if let transformed = transform(element) {
+        result.append(transformed)
+      }
+      return true
+    }
+    return result
+  }
+
   /// Attempt to access the item at `index` as a string.
   public subscript(index: Int) -> String? {
     if let cstr = sourcekitd.api.variant_array_get_string(array, index) {

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -57,6 +57,7 @@ public struct sourcekitd_keys {
   public let num_bytes_to_erase: sourcekitd_uid_t
   public let offset: sourcekitd_uid_t
   public let ranges: sourcekitd_uid_t
+  public let receivers: sourcekitd_uid_t
   public let refactor_actions: sourcekitd_uid_t
   public let request: sourcekitd_uid_t
   public let results: sourcekitd_uid_t
@@ -136,6 +137,7 @@ public struct sourcekitd_keys {
     num_bytes_to_erase = api.uid_get_from_cstr("key.num_bytes_to_erase")!
     offset = api.uid_get_from_cstr("key.offset")!
     ranges = api.uid_get_from_cstr("key.ranges")!
+    receivers = api.uid_get_from_cstr("key.receivers")!
     refactor_actions = api.uid_get_from_cstr("key.refactor_actions")!
     request = api.uid_get_from_cstr("key.request")!
     results = api.uid_get_from_cstr("key.results")!

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -44,6 +44,7 @@ public struct sourcekitd_keys {
   public let groupname: sourcekitd_uid_t
   public let id: sourcekitd_uid_t
   public let is_system: sourcekitd_uid_t
+  public let isDynamic: sourcekitd_uid_t
   public let kind: sourcekitd_uid_t
   public let length: sourcekitd_uid_t
   public let line: sourcekitd_uid_t
@@ -122,6 +123,7 @@ public struct sourcekitd_keys {
     groupname = api.uid_get_from_cstr("key.groupname")!
     id = api.uid_get_from_cstr("key.id")!
     is_system = api.uid_get_from_cstr("key.is_system")!
+    isDynamic = api.uid_get_from_cstr("key.is_dynamic")!
     kind = api.uid_get_from_cstr("key.kind")!
     length = api.uid_get_from_cstr("key.length")!
     line = api.uid_get_from_cstr("key.line")!

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1654,46 +1654,6 @@ extension SourceKitServer {
     )
   }
 
-  /// Extracts the locations of an indexed symbol's occurrences,
-  /// e.g. for definition or reference lookups.
-  ///
-  /// - Parameters:
-  ///   - result: The symbol to look up
-  ///   - index: The index in which the occurrences will be looked up
-  ///   - useLocalFallback: Whether to consider the best known local declaration if no other locations are found
-  ///   - extractOccurrences: A function fetching the occurrences by the desired roles given a usr from the index
-  /// - Returns: The resolved symbol locations
-  private func extractIndexedOccurrences(
-    symbols: [SymbolDetails],
-    index: IndexStoreDB?,
-    useLocalFallback: Bool = false,
-    extractOccurrences: (SymbolDetails, IndexStoreDB) -> [SymbolOccurrence]
-  ) -> [(occurrence: SymbolOccurrence?, location: Location)] {
-    guard let symbol = symbols.first else {
-      return []
-    }
-
-    let fallback: [(occurrence: SymbolOccurrence?, location: Location)]
-    if useLocalFallback, let bestLocalDeclaration = symbol.bestLocalDeclaration {
-      fallback = [(occurrence: nil, location: bestLocalDeclaration)]
-    } else {
-      fallback = []
-    }
-
-    guard let index = index else {
-      return fallback
-    }
-
-    let occurs = extractOccurrences(symbol, index)
-    let resolved = occurs.compactMap { occur in
-      indexToLSPLocation(occur.location).map {
-        (occurrence: occur, location: $0)
-      }
-    }
-
-    return resolved.isEmpty ? fallback : resolved
-  }
-
   func declaration(
     _ req: DeclarationRequest,
     workspace: Workspace,
@@ -1702,70 +1662,87 @@ extension SourceKitServer {
     return try await languageService.declaration(req)
   }
 
-  func definition(
+  /// Returns the result of a `DefinitionRequest` by running a `SymbolInfoRequest`, inspecting
+  /// its result and doing index lookups, if necessary.
+  ///
+  /// In contrast to `definition`, this does not fall back to sending a `DefinitionRequest` to the
+  /// toolchain language server.
+  private func indexBasedDefinition(
     _ req: DefinitionRequest,
     workspace: Workspace,
     languageService: ToolchainLanguageServer
-  ) async throws -> LocationsOrLocationLinksResponse? {
+  ) async throws -> [Location] {
     let symbols = try await languageService.symbolInfo(
       SymbolInfoRequest(
         textDocument: req.textDocument,
         position: req.position
       )
     )
-    let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
+    guard let symbol = symbols.first else {
+      return []
+    }
+
+    if let symbol = symbols.first, let bestLocalDeclaration = symbol.bestLocalDeclaration, !(symbol.isDynamic ?? false)
+    {
+      // If we have a non-dynamic symbol, we don't need to do an index lookup
+      return [bestLocalDeclaration]
+    }
+
     // If this symbol is a module then generate a textual interface
-    if let symbol = symbols.first, symbol.kind == .module, let name = symbol.name {
-      return try await self.definitionInInterface(
+    if symbol.kind == .module, let name = symbol.name {
+      let interfaceLocation = try await self.definitionInInterface(
         req,
         moduleName: name,
         symbolUSR: nil,
         languageService: languageService
       )
+      return [interfaceLocation]
     }
 
-    let resolved = self.extractIndexedOccurrences(symbols: symbols, index: index, useLocalFallback: true) {
-      (symbolDetails, index) in
-      guard symbolDetails.isDynamic ?? false else {
-        // If the symbol isn't dynamic, we won't get more information from the index compared to what we already have
-        // in the symbolDetails response. Return an empty array so that `extractIndexedOccurrences` falls back to the
-        // location in the symbol details response.
-        return []
+    guard let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index else {
+      return []
+    }
+    guard let usr = symbol.usr else { return [] }
+    logger.info("performing indexed jump-to-def with usr \(usr)")
+    var occurances = index.occurrences(ofUSR: usr, roles: [.definition])
+    if occurances.isEmpty {
+      occurances = index.occurrences(ofUSR: usr, roles: [.declaration])
+    }
+    if symbol.isDynamic ?? false {
+      occurances += occurances.flatMap {
+        index.occurrences(relatedToUSR: $0.symbol.usr, roles: .overrideOf)
       }
-      guard let usr = symbolDetails.usr else { return [] }
-      logger.info("performing indexed jump-to-def with usr \(usr)")
-      var occurs = index.occurrences(ofUSR: usr, roles: [.definition])
-      if occurs.isEmpty {
-        occurs = index.occurrences(ofUSR: usr, roles: [.declaration])
-      }
-      if symbolDetails.isDynamic ?? false {
-        occurs += occurs.flatMap {
-          index.occurrences(relatedToUSR: $0.symbol.usr, roles: .overrideOf)
-        }
-      }
-      return occurs
     }
 
-    // if first resolved location is in `.swiftinterface` file. Use moduleName to return
-    // textual interface
-    if let firstResolved = resolved.first,
-      let moduleName = firstResolved.occurrence?.location.moduleName,
-      firstResolved.location.uri.fileURL?.pathExtension == "swiftinterface"
-    {
-      return try await self.definitionInInterface(
-        req,
-        moduleName: moduleName,
-        symbolUSR: firstResolved.occurrence?.symbol.usr,
-        languageService: languageService
-      )
+    return try await occurances.asyncCompactMap { occurance in
+      if URL(fileURLWithPath: occurance.location.path).pathExtension == "swiftinterface" {
+        // if first resolved location is in `.swiftinterface` file. Use moduleName to return
+        // textual interface
+        return try await self.definitionInInterface(
+          req,
+          moduleName: occurance.location.moduleName,
+          symbolUSR: occurance.symbol.usr,
+          languageService: languageService
+        )
+      }
+      return indexToLSPLocation(occurance.location)
     }
-    let locs = resolved.map(\.location)
+  }
+
+  func definition(
+    _ req: DefinitionRequest,
+    workspace: Workspace,
+    languageService: ToolchainLanguageServer
+  ) async throws -> LocationsOrLocationLinksResponse? {
+    let indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
     // If we're unable to handle the definition request using our index, see if the
     // language service can handle it (e.g. clangd can provide AST based definitions).
-    if locs.isEmpty {
-      return try await languageService.definition(req)
+    if indexBasedResponse.isEmpty {
+      do {
+        return try await languageService.definition(req)
+      } catch {}
     }
-    return .locations(locs)
+    return .locations(indexBasedResponse)
   }
 
   func definitionInInterface(
@@ -1773,14 +1750,14 @@ extension SourceKitServer {
     moduleName: String,
     symbolUSR: String?,
     languageService: ToolchainLanguageServer
-  ) async throws -> LocationsOrLocationLinksResponse? {
+  ) async throws -> Location {
     let openInterface = OpenInterfaceRequest(textDocument: req.textDocument, name: moduleName, symbolUSR: symbolUSR)
     guard let interfaceDetails = try await languageService.openInterface(openInterface) else {
       throw ResponseError.unknown("Could not generate Swift Interface for \(moduleName)")
     }
     let position = interfaceDetails.position ?? Position(line: 0, utf16index: 0)
     let loc = Location(uri: interfaceDetails.uri, range: Range(position))
-    return .locations([loc])
+    return loc
   }
 
   func implementation(
@@ -1794,17 +1771,18 @@ extension SourceKitServer {
         position: req.position
       )
     )
-    let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
-    let extractedResult = self.extractIndexedOccurrences(symbols: symbols, index: index) { (symbolDetails, index) in
-      guard let usr = symbolDetails.usr else { return [] }
-      var occurs = index.occurrences(ofUSR: usr, roles: .baseOf)
-      if occurs.isEmpty {
-        occurs = index.occurrences(relatedToUSR: usr, roles: .overrideOf)
-      }
-      return occurs
+    guard let symbol = symbols.first,
+      let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
+    else {
+      return nil
+    }
+    guard let usr = symbol.usr else { return nil }
+    var occurrances = index.occurrences(ofUSR: usr, roles: .baseOf)
+    if occurrances.isEmpty {
+      occurrances = index.occurrences(relatedToUSR: usr, roles: .overrideOf)
     }
 
-    return .locations(extractedResult.map(\.location))
+    return .locations(occurrances.compactMap { indexToLSPLocation($0.location) })
   }
 
   func references(
@@ -1818,18 +1796,17 @@ extension SourceKitServer {
         position: req.position
       )
     )
-    let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
-    let extractedResult = self.extractIndexedOccurrences(symbols: symbols, index: index) { (symbolDetails, index) in
-      guard let usr = symbolDetails.usr else { return [] }
-      logger.info("performing indexed jump-to-def with usr \(usr)")
-      var roles: SymbolRole = [.reference]
-      if req.context.includeDeclaration {
-        roles.formUnion([.declaration, .definition])
-      }
-      return index.occurrences(ofUSR: usr, roles: roles)
+    guard let symbol = symbols.first, let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
+    else {
+      return []
     }
-
-    return extractedResult.map(\.location)
+    guard let usr = symbol.usr else { return [] }
+    logger.info("performing indexed jump-to-def with usr \(usr)")
+    var roles: SymbolRole = [.reference]
+    if req.context.includeDeclaration {
+      roles.formUnion([.declaration, .definition])
+    }
+    return index.occurrences(ofUSR: usr, roles: roles).compactMap { indexToLSPLocation($0.location) }
   }
 
   private func indexToLSPCallHierarchyItem(
@@ -1864,23 +1841,23 @@ extension SourceKitServer {
         position: req.position
       )
     )
-    let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
+    guard let symbol = symbols.first, let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index
+    else {
+      return nil
+    }
     // For call hierarchy preparation we only locate the definition
-    let extractedResult = self.extractIndexedOccurrences(symbols: symbols, index: index) { (symbolDetails, index) in
-      guard let usr = symbolDetails.usr else { return [] }
-      return index.occurrences(ofUSR: usr, roles: [.definition, .declaration])
-    }
-    return extractedResult.compactMap { info -> CallHierarchyItem? in
-      guard let occurrence = info.occurrence else {
-        return nil
+    guard let usr = symbol.usr else { return nil }
+    return index.occurrences(ofUSR: usr, roles: [.definition, .declaration])
+      .compactMap { info -> CallHierarchyItem? in
+        guard let location = indexToLSPLocation(info.location) else {
+          return nil
+        }
+        return self.indexToLSPCallHierarchyItem(
+          symbol: info.symbol,
+          moduleName: info.location.moduleName,
+          location: location
+        )
       }
-      let symbol = occurrence.symbol
-      return self.indexToLSPCallHierarchyItem(
-        symbol: symbol,
-        moduleName: occurrence.location.moduleName,
-        location: info.location
-      )
-    }
   }
 
   /// Extracts our implementation-specific data about a call hierarchy
@@ -2021,25 +1998,25 @@ extension SourceKitServer {
         position: req.position
       )
     )
+    guard let symbol = symbols.first else {
+      return nil
+    }
     guard let index = await self.workspaceForDocument(uri: req.textDocument.uri)?.index else {
-      return []
+      return nil
     }
-    let extractedResult = self.extractIndexedOccurrences(symbols: symbols, index: index) { (symbolDetails, index) in
-      guard let usr = symbolDetails.usr else { return [] }
-      return index.occurrences(ofUSR: usr, roles: [.definition, .declaration])
-    }
-    return extractedResult.compactMap { info -> TypeHierarchyItem? in
-      guard let occurrence = info.occurrence else {
-        return nil
+    guard let usr = symbol.usr else { return nil }
+    return index.occurrences(ofUSR: usr, roles: [.definition, .declaration])
+      .compactMap { info -> TypeHierarchyItem? in
+        guard let location = indexToLSPLocation(info.location) else {
+          return nil
+        }
+        return self.indexToLSPTypeHierarchyItem(
+          symbol: info.symbol,
+          moduleName: info.location.moduleName,
+          location: location,
+          index: index
+        )
       }
-      let symbol = occurrence.symbol
-      return self.indexToLSPTypeHierarchyItem(
-        symbol: symbol,
-        moduleName: occurrence.location.moduleName,
-        location: info.location,
-        index: index
-      )
-    }
   }
 
   /// Extracts our implementation-specific data about a type hierarchy

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -117,10 +117,15 @@ extension SwiftLanguageServer {
 
     var location: Location? = nil
     if let filepath: String = dict[keys.filepath],
-      let offset: Int = dict[keys.offset],
-      let pos = snapshot.positionOf(utf8Offset: offset)
+      let line: Int = dict[keys.line],
+      let column: Int = dict[keys.column]
     {
-      location = Location(uri: DocumentURI(URL(fileURLWithPath: filepath)), range: Range(pos))
+      let position = Position(
+        line: line - 1,
+        // FIXME: we need to convert the utf8/utf16 column, which may require reading the file!
+        utf16index: column - 1
+      )
+      location = Location(uri: DocumentURI(URL(fileURLWithPath: filepath)), range: Range(position))
     }
 
     let refactorActionsArray: SKDResponseArray? = dict[keys.refactor_actions]

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -131,7 +131,8 @@ extension SwiftLanguageServer {
         containerName: nil,
         usr: dict[keys.usr],
         bestLocalDeclaration: location,
-        kind: kind.asSymbolKind(self.sourcekitd.values)
+        kind: kind.asSymbolKind(self.sourcekitd.values),
+        isDynamic: dict[keys.isDynamic] ?? false
       ),
       annotatedDeclaration: dict[keys.annotated_decl],
       documentationXML: dict[keys.doc_full_as_xml],

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -130,6 +130,9 @@ extension SwiftLanguageServer {
 
     let refactorActionsArray: SKDResponseArray? = dict[keys.refactor_actions]
 
+    let receiversArray: SKDResponseArray? = dict[keys.receivers]
+    let receiverUsrs = receiversArray?.compactMap { $0[keys.usr] as String? } ?? []
+
     return CursorInfo(
       SymbolDetails(
         name: dict[keys.name],
@@ -137,7 +140,8 @@ extension SwiftLanguageServer {
         usr: dict[keys.usr],
         bestLocalDeclaration: location,
         kind: kind.asSymbolKind(self.sourcekitd.values),
-        isDynamic: dict[keys.isDynamic] ?? false
+        isDynamic: dict[keys.isDynamic] ?? false,
+        receiverUsrs: receiverUsrs
       ),
       annotatedDeclaration: dict[keys.annotated_decl],
       documentationXML: dict[keys.doc_full_as_xml],


### PR DESCRIPTION
Fixes #809
rdar://114864256