### PR TITLE
[5.10] Never return error for diagnostics request 

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1476,9 +1476,10 @@ extension SwiftLanguageServer {
           req.reply(.full(.init(items: diagnostics)))
 
         case .failure(let error):
-          let message = "document diagnostic failed \(uri): \(error)"
-          log(message, level: .warning)
-          return req.reply(.failure(.unknown(message)))
+          // VS Code does not request diagnostics again for a document if the diagnostics request failed.
+          // Since sourcekit-lsp usually recovers from failures (e.g. after sourcekitd crashes), this is undesirable.
+          // Instead of returning an error, return empty results.
+          return req.reply(.full(.init(items: [])))
       }
     }
   }


### PR DESCRIPTION
* **Explanation**: VS Code does not request diagnostics again for a document if the diagnostics request failed. Since sourcekit-lsp usually recovers from failures (e.g. after sourcekitd crashes), this is undesirable. Instead of returning an error, return empty results. This causes VS Code to re-request diagnostics after an edit is made, which will succeed after sourcekitd has been restarted.
* **Scope**: The SourceKit-LSP diagnostics request after sourcekitd crashed
* **Risk**: Very low, just returns empty results where it used to return an error
* **Testing**: Manual testing of the change in https://github.com/apple/sourcekit-lsp/pull/981. This is functionally equivalent and trivial
* **Issue**: #958 / rdar://117732149
* **Reviewer**:  @bnbarham