### PR TITLE
Revert "Adjust arguments based on move of SwiftPM's module output directory"

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -449,7 +449,7 @@ extension SwiftPMWorkspace {
     }
     args += ["-c"]
     args += td.sources.map { $0.pathString }
-    args += ["-I", td.moduleOutputPath.parentDirectory.pathString]
+    args += ["-I", buildPath.pathString]
     args += try td.compileArguments()
 
     return FileBuildSettings(

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -159,7 +159,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       check("-target", hostTriple.tripleString, arguments: arguments)
       #endif
 
-      check("-I", build.appending(component: "Modules").pathString, arguments: arguments)
+      check("-I", build.pathString, arguments: arguments)
 
       check(aswift.pathString, arguments: arguments)
     }


### PR DESCRIPTION
Reverts apple/sourcekit-lsp#987 to match SwiftPM.