### PR TITLE
Make ToolchainRegistry initializer synchronous

### DIFF
--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -18,6 +18,7 @@ import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import class TSCBasic.Process
 import enum TSCBasic.ProcessEnv
+import struct TSCBasic.ProcessEnvironmentKey
 import func TSCBasic.getEnvSearchPaths
 import var TSCBasic.localFileSystem
 
@@ -29,63 +30,141 @@ import var TSCBasic.localFileSystem
 public final actor ToolchainRegistry {
 
   /// The toolchains, in the order they were registered.
-  public private(set) var toolchains: [Toolchain] = []
+  public let toolchains: [Toolchain]
 
   /// The toolchains indexed by their identifier.
   ///
   /// Multiple toolchains may exist for the XcodeDefault toolchain identifier.
-  private var toolchainsByIdentifier: [String: [Toolchain]] = [:]
+  private let toolchainsByIdentifier: [String: [Toolchain]]
 
   /// The toolchains indexed by their path.
   ///
   /// Note: Not all toolchains have a path.
-  private var toolchainsByPath: [AbsolutePath: Toolchain] = [:]
+  private let toolchainsByPath: [AbsolutePath: Toolchain]
 
   /// The currently selected toolchain identifier on Darwin.
-  public lazy var darwinToolchainOverride: String? = {
-    if let id = ProcessEnv.vars["TOOLCHAINS"], !id.isEmpty, id != "default" {
-      return id
-    }
-    return nil
-  }()
+  public let darwinToolchainOverride: String?
 
-  /// Creates an empty toolchain registry.
-  private init() {}
+  /// Creates a toolchain registry from a list of toolchains.
+  ///
+  /// - Parameters:
+  ///   - toolchains: The toolchains that should be stored in the registry.
+  ///   - darwinToolchainOverride: The contents of the `TOOLCHAINS` environment
+  ///     variable, which picks the default toolchain.
+  @_spi(Testing)
+  public init(
+    toolchains toolchainsParam: [Toolchain],
+    darwinToolchainOverride: String?
+  ) {
+    var toolchains: [Toolchain] = []
+    var toolchainsByIdentifier: [String: [Toolchain]] = [:]
+    var toolchainsByPath: [AbsolutePath: Toolchain] = [:]
+    for toolchain in toolchainsParam {
+      // Non-XcodeDefault toolchain: disallow all duplicates.
+      if toolchain.identifier != ToolchainRegistry.darwinDefaultToolchainIdentifier {
+        guard toolchainsByIdentifier[toolchain.identifier] == nil else {
+          continue
+        }
+      }
+
+      // Toolchain should always be unique by path if it is present.
+      if let path = toolchain.path {
+        guard toolchainsByPath[path] == nil else {
+          continue
+        }
+        toolchainsByPath[path] = toolchain
+      }
+
+      toolchainsByIdentifier[toolchain.identifier, default: []].append(toolchain)
+      toolchains.append(toolchain)
+    }
+
+    self.toolchains = toolchains
+    self.toolchainsByIdentifier = toolchainsByIdentifier
+    self.toolchainsByPath = toolchainsByPath
+
+    if let darwinToolchainOverride, !darwinToolchainOverride.isEmpty, darwinToolchainOverride != "default" {
+      self.darwinToolchainOverride = darwinToolchainOverride
+    } else {
+      self.darwinToolchainOverride = nil
+    }
+  }
 
   /// A toolchain registry used for testing that scans for toolchains based on environment variables and Xcode
   /// installations but not next to the `sourcekit-lsp` binary because there is no `sourcekit-lsp` binary during
   /// testing.
   @_spi(Testing)
   public static var forTesting: ToolchainRegistry {
-    get async {
-      await ToolchainRegistry(localFileSystem)
-    }
+    ToolchainRegistry(localFileSystem)
   }
-
-  /// A toolchain registry that doesn't contain any toolchains.
-  @_spi(Testing)
-  public static var empty: ToolchainRegistry { ToolchainRegistry() }
 
   /// Creates a toolchain registry populated by scanning for toolchains according to the given paths
   /// and variables.
   ///
   /// If called with the default values, creates a toolchain registry that searches:
-  /// * env SOURCEKIT_TOOLCHAIN_PATH <-- will override default toolchain
-  /// * installPath <-- will override default toolchain
+  /// * `env SOURCEKIT_TOOLCHAIN_PATH` <-- will override default toolchain
+  /// * `installPath` <-- will override default toolchain
   /// * (Darwin) The currently selected Xcode
-  /// * (Darwin) [~]/Library/Developer/Toolchains
-  /// * env SOURCEKIT_PATH, PATH
-  ///
-  /// This is equivalent to
-  /// ```
-  /// let tr = ToolchainRegistry()
-  /// tr.scanForToolchains()
-  /// ```
+  /// * (Darwin) `[~]/Library/Developer/Toolchains`
+  /// * `env SOURCEKIT_PATH, PATH`
   public init(
     installPath: AbsolutePath? = nil,
-    _ fileSystem: FileSystem
-  ) async {
-    scanForToolchains(installPath: installPath, fileSystem)
+    environmentVariables: [ProcessEnvironmentKey] = ["SOURCEKIT_TOOLCHAIN_PATH"],
+    xcodes: [AbsolutePath] = [_currentXcodeDeveloperPath].compactMap({ $0 }),
+    darwinToolchainOverride: String? = ProcessEnv.block["TOOLCHAINS"],
+    _ fileSystem: FileSystem = localFileSystem
+  ) {
+    // The paths at which we have found toolchains
+    var toolchainPaths: [AbsolutePath] = []
+
+    // Scan for toolchains in the paths given by `environmentVariables`.
+    for envVar in environmentVariables {
+      if let pathStr = ProcessEnv.block[envVar], let path = try? AbsolutePath(validating: pathStr) {
+        toolchainPaths.append(path)
+      }
+    }
+
+    // Search for toolchains relative to the path at which sourcekit-lsp is installed.
+    if let installPath = installPath {
+      toolchainPaths.append(installPath)
+    }
+
+    // Search for toolchains in the Xcode developer directories and global toolchain install paths
+    let toolchainSearchPaths =
+      xcodes.map {
+        if $0.extension == "app" {
+          return $0.appending(components: "Contents", "Developer", "Toolchains")
+        } else {
+          return $0.appending(component: "Toolchains")
+        }
+      } + [
+        try! AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains"),
+        try! AbsolutePath(validating: "/Library/Developer/Toolchains"),
+      ]
+
+    for xctoolchainSearchPath in toolchainSearchPaths {
+      guard let direntries = try? fileSystem.getDirectoryContents(xctoolchainSearchPath) else {
+        continue
+      }
+      for name in direntries {
+        let path = xctoolchainSearchPath.appending(component: name)
+        if path.extension == "xctoolchain" {
+          toolchainPaths.append(path)
+        }
+      }
+    }
+
+    // Scan for toolchains by the given PATH-like environment variables.
+    for envVar: ProcessEnvironmentKey in ["SOURCEKIT_PATH", "PATH", "Path"] {
+      for path in getEnvSearchPaths(pathString: ProcessEnv.block[envVar], currentWorkingDirectory: nil) {
+        toolchainPaths.append(path)
+      }
+    }
+
+    self.init(
+      toolchains: toolchainPaths.compactMap { Toolchain($0, fileSystem) },
+      darwinToolchainOverride: darwinToolchainOverride
+    )
   }
 
   /// The default toolchain.
@@ -102,7 +181,6 @@ public final actor ToolchainRegistry {
       } else {
         return toolchains.first
       }
-      return nil
     }
   }
 
@@ -140,164 +218,8 @@ extension ToolchainRegistry {
 }
 
 extension ToolchainRegistry {
-  public enum Error: Swift.Error {
-
-    /// There is already a toolchain with the given identifier.
-    case duplicateToolchainIdentifier
-
-    /// There is already a toolchain with the given path.
-    case duplicateToolchainPath
-
-    /// The toolchain does not exist, or has no tools.
-    case invalidToolchain
-  }
-
-  /// Register the given toolchain.
-  ///
-  /// - parameter toolchain: The new toolchain to register.
-  /// - throws: If `toolchain.identifier` has already been seen.
-  @_spi(Testing)
-  public func registerToolchain(_ toolchain: Toolchain) throws {
-    // Non-XcodeDefault toolchain: disallow all duplicates.
-    if toolchain.identifier != ToolchainRegistry.darwinDefaultToolchainIdentifier {
-      guard toolchainsByIdentifier[toolchain.identifier] == nil else {
-        throw Error.duplicateToolchainIdentifier
-      }
-    }
-
-    // Toolchain should always be unique by path if it is present.
-    if let path = toolchain.path {
-      guard toolchainsByPath[path] == nil else {
-        throw Error.duplicateToolchainPath
-      }
-      toolchainsByPath[path] = toolchain
-    }
-
-    toolchainsByIdentifier[toolchain.identifier, default: []].append(toolchain)
-    toolchains.append(toolchain)
-  }
-
-  /// Register the toolchain at the given path.
-  ///
-  /// - parameter path: The path to search for a toolchain to register.
-  /// - returns: The toolchain, if any.
-  /// - throws: If there is no toolchain at the given `path`, or if `toolchain.identifier` has
-  ///   already been seen.
-  public func registerToolchain(
-    _ path: AbsolutePath,
-    _ fileSystem: FileSystem = localFileSystem
-  ) throws {
-    guard let toolchain = Toolchain(path, fileSystem) else {
-      throw Error.invalidToolchain
-    }
-    try registerToolchain(toolchain)
-  }
-}
-
-extension ToolchainRegistry {
-
-  /// Scans for toolchains according to the given paths and variables.
-  ///
-  /// If called with the default values, creates a toolchain registry that searches:
-  /// * env SOURCEKIT_TOOLCHAIN_PATH <-- will override default toolchain
-  /// * installPath <-- will override default toolchain
-  /// * (Darwin) The currently selected Xcode
-  /// * (Darwin) [~]/Library/Developer/Toolchains
-  /// * env SOURCEKIT_PATH, PATH (or Path)
-  @_spi(Testing)
-  public func scanForToolchains(
-    installPath: AbsolutePath? = nil,
-    environmentVariables: [String] = ["SOURCEKIT_TOOLCHAIN_PATH"],
-    xcodes: [AbsolutePath] = [currentXcodeDeveloperPath].compactMap({ $0 }),
-    xctoolchainSearchPaths: [AbsolutePath]? = nil,
-    pathVariables: [String] = ["SOURCEKIT_PATH", "PATH", "Path"],
-    _ fileSystem: FileSystem
-  ) {
-    let xctoolchainSearchPaths =
-      try! xctoolchainSearchPaths ?? [
-        AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains"),
-        AbsolutePath(validating: "/Library/Developer/Toolchains"),
-      ]
-
-    scanForToolchains(environmentVariables: environmentVariables, fileSystem)
-    if let installPath = installPath {
-      try? registerToolchain(installPath, fileSystem)
-    }
-    for xcode in xcodes {
-      scanForToolchains(xcode: xcode, fileSystem)
-    }
-    for xctoolchainSearchPath in xctoolchainSearchPaths {
-      scanForToolchains(xctoolchainSearchPath: xctoolchainSearchPath, fileSystem)
-    }
-    scanForToolchains(pathVariables: pathVariables, fileSystem)
-  }
-
-  /// Scan for toolchains in the paths given by `environmentVariables` and possibly override the
-  /// default toolchain with the first one found.
-  ///
-  /// - parameters:
-  ///   - environmentVariables: A list of environment variable names to search for toolchain paths.
-  @_spi(Testing)
-  public func scanForToolchains(
-    environmentVariables: [String],
-    _ fileSystem: FileSystem = localFileSystem
-  ) {
-    for envVar in environmentVariables {
-      if let pathStr = ProcessEnv.vars[envVar],
-        let path = try? AbsolutePath(validating: pathStr)
-      {
-        try? registerToolchain(path, fileSystem)
-      }
-    }
-  }
-
-  /// Scan for toolchains by the given PATH-like environment variables.
-  ///
-  /// - parameters:
-  ///   - pathVariables: A list of PATH-like environment variable names to search.
-  @_spi(Testing)
-  public func scanForToolchains(pathVariables: [String], _ fileSystem: FileSystem = localFileSystem) {
-    pathVariables.lazy.flatMap { envVar in
-      getEnvSearchPaths(pathString: ProcessEnv.vars[envVar], currentWorkingDirectory: nil)
-    }
-    .forEach { path in
-      _ = try? registerToolchain(path, fileSystem)
-    }
-  }
-
-  /// Scan for toolchains in the given Xcode, which should be given as a path to either the
-  /// application (e.g. "Xcode.app") or the application's Developer directory.
-  ///
-  /// - parameter xcode: The path to Xcode.app or Xcode.app/Contents/Developer.
-  @_spi(Testing)
-  public func scanForToolchains(xcode: AbsolutePath, _ fileSystem: FileSystem = localFileSystem) {
-    var path = xcode
-    if path.extension == "app" {
-      path = path.appending(components: "Contents", "Developer")
-    }
-    scanForToolchains(xctoolchainSearchPath: path.appending(component: "Toolchains"), fileSystem)
-  }
-
-  /// Scan for `xctoolchain` directories in the given search path.
-  ///
-  /// - parameter toolchains: Directory containing xctoolchains, e.g. /Library/Developer/Toolchains
-  @_spi(Testing)
-  public func scanForToolchains(
-    xctoolchainSearchPath searchPath: AbsolutePath,
-    _ fileSystem: FileSystem = localFileSystem
-  ) {
-    guard let direntries = try? fileSystem.getDirectoryContents(searchPath) else { return }
-    for name in direntries {
-      let path = searchPath.appending(component: name)
-      if path.extension == "xctoolchain" {
-        _ = try? registerToolchain(path, fileSystem)
-      }
-    }
-  }
-
   /// The path of the current Xcode.app/Contents/Developer.
-  @_spi(Testing)
-  public static var currentXcodeDeveloperPath: AbsolutePath? {
+  public static var _currentXcodeDeveloperPath: AbsolutePath? {
     guard let str = try? Process.checkNonZeroExit(args: "/usr/bin/xcode-select", "-p") else { return nil }
     return try? AbsolutePath(validating: str.trimmingCharacters(in: .whitespacesAndNewlines))
   }

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -105,7 +105,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
 
     let clientConnection = LocalConnection()
     self.serverToClientConnection = clientConnection
-    server = await SourceKitServer(
+    server = SourceKitServer(
       client: clientConnection,
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: serverOptions,

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -219,7 +219,7 @@ struct SourceKitLSP: ParsableCommand {
     return serverOptions
   }
 
-  func run() async throws {
+  func run() throws {
     // Dup stdout and redirect the fd to stderr so that a careless print()
     // will not break our connection stream.
     let realStdout = dup(STDOUT_FILENO)
@@ -242,7 +242,7 @@ struct SourceKitLSP: ParsableCommand {
 
     let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
 
-    let server = await SourceKitServer(
+    let server = SourceKitServer(
       client: clientConnection,
       toolchainRegistry: ToolchainRegistry(installPath: installPath, localFileSystem),
       options: mapOptions(),

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -21,10 +21,7 @@ import enum PackageLoading.Platform
 
 final class ToolchainRegistryTests: XCTestCase {
   func testDefaultSingleToolchain() async throws {
-    let tr = ToolchainRegistry(
-      toolchains: [Toolchain(identifier: "a", displayName: "a", path: nil)],
-      darwinToolchainOverride: nil
-    )
+    let tr = ToolchainRegistry(toolchains: [Toolchain(identifier: "a", displayName: "a", path: nil)])
     await assertEqual(tr.default?.identifier, "a")
   }
 
@@ -33,8 +30,7 @@ final class ToolchainRegistryTests: XCTestCase {
       toolchains: [
         Toolchain(identifier: "a", displayName: "a", path: nil),
         Toolchain(identifier: "b", displayName: "b", path: nil),
-      ],
-      darwinToolchainOverride: nil
+      ]
     )
     await assertEqual(tr.default?.identifier, "a")
     await assertTrue(tr.default === tr.toolchain(identifier: "a"))
@@ -49,8 +45,7 @@ final class ToolchainRegistryTests: XCTestCase {
       toolchains: [
         Toolchain(identifier: "a", displayName: "a", path: nil),
         Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil),
-      ],
-      darwinToolchainOverride: nil
+      ]
     )
     await assertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
   }
@@ -450,12 +445,7 @@ final class ToolchainRegistryTests: XCTestCase {
       XCTAssertNotNil(t2.clangd)
       XCTAssertNotNil(t2.swiftc)
 
-      let tr = ToolchainRegistry(
-        toolchains: [
-          Toolchain(path.parentDirectory, fs)!
-        ],
-        darwinToolchainOverride: nil
-      )
+      let tr = ToolchainRegistry(toolchains: [Toolchain(path.parentDirectory, fs)!])
       let t3 = try await unwrap(tr.toolchain(identifier: t2.identifier))
       XCTAssertEqual(t3.sourcekitd, t2.sourcekitd)
       XCTAssertEqual(t3.clang, t2.clang)
@@ -495,12 +485,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testDuplicateToolchainOnlyRegisteredOnce() async throws {
     let toolchain = Toolchain(identifier: "a", displayName: "a", path: nil)
-    let tr = ToolchainRegistry(
-      toolchains: [
-        toolchain, toolchain,
-      ],
-      darwinToolchainOverride: nil
-    )
+    let tr = ToolchainRegistry(toolchains: [toolchain, toolchain])
     assertEqual(await tr.toolchains.count, 1)
   }
 
@@ -509,10 +494,7 @@ final class ToolchainRegistryTests: XCTestCase {
     let first = Toolchain(identifier: "a", displayName: "a", path: path)
     let second = Toolchain(identifier: "b", displayName: "b", path: path)
 
-    let tr = ToolchainRegistry(
-      toolchains: [first, second],
-      darwinToolchainOverride: nil
-    )
+    let tr = ToolchainRegistry(toolchains: [first, second])
     assertEqual(await tr.toolchains.count, 1)
   }
 
@@ -529,7 +511,7 @@ final class ToolchainRegistryTests: XCTestCase {
       displayName: "b",
       path: pathB
     )
-    let tr = ToolchainRegistry(toolchains: [xcodeA, xcodeB], darwinToolchainOverride: nil)
+    let tr = ToolchainRegistry(toolchains: [xcodeA, xcodeB])
     await assertTrue(tr.toolchain(path: pathA) === xcodeA)
     await assertTrue(tr.toolchain(path: pathB) === xcodeB)
 

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -19,20 +19,23 @@ import XCTest
 
 import enum PackageLoading.Platform
 
-extension ToolchainRegistry {
-  func setDarwinToolchainOverride(_ newValue: String?) {
-    self.darwinToolchainOverride = newValue
-  }
-}
-
 final class ToolchainRegistryTests: XCTestCase {
-  func testDefaultBasic() async throws {
-    let tr = ToolchainRegistry.empty
-    await assertNil(tr.default)
-    try await tr.registerToolchain(Toolchain(identifier: "a", displayName: "a", path: nil))
+  func testDefaultSingleToolchain() async throws {
+    let tr = ToolchainRegistry(
+      toolchains: [Toolchain(identifier: "a", displayName: "a", path: nil)],
+      darwinToolchainOverride: nil
+    )
     await assertEqual(tr.default?.identifier, "a")
-    let b = Toolchain(identifier: "b", displayName: "b", path: nil)
-    try await tr.registerToolchain(b)
+  }
+
+  func testDefaultTwoToolchains() async throws {
+    let tr = ToolchainRegistry(
+      toolchains: [
+        Toolchain(identifier: "a", displayName: "a", path: nil),
+        Toolchain(identifier: "b", displayName: "b", path: nil),
+      ],
+      darwinToolchainOverride: nil
+    )
     await assertEqual(tr.default?.identifier, "a")
     await assertTrue(tr.default === tr.toolchain(identifier: "a"))
   }
@@ -42,13 +45,12 @@ final class ToolchainRegistryTests: XCTestCase {
     defer { Platform.current = prevPlatform }
     Platform.current = .darwin
 
-    let tr = ToolchainRegistry.empty
-    await tr.setDarwinToolchainOverride(nil)
-    await assertNil(tr.default)
-    let a = Toolchain(identifier: "a", displayName: "a", path: nil)
-    try await tr.registerToolchain(a)
-    try await tr.registerToolchain(
-      Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil)
+    let tr = ToolchainRegistry(
+      toolchains: [
+        Toolchain(identifier: "a", displayName: "a", path: nil),
+        Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil),
+      ],
+      darwinToolchainOverride: nil
     )
     await assertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
   }
@@ -69,116 +71,240 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNotNil(t.sourcekitd)
   }
 
-  func testSearchDarwin() async throws {
-    // FIXME: requires PropertyListEncoder
-    #if os(macOS)
+  func testFindXcodeDefaultToolchain() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
     let fs = InMemoryFileSystem()
-    let tr1 = await ToolchainRegistry(fs)
-    await tr1.setDarwinToolchainOverride(nil)
-
-    let xcodeDeveloper = ToolchainRegistry.currentXcodeDeveloperPath!
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
     let toolchains = xcodeDeveloper.appending(components: "Toolchains")
-
     try makeXCToolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
       opensource: false,
-      toolchains.appending(component: "XcodeDefault.xctoolchain"),
+      path: toolchains.appending(component: "XcodeDefault.xctoolchain"),
       fs,
       sourcekitd: true
     )
 
-    await assertNil(tr1.default)
-    await assertTrue(tr1.toolchains.isEmpty)
+    let tr = ToolchainRegistry(
+      xcodes: [xcodeDeveloper],
+      darwinToolchainOverride: nil,
+      fs
+    )
 
-    await tr1.scanForToolchains(xcode: xcodeDeveloper, fs)
+    assertEqual(await tr.toolchains.count, 1)
+    assertEqual(await tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
+    assertEqual(await tr.default?.path, toolchains.appending(component: "XcodeDefault.xctoolchain"))
+    assertNotNil(await tr.default?.sourcekitd)
 
-    await assertEqual(tr1.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
-    await assertEqual(tr1.default?.path, toolchains.appending(component: "XcodeDefault.xctoolchain"))
-    await assertNotNil(tr1.default?.sourcekitd)
-    await assertEqual(tr1.toolchains.count, 1)
+    assertTrue(await tr.toolchains.first === tr.default)
+  }
 
-    let tr = await ToolchainRegistry(fs)
-    await tr.setDarwinToolchainOverride(nil)
-
-    await assertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
-    await assertEqual(tr.default?.path, toolchains.appending(component: "XcodeDefault.xctoolchain"))
-    await assertNotNil(tr.default?.sourcekitd)
-    await assertEqual(tr.toolchains.count, 1)
-
-    let defaultToolchain = await tr.default!
-
-    await assertTrue(tr.toolchains.first === defaultToolchain)
+  func testFindNonXcodeDefaultToolchains() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+    let fs = InMemoryFileSystem()
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
+    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
     try makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
-      toolchains.appending(component: "A.xctoolchain"),
+      path: toolchains.appending(component: "A.xctoolchain"),
       fs,
       sourcekitd: true
     )
     try makeXCToolchain(
       identifier: "com.apple.fake.B",
       opensource: false,
-      toolchains.appending(component: "B.xctoolchain"),
+      path: toolchains.appending(component: "B.xctoolchain"),
       fs,
       sourcekitd: true
     )
 
-    await tr.scanForToolchains(fs)
-    await assertEqual(tr.toolchains.count, 3)
+    let tr = ToolchainRegistry(
+      xcodes: [xcodeDeveloper],
+      darwinToolchainOverride: nil,
+      fs
+    )
+
+    assertEqual(await tr.toolchains.map(\.identifier).sorted(), ["com.apple.fake.A", "com.apple.fake.B"])
+  }
+
+  func testIgnoreToolchainsWithWrongExtensions() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+    let fs = InMemoryFileSystem()
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
+    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
     try makeXCToolchain(
       identifier: "com.apple.fake.C",
       opensource: false,
-      toolchains.appending(component: "C.wrong_extension"),
+      path: toolchains.appending(component: "C.wrong_extension"),
       fs,
       sourcekitd: true
     )
     try makeXCToolchain(
       identifier: "com.apple.fake.D",
       opensource: false,
-      toolchains.appending(component: "D_no_extension"),
+      path: toolchains.appending(component: "D_no_extension"),
       fs,
       sourcekitd: true
     )
 
-    await tr.scanForToolchains(fs)
-    await assertEqual(tr.toolchains.count, 3)
+    let tr = ToolchainRegistry(
+      darwinToolchainOverride: nil,
+      fs
+    )
+
+    assertTrue(await tr.toolchains.isEmpty)
+
+  }
+  func testTwoToolchainsWithSameIdentifier() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+
+    let fs = InMemoryFileSystem()
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
+    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
+    try makeXCToolchain(
+      identifier: "com.apple.fake.A",
+      opensource: false,
+      path: toolchains.appending(component: "A.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
 
     try makeXCToolchain(
       identifier: "com.apple.fake.A",
       opensource: false,
-      toolchains.appending(component: "E.xctoolchain"),
+      path: toolchains.appending(component: "E.xctoolchain"),
       fs,
       sourcekitd: true
     )
 
-    await tr.scanForToolchains(fs)
-    await assertEqual(tr.toolchains.count, 3)
+    let tr = ToolchainRegistry(
+      xcodes: [xcodeDeveloper],
+      darwinToolchainOverride: nil,
+      fs
+    )
+
+    assertEqual(await tr.toolchains.count, 1)
+  }
+
+  func testGloballyInstalledToolchains() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+    let fs = InMemoryFileSystem()
 
     try makeXCToolchain(
       identifier: "org.fake.global.A",
       opensource: true,
-      try AbsolutePath(validating: "/Library/Developer/Toolchains/A.xctoolchain"),
+      path: try AbsolutePath(validating: "/Library/Developer/Toolchains/A.xctoolchain"),
       fs,
       sourcekitd: true
     )
     try makeXCToolchain(
       identifier: "org.fake.global.B",
       opensource: true,
-      try AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"),
+      path: try AbsolutePath(expandingTilde: "~/Library/Developer/Toolchains/B.xctoolchain"),
       fs,
       sourcekitd: true
     )
 
-    await tr.scanForToolchains(fs)
-    await assertEqual(tr.toolchains.count, 5)
+    let tr = ToolchainRegistry(
+      darwinToolchainOverride: nil,
+      fs
+    )
+    assertEqual(await tr.toolchains.map(\.identifier), ["org.fake.global.B", "org.fake.global.A"])
+  }
+
+  func testFindToolchainBasedOnInstallPath() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+    let fs = InMemoryFileSystem()
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
+    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
     let path = toolchains.appending(component: "Explicit.xctoolchain")
     try makeXCToolchain(
       identifier: "org.fake.explicit",
       opensource: false,
-      toolchains.appending(component: "Explicit.xctoolchain"),
+      path: toolchains.appending(component: "Explicit.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
+
+    let trInstall = ToolchainRegistry(
+      installPath: path.appending(components: "usr", "bin"),
+      xcodes: [],
+      darwinToolchainOverride: nil,
+      fs
+    )
+    await assertEqual(trInstall.default?.identifier, "org.fake.explicit")
+    await assertEqual(trInstall.default?.path, path)
+  }
+
+  func testDarwinToolchainOverride() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+
+    let fs = InMemoryFileSystem()
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
+    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
+    try makeXCToolchain(
+      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
+      opensource: false,
+      path: toolchains.appending(component: "XcodeDefault.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
+
+    try makeXCToolchain(
+      identifier: "org.fake.global.A",
+      opensource: false,
+      path: toolchains.appending(component: "A.xctoolchain"),
+      fs,
+      sourcekitd: true
+    )
+
+    let toolchainRegistry = ToolchainRegistry(
+      xcodes: [xcodeDeveloper],
+      darwinToolchainOverride: nil,
+      fs
+    )
+    await assertEqual(toolchainRegistry.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
+
+    let darwinToolchainOverrideRegistry = ToolchainRegistry(
+      xcodes: [xcodeDeveloper],
+      darwinToolchainOverride: "org.fake.global.A",
+      fs
+    )
+    await assertEqual(darwinToolchainOverrideRegistry.darwinToolchainIdentifier, "org.fake.global.A")
+    await assertEqual(darwinToolchainOverrideRegistry.default?.identifier, "org.fake.global.A")
+  }
+
+  func testCreateToolchainFromBinPath() async throws {
+    #if !os(macOS)
+    try XCTSkipIf(true, "Finding toolchains in Xcode is only supported on macOS")
+    #endif
+
+    let fs = InMemoryFileSystem()
+    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
+    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
+
+    let path = toolchains.appending(component: "Explicit.xctoolchain")
+    try makeXCToolchain(
+      identifier: "org.fake.explicit",
+      opensource: false,
+      path: toolchains.appending(component: "Explicit.xctoolchain"),
       fs,
       sourcekitd: true
     )
@@ -192,38 +318,12 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertEqual(tc?.identifier, tcBin?.identifier)
     XCTAssertEqual(tc?.path, tcBin?.path)
     XCTAssertEqual(tc?.displayName, tcBin?.displayName)
-
-    let trInstall = ToolchainRegistry.empty
-    await trInstall.scanForToolchains(
-      installPath: path.appending(components: "usr", "bin"),
-      environmentVariables: [],
-      xcodes: [],
-      xctoolchainSearchPaths: [],
-      pathVariables: [],
-      fs
-    )
-    await assertEqual(trInstall.default?.identifier, "org.fake.explicit")
-    await assertEqual(trInstall.default?.path, path)
-
-    let overrideReg = await ToolchainRegistry(fs)
-    await overrideReg.setDarwinToolchainOverride("org.fake.global.B")
-    await assertEqual(overrideReg.darwinToolchainIdentifier, "org.fake.global.B")
-    await assertEqual(overrideReg.default?.identifier, "org.fake.global.B")
-
-    let checkByDir = ToolchainRegistry.empty
-    await checkByDir.scanForToolchains(xctoolchainSearchPath: toolchains, fs)
-    await assertEqual(checkByDir.toolchains.count, 4)
-    #endif
   }
 
   func testSearchPATH() async throws {
     let fs = InMemoryFileSystem()
-    let tr = await ToolchainRegistry(fs)
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
     try makeToolchain(binPath: binPath, fs, sourcekitd: true)
-
-    await assertNil(tr.default)
-    await assertTrue(tr.toolchains.isEmpty)
 
     #if os(Windows)
     let separator: String = ";"
@@ -237,12 +337,9 @@ final class ToolchainRegistryTests: XCTestCase {
     )
     defer { try! ProcessEnv.setVar("SOURCEKIT_PATH", value: "") }
 
-    await tr.scanForToolchains(fs)
+    let tr = ToolchainRegistry(fs)
 
-    guard let tc = await tr.toolchains.first(where: { tc in tc.path == binPath }) else {
-      XCTFail("couldn't find expected toolchain")
-      return
-    }
+    let tc = try unwrap(await tr.toolchains.first(where: { tc in tc.path == binPath }))
 
     await assertEqual(tr.default?.identifier, tc.identifier)
     XCTAssertEqual(tc.identifier, binPath.pathString)
@@ -251,37 +348,20 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNil(tc.swiftc)
     XCTAssertNotNil(tc.sourcekitd)
     XCTAssertNil(tc.libIndexStore)
-
-    let binPath2 = try AbsolutePath(validating: "/other/my_toolchain/bin")
-    try ProcessEnv.setVar(
-      "SOME_TEST_ENV_PATH",
-      value: ["/bogus", binPath2.pathString, "bogus2"].joined(separator: separator)
-    )
-    try makeToolchain(binPath: binPath2, fs, sourcekitd: true)
-    await tr.scanForToolchains(pathVariables: ["NOPE", "SOME_TEST_ENV_PATH", "MORE_NOPE"], fs)
-
-    guard let tc2 = await tr.toolchains.first(where: { tc in tc.path == binPath2 }) else {
-      XCTFail("couldn't find expected toolchain")
-      return
-    }
-
-    await assertEqual(tr.default?.identifier, tc.identifier)
-    XCTAssertEqual(tc2.identifier, binPath2.pathString)
-    XCTAssertNotNil(tc2.sourcekitd)
   }
 
   func testSearchExplicitEnvBuiltin() async throws {
     let fs = InMemoryFileSystem()
-    let tr = await ToolchainRegistry(fs)
+
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
     try makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
-    await assertNil(tr.default)
-    await assertTrue(tr.toolchains.isEmpty)
-
     try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.parentDirectory.pathString)
 
-    await tr.scanForToolchains(environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"], fs)
+    let tr = ToolchainRegistry(
+      environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
+      fs
+    )
 
     guard let tc = await tr.toolchains.first(where: { tc in tc.path == binPath.parentDirectory }) else {
       XCTFail("couldn't find expected toolchain")
@@ -299,16 +379,12 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testSearchExplicitEnv() async throws {
     let fs = InMemoryFileSystem()
-    let tr = await ToolchainRegistry(fs)
     let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
     try makeToolchain(binPath: binPath, fs, sourcekitd: true)
 
-    await assertNil(tr.default)
-    await assertTrue(tr.toolchains.isEmpty)
-
     try ProcessEnv.setVar("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.parentDirectory.pathString)
 
-    await tr.scanForToolchains(
+    let tr = ToolchainRegistry(
       environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],
       fs
     )
@@ -374,8 +450,12 @@ final class ToolchainRegistryTests: XCTestCase {
       XCTAssertNotNil(t2.clangd)
       XCTAssertNotNil(t2.swiftc)
 
-      let tr = ToolchainRegistry.empty
-      try await tr.registerToolchain(path.parentDirectory, fs)
+      let tr = ToolchainRegistry(
+        toolchains: [
+          Toolchain(path.parentDirectory, fs)!
+        ],
+        darwinToolchainOverride: nil
+      )
       let t3 = try await unwrap(tr.toolchain(identifier: t2.identifier))
       XCTAssertEqual(t3.sourcekitd, t2.sourcekitd)
       XCTAssertEqual(t3.clang, t2.clang)
@@ -413,59 +493,30 @@ final class ToolchainRegistryTests: XCTestCase {
     XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t3"), fs))
   }
 
-  func testDuplicateError() async throws {
-    let tr = ToolchainRegistry.empty
+  func testDuplicateToolchainOnlyRegisteredOnce() async throws {
     let toolchain = Toolchain(identifier: "a", displayName: "a", path: nil)
-    try await tr.registerToolchain(toolchain)
-    await assertThrowsError(
-      try await tr.registerToolchain(toolchain),
-      "Expected error registering toolchain twice"
-    ) { e in
-      guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainIdentifier else {
-        XCTFail("Expected .duplicateToolchainIdentifier not \(e)")
-        return
-      }
-    }
+    let tr = ToolchainRegistry(
+      toolchains: [
+        toolchain, toolchain,
+      ],
+      darwinToolchainOverride: nil
+    )
+    assertEqual(await tr.toolchains.count, 1)
   }
 
-  func testDuplicatePathError() async throws {
-    let tr = ToolchainRegistry.empty
+  func testDuplicatePathOnlyRegisteredOnce() async throws {
     let path = try AbsolutePath(validating: "/foo/bar")
     let first = Toolchain(identifier: "a", displayName: "a", path: path)
     let second = Toolchain(identifier: "b", displayName: "b", path: path)
-    try await tr.registerToolchain(first)
-    await assertThrowsError(
-      try await tr.registerToolchain(second),
-      "Expected error registering toolchain twice"
-    ) { e in
-      guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainPath else {
-        XCTFail("Error mismatch: expected duplicateToolchainPath not \(e)")
-        return
-      }
-    }
-  }
 
-  func testDuplicateXcodeError() async throws {
-    let tr = ToolchainRegistry.empty
-    let xcodeToolchain = Toolchain(
-      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
-      displayName: "a",
-      path: try AbsolutePath(validating: "/versionA")
+    let tr = ToolchainRegistry(
+      toolchains: [first, second],
+      darwinToolchainOverride: nil
     )
-    try await tr.registerToolchain(xcodeToolchain)
-    await assertThrowsError(
-      try await tr.registerToolchain(xcodeToolchain),
-      "Expected error registering toolchain twice"
-    ) { e in
-      guard let error = e as? ToolchainRegistry.Error, error == .duplicateToolchainPath else {
-        XCTFail("Error mismatch: expected duplicateToolchainPath not \(e)")
-        return
-      }
-    }
+    assertEqual(await tr.toolchains.count, 1)
   }
 
   func testMultipleXcodes() async throws {
-    let tr = ToolchainRegistry.empty
     let pathA = try AbsolutePath(validating: "/versionA")
     let xcodeA = Toolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
@@ -478,13 +529,15 @@ final class ToolchainRegistryTests: XCTestCase {
       displayName: "b",
       path: pathB
     )
-    try await tr.registerToolchain(xcodeA)
-    try await tr.registerToolchain(xcodeB)
+    let tr = ToolchainRegistry(toolchains: [xcodeA, xcodeB], darwinToolchainOverride: nil)
     await assertTrue(tr.toolchain(path: pathA) === xcodeA)
     await assertTrue(tr.toolchain(path: pathB) === xcodeB)
 
     let toolchains = await tr.toolchains(identifier: xcodeA.identifier)
     XCTAssert(toolchains.count == 2)
+    guard toolchains.count == 2 else {
+      return
+    }
     XCTAssert(toolchains[0] === xcodeA)
     XCTAssert(toolchains[1] === xcodeB)
   }
@@ -493,14 +546,14 @@ final class ToolchainRegistryTests: XCTestCase {
     let fs = InMemoryFileSystem()
     try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
 
-    let trEmpty = await ToolchainRegistry(installPath: nil, fs)
+    let trEmpty = ToolchainRegistry(installPath: nil, fs)
     await assertNil(trEmpty.default)
 
-    let tr1 = await ToolchainRegistry(installPath: try AbsolutePath(validating: "/t1/bin"), fs)
+    let tr1 = ToolchainRegistry(installPath: try AbsolutePath(validating: "/t1/bin"), fs)
     await assertEqual(tr1.default?.path, try AbsolutePath(validating: "/t1/bin"))
     await assertNotNil(tr1.default?.sourcekitd)
 
-    let tr2 = await ToolchainRegistry(installPath: try AbsolutePath(validating: "/t2/bin"), fs)
+    let tr2 = ToolchainRegistry(installPath: try AbsolutePath(validating: "/t2/bin"), fs)
     await assertNil(tr2.default)
   }
 
@@ -511,8 +564,7 @@ final class ToolchainRegistryTests: XCTestCase {
 
     try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: "/t2/bin")
 
-    let tr = ToolchainRegistry.empty
-    await tr.scanForToolchains(
+    let tr = ToolchainRegistry(
       installPath: try AbsolutePath(validating: "/t1/bin"),
       environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
       fs
@@ -524,11 +576,10 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 }
 
-#if os(macOS)
 private func makeXCToolchain(
   identifier: String,
   opensource: Bool,
-  _ path: AbsolutePath,
+  path: AbsolutePath,
   _ fs: FileSystem,
   clang: Bool = false,
   clangd: Bool = false,
@@ -562,7 +613,6 @@ private func makeXCToolchain(
     libIndexStore: libIndexStore
   )
 }
-#endif
 
 private func makeToolchain(
   binPath: AbsolutePath,

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -20,10 +20,6 @@ import XCTest
 import enum PackageLoading.Platform
 
 extension ToolchainRegistry {
-  func setDefault(_ newDefault: Toolchain?) {
-    self.default = newDefault
-  }
-
   func setDarwinToolchainOverride(_ newValue: String?) {
     self.darwinToolchainOverride = newValue
   }
@@ -37,10 +33,6 @@ final class ToolchainRegistryTests: XCTestCase {
     await assertEqual(tr.default?.identifier, "a")
     let b = Toolchain(identifier: "b", displayName: "b", path: nil)
     try await tr.registerToolchain(b)
-    await assertEqual(tr.default?.identifier, "a")
-    await tr.setDefault(b)
-    await assertEqual(tr.default?.identifier, "b")
-    await tr.setDefault(nil)
     await assertEqual(tr.default?.identifier, "a")
     await assertTrue(tr.default === tr.toolchain(identifier: "a"))
   }
@@ -58,10 +50,6 @@ final class ToolchainRegistryTests: XCTestCase {
     try await tr.registerToolchain(
       Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil)
     )
-    await assertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
-    await tr.setDefault(a)
-    await assertEqual(tr.default?.identifier, "a")
-    await tr.setDefault(nil)
     await assertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
   }
 
@@ -322,7 +310,6 @@ final class ToolchainRegistryTests: XCTestCase {
 
     await tr.scanForToolchains(
       environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],
-      setDefault: false,
       fs
     )
 
@@ -388,8 +375,8 @@ final class ToolchainRegistryTests: XCTestCase {
       XCTAssertNotNil(t2.swiftc)
 
       let tr = ToolchainRegistry.empty
-      let t3 = try await tr.registerToolchain(path.parentDirectory, fs)
-      XCTAssertEqual(t3.identifier, t2.identifier)
+      try await tr.registerToolchain(path.parentDirectory, fs)
+      let t3 = try await unwrap(tr.toolchain(identifier: t2.identifier))
       XCTAssertEqual(t3.sourcekitd, t2.sourcekitd)
       XCTAssertEqual(t3.clang, t2.clang)
       XCTAssertEqual(t3.clangd, t2.clangd)

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -97,7 +97,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
-          toolchainRegistry: ToolchainRegistry(toolchains: [], darwinToolchainOverride: nil),
+          toolchainRegistry: ToolchainRegistry(toolchains: []),
           fileSystem: fs,
           buildSetup: SourceKitServer.Options.testDefault.buildSetup
         )

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -39,7 +39,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
@@ -66,7 +66,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
@@ -97,7 +97,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       await assertThrowsError(
         try await SwiftPMWorkspace(
           workspacePath: packageRoot,
-          toolchainRegistry: ToolchainRegistry.empty,
+          toolchainRegistry: ToolchainRegistry(toolchains: [], darwinToolchainOverride: nil),
           fileSystem: fs,
           buildSetup: SourceKitServer.Options.testDefault.buildSetup
         )
@@ -121,7 +121,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -181,7 +181,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
 
       let config = BuildSetup(
         configuration: .release,
@@ -226,7 +226,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -259,7 +259,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -302,7 +302,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -363,7 +363,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -398,7 +398,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -524,7 +524,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString)
       )
 
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -588,7 +588,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let ws = try await SwiftPMWorkspace(
         workspacePath: symlinkRoot,
-        toolchainRegistry: await ToolchainRegistry.forTesting,
+        toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         buildSetup: SourceKitServer.Options.testDefault.buildSetup
       )
@@ -625,7 +625,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
@@ -661,7 +661,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
-      let tr = await ToolchainRegistry.forTesting
+      let tr = ToolchainRegistry.forTesting
       let ws = try await SwiftPMWorkspace(
         workspacePath: packageRoot,
         toolchainRegistry: tr,


### PR DESCRIPTION
This requires a bit of a restructuring of `ToolchainRegistry` because calling `scanForToolchain` on `self` is a suspension point. Instead, we need to implement the entire toolchain discovery in the initializer itself, which really isn’t that bad anyway.

This allows us to make the `SourceKitLSP.run` function synchronous again.

Fixes https://github.com/apple/sourcekit-lsp/issues/1023
rdar://120976054