### PR TITLE
Support the prepare rename request

### DIFF
--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -365,6 +365,14 @@ extension SourceKitServer {
     }
     return edits
   }
+
+  func prepareRename(
+    _ request: PrepareRenameRequest,
+    workspace: Workspace,
+    languageService: ToolchainLanguageServer
+  ) async throws -> PrepareRenameResponse? {
+    try await languageService.prepareRename(request)
+  }
 }
 
 // MARK: - Swift
@@ -577,6 +585,25 @@ extension SwiftLanguageServer {
       }
     }
   }
+
+  public func prepareRename(_ request: PrepareRenameRequest) async throws -> PrepareRenameResponse? {
+    let snapshot = try self.documentManager.latestSnapshot(request.textDocument.uri)
+
+    let response = try await self.relatedIdentifiers(
+      at: request.position,
+      in: snapshot,
+      includeNonEditableBaseNames: true
+    )
+    guard let name = response.name,
+      let range = response.relatedIdentifiers.first(where: { $0.range.contains(request.position) })?.range
+    else {
+      return nil
+    }
+    return PrepareRenameResponse(
+      range: range,
+      placeholder: name
+    )
+  }
 }
 
 // MARK: - Clang
@@ -594,5 +621,9 @@ extension ClangLanguageServerShim {
     newName: String
   ) async throws -> [TextEdit] {
     throw ResponseError.internalError("Global rename not implemented for clangd")
+  }
+
+  public func prepareRename(_ request: PrepareRenameRequest) async throws -> PrepareRenameResponse? {
+    return nil
   }
 }

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -911,6 +911,8 @@ extension SourceKitServer: MessageHandler {
       await self.handleRequest(for: request, requestHandler: self.inlayHint)
     case let request as RequestAndReply<DocumentDiagnosticsRequest>:
       await self.handleRequest(for: request, requestHandler: self.documentDiagnostic)
+    case let request as RequestAndReply<PrepareRenameRequest>:
+      await self.handleRequest(for: request, requestHandler: self.prepareRename)
     // IMPORTANT: When adding a new entry to this switch, also add it to the `TaskMetadata` initializer.
     default:
       reply(.failure(ResponseError.methodNotFound(R.method)))
@@ -1175,7 +1177,7 @@ extension SourceKitServer {
           supportsCodeActions: true
         )
       ),
-      renameProvider: .value(RenameOptions()),
+      renameProvider: .value(RenameOptions(prepareProvider: true)),
       colorProvider: .bool(true),
       foldingRangeProvider: .bool(!registry.clientHasDynamicFoldingRangeRegistration),
       declarationProvider: .bool(true),

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -161,6 +161,9 @@ public protocol ToolchainLanguageServer: AnyObject {
     newName: String
   ) async throws -> [TextEdit]
 
+  /// Return compound decl name that will be used as a placeholder for a rename request at a specific position.
+  func prepareRename(_ request: PrepareRenameRequest) async throws -> PrepareRenameResponse?
+
   // MARK: - Other
 
   func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny?

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -640,4 +640,41 @@ final class RenameTests: XCTestCase {
       ]
     )
   }
+
+  func testPrepeareRenameOnDefinition() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+    let positions = testClient.openDocument(
+      """
+      func 1️⃣foo2️⃣(a: Int) {}
+      """,
+      uri: uri
+    )
+    let response = try await testClient.send(
+      PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let range = try XCTUnwrap(response?.range)
+    let placeholder = try XCTUnwrap(response?.placeholder)
+    XCTAssertEqual(range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(placeholder, "foo(a:)")
+  }
+
+  func testPrepeareRenameOnReference() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+    let positions = testClient.openDocument(
+      """
+      func foo(a: Int, b: Int = 1) {}
+      1️⃣foo2️⃣(a: 1)
+      """,
+      uri: uri
+    )
+    let response = try await testClient.send(
+      PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let range = try XCTUnwrap(response?.range)
+    let placeholder = try XCTUnwrap(response?.placeholder)
+    XCTAssertEqual(range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(placeholder, "foo(a:b:)")
+  }
 }


### PR DESCRIPTION
This allows us to return the current compound decl name when renaming a function, which will get populated as the default value for the text field in which the user enters the new symbol name.

rdar://118995649