### PR TITLE
Log messages from the build server and clangd

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -26,12 +26,14 @@ public final class TestJSONRPCConnection {
 
   public init() {
     clientConnection = JSONRPCConnection(
+      name: "client",
       protocol: testMessageRegistry,
       inFD: serverToClient.fileHandleForReading,
       outFD: clientToServer.fileHandleForWriting
     )
 
     serverConnection = JSONRPCConnection(
+      name: "server",
       protocol: testMessageRegistry,
       inFD: clientToServer.fileHandleForReading,
       outFD: serverToClient.fileHandleForWriting

--- a/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolJSONRPC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(LanguageServerProtocolJSONRPC STATIC
   DisableSigpipe.swift
   JSONRPCConnection.swift
+  LoggableMessageTypes.swift
   MessageCoding.swift
   MessageSplitting.swift)
 set_target_properties(LanguageServerProtocolJSONRPC PROPERTIES

--- a/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
@@ -31,19 +31,6 @@ fileprivate extension Encodable {
   }
 }
 
-// MARK: - DocumentURI
-
-extension DocumentURI {
-  public var redactedDescription: String {
-    return "<DocumentURI length=\(description.count) hash=\(description.hashForLogging)>"
-  }
-}
-#if swift(<5.10)
-extension DocumentURI: CustomLogStringConvertible {}
-#else
-extension DocumentURI: @retroactive CustomLogStringConvertible {}
-#endif
-
 // MARK: - RequestType
 
 fileprivate struct AnyRequestType: CustomLogStringConvertible {

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -191,6 +191,12 @@ public actor BuildServerBuildSystem: MessageHandler {
   ///
   /// We need to notify the delegate about any updated build settings.
   public nonisolated func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) {
+    logger.info(
+      """
+      Received notification from build server:
+      \(params.forLogging)
+      """
+    )
     bspMessageHandlingQueue.async {
       if let params = params as? BuildTargetsChangedNotification {
         await self.handleBuildTargetsChanged(params)
@@ -209,6 +215,12 @@ public actor BuildServerBuildSystem: MessageHandler {
     from clientID: ObjectIdentifier,
     reply: @escaping (LSPResult<R.Response>) -> Void
   ) {
+    logger.info(
+      """
+      Received request from build server:
+      \(params.forLogging)
+      """
+    )
     reply(.failure(ResponseError.methodNotFound(R.method)))
   }
 
@@ -339,6 +351,7 @@ private func makeJSONRPCBuildServer(
   let serverToClient = Pipe()
 
   let connection = JSONRPCConnection(
+    name: "build server",
     protocol: BuildServerProtocol.bspRegistry,
     inFD: serverToClient.fileHandleForReading,
     outFD: clientToServer.fileHandleForWriting

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -6,9 +6,9 @@ add_library(SKSupport STATIC
   ByteString.swift
   Connection+Send.swift
   dlopen.swift
+  DocumentURI+CustomLogStringConvertible.swift
   FileSystem.swift
   LineTable.swift
-  LoggableMessageTypes.swift
   Random.swift
   Result.swift
   ThreadSafeBox.swift

--- a/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
+++ b/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LSPLogging
+import LanguageServerProtocol
+
+// MARK: - DocumentURI
+
+extension DocumentURI {
+  public var redactedDescription: String {
+    return "<DocumentURI length=\(description.count) hash=\(description.hashForLogging)>"
+  }
+}
+#if swift(<5.10)
+extension DocumentURI: CustomLogStringConvertible {}
+#else
+extension DocumentURI: @retroactive CustomLogStringConvertible {}
+#endif

--- a/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageServer.swift
@@ -200,6 +200,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     let clangdToUs: Pipe = Pipe()
 
     let connectionToClangd = JSONRPCConnection(
+      name: "clangd",
       protocol: MessageRegistry.lspProtocol,
       inFD: clangdToUs.fileHandleForReading,
       outFD: usToClangd.fileHandleForWriting
@@ -302,6 +303,12 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   ///
   /// We should either handle it ourselves or forward it to the editor.
   nonisolated func handle(_ params: some NotificationType, from clientID: ObjectIdentifier) {
+    logger.info(
+      """
+      Received notification from clangd:
+      \(params.forLogging)
+      """
+    )
     clangdMessageHandlingQueue.async {
       switch params {
       case let publishDiags as PublishDiagnosticsNotification:
@@ -324,6 +331,12 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     from clientID: ObjectIdentifier,
     reply: @escaping (LSPResult<R.Response>) -> Void
   ) {
+    logger.info(
+      """
+      Received request from clangd:
+      \(params.forLogging)
+      """
+    )
     clangdMessageHandlingQueue.async {
       guard let sourceKitServer = await self.sourceKitServer else {
         // `SourceKitServer` has been destructed. We are tearing down the language

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -221,6 +221,7 @@ struct SourceKitLSP: ParsableCommand {
     let realStdoutHandle = FileHandle(fileDescriptor: realStdout, closeOnDealloc: false)
 
     let clientConnection = JSONRPCConnection(
+      name: "client",
       protocol: MessageRegistry.lspProtocol,
       inFD: FileHandle.standardInput,
       outFD: realStdoutHandle,

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -252,6 +252,7 @@ class ConnectionTests: XCTestCase {
       expectation.assertForOverFulfill = true
 
       let conn = JSONRPCConnection(
+        name: "test",
         protocol: MessageRegistry(requests: [], notifications: []),
         inFD: to.fileHandleForReading,
         outFD: from.fileHandleForWriting


### PR DESCRIPTION
Log messages sent to clangd and the build server in a similar way that we log requests to sourcekitd.

Fixes #886
rdar://116705677