### PR TITLE
Migrate `ToolchainRegistry` to be an actor

### DIFF
--- a/Sources/LSPTestSupport/Assertions.swift
+++ b/Sources/LSPTestSupport/Assertions.swift
@@ -69,9 +69,19 @@ public func assertEqual<T: Equatable>(
   XCTAssertEqual(expression1, expression2, message(), file: file, line: line)
 }
 
+/// Same as `XCTAssertTrue` but doesn't take autoclosures and thus `expression` can contain `await`.
+public func assertTrue(
+  _ expression: Bool,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssertTrue(expression, message(), file: file, line: line)
+}
+
 /// Same as `XCTAssertNil` but doesn't take autoclosures and thus `expression`
 /// can contain `await`.
-public func assertNil<T: Equatable>(
+public func assertNil<T>(
   _ expression: T?,
   _ message: @autoclosure () -> String = "",
   file: StaticString = #filePath,
@@ -82,7 +92,7 @@ public func assertNil<T: Equatable>(
 
 /// Same as `XCTAssertNotNil` but doesn't take autoclosures and thus `expression`
 /// can contain `await`.
-public func assertNotNil<T: Equatable>(
+public func assertNotNil<T>(
   _ expression: T?,
   _ message: @autoclosure () -> String = "",
   file: StaticString = #filePath,

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -26,24 +26,23 @@ import var TSCBasic.localFileSystem
 /// Most users will use the `shared` ToolchainRegistry, although it's possible to create more. A
 /// ToolchainRegistry is usually initialized by performing a search of predetermined paths,
 /// e.g. `ToolchainRegistry(searchPaths: ToolchainRegistry.defaultSearchPaths)`.
-public final class ToolchainRegistry {
+public final actor ToolchainRegistry {
 
-  /// The toolchains, in the order they were registered. **Must be accessed on `queue`**.
-  var _toolchains: [Toolchain] = []
+  /// The toolchains, in the order they were registered.
+  public private(set) var toolchains: [Toolchain] = []
 
-  /// The toolchains indexed by their identifier. **Must be accessed on `queue`**.
+  /// The toolchains indexed by their identifier.
+  ///
   /// Multiple toolchains may exist for the XcodeDefault toolchain identifier.
-  var toolchainsByIdentifier: [String: [Toolchain]] = [:]
+  private var toolchainsByIdentifier: [String: [Toolchain]] = [:]
 
-  /// The toolchains indexed by their path. **Must be accessed on `queue`**.
+  /// The toolchains indexed by their path.
+  ///
   /// Note: Not all toolchains have a path.
-  var toolchainsByPath: [AbsolutePath: Toolchain] = [:]
+  private var toolchainsByPath: [AbsolutePath: Toolchain] = [:]
 
-  /// The default toolchain. **Must be accessed on `queue`**.
-  var _default: Toolchain? = nil
-
-  /// Mutex for registering and accessing toolchains.
-  var queue: DispatchQueue = DispatchQueue(label: "toolchain-registry-queue")
+  /// The default toolchain.
+  private var _default: Toolchain? = nil
 
   /// The currently selected toolchain identifier on Darwin.
   public lazy var darwinToolchainOverride: String? = {
@@ -55,9 +54,11 @@ public final class ToolchainRegistry {
 
   /// Creates an empty toolchain registry.
   public init() {}
-}
 
-extension ToolchainRegistry {
+  /// A task that produces the shared toolchain registry.
+  private static var sharedRegistryTask: Task<ToolchainRegistry, Never> = Task {
+    await ToolchainRegistry(localFileSystem)
+  }
 
   /// The global toolchain registry, initially populated by scanning for toolchains.
   ///
@@ -66,7 +67,18 @@ extension ToolchainRegistry {
   /// * (Darwin) The currently selected Xcode
   /// * (Darwin) [~]/Library/Developer/Toolchains
   /// * env SOURCEKIT_PATH, PATH
-  public static var shared: ToolchainRegistry = ToolchainRegistry(localFileSystem)
+  public static var shared: ToolchainRegistry {
+    get async {
+      return await sharedRegistryTask.value
+    }
+  }
+
+  /// Set the globally shared toolchain registry.
+  public static func setSharedToolchainRegistry(_ toolchainRegistry: ToolchainRegistry) {
+    sharedRegistryTask = Task {
+      toolchainRegistry
+    }
+  }
 
   /// Creates a toolchain registry populated by scanning for toolchains according to the given paths
   /// and variables.
@@ -83,10 +95,10 @@ extension ToolchainRegistry {
   /// let tr = ToolchainRegistry()
   /// tr.scanForToolchains()
   /// ```
-  public convenience init(
+  public init(
     installPath: AbsolutePath? = nil,
     _ fileSystem: FileSystem
-  ) {
+  ) async {
     self.init()
     scanForToolchains(installPath: installPath, fileSystem)
   }
@@ -103,34 +115,31 @@ extension ToolchainRegistry {
   /// The default toolchain must be only of the registered toolchains.
   public var `default`: Toolchain? {
     get {
-      return queue.sync {
-        if _default == nil {
-          if let tc = toolchainsByIdentifier[darwinToolchainIdentifier]?.first {
-            _default = tc
-          } else {
-            _default = _toolchains.first
-          }
+      if _default == nil {
+        if let tc = toolchainsByIdentifier[darwinToolchainIdentifier]?.first {
+          _default = tc
+        } else {
+          _default = toolchains.first
         }
-        return _default
       }
+      return _default
     }
 
     set {
-      queue.sync {
-        guard let toolchain = newValue else {
-          _default = nil
-          return
-        }
-        precondition(
-          _toolchains.contains { $0 === toolchain },
-          "default toolchain must be registered first"
-        )
-        _default = toolchain
+      guard let toolchain = newValue else {
+        _default = nil
+        return
       }
+      precondition(
+        toolchains.contains { $0 === toolchain },
+        "default toolchain must be registered first"
+      )
+      _default = toolchain
     }
   }
 
   /// The standard default toolchain identifier on Darwin.
+  @_spi(Testing)
   public static let darwinDefaultToolchainIdentifier: String = "com.apple.dt.toolchain.XcodeDefault"
 
   /// The current toolchain identifier on Darwin, which is either specified byt the `TOOLCHAINS`
@@ -138,30 +147,31 @@ extension ToolchainRegistry {
   ///
   /// The value of `default.identifier` may be different if the default toolchain has been
   /// explicitly overridden in code, or if there is no toolchain with this identifier.
+  @_spi(Testing)
   public var darwinToolchainIdentifier: String {
     return darwinToolchainOverride ?? ToolchainRegistry.darwinDefaultToolchainIdentifier
   }
+}
 
-  /// All toolchains, in the order they were added.
-  public var toolchains: [Toolchain] {
-    return queue.sync { _toolchains }
-  }
-
+/// Inspecting internal state for testing purposes.
+extension ToolchainRegistry {
+  @_spi(Testing)
   public func toolchains(identifier: String) -> [Toolchain] {
-    return queue.sync { toolchainsByIdentifier[identifier] ?? [] }
+    return toolchainsByIdentifier[identifier] ?? []
   }
 
+  @_spi(Testing)
   public func toolchain(identifier: String) -> Toolchain? {
     return toolchains(identifier: identifier).first
   }
 
+  @_spi(Testing)
   public func toolchain(path: AbsolutePath) -> Toolchain? {
-    return queue.sync { toolchainsByPath[path] }
+    return toolchainsByPath[path]
   }
 }
 
 extension ToolchainRegistry {
-
   public enum Error: Swift.Error {
 
     /// There is already a toolchain with the given identifier.
@@ -178,11 +188,8 @@ extension ToolchainRegistry {
   ///
   /// - parameter toolchain: The new toolchain to register.
   /// - throws: If `toolchain.identifier` has already been seen.
+  @_spi(Testing)
   public func registerToolchain(_ toolchain: Toolchain) throws {
-    try queue.sync { try _registerToolchain(toolchain) }
-  }
-
-  func _registerToolchain(_ toolchain: Toolchain) throws {
     // Non-XcodeDefault toolchain: disallow all duplicates.
     if toolchain.identifier != ToolchainRegistry.darwinDefaultToolchainIdentifier {
       guard toolchainsByIdentifier[toolchain.identifier] == nil else {
@@ -198,10 +205,8 @@ extension ToolchainRegistry {
       toolchainsByPath[path] = toolchain
     }
 
-    var toolchains = toolchainsByIdentifier[toolchain.identifier] ?? []
+    toolchainsByIdentifier[toolchain.identifier, default: []].append(toolchain)
     toolchains.append(toolchain)
-    toolchainsByIdentifier[toolchain.identifier] = toolchains
-    _toolchains.append(toolchain)
   }
 
   /// Register the toolchain at the given path.
@@ -214,16 +219,11 @@ extension ToolchainRegistry {
     _ path: AbsolutePath,
     _ fileSystem: FileSystem = localFileSystem
   ) throws -> Toolchain {
-    return try queue.sync { try _registerToolchain(path, fileSystem) }
-  }
-
-  func _registerToolchain(_ path: AbsolutePath, _ fileSystem: FileSystem) throws -> Toolchain {
-    if let toolchain = Toolchain(path, fileSystem) {
-      try _registerToolchain(toolchain)
-      return toolchain
-    } else {
+    guard let toolchain = Toolchain(path, fileSystem) else {
       throw Error.invalidToolchain
     }
+    try registerToolchain(toolchain)
+    return toolchain
   }
 }
 
@@ -237,6 +237,7 @@ extension ToolchainRegistry {
   /// * (Darwin) The currently selected Xcode
   /// * (Darwin) [~]/Library/Developer/Toolchains
   /// * env SOURCEKIT_PATH, PATH (or Path)
+  @_spi(Testing)
   public func scanForToolchains(
     installPath: AbsolutePath? = nil,
     environmentVariables: [String] = ["SOURCEKIT_TOOLCHAIN_PATH"],
@@ -251,18 +252,20 @@ extension ToolchainRegistry {
         AbsolutePath(validating: "/Library/Developer/Toolchains"),
       ]
 
-    queue.sync {
-      _scanForToolchains(environmentVariables: environmentVariables, setDefault: true, fileSystem)
-      if let installPath = installPath,
-        let toolchain = try? _registerToolchain(installPath, fileSystem),
-        _default == nil
-      {
-        _default = toolchain
-      }
-      xcodes.forEach { _scanForToolchains(xcode: $0, fileSystem) }
-      xctoolchainSearchPaths.forEach { _scanForToolchains(xctoolchainSearchPath: $0, fileSystem) }
-      _scanForToolchains(pathVariables: pathVariables, fileSystem)
+    scanForToolchains(environmentVariables: environmentVariables, setDefault: true, fileSystem)
+    if let installPath = installPath,
+      let toolchain = try? registerToolchain(installPath, fileSystem),
+      _default == nil
+    {
+      _default = toolchain
     }
+    for xcode in xcodes {
+      scanForToolchains(xcode: xcode, fileSystem)
+    }
+    for xctoolchainSearchPath in xctoolchainSearchPaths {
+      scanForToolchains(xctoolchainSearchPath: xctoolchainSearchPath, fileSystem)
+    }
+    scanForToolchains(pathVariables: pathVariables, fileSystem)
   }
 
   /// Scan for toolchains in the paths given by `environmentVariables` and possibly override the
@@ -271,30 +274,17 @@ extension ToolchainRegistry {
   /// - parameters:
   ///   - environmentVariables: A list of environment variable names to search for toolchain paths.
   ///   - setDefault: If true, the first toolchain found will be set as the default.
+  @_spi(Testing)
   public func scanForToolchains(
     environmentVariables: [String],
     setDefault: Bool,
     _ fileSystem: FileSystem = localFileSystem
   ) {
-    queue.sync {
-      _scanForToolchains(
-        environmentVariables: environmentVariables,
-        setDefault: setDefault,
-        fileSystem
-      )
-    }
-  }
-
-  func _scanForToolchains(
-    environmentVariables: [String],
-    setDefault: Bool,
-    _ fileSystem: FileSystem
-  ) {
     var shouldSetDefault = setDefault
     for envVar in environmentVariables {
       if let pathStr = ProcessEnv.vars[envVar],
         let path = try? AbsolutePath(validating: pathStr),
-        let toolchain = try? _registerToolchain(path, fileSystem),
+        let toolchain = try? registerToolchain(path, fileSystem),
         shouldSetDefault
       {
         shouldSetDefault = false
@@ -308,18 +298,13 @@ extension ToolchainRegistry {
   /// - parameters:
   ///   - pathVariables: A list of PATH-like environment variable names to search.
   ///   - setDefault: If true, the first toolchain found will be set as the default.
-  public
-    func scanForToolchains(pathVariables: [String], _ fileSystem: FileSystem = localFileSystem)
-  {
-    queue.sync { _scanForToolchains(pathVariables: pathVariables, fileSystem) }
-  }
-
-  func _scanForToolchains(pathVariables: [String], _ fileSystem: FileSystem) {
+  @_spi(Testing)
+  public func scanForToolchains(pathVariables: [String], _ fileSystem: FileSystem = localFileSystem) {
     pathVariables.lazy.flatMap { envVar in
       getEnvSearchPaths(pathString: ProcessEnv.vars[envVar], currentWorkingDirectory: nil)
     }
     .forEach { path in
-      _ = try? _registerToolchain(path, fileSystem)
+      _ = try? registerToolchain(path, fileSystem)
     }
   }
 
@@ -327,39 +312,34 @@ extension ToolchainRegistry {
   /// application (e.g. "Xcode.app") or the application's Developer directory.
   ///
   /// - parameter xcode: The path to Xcode.app or Xcode.app/Contents/Developer.
+  @_spi(Testing)
   public func scanForToolchains(xcode: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) {
-    queue.sync { _scanForToolchains(xcode: xcode, fileSystem) }
-  }
-
-  func _scanForToolchains(xcode: AbsolutePath, _ fileSystem: FileSystem) {
     var path = xcode
     if path.extension == "app" {
       path = path.appending(components: "Contents", "Developer")
     }
-    _scanForToolchains(xctoolchainSearchPath: path.appending(component: "Toolchains"), fileSystem)
+    scanForToolchains(xctoolchainSearchPath: path.appending(component: "Toolchains"), fileSystem)
   }
 
   /// Scan for `xctoolchain` directories in the given search path.
   ///
   /// - parameter toolchains: Directory containing xctoolchains, e.g. /Library/Developer/Toolchains
+  @_spi(Testing)
   public func scanForToolchains(
     xctoolchainSearchPath searchPath: AbsolutePath,
     _ fileSystem: FileSystem = localFileSystem
   ) {
-    queue.sync { _scanForToolchains(xctoolchainSearchPath: searchPath, fileSystem) }
-  }
-
-  func _scanForToolchains(xctoolchainSearchPath searchPath: AbsolutePath, _ fileSystem: FileSystem) {
     guard let direntries = try? fileSystem.getDirectoryContents(searchPath) else { return }
     for name in direntries {
       let path = searchPath.appending(component: name)
       if path.extension == "xctoolchain" {
-        _ = try? _registerToolchain(path, fileSystem)
+        _ = try? registerToolchain(path, fileSystem)
       }
     }
   }
 
   /// The path of the current Xcode.app/Contents/Developer.
+  @_spi(Testing)
   public static var currentXcodeDeveloperPath: AbsolutePath? {
     guard let str = try? Process.checkNonZeroExit(args: "/usr/bin/xcode-select", "-p") else { return nil }
     return try? AbsolutePath(validating: str.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -43,6 +43,14 @@ public enum ReloadPackageStatus {
   case end
 }
 
+/// Same as `toolchainRegistry.default`.
+///
+/// Needed to work around a compiler crash that prevents us from accessing `toolchainRegistry.default` in
+/// `SwiftPMWorkspace.init`.
+private func getDefaultToolchain(_ toolchainRegistry: ToolchainRegistry) async -> SKCore.Toolchain? {
+  return await toolchainRegistry.default
+}
+
 /// Swift Package Manager build system and workspace support.
 ///
 /// This class implements the `BuildSystem` interface to provide the build settings for a Swift
@@ -109,7 +117,7 @@ public actor SwiftPMWorkspace {
 
     self.packageRoot = try resolveSymlinks(packageRoot)
 
-    guard let destinationToolchainBinDir = toolchainRegistry.default?.swiftc?.parentDirectory else {
+    guard let destinationToolchainBinDir = await getDefaultToolchain(toolchainRegistry)?.swiftc?.parentDirectory else {
       throw Error.cannotDetermineHostToolchain
     }
 

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
@@ -46,7 +46,7 @@ public struct IndexedSingleSwiftFileWorkspace {
     let testFileURL = testWorkspaceDirectory.appendingPathComponent("test.swift")
     let indexURL = testWorkspaceDirectory.appendingPathComponent("index")
     self.indexDBURL = testWorkspaceDirectory.appendingPathComponent("index-db")
-    guard let swiftc = ToolchainRegistry.shared.default?.swiftc?.asURL else {
+    guard let swiftc = await ToolchainRegistry.shared.default?.swiftc?.asURL else {
       throw Error.swiftcNotFound
     }
 

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
@@ -13,7 +13,7 @@
 import Foundation
 import ISDBTibs
 import LanguageServerProtocol
-import SKCore
+@_spi(Testing) import SKCore
 import SourceKitLSP
 import TSCBasic
 
@@ -46,7 +46,7 @@ public struct IndexedSingleSwiftFileWorkspace {
     let testFileURL = testWorkspaceDirectory.appendingPathComponent("test.swift")
     let indexURL = testWorkspaceDirectory.appendingPathComponent("index")
     self.indexDBURL = testWorkspaceDirectory.appendingPathComponent("index-db")
-    guard let swiftc = await ToolchainRegistry.shared.default?.swiftc?.asURL else {
+    guard let swiftc = await ToolchainRegistry.forTesting.default?.swiftc?.asURL else {
       throw Error.swiftcNotFound
     }
 

--- a/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
@@ -72,7 +72,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
 
   /// Build a SwiftPM package package manifest is located in the directory at `path`.
   public static func build(at path: URL) async throws {
-    guard let swift = ToolchainRegistry.shared.default?.swift?.asURL else {
+    guard let swift = await ToolchainRegistry.shared.default?.swift?.asURL else {
       throw Error.swiftNotFound
     }
     let arguments = [

--- a/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import LanguageServerProtocol
-import SKCore
+@_spi(Testing) import SKCore
 import TSCBasic
 
 public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
@@ -72,7 +72,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
 
   /// Build a SwiftPM package package manifest is located in the directory at `path`.
   public static func build(at path: URL) async throws {
-    guard let swift = await ToolchainRegistry.shared.default?.swift?.asURL else {
+    guard let swift = await ToolchainRegistry.forTesting.default?.swift?.asURL else {
       throw Error.swiftNotFound
     }
     let arguments = [

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -105,7 +105,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
 
     let clientConnection = LocalConnection()
     self.serverToClientConnection = clientConnection
-    server = SourceKitServer(
+    server = await SourceKitServer(
       client: clientConnection,
       options: serverOptions,
       onExit: {

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -14,7 +14,7 @@ import Foundation
 import LSPTestSupport
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
-import SKCore
+@_spi(Testing) import SKCore
 import SKSupport
 import SourceKitLSP
 import SwiftSyntax
@@ -107,6 +107,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
     self.serverToClientConnection = clientConnection
     server = await SourceKitServer(
       client: clientConnection,
+      toolchainRegistry: ToolchainRegistry.forTesting,
       options: serverOptions,
       onExit: {
         clientConnection.close()

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -87,5 +87,3 @@ fileprivate extension URL {
     #endif
   }
 }
-
-public let hasClangd = ToolchainRegistry.shared.default?.clangd != nil

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -441,9 +441,9 @@ public actor SourceKitServer {
     fileSystem: FileSystem = localFileSystem,
     options: Options,
     onExit: @escaping () -> Void = {}
-  ) {
+  ) async {
     self.fs = fileSystem
-    self.toolchainRegistry = ToolchainRegistry.shared
+    self.toolchainRegistry = await ToolchainRegistry.shared
     self.options = options
     self.onExit = onExit
 
@@ -521,7 +521,7 @@ public actor SourceKitServer {
     return try await client.send(request)
   }
 
-  func toolchain(for uri: DocumentURI, _ language: Language) -> Toolchain? {
+  func toolchain(for uri: DocumentURI, _ language: Language) async -> Toolchain? {
     let supportsLang = { (toolchain: Toolchain) -> Bool in
       // FIXME: the fact that we're looking at clangd/sourcekitd instead of the compiler indicates this method needs a parameter stating what kind of tool we're looking for.
       switch language {
@@ -534,11 +534,11 @@ public actor SourceKitServer {
       }
     }
 
-    if let toolchain = toolchainRegistry.default, supportsLang(toolchain) {
+    if let toolchain = await toolchainRegistry.default, supportsLang(toolchain) {
       return toolchain
     }
 
-    for toolchain in toolchainRegistry.toolchains {
+    for toolchain in await toolchainRegistry.toolchains {
       if supportsLang(toolchain) {
         return toolchain
       }
@@ -683,7 +683,7 @@ public actor SourceKitServer {
       return service
     }
 
-    guard let toolchain = toolchain(for: uri, language),
+    guard let toolchain = await toolchain(for: uri, language),
       let service = await languageService(for: toolchain, language, in: workspace)
     else {
       return nil

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -439,11 +439,12 @@ public actor SourceKitServer {
   public init(
     client: Connection,
     fileSystem: FileSystem = localFileSystem,
+    toolchainRegistry: ToolchainRegistry,
     options: Options,
     onExit: @escaping () -> Void = {}
-  ) async {
+  ) {
     self.fs = fileSystem
-    self.toolchainRegistry = await ToolchainRegistry.shared
+    self.toolchainRegistry = toolchainRegistry
     self.options = options
     self.onExit = onExit
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -164,7 +164,7 @@ public final class Workspace {
 
     if let storePath = await firstNonNil(indexOptions.indexStorePath, await buildSystem?.indexStorePath),
       let dbPath = await firstNonNil(indexOptions.indexDatabasePath, await buildSystem?.indexDatabasePath),
-      let libPath = toolchainRegistry.default?.libIndexStore
+      let libPath = await toolchainRegistry.default?.libIndexStore
     {
       do {
         let lib = try IndexStoreLibrary(dylibPath: libPath.pathString)

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -241,10 +241,10 @@ struct SourceKitLSP: ParsableCommand {
     )
 
     let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
-    await ToolchainRegistry.setSharedToolchainRegistry(ToolchainRegistry(installPath: installPath, localFileSystem))
 
     let server = await SourceKitServer(
       client: clientConnection,
+      toolchainRegistry: ToolchainRegistry(installPath: installPath, localFileSystem),
       options: mapOptions(),
       onExit: {
         clientConnection.close()

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -219,7 +219,7 @@ struct SourceKitLSP: ParsableCommand {
     return serverOptions
   }
 
-  func run() throws {
+  func run() async throws {
     // Dup stdout and redirect the fd to stderr so that a careless print()
     // will not break our connection stream.
     let realStdout = dup(STDOUT_FILENO)
@@ -241,9 +241,9 @@ struct SourceKitLSP: ParsableCommand {
     )
 
     let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
-    ToolchainRegistry.shared = ToolchainRegistry(installPath: installPath, localFileSystem)
+    await ToolchainRegistry.setSharedToolchainRegistry(ToolchainRegistry(installPath: installPath, localFileSystem))
 
-    let server = SourceKitServer(
+    let server = await SourceKitServer(
       client: clientConnection,
       options: mapOptions(),
       onExit: {

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -30,7 +30,7 @@ extension ToolchainRegistry {
 
 final class ToolchainRegistryTests: XCTestCase {
   func testDefaultBasic() async throws {
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     await assertNil(tr.default)
     try await tr.registerToolchain(Toolchain(identifier: "a", displayName: "a", path: nil))
     await assertEqual(tr.default?.identifier, "a")
@@ -49,7 +49,7 @@ final class ToolchainRegistryTests: XCTestCase {
     defer { Platform.current = prevPlatform }
     Platform.current = .darwin
 
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     await tr.setDarwinToolchainOverride(nil)
     await assertNil(tr.default)
     let a = Toolchain(identifier: "a", displayName: "a", path: nil)
@@ -204,7 +204,7 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertEqual(tc?.path, tcBin?.path)
     XCTAssertEqual(tc?.displayName, tcBin?.displayName)
 
-    let trInstall = ToolchainRegistry()
+    let trInstall = ToolchainRegistry.empty
     await trInstall.scanForToolchains(
       installPath: path.appending(components: "usr", "bin"),
       environmentVariables: [],
@@ -221,7 +221,7 @@ final class ToolchainRegistryTests: XCTestCase {
     await assertEqual(overrideReg.darwinToolchainIdentifier, "org.fake.global.B")
     await assertEqual(overrideReg.default?.identifier, "org.fake.global.B")
 
-    let checkByDir = ToolchainRegistry()
+    let checkByDir = ToolchainRegistry.empty
     await checkByDir.scanForToolchains(xctoolchainSearchPath: toolchains, fs)
     await assertEqual(checkByDir.toolchains.count, 4)
     #endif
@@ -386,7 +386,7 @@ final class ToolchainRegistryTests: XCTestCase {
       XCTAssertNotNil(t2.clangd)
       XCTAssertNotNil(t2.swiftc)
 
-      let tr = ToolchainRegistry()
+      let tr = ToolchainRegistry.empty
       let t3 = try await tr.registerToolchain(path.parentDirectory, fs)
       XCTAssertEqual(t3.identifier, t2.identifier)
       XCTAssertEqual(t3.sourcekitd, t2.sourcekitd)
@@ -426,7 +426,7 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testDuplicateError() async throws {
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     let toolchain = Toolchain(identifier: "a", displayName: "a", path: nil)
     try await tr.registerToolchain(toolchain)
     await assertThrowsError(
@@ -441,7 +441,7 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testDuplicatePathError() async throws {
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     let path = try AbsolutePath(validating: "/foo/bar")
     let first = Toolchain(identifier: "a", displayName: "a", path: path)
     let second = Toolchain(identifier: "b", displayName: "b", path: path)
@@ -458,7 +458,7 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testDuplicateXcodeError() async throws {
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     let xcodeToolchain = Toolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
       displayName: "a",
@@ -477,7 +477,7 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testMultipleXcodes() async throws {
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     let pathA = try AbsolutePath(validating: "/versionA")
     let xcodeA = Toolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
@@ -523,7 +523,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
     try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: "/t2/bin")
 
-    let tr = ToolchainRegistry()
+    let tr = ToolchainRegistry.empty
     await tr.scanForToolchains(
       installPath: try AbsolutePath(validating: "/t1/bin"),
       environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -14,7 +14,7 @@ import Build
 import LSPTestSupport
 import LanguageServerProtocol
 import PackageModel
-import SKCore
+@_spi(Testing) import SKCore
 import SKSwiftPMWorkspace
 import SKTestSupport
 import SourceKitLSP
@@ -39,7 +39,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
@@ -66,7 +66,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
@@ -97,7 +97,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
-          toolchainRegistry: ToolchainRegistry(),
+          toolchainRegistry: ToolchainRegistry.empty,
           fileSystem: fs,
           buildSetup: SourceKitServer.Options.testDefault.buildSetup
         )
@@ -122,7 +122,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -182,7 +182,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
 
       let config = BuildSetup(
         configuration: .release,
@@ -228,7 +228,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -262,7 +262,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -306,7 +306,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -368,7 +368,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -404,7 +404,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -499,7 +499,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
-        toolchainRegistry: ToolchainRegistry.shared,
+        toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
@@ -544,7 +544,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString)
       )
 
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -603,7 +603,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString)
       )
 
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -648,7 +648,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -684,7 +684,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
-      let tr = await ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -39,7 +39,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
@@ -66,7 +66,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
@@ -122,7 +122,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -182,7 +182,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
 
       let config = BuildSetup(
         configuration: .release,
@@ -228,7 +228,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -262,7 +262,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -306,7 +306,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -368,7 +368,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -404,7 +404,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -544,7 +544,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString)
       )
 
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -603,7 +603,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString)
       )
 
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -648,7 +648,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -684,7 +684,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
-      let tr = ToolchainRegistry.shared
+      let tr = await ToolchainRegistry.shared
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -15,7 +15,7 @@ import ISDBTestSupport
 import ISDBTibs
 import LSPTestSupport
 import LanguageServerProtocol
-import SKCore
+@_spi(Testing) import SKCore
 import SKSupport
 import SKTestSupport
 import SourceKitD
@@ -27,7 +27,7 @@ import class TSCBasic.Process
 
 final class SourceKitDTests: XCTestCase {
   func testMultipleNotificationHandlers() async throws {
-    let sourcekitdPath = await ToolchainRegistry.shared.default!.sourcekitd!
+    let sourcekitdPath = await ToolchainRegistry.forTesting.default!.sourcekitd!
     let sourcekitd = try SourceKitDImpl.getOrCreate(dylibPath: sourcekitdPath)
     let keys = sourcekitd.keys
     let path = DocumentURI.for(.swift).pseudoPath

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -26,18 +26,9 @@ import enum PackageLoading.Platform
 import class TSCBasic.Process
 
 final class SourceKitDTests: XCTestCase {
-  static var sourcekitdPath: AbsolutePath! = nil
-  static var sdkpath: String? = nil
-
-  override class func setUp() {
-    sourcekitdPath = ToolchainRegistry.shared.default!.sourcekitd!
-    guard case .darwin? = Platform.current else { return }
-    sdkpath = try? Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx")
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-
   func testMultipleNotificationHandlers() async throws {
-    let sourcekitd = try SourceKitDImpl.getOrCreate(dylibPath: SourceKitDTests.sourcekitdPath)
+    let sourcekitdPath = await ToolchainRegistry.shared.default!.sourcekitd!
+    let sourcekitd = try SourceKitDImpl.getOrCreate(dylibPath: sourcekitdPath)
     let keys = sourcekitd.keys
     let path = DocumentURI.for(.swift).pseudoPath
 
@@ -75,7 +66,10 @@ final class SourceKitDTests: XCTestCase {
     sourcekitd.addNotificationHandler(handler2)
 
     let args = SKDRequestArray(sourcekitd: sourcekitd)
-    if let sdkpath = SourceKitDTests.sdkpath {
+    if case .darwin? = Platform.current,
+      let sdkpath = try? await Process.checkNonZeroExit(args: "/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    {
       args += ["-sdk", sdkpath]
     }
     args.append(path)

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -13,7 +13,7 @@
 import BuildServerProtocol
 import LSPTestSupport
 import LanguageServerProtocol
-import SKCore
+@_spi(Testing) import SKCore
 import SKTestSupport
 import SourceKitLSP
 import TSCBasic
@@ -99,7 +99,7 @@ final class BuildSystemTests: XCTestCase {
       documentManager: DocumentManager(),
       rootUri: nil,
       capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
-      toolchainRegistry: ToolchainRegistry.shared,
+      toolchainRegistry: ToolchainRegistry.forTesting,
       buildSetup: SourceKitServer.Options.testDefault.buildSetup,
       underlyingBuildSystem: buildSystem,
       index: nil,

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -90,7 +90,6 @@ final class BuildSystemTests: XCTestCase {
   private var haveClangd: Bool = false
 
   override func setUp() async throws {
-    haveClangd = ToolchainRegistry.shared.toolchains.contains { $0.clangd != nil }
     testClient = try await TestSourceKitLSPClient()
     buildSystem = TestBuildSystem()
 

--- a/Tests/SourceKitLSPTests/ClangdTests.swift
+++ b/Tests/SourceKitLSPTests/ClangdTests.swift
@@ -16,8 +16,6 @@ import XCTest
 
 final class ClangdTests: XCTestCase {
   func testClangdGoToInclude() async throws {
-    try XCTSkipIf(!hasClangd)
-
     let ws = try await MultiFileTestWorkspace(files: [
       "Object.h": "",
       "main.c": """
@@ -49,8 +47,6 @@ final class ClangdTests: XCTestCase {
   }
 
   func testClangdGoToDefinitionWithoutIndex() async throws {
-    try XCTSkipIf(!hasClangd)
-
     let ws = try await MultiFileTestWorkspace(files: [
       "Object.h": """
       struct Object {
@@ -91,8 +87,6 @@ final class ClangdTests: XCTestCase {
   }
 
   func testClangdGoToDeclaration() async throws {
-    try XCTSkipIf(!hasClangd)
-
     let ws = try await MultiFileTestWorkspace(files: [
       "Object.h": """
       struct Object {

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -17,28 +17,9 @@ import SKTestSupport
 import XCTest
 
 final class LocalClangTests: XCTestCase {
-
-  /// Whether to fail tests if clangd cannot be found.
-  ///
-  /// - Note: Swift CI doesn't build clangd on all jobs
-  private static let requireClangd: Bool = false
-
-  /// Whether clangd exists in the toolchain.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var haveClangd: Bool = false
-
-  override func setUp() async throws {
-    haveClangd = ToolchainRegistry.shared.toolchains.contains { $0.clangd != nil }
-    if LocalClangTests.requireClangd && !haveClangd {
-      XCTFail("cannot find clangd in toolchain")
-    }
-  }
-
   // MARK: - Tests
 
   func testSymbolInfo() async throws {
-    guard haveClangd else { return }
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.cpp)
 
@@ -114,7 +95,6 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testFoldingRange() async throws {
-    guard haveClangd else { return }
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.cpp)
 
@@ -142,7 +122,6 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testDocumentSymbols() async throws {
-    guard haveClangd else { return }
     let testClient = try await TestSourceKitLSPClient(
       capabilities: ClientCapabilities(
         textDocument: TextDocumentClientCapabilities(
@@ -238,8 +217,6 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testClangStdHeaderCanary() async throws {
-    try XCTSkipIf(!haveClangd)
-
     // Note: tests generally should avoid including system headers
     // to keep them fast and portable. This test is specifically
     // ensuring clangd can find libc++ and builtin headers.
@@ -266,8 +243,6 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testClangModules() async throws {
-    try XCTSkipIf(!haveClangd)
-
     let ws = try await MultiFileTestWorkspace(files: [
       "ClangModuleA.h": """
       #ifndef ClangModuleA_h
@@ -302,8 +277,6 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testSemanticHighlighting() async throws {
-    try XCTSkipIf(!hasClangd)
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.c)
 
@@ -335,8 +308,6 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testDocumentDependenciesUpdated() async throws {
-    try XCTSkipIf(!hasClangd)
-
     let ws = try await MultiFileTestWorkspace(files: [
       "Object.h": """
       struct Object {

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -13,7 +13,7 @@
 import Foundation
 import LSPTestSupport
 import LanguageServerProtocol
-import SKCore
+@_spi(Testing) import SKCore
 import SKTestSupport
 import SourceKitLSP
 import TSCBasic
@@ -396,7 +396,7 @@ final class WorkspaceTests: XCTestCase {
     let packageDir = try ws.uri(for: "Package.swift").fileURL!.deletingLastPathComponent()
 
     try await TSCBasic.Process.checkNonZeroExit(arguments: [
-      ToolchainRegistry.shared.default!.swift!.pathString,
+      ToolchainRegistry.forTesting.default!.swift!.pathString,
       "build",
       "--package-path", packageDir.path,
       "-Xswiftc", "-index-ignore-system-modules",


### PR DESCRIPTION
While doing this, remove the static shared toolchain registry. Global state is never a good thing and we needed to modify it in tests. The design becomes a lot cleaner if we explicitly pass the toolchain registry.