### PR TITLE
Guard usages of `@retroactive` by Swift 5.11, not 5.10

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -178,7 +178,7 @@ private let testMessageRegistry = MessageRegistry(
   notifications: [EchoNotification.self]
 )
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension String: ResponseType {}
 #else
 extension String: @retroactive ResponseType {}

--- a/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
+++ b/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
@@ -21,7 +21,7 @@ extension DocumentURI {
     return "<DocumentURI length=\(description.count) hash=\(description.hashForLogging)>"
   }
 }
-#if swift(<5.10)
+#if swift(<5.11)
 extension DocumentURI: CustomLogStringConvertible {}
 #else
 extension DocumentURI: @retroactive CustomLogStringConvertible {}

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -31,7 +31,7 @@ extension IndexStoreDB {
   }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension IndexStoreDB: MainFilesProvider {}
 #else
 extension IndexStoreDB: @retroactive MainFilesProvider {}

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -48,7 +48,7 @@ extension AbsolutePath {
     .directory
   }
 }
-#if swift(<5.10)
+#if swift(<5.11)
 extension AbsolutePath: ExpressibleByArgument {}
 #else
 extension AbsolutePath: @retroactive ExpressibleByArgument {}
@@ -65,7 +65,7 @@ extension RelativePath {
     self = path
   }
 }
-#if swift(<5.10)
+#if swift(<5.11)
 extension RelativePath: ExpressibleByArgument {}
 #else
 extension RelativePath: @retroactive ExpressibleByArgument {}
@@ -80,19 +80,19 @@ extension PathPrefixMapping {
     )
   }
 }
-#if swift(<5.10)
+#if swift(<5.11)
 extension PathPrefixMapping: ExpressibleByArgument {}
 #else
 extension PathPrefixMapping: @retroactive ExpressibleByArgument {}
 #endif
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension SKSupport.BuildConfiguration: ExpressibleByArgument {}
 #else
 extension SKSupport.BuildConfiguration: @retroactive ExpressibleByArgument {}
 #endif
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension SKSupport.WorkspaceType: ExpressibleByArgument {}
 #else
 extension SKSupport.WorkspaceType: @retroactive ExpressibleByArgument {}


### PR DESCRIPTION
I incorrectly thought that `@retroactive` gets introduced by Swift 5.10 but it’s only available in Swift 5.11.