### PR TITLE
Add semantic highlighting for function parameter labels

### DIFF
--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -155,6 +155,8 @@ extension SyntaxClassification {
       return (.comment, [])
     case .docLineComment, .docBlockComment:
       return (.comment, .documentation)
+    case .argumentLabel:
+      return (.function, [])
     }
   }
 }

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -430,7 +430,7 @@ final class SemanticTokensTests: XCTestCase {
       [
         Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
         Token(line: 0, utf16index: 5, length: 1, kind: .identifier),
-        Token(line: 0, utf16index: 7, length: 1, kind: .identifier),
+        Token(line: 0, utf16index: 7, length: 1, kind: .function),
         Token(line: 0, utf16index: 10, length: 3, kind: .struct, modifiers: .defaultLibrary),
         Token(line: 0, utf16index: 17, length: 1, kind: .identifier),
         Token(line: 0, utf16index: 20, length: 6, kind: .struct, modifiers: .defaultLibrary),
@@ -833,10 +833,49 @@ final class SemanticTokensTests: XCTestCase {
         Token(line: 2, utf16index: 7, length: 8, kind: .identifier),
         Token(line: 4, utf16index: 0, length: 4, kind: .keyword),
         Token(line: 4, utf16index: 5, length: 1, kind: .identifier),
-        Token(line: 5, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 5, utf16index: 4, length: 1, kind: .function),
         Token(line: 5, utf16index: 7, length: 7, kind: .actor),
-        Token(line: 6, utf16index: 4, length: 1, kind: .identifier),
+        Token(line: 6, utf16index: 4, length: 1, kind: .function),
         Token(line: 6, utf16index: 7, length: 8, kind: .struct),
+      ]
+    )
+  }
+
+  func testArgumentLabels() async throws {
+    let text = """
+      func foo(arg: Int) {}
+      foo(arg: 1)
+      """
+
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 0, utf16index: 5, length: 3, kind: .identifier),
+        Token(line: 0, utf16index: 9, length: 3, kind: .function),
+        Token(line: 0, utf16index: 14, length: 3, kind: .struct, modifiers: .defaultLibrary),
+        Token(line: 1, utf16index: 0, length: 3, kind: .function),
+        Token(line: 1, utf16index: 4, length: 3, kind: .function),
+        Token(line: 1, utf16index: 9, length: 1, kind: .number),
+      ]
+    )
+  }
+
+  func testFunctionDeclarationWithFirstAndSecondName() async throws {
+    let text = """
+      func foo(arg internalName: Int) {}
+      """
+
+    let tokens = try await openAndPerformSemanticTokensRequest(text: text)
+    XCTAssertEqual(
+      tokens,
+      [
+        Token(line: 0, utf16index: 0, length: 4, kind: .keyword),
+        Token(line: 0, utf16index: 5, length: 3, kind: .identifier),
+        Token(line: 0, utf16index: 9, length: 3, kind: .function),
+        Token(line: 0, utf16index: 13, length: 12, kind: .identifier),
+        Token(line: 0, utf16index: 27, length: 3, kind: .struct, modifiers: .defaultLibrary),
       ]
     )
   }


### PR DESCRIPTION
This highlights `arg` in the following as a `parameter`. 

```swift
func foo(arg: Int) {}
foo(arg: 1)
```

LSP doesn’t explicitly state what `parameter` means. `clangd` uses `parameter` for parameter declarations, Python also uses `parameter` for parameter labels.

Here’s how syntax coloring looks with this patch in VS Code with the GitHub light theme (underlined are the changed tokens).

<img width="551" alt="Screenshot 2023-11-29 at 10 16 08" src="https://github.com/apple/sourcekit-lsp/assets/4062178/18796814-decb-458a-9e89-3c6ca87571ee">

Companion of https://github.com/apple/swift-syntax/pull/2375.
