### PR TITLE
Add deprecated serverSideFiltering for backward compatibility

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/SKCompletionOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SKCompletionOptions.swift
@@ -18,8 +18,12 @@ public struct SKCompletionOptions: Codable, Hashable {
   /// The maximum number of completion results to return, or `nil` for unlimited.
   public var maxResults: Int?
 
+  /// Older `sourcekit-lsp` binaries reject request sent from client to
+  /// server when the parameter is missing. By adding the parameter with default
+  /// value true the client that uses **LanguageServerProtocol** as model can still
+  /// interact with shipped `sourcekit-lsp` instances.
   @available(*, deprecated, message: "Not used")
-  public var serverSideFiltering: Bool = true
+  public private(set) var serverSideFiltering: Bool = true
 
   public init(maxResults: Int? = 200) {
     self.maxResults = maxResults

--- a/Sources/LanguageServerProtocol/SupportTypes/SKCompletionOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SKCompletionOptions.swift
@@ -18,6 +18,9 @@ public struct SKCompletionOptions: Codable, Hashable {
   /// The maximum number of completion results to return, or `nil` for unlimited.
   public var maxResults: Int?
 
+  @available(*, deprecated, message: "Not used")
+  public var serverSideFiltering: Bool = true
+
   public init(maxResults: Int? = 200) {
     self.maxResults = maxResults
   }


### PR DESCRIPTION
Re-add deprecated serverSideFiltering parameter.

resoning: currently shipped **sourcekit-lsp** binaries reject request sent from client to server when the parameter is missing. By adding the parameter with default value **true** the client that uses **LanguageServerProtocol** as model can still interact with shipped **sourcekit-lsp** instances.