### PR TITLE
Ensure rename tests don’t fail if running with a sourcekitd that doesn’t support rename yet

### DIFF
--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -592,8 +592,10 @@ extension SwiftLanguageServer {
       in: snapshot,
       includeNonEditableBaseNames: true
     )
-    guard let name = response.name,
-      let range = response.relatedIdentifiers.first(where: { $0.range.contains(request.position) })?.range
+    guard let name = response.name else {
+      throw ResponseError.unknown("Running sourcekit-lsp with a version of sourcekitd that does not support rename")
+    }
+    guard let range = response.relatedIdentifiers.first(where: { $0.range.contains(request.position) })?.range
     else {
       return nil
     }

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -46,13 +46,22 @@ private func assertSingleFileRename(
   let uri = DocumentURI.for(.swift, testName: testName)
   let positions = testClient.openDocument(markedSource, uri: uri)
   for marker in positions.allMarkers {
-    let response = try await testClient.send(
-      RenameRequest(
-        textDocument: TextDocumentIdentifier(uri),
-        position: positions[marker],
-        newName: newName
+    let response: WorkspaceEdit?
+    do {
+      response = try await testClient.send(
+        RenameRequest(
+          textDocument: TextDocumentIdentifier(uri),
+          position: positions[marker],
+          newName: newName
+        )
       )
-    )
+    } catch let error as ResponseError {
+      if error.message == "Running sourcekit-lsp with a version of sourcekitd that does not support rename" {
+        throw XCTSkip(error.message)
+      } else {
+        throw error
+      }
+    }
     let edits = try XCTUnwrap(response?.changes?[uri], "while performing rename at \(marker)", file: file, line: line)
     let source = extractMarkers(markedSource).textWithoutMarkers
     let renamed = apply(edits: edits, to: source)
@@ -127,9 +136,18 @@ private func assertMultiFileRename(
       ws.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
     }
     for marker in markers {
-      let response = try await ws.testClient.send(
-        RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions[marker], newName: newName)
-      )
+      let response: WorkspaceEdit?
+      do {
+        response = try await ws.testClient.send(
+          RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions[marker], newName: newName)
+        )
+      } catch let error as ResponseError {
+        if error.message == "Running sourcekit-lsp with a version of sourcekitd that does not support rename" {
+          throw XCTSkip(error.message)
+        } else {
+          throw error
+        }
+      }
       let changes = try XCTUnwrap(response?.changes)
       try assertRenamedSourceMatches(
         originalFiles: files,
@@ -696,9 +714,18 @@ final class RenameTests: XCTestCase {
       """,
       uri: uri
     )
-    let response = try await testClient.send(
-      PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
-    )
+    let response: PrepareRenameResponse?
+    do {
+      response = try await testClient.send(
+        PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+      )
+    } catch let error as ResponseError {
+      if error.message == "Running sourcekit-lsp with a version of sourcekitd that does not support rename" {
+        throw XCTSkip(error.message)
+      } else {
+        throw error
+      }
+    }
     let range = try XCTUnwrap(response?.range)
     let placeholder = try XCTUnwrap(response?.placeholder)
     XCTAssertEqual(range, positions["1️⃣"]..<positions["2️⃣"])
@@ -715,9 +742,18 @@ final class RenameTests: XCTestCase {
       """,
       uri: uri
     )
-    let response = try await testClient.send(
-      PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
-    )
+    let response: PrepareRenameResponse?
+    do {
+      response = try await testClient.send(
+        PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+      )
+    } catch let error as ResponseError {
+      if error.message == "Running sourcekit-lsp with a version of sourcekitd that does not support rename" {
+        throw XCTSkip(error.message)
+      } else {
+        throw error
+      }
+    }
     let range = try XCTUnwrap(response?.range)
     let placeholder = try XCTUnwrap(response?.placeholder)
     XCTAssertEqual(range, positions["1️⃣"]..<positions["2️⃣"])


### PR DESCRIPTION
Just another case of making sure that sourcekit-lsp’s tests don’t fail after checking out the repo and running its tests using eg. Xcode 15.1 without an open source toolchain snapshot.