### PR TITLE
Increase default timeout to 2 minutes

### DIFF
--- a/Sources/LSPTestSupport/Timeouts.swift
+++ b/Sources/LSPTestSupport/Timeouts.swift
@@ -14,4 +14,4 @@ import Foundation
 
 /// The default duration how long tests should wait for responses from
 /// SourceKit-LSP / sourcekitd / clangd.
-public let defaultTimeout: TimeInterval = 60
+public let defaultTimeout: TimeInterval = 120


### PR DESCRIPTION
In some cases, when Xcode doesn’t have a module cache for SDK modules, building SwiftPM project in the tests can take longer than 1 minute. Increase the timeout to 2 minutes.