### PR TITLE
Allow configuring workspace type via flag

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
@@ -18,12 +18,22 @@ public enum BuildConfiguration: Hashable, Codable {
   case release
 }
 
+/// The type of workspace; default workspace type selection logic can be overridden.
+///
+/// **(LSP Extension)**
+public enum WorkspaceType: Hashable, Codable {
+  case buildserver, compdb, swiftpm
+}
+
 /// Build settings that should be used for a workspace.
 ///
 /// **(LSP Extension)**
 public struct WorkspaceBuildSetup: Hashable, Codable {
   /// The configuration that the workspace should be built in.
   public let buildConfiguration: BuildConfiguration?
+
+  /// The default workspace type to use for this workspace.
+  public let defaultWorkspaceType: WorkspaceType?
 
   /// The build directory for the workspace.
   public let scratchPath: DocumentURI?
@@ -42,6 +52,7 @@ public struct WorkspaceBuildSetup: Hashable, Codable {
 
   public init(
     buildConfiguration: BuildConfiguration? = nil,
+    defaultWorkspaceType: WorkspaceType? = nil,
     scratchPath: DocumentURI? = nil,
     cFlags: [String]? = nil,
     cxxFlags: [String]? = nil,
@@ -49,6 +60,7 @@ public struct WorkspaceBuildSetup: Hashable, Codable {
     swiftFlags: [String]? = nil
   ) {
     self.buildConfiguration = buildConfiguration
+    self.defaultWorkspaceType = defaultWorkspaceType
     self.scratchPath = scratchPath
     self.cFlags = cFlags
     self.cxxFlags = cxxFlags

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
@@ -22,7 +22,7 @@ public enum BuildConfiguration: Hashable, Codable {
 ///
 /// **(LSP Extension)**
 public enum WorkspaceType: Hashable, Codable {
-  case buildserver, compdb, swiftpm
+  case buildServer, compilationDatabase, swiftPM
 }
 
 /// Build settings that should be used for a workspace.

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -38,7 +38,12 @@ public struct BuildSetup {
   /// Additional build flags
   public var flags: BuildFlags
 
-  public init(configuration: BuildConfiguration?, defaultWorkspaceType: WorkspaceType?, path: AbsolutePath?, flags: BuildFlags) {
+  public init(
+    configuration: BuildConfiguration?,
+    defaultWorkspaceType: WorkspaceType?,
+    path: AbsolutePath?,
+    flags: BuildFlags
+  ) {
     self.configuration = configuration
     self.defaultWorkspaceType = defaultWorkspaceType
     self.path = path

--- a/Sources/SKCore/BuildSetup.swift
+++ b/Sources/SKCore/BuildSetup.swift
@@ -21,6 +21,7 @@ public struct BuildSetup {
   /// Default configuration
   public static let `default` = BuildSetup(
     configuration: nil,
+    defaultWorkspaceType: nil,
     path: nil,
     flags: BuildFlags()
   )
@@ -28,14 +29,18 @@ public struct BuildSetup {
   /// Build configuration (debug|release).
   public var configuration: BuildConfiguration?
 
+  /// Default workspace type (buildserver|compdb|swiftpm). Overrides workspace type selection logic.
+  public var defaultWorkspaceType: WorkspaceType?
+
   /// Build artifacts directory path. If nil, the build system may choose a default value.
   public var path: AbsolutePath?
 
   /// Additional build flags
   public var flags: BuildFlags
 
-  public init(configuration: BuildConfiguration?, path: AbsolutePath?, flags: BuildFlags) {
+  public init(configuration: BuildConfiguration?, defaultWorkspaceType: WorkspaceType?, path: AbsolutePath?, flags: BuildFlags) {
     self.configuration = configuration
+    self.defaultWorkspaceType = defaultWorkspaceType
     self.path = path
     self.flags = flags
   }
@@ -49,6 +54,7 @@ public struct BuildSetup {
     flags = flags.merging(other.flags)
     return BuildSetup(
       configuration: other.configuration ?? self.configuration,
+      defaultWorkspaceType: other.defaultWorkspaceType ?? self.defaultWorkspaceType,
       path: other.path ?? self.path,
       flags: flags
     )

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(SKSupport STATIC
   Random.swift
   Result.swift
   ThreadSafeBox.swift
+  WorkspaceType.swift
 )
 set_target_properties(SKSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SKSupport/WorkspaceType.swift
+++ b/Sources/SKSupport/WorkspaceType.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum WorkspaceType: String {
+  case buildserver
+  case compdb
+  case swiftpm
+}

--- a/Sources/SKSupport/WorkspaceType.swift
+++ b/Sources/SKSupport/WorkspaceType.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public enum WorkspaceType: String {
-  case buildserver
-  case compdb
-  case swiftpm
+  case buildServer
+  case compilationDatabase
+  case swiftPM
 }

--- a/Sources/SourceKitLSP/SourceKitServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitServer+Options.swift
@@ -30,6 +30,9 @@ extension SourceKitServer {
     /// Additional arguments to pass to `clangd` on the command-line.
     public var clangdOptions: [String]
 
+    /// Overrides default workspace type selection.
+    public var workspaceType: WorkspaceType?
+
     /// Additional paths to search for a compilation database, relative to a workspace root.
     public var compilationDatabaseSearchPaths: [RelativePath]
 
@@ -52,6 +55,7 @@ extension SourceKitServer {
     public init(
       buildSetup: BuildSetup = .default,
       clangdOptions: [String] = [],
+      workspaceType: WorkspaceType? = nil,
       compilationDatabaseSearchPaths: [RelativePath] = [],
       indexOptions: IndexOptions = .init(),
       completionOptions: SKCompletionOptions = .init(),
@@ -60,6 +64,7 @@ extension SourceKitServer {
     ) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
+      self.workspaceType = workspaceType
       self.compilationDatabaseSearchPaths = compilationDatabaseSearchPaths
       self.indexOptions = indexOptions
       self.completionOptions = completionOptions

--- a/Sources/SourceKitLSP/SourceKitServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitServer+Options.swift
@@ -30,9 +30,6 @@ extension SourceKitServer {
     /// Additional arguments to pass to `clangd` on the command-line.
     public var clangdOptions: [String]
 
-    /// Overrides default workspace type selection.
-    public var workspaceType: WorkspaceType?
-
     /// Additional paths to search for a compilation database, relative to a workspace root.
     public var compilationDatabaseSearchPaths: [RelativePath]
 
@@ -55,7 +52,6 @@ extension SourceKitServer {
     public init(
       buildSetup: BuildSetup = .default,
       clangdOptions: [String] = [],
-      workspaceType: WorkspaceType? = nil,
       compilationDatabaseSearchPaths: [RelativePath] = [],
       indexOptions: IndexOptions = .init(),
       completionOptions: SKCompletionOptions = .init(),
@@ -64,7 +60,6 @@ extension SourceKitServer {
     ) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
-      self.workspaceType = workspaceType
       self.compilationDatabaseSearchPaths = compilationDatabaseSearchPaths
       self.indexOptions = indexOptions
       self.completionOptions = completionOptions

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1015,6 +1015,7 @@ extension SourceKitServer {
       capabilityRegistry: capabilityRegistry,
       toolchainRegistry: self.toolchainRegistry,
       buildSetup: self.options.buildSetup.merging(workspaceBuildSetup),
+      workspaceType: self.options.workspaceType,
       compilationDatabaseSearchPaths: self.options.compilationDatabaseSearchPaths,
       indexOptions: self.options.indexOptions,
       reloadPackageStatusCallback: { status in

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -974,6 +974,17 @@ extension LanguageServerProtocol.BuildConfiguration {
   }
 }
 
+extension LanguageServerProtocol.WorkspaceType {
+  /// Convert `LanguageServerProtocol.WorkspaceType` to `SkSupport.WorkspaceType`.
+  var workspaceType: SKSupport.WorkspaceType {
+    switch self {
+    case .buildserver: return .buildserver
+    case .compdb: return .compdb
+    case .swiftpm: return .swiftpm
+    }
+  }
+}
+
 // MARK: - Request and notification handling
 
 extension SourceKitServer {
@@ -991,6 +1002,7 @@ extension SourceKitServer {
     }
     return SKCore.BuildSetup(
       configuration: buildParams?.buildConfiguration?.configuration,
+      defaultWorkspaceType: buildParams?.defaultWorkspaceType?.workspaceType,
       path: scratchPath,
       flags: BuildFlags(
         cCompilerFlags: buildParams?.cFlags ?? [],
@@ -1015,7 +1027,6 @@ extension SourceKitServer {
       capabilityRegistry: capabilityRegistry,
       toolchainRegistry: self.toolchainRegistry,
       buildSetup: self.options.buildSetup.merging(workspaceBuildSetup),
-      workspaceType: self.options.workspaceType,
       compilationDatabaseSearchPaths: self.options.compilationDatabaseSearchPaths,
       indexOptions: self.options.indexOptions,
       reloadPackageStatusCallback: { status in

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -974,13 +974,13 @@ extension LanguageServerProtocol.BuildConfiguration {
   }
 }
 
-extension LanguageServerProtocol.WorkspaceType {
+private extension LanguageServerProtocol.WorkspaceType {
   /// Convert `LanguageServerProtocol.WorkspaceType` to `SkSupport.WorkspaceType`.
   var workspaceType: SKSupport.WorkspaceType {
     switch self {
-    case .buildserver: return .buildserver
-    case .compdb: return .compdb
-    case .swiftpm: return .swiftpm
+    case .buildServer: return .buildServer
+    case .compilationDatabase: return .compilationDatabase
+    case .swiftPM: return .swiftPM
     }
   }
 }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -38,6 +38,10 @@ fileprivate func firstNonNil<T>(
   return try await defaultValue()
 }
 
+public enum WorkspaceType: String {
+  case buildserver, compdb, swiftpm
+}
+
 /// Represents the configuration and state of a project or combination of projects being worked on
 /// together.
 ///
@@ -103,14 +107,53 @@ public final class Workspace {
     capabilityRegistry: CapabilityRegistry,
     toolchainRegistry: ToolchainRegistry,
     buildSetup: BuildSetup,
+    workspaceType: WorkspaceType?,
     compilationDatabaseSearchPaths: [RelativePath],
     indexOptions: IndexOptions = IndexOptions(),
     reloadPackageStatusCallback: @escaping (ReloadPackageStatus) async -> Void
   ) async throws {
     var buildSystem: BuildSystem? = nil
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
-      if let buildServer = await BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
-        buildSystem = buildServer
+      if let workspaceType = workspaceType {
+        switch workspaceType {
+          case WorkspaceType.swiftpm:
+            if let swiftpm = await SwiftPMWorkspace(
+              url: rootUrl,
+              toolchainRegistry: toolchainRegistry,
+              buildSetup: buildSetup,
+              reloadPackageStatusCallback: reloadPackageStatusCallback
+            ) {
+              buildSystem = swiftpm
+            } else {
+              logger.error(
+                "Could not set up a swiftpm build system for workspace at '\(rootUri.forLogging)'"
+              )
+              buildSystem = nil
+            }
+          case WorkspaceType.buildserver:
+            if let buildServer = await BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
+              buildSystem = buildServer
+            } else {
+              logger.error(
+                "Could not set up a build server build system for workspace at '\(rootUri.forLogging)'"
+              )
+              buildSystem = nil
+            }
+          case WorkspaceType.compdb:
+            if let compdb = CompilationDatabaseBuildSystem(
+              projectRoot: rootPath,
+              searchPaths: compilationDatabaseSearchPaths
+            ) {
+              buildSystem = compdb
+            } else {
+              logger.error(
+                "Could not set up a compilation database build system for workspace at '\(rootUri.forLogging)'"
+              )
+              buildSystem = nil
+            }
+        }
+      } else if let buildServer = await BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup) {
+          buildSystem = buildServer
       } else if let swiftpm = await SwiftPMWorkspace(
         url: rootUrl,
         toolchainRegistry: toolchainRegistry,

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -130,12 +130,14 @@ public final class Workspace {
     }
 
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
-      if let defaultWorkspaceType = buildSetup.defaultWorkspaceType, let defaultBuildSystem: BuildSystem? =
-        switch defaultWorkspaceType {
-          case .buildserver: await buildBuildServerWorkspace(rootPath: rootPath)
-          case .compdb: buildCompDBWorkspace(rootPath: rootPath)
-          case .swiftpm: await buildSwiftPMWorkspace(rootUrl: rootUrl)
-      } {
+      let defaultBuildSystem: BuildSystem? =
+        switch buildSetup.defaultWorkspaceType {
+          case .buildServer: await buildBuildServerWorkspace(rootPath: rootPath)
+          case .compilationDatabase: buildCompDBWorkspace(rootPath: rootPath)
+          case .swiftPM: await buildSwiftPMWorkspace(rootUrl: rootUrl)
+          case nil: nil
+        }
+      if let defaultBuildSystem {
         buildSystem = defaultBuildSystem
       } else if let buildServer = await buildBuildServerWorkspace(rootPath: rootPath) {
         buildSystem = buildServer

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -132,10 +132,10 @@ public final class Workspace {
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
       let defaultBuildSystem: BuildSystem? =
         switch buildSetup.defaultWorkspaceType {
-          case .buildServer: await buildBuildServerWorkspace(rootPath: rootPath)
-          case .compilationDatabase: buildCompDBWorkspace(rootPath: rootPath)
-          case .swiftPM: await buildSwiftPMWorkspace(rootUrl: rootUrl)
-          case nil: nil
+        case .buildServer: await buildBuildServerWorkspace(rootPath: rootPath)
+        case .compilationDatabase: buildCompDBWorkspace(rootPath: rootPath)
+        case .swiftPM: await buildSwiftPMWorkspace(rootUrl: rootUrl)
+        case nil: nil
         }
       if let defaultBuildSystem {
         buildSystem = defaultBuildSystem

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -176,8 +176,7 @@ struct SourceKitLSP: ParsableCommand {
   var indexPrefixMappings = [PathPrefixMapping]()
 
   @Option(
-    name: .customLong("default-workspace-type"),
-    help: "Override default workspace type selection; one of 'swiftpm', 'compdb', or 'buildserver'"
+    help: "Override default workspace type selection; one of 'swiftPM', 'compilationDatabase', or 'buildServer'"
   )
   var defaultWorkspaceType: SKSupport.WorkspaceType?
 

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -177,7 +177,7 @@ struct SourceKitLSP: ParsableCommand {
 
   @Option(
     name: .customLong("workspace-type"),
-    help: "Override default workspace type selection"
+    help: "Override default workspace type selection; one of 'swiftpm', 'compdb', or 'buildserver'"
   )
   var workspaceType: WorkspaceType?
 

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -92,6 +92,12 @@ extension SKSupport.BuildConfiguration: ExpressibleByArgument {}
 extension SKSupport.BuildConfiguration: @retroactive ExpressibleByArgument {}
 #endif
 
+#if swift(<5.10)
+extension WorkspaceType: ExpressibleByArgument {}
+#else
+extension WorkspaceType: @retroactive ExpressibleByArgument {}
+#endif
+
 @main
 struct SourceKitLSP: ParsableCommand {
   static let configuration = CommandConfiguration(
@@ -170,6 +176,12 @@ struct SourceKitLSP: ParsableCommand {
   var indexPrefixMappings = [PathPrefixMapping]()
 
   @Option(
+    name: .customLong("workspace-type"),
+    help: "Override default workspace type selection"
+  )
+  var workspaceType: WorkspaceType?
+
+  @Option(
     name: .customLong("compilation-db-search-path"),
     parsing: .singleValue,
     help:
@@ -197,6 +209,7 @@ struct SourceKitLSP: ParsableCommand {
     serverOptions.buildSetup.flags.linkerFlags = buildFlagsLinker
     serverOptions.buildSetup.flags.swiftCompilerFlags = buildFlagsSwift
     serverOptions.clangdOptions = clangdOptions
+    serverOptions.workspaceType = workspaceType
     serverOptions.compilationDatabaseSearchPaths = compilationDatabaseSearchPaths
     serverOptions.indexOptions.indexStorePath = indexStorePath
     serverOptions.indexOptions.indexDatabasePath = indexDatabasePath

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -93,9 +93,9 @@ extension SKSupport.BuildConfiguration: @retroactive ExpressibleByArgument {}
 #endif
 
 #if swift(<5.10)
-extension WorkspaceType: ExpressibleByArgument {}
+extension SKSupport.WorkspaceType: ExpressibleByArgument {}
 #else
-extension WorkspaceType: @retroactive ExpressibleByArgument {}
+extension SKSupport.WorkspaceType: @retroactive ExpressibleByArgument {}
 #endif
 
 @main
@@ -176,10 +176,10 @@ struct SourceKitLSP: ParsableCommand {
   var indexPrefixMappings = [PathPrefixMapping]()
 
   @Option(
-    name: .customLong("workspace-type"),
+    name: .customLong("default-workspace-type"),
     help: "Override default workspace type selection; one of 'swiftpm', 'compdb', or 'buildserver'"
   )
-  var workspaceType: WorkspaceType?
+  var defaultWorkspaceType: SKSupport.WorkspaceType?
 
   @Option(
     name: .customLong("compilation-db-search-path"),
@@ -203,13 +203,13 @@ struct SourceKitLSP: ParsableCommand {
     var serverOptions = SourceKitServer.Options()
 
     serverOptions.buildSetup.configuration = buildConfiguration
+    serverOptions.buildSetup.defaultWorkspaceType = defaultWorkspaceType
     serverOptions.buildSetup.path = scratchPath
     serverOptions.buildSetup.flags.cCompilerFlags = buildFlagsCc
     serverOptions.buildSetup.flags.cxxCompilerFlags = buildFlagsCxx
     serverOptions.buildSetup.flags.linkerFlags = buildFlagsLinker
     serverOptions.buildSetup.flags.swiftCompilerFlags = buildFlagsSwift
     serverOptions.clangdOptions = clangdOptions
-    serverOptions.workspaceType = workspaceType
     serverOptions.compilationDatabaseSearchPaths = compilationDatabaseSearchPaths
     serverOptions.indexOptions.indexStorePath = indexStorePath
     serverOptions.indexOptions.indexDatabasePath = indexDatabasePath

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -58,6 +58,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     let buildSetup = BuildSetup(
       configuration: .debug,
+      defaultWorkspaceType: nil,
       path: nil,
       flags: BuildFlags(swiftCompilerFlags: [
         "-Xfrontend",
@@ -97,6 +98,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     let buildSetup = BuildSetup(
       configuration: .debug,
+      defaultWorkspaceType: nil,
       path: nil,
       flags: BuildFlags(swiftCompilerFlags: [
         "-sdk",
@@ -169,6 +171,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     let buildSetup = BuildSetup(
       configuration: .debug,
+      defaultWorkspaceType: nil,
       path: nil,
       flags: BuildFlags(cxxCompilerFlags: [
         "-v"
@@ -204,6 +207,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     let buildSetup = BuildSetup(
       configuration: .debug,
+      defaultWorkspaceType: nil,
       path: nil,
       flags: BuildFlags(cxxCompilerFlags: [
         "-isysroot",
@@ -254,6 +258,7 @@ final class FallbackBuildSystemTests: XCTestCase {
 
     let buildSetup = BuildSetup(
       configuration: .debug,
+      defaultWorkspaceType: nil,
       path: nil,
       flags: BuildFlags(cCompilerFlags: [
         "-v"

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -186,6 +186,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let config = BuildSetup(
         configuration: .release,
+        defaultWorkspaceType: nil,
         path: packageRoot.appending(component: "non_default_build_path"),
         flags: BuildFlags(cCompilerFlags: ["-m32"], swiftCompilerFlags: ["-typecheck"])
       )


### PR DESCRIPTION
Fixes #984

I opted to log an error and continue with no build system set if the selected workspace type fails to create. A reasonable alternative might be to fall back to default selection logic, but this might make it harder to tell if something is wrong.