### PR TITLE
Support rename across Swift files

### DIFF
--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(SKSupport STATIC
   AsyncUtils.swift
   BuildConfiguration.swift
   ByteString.swift
+  Collection+Only.swift
   Connection+Send.swift
   dlopen.swift
   FileSystem.swift

--- a/Sources/SKSupport/Collection+Only.swift
+++ b/Sources/SKSupport/Collection+Only.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public extension Collection {
+  /// If the collection contains a single element, return it, otherwise `nil`.
+  var only: Element? {
+    if !isEmpty && index(after: startIndex) == endIndex {
+      return self.first!
+    } else {
+      return nil
+    }
+  }
+}

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -336,6 +336,11 @@ public struct DocumentPositions {
     }
     return position
   }
+
+  /// Returns all position makers within these `DocumentPositions`.
+  public var allMarkers: [String] {
+    return positions.keys.sorted()
+  }
 }
 
 // MARK: - WeakMessageHelper

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -40,6 +40,12 @@ public final class SKDRequestArray {
   public func append(_ value: SKDRequestDictionary) {
     sourcekitd.api.request_array_set_value(array, -1, value.dict)
   }
+
+  public static func += (array: SKDRequestArray, other: some Sequence<SKDRequestDictionary>) {
+    for item in other {
+      array.append(item)
+    }
+  }
 }
 
 extension SKDRequestArray: CustomStringConvertible {

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(SourceKitLSP STATIC
   DocumentManager.swift
   IndexStoreDB+MainFilesProvider.swift
   ResponseError+Init.swift
+  Rename.swift
   Sequence+AsyncMap.swift
   SourceKitIndexDelegate.swift
   SourceKitLSPCommandMetadata.swift
@@ -25,7 +26,6 @@ target_sources(SourceKitLSP PRIVATE
   Swift/EditorPlaceholder.swift
   Swift/OpenInterface.swift
   Swift/RelatedIdentifiers.swift
-  Swift/Rename.swift
   Swift/SemanticRefactorCommand.swift
   Swift/SemanticRefactoring.swift
   Swift/SemanticTokens.swift

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -597,10 +597,6 @@ extension ClangLanguageServerShim {
   func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
     return try await forwardRequestToClangd(req)
   }
-
-  func rename(_ request: RenameRequest) async throws -> WorkspaceEdit? {
-    return try await forwardRequestToClangd(request)
-  }
 }
 
 /// Clang build settings derived from a `FileBuildSettingsChange`.

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -325,7 +325,7 @@ extension SourceKitServer {
         for (url, renameLocations) in locationsByFile {
           let uri = DocumentURI(url)
           if edits.changes![uri] != nil {
-            // We already have edits for this document provided by the language service, so we don't need to compute 
+            // We already have edits for this document provided by the language service, so we don't need to compute
             // rename ranges for it.
             continue
           }

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -25,18 +25,6 @@ import SourceKitD
 ///  - `foo(_:b:)`
 ///  - `foo` if no argument labels are specified, eg. for a variable.
 fileprivate struct CompoundDeclName {
-  enum CompoundDeclNameParsingError: Error, CustomStringConvertible {
-    case missingClosingParenthesis
-    case closingParenthesisNotAtEnd
-
-    var description: String {
-      switch self {
-      case .missingClosingParenthesis: "Name contains '(' but no matching ')'"
-      case .closingParenthesisNotAtEnd: "Additional text after ')'"
-      }
-    }
-  }
-
   /// The parameter of a compound decl name, which can either be the parameter's name or `_` to indicate that the
   /// parameter is unnamed.
   enum Parameter: Equatable {
@@ -62,7 +50,7 @@ fileprivate struct CompoundDeclName {
   let parameters: [Parameter]
 
   /// Parse a compound decl name into its base names and parameters.
-  init(_ compoundDeclName: String) throws {
+  init(_ compoundDeclName: String) {
     guard let openParen = compoundDeclName.firstIndex(of: "(") else {
       // We don't have a compound name. Everything is the base name
       self.baseName = compoundDeclName
@@ -70,12 +58,7 @@ fileprivate struct CompoundDeclName {
       return
     }
     self.baseName = String(compoundDeclName[..<openParen])
-    guard let closeParen = compoundDeclName.firstIndex(of: ")") else {
-      throw CompoundDeclNameParsingError.missingClosingParenthesis
-    }
-    guard compoundDeclName.index(after: closeParen) == compoundDeclName.endIndex else {
-      throw CompoundDeclNameParsingError.closingParenthesisNotAtEnd
-    }
+    let closeParen = compoundDeclName.firstIndex(of: ")") ?? compoundDeclName.endIndex
     let parametersText = compoundDeclName[compoundDeclName.index(after: openParen)..<closeParen]
     // Split by `:` to get the parameter names. Drop the last element so that we don't have a trailing empty element
     // after the last `:`.
@@ -548,8 +531,8 @@ extension SwiftLanguageServer {
       oldName: oldNameString,
       in: snapshot
     )
-    let oldName = try CompoundDeclName(oldNameString)
-    let newName = try CompoundDeclName(newNameString)
+    let oldName = CompoundDeclName(oldNameString)
+    let newName = CompoundDeclName(newNameString)
 
     try Task.checkCancellation()
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1646,17 +1646,6 @@ extension SourceKitServer {
     return try await languageService.executeCommand(executeCommand)
   }
 
-  func rename(_ request: RenameRequest) async throws -> WorkspaceEdit? {
-    let uri = request.textDocument.uri
-    guard let workspace = await workspaceForDocument(uri: uri) else {
-      throw ResponseError.workspaceNotOpen(uri)
-    }
-    guard let languageService = workspace.documentService[uri] else {
-      return nil
-    }
-    return try await languageService.rename(request)
-  }
-
   func codeAction(
     _ req: CodeActionRequest,
     workspace: Workspace,

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1169,6 +1169,7 @@ extension SourceKitServer {
           supportsCodeActions: true
         )
       ),
+      renameProvider: .value(RenameOptions()),
       colorProvider: .bool(true),
       foldingRangeProvider: .bool(!registry.clientHasDynamicFoldingRangeRegistration),
       declarationProvider: .bool(true),

--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -15,32 +15,11 @@ import LanguageServerProtocol
 import SourceKitD
 
 struct RelatedIdentifier {
-  enum Usage {
-    /// The definition of a function/subscript/variable/...
-    case definition
-
-    /// The symbol is being referenced.
-    ///
-    /// This includes
-    ///  - References to variables
-    ///  - Unapplied references to functions (`myStruct.memberFunc`)
-    ///  - Calls to subscripts (`myArray[1]`, location is `[` here, length 1)
-    case reference
-
-    /// A function that is being called.
-    case call
-
-    /// Unknown name usage occurs if we don't have an entry in the index that
-    /// tells us whether the location is a call, reference or a definition. The
-    /// most common reasons why this happens is if the editor is adding syntactic
-    /// results (eg. from comments or string literals).
-    case unknown
-  }
   let range: Range<Position>
-  let usage: Usage
+  let usage: RenameLocation.Usage
 }
 
-extension RelatedIdentifier.Usage {
+extension RenameLocation.Usage {
   fileprivate init?(_ uid: sourcekitd_uid_t?, _ keys: sourcekitd_keys) {
     switch uid {
     case keys.syntacticRenameDefinition:
@@ -116,7 +95,7 @@ extension SwiftLanguageServer {
         let length: Int = value[keys.length],
         let end: Position = snapshot.positionOf(utf8Offset: offset + length)
       {
-        let usage = RelatedIdentifier.Usage(value[keys.nameType], keys) ?? .unknown
+        let usage = RenameLocation.Usage(value[keys.nameType], keys) ?? .unknown
         relatedIdentifiers.append(
           RelatedIdentifier(range: start..<end, usage: usage)
         )

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -89,7 +89,7 @@ public struct SwiftCompileCommand: Equatable {
 
 public actor SwiftLanguageServer: ToolchainLanguageServer {
   /// The ``SourceKitServer`` instance that created this `ClangLanguageServerShim`.
-  private weak var sourceKitServer: SourceKitServer?
+  weak var sourceKitServer: SourceKitServer?
 
   let sourcekitd: SourceKitD
 

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -486,4 +486,182 @@ final class RenameTests: XCTestCase {
         """
     )
   }
+
+  func testCrossFileSwiftRename() async throws {
+    let ws = try await SwiftPMTestWorkspace(
+      files: [
+        "a.swift": """
+        func 1️⃣foo2️⃣() {}
+        """,
+        "b.swift": """
+        func test() {
+          3️⃣foo4️⃣()
+        }
+        """,
+      ],
+      build: true
+    )
+
+    let (aUri, aPositions) = try ws.openDocument("a.swift")
+    let response = try await ws.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(aUri), position: aPositions["1️⃣"], newName: "bar")
+    )
+    let changes = try XCTUnwrap(response?.changes)
+    XCTAssertEqual(
+      changes,
+      [
+        aUri: [TextEdit(range: aPositions["1️⃣"]..<aPositions["2️⃣"], newText: "bar")],
+        try ws.uri(for: "b.swift"): [
+          TextEdit(range: try ws.position(of: "3️⃣", in: "b.swift")..<ws.position(of: "4️⃣", in: "b.swift"), newText: "bar")
+        ],
+      ]
+    )
+  }
+
+  func testSwiftCrossModuleRename() async throws {
+    let ws = try await SwiftPMTestWorkspace(
+      files: [
+        "LibA/LibA.swift": """
+        public func 1️⃣foo2️⃣(3️⃣argLabel4️⃣: Int) {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          5️⃣foo6️⃣(7️⃣argLabel8️⃣: 1)
+        }
+        """,
+      ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+           .target(name: "LibA"),
+           .target(name: "LibB", dependencies: ["LibA"]),
+          ]
+        )
+        """,
+      build: true
+    )
+
+    let expectedChanges = [
+      try ws.uri(for: "LibA.swift"): [
+        TextEdit(
+          range: try ws.position(of: "1️⃣", in: "LibA.swift")..<ws.position(of: "2️⃣", in: "LibA.swift"),
+          newText: "bar"
+        ),
+        TextEdit(
+          range: try ws.position(of: "3️⃣", in: "LibA.swift")..<ws.position(of: "4️⃣", in: "LibA.swift"),
+          newText: "new"
+        ),
+      ],
+      try ws.uri(for: "LibB.swift"): [
+        TextEdit(
+          range: try ws.position(of: "5️⃣", in: "LibB.swift")..<ws.position(of: "6️⃣", in: "LibB.swift"),
+          newText: "bar"
+        ),
+        TextEdit(
+          range: try ws.position(of: "7️⃣", in: "LibB.swift")..<ws.position(of: "8️⃣", in: "LibB.swift"),
+          newText: "new"
+        ),
+      ],
+    ]
+
+    let (aUri, aPositions) = try ws.openDocument("LibA.swift")
+
+    let definitionResponse = try await ws.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(aUri), position: aPositions["1️⃣"], newName: "bar(new:)")
+    )
+    XCTAssertEqual(try XCTUnwrap(definitionResponse?.changes), expectedChanges)
+
+    let (bUri, bPositions) = try ws.openDocument("LibB.swift")
+
+    let callResponse = try await ws.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(bUri), position: bPositions["5️⃣"], newName: "bar(new:)")
+    )
+    XCTAssertEqual(try XCTUnwrap(callResponse?.changes), expectedChanges)
+  }
+
+  func testTryIndexLocationsDontMatchInMemoryLocations() async throws {
+    let ws = try await SwiftPMTestWorkspace(
+      files: [
+        "a.swift": """
+        func 1️⃣foo2️⃣() {}
+        """,
+        "b.swift": """
+        0️⃣func test() {
+          foo()
+        }
+        """,
+      ],
+      build: true
+    )
+
+    // Modify b.swift so that the locations from the index no longer match the in-memory document.
+    let (bUri, bPositions) = try ws.openDocument("b.swift")
+    ws.testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(bUri, version: 1),
+        contentChanges: [TextDocumentContentChangeEvent(range: Range(bPositions["0️⃣"]), text: "\n")]
+      )
+    )
+
+    // We should notice that the locations from the index don't match the current state of b.swift and not include any
+    // edits in b.swift
+    let (aUri, aPositions) = try ws.openDocument("a.swift")
+    let response = try await ws.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(aUri), position: aPositions["1️⃣"], newName: "bar")
+    )
+    let changes = try XCTUnwrap(response?.changes)
+    XCTAssertEqual(
+      changes,
+      [aUri: [TextEdit(range: aPositions["1️⃣"]..<aPositions["2️⃣"], newText: "bar")]]
+    )
+  }
+
+  func testTryIndexLocationsDontMatchInMemoryLocationsByLineColumnButNotOffset() async throws {
+    let ws = try await SwiftPMTestWorkspace(
+      files: [
+        "a.swift": """
+        func 1️⃣foo2️⃣() {}
+        """,
+        "b.swift": """
+        0️⃣func test() {
+          3️⃣foo4️⃣()
+        }
+        """,
+      ],
+      build: true
+    )
+
+    // Modify b.swift so that the locations from the index no longer match the in-memory document based on offsets but
+    // without introducing new lines so that line/column references are still correct
+    let (bUri, bPositions) = try ws.openDocument("b.swift")
+    ws.testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(bUri, version: 1),
+        contentChanges: [
+          TextDocumentContentChangeEvent(range: Range(bPositions["0️⃣"]), text: "/* this is just a comment */")
+        ]
+      )
+    )
+
+    // Index and find-syntactic-rename ranges work based on line/column so we should still be able to match the location
+    // of `foo` after the edit.
+    let (aUri, aPositions) = try ws.openDocument("a.swift")
+    let response = try await ws.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(aUri), position: aPositions["1️⃣"], newName: "bar")
+    )
+    let changes = try XCTUnwrap(response?.changes)
+    XCTAssertEqual(
+      changes,
+      [
+        aUri: [TextEdit(range: aPositions["1️⃣"]..<aPositions["2️⃣"], newText: "bar")],
+        bUri: [TextEdit(range: bPositions["3️⃣"]..<bPositions["4️⃣"], newText: "bar")],
+      ]
+    )
+  }
 }

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -366,40 +366,32 @@ final class RenameTests: XCTestCase {
     )
   }
 
-  func testErrorIfNewNameDoesntContainClosingParenthesis() async throws {
-    let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
-    let positions = testClient.openDocument(
+  func testNewNameDoesntContainClosingParenthesis() async throws {
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       2️⃣foo(a: 1)
       """,
-      uri: uri
+      newName: "bar(x:",
+      expected: """
+        func bar(x: Int) {}
+        bar(x: 1)
+        """
     )
-    let request = RenameRequest(
-      textDocument: TextDocumentIdentifier(uri),
-      position: positions["1️⃣"],
-      newName: "bar(x:"
-    )
-    await assertThrowsError(try await testClient.send(request))
   }
 
-  func testErrorIfNewNameContainsTextAfterParenthesis() async throws {
-    let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
-    let positions = testClient.openDocument(
+  func testNewNameContainsTextAfterParenthesis() async throws {
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       2️⃣foo(a: 1)
       """,
-      uri: uri
+      newName: "bar(x:)other:",
+      expected: """
+        func bar(x: Int) {}
+        bar(x: 1)
+        """
     )
-    let request = RenameRequest(
-      textDocument: TextDocumentIdentifier(uri),
-      position: positions["1️⃣"],
-      newName: "bar(x:)other:"
-    )
-    await assertThrowsError(try await testClient.send(request))
   }
 
   func testSpacesInNewParameterNames() async throws {

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -32,7 +32,7 @@ private func apply(edits: [TextEdit], to source: String) -> String {
   return lineTable.content
 }
 
-private func assertRename(
+private func assertSingleFileRename(
   _ markedSource: String,
   newName: String,
   expected: String,
@@ -57,7 +57,7 @@ private func assertRename(
 
 final class RenameTests: XCTestCase {
   func testRenameVariableBaseName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       let 1️⃣foo = 1
       print(foo)
@@ -71,7 +71,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameFunctionBaseName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo() {}
       foo()
@@ -85,7 +85,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameFunctionParameter() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(x: Int) {}
       foo(x: 1)
@@ -99,7 +99,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testSecondParameterNameIfMatches() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(x y: Int) {}
       foo(x: 1)
@@ -113,7 +113,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIntroduceLabel() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(_ y: Int) {}
       foo(1)
@@ -127,7 +127,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRemoveLabel() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(x: Int) {}
       foo(x: 1)
@@ -141,7 +141,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRemoveLabelWithExistingInternalName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(x a: Int) {}
       foo(x: 1)
@@ -155,7 +155,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameSubscript() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {
         1️⃣subscript(x x: Int) -> Int { x }
@@ -173,7 +173,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRemoveExternalLabelFromSubscript() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {
         1️⃣subscript(x x: Int) -> Int { x }
@@ -191,7 +191,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIntroduceExternalLabelFromSubscript() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {
         1️⃣subscript(x: Int) -> Int { x }
@@ -209,7 +209,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIgnoreRenameSubscriptBaseName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {
         1️⃣subscript(x: Int) -> Int { x }
@@ -227,7 +227,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameInitializerLabels() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {
         1️⃣init(x: Int) {}
@@ -245,7 +245,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIgnoreRenameOfInitBaseName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {
         1️⃣init(x: Int) {}
@@ -263,7 +263,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameCompoundFunctionName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       _ = foo(a:)
@@ -277,7 +277,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRemoveLabelFromCompoundFunctionName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       _ = foo(a:)
@@ -291,7 +291,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIntroduceLabelToCompoundFunctionName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(_ a: Int) {}
       _ = foo(_:)
@@ -305,7 +305,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameFromReference() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func foo(_ a: Int) {}
       _ = 1️⃣foo(_:)
@@ -319,7 +319,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameMultipleParameters() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int, b: Int) {}
       foo(a: 1, b: 1)
@@ -333,7 +333,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testDontRenameParametersOmittedFromNewName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int, b: Int) {}
       foo(a: 1, b: 1)
@@ -347,7 +347,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIgnoreAdditionalParametersInNewName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       foo(a: 1)
@@ -361,7 +361,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testOnlySpecifyBaseNameWhenRenamingFunction() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       foo(a: 1)
@@ -375,7 +375,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testIgnoreParametersInNewNameWhenRenamingVariable() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       let 1️⃣foo = 1
       _ = foo
@@ -421,7 +421,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testSpacesInNewParameterNames() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(a: Int) {}
       foo(a: 1)
@@ -435,7 +435,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameOperator() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       struct Foo {}
       func 1️⃣+(x: Foo, y: Foo) {}
@@ -451,7 +451,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameParameterToEmptyName() async throws {
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       func 1️⃣foo(x: Int) {}
       foo(x: 1)
@@ -468,7 +468,7 @@ final class RenameTests: XCTestCase {
     #if !canImport(Darwin)
     throw XCTSkip("#selector in test case doesn't compile without Objective-C runtime.")
     #endif
-    try await assertRename(
+    try await assertSingleFileRename(
       """
       import Foundation
       class Foo: NSObject {


### PR DESCRIPTION
Best reviewed commit by commit. 

- Refactor rename to support index-based discovery of rename locations
  - Just shuffling code around and renaming a few variables. No functionality change
- Support rename across Swift files
  - Actually implement global rename
- Address stylistic review comments from #990
- Increase test coverage of rename
- Allow rename when the new name is missing the `)` or if it has text after `)`
  - All these commits are about addressing review comment from #990 

rdar://118995700