### PR TITLE
Prefer a toolchain if it is a proper superset of another toolchain

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -43,12 +43,9 @@ Install the following dependencies of SourceKit-LSP:
 * libsqlite3-dev libncurses5-dev python3
 
 ```sh
-$ export PATH="<path_to_swift_toolchain>/usr/bin:${PATH}"
 $ swift package update
 $ swift build -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift -Xcxx -I<path_to_swift_toolchain>/usr/lib/swift/Block
 ```
-
-Setting `PATH` as described above is important even if `<path_to_swift_toolchain>/usr/bin` is already in your `PATH` because `/usr/bin` must be the **first** path to search.
 
 After building, the server will be located at `.build/debug/sourcekit-lsp`, or a similar path, if you passed any custom options to `swift build`. Editors will generally need to be provided with this path in order to run the newly built server - see [Editors](../Editors) for more information about configuration.
 

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -86,6 +86,31 @@ public final class Toolchain {
     self.sourcekitd = sourcekitd
     self.libIndexStore = libIndexStore
   }
+
+  /// Returns `true` if this toolchain has strictly more tools than `other`.
+  ///
+  /// ### Examples
+  /// - A toolchain that contains both `swiftc` and  `clangd` is a superset of one that only contains `swiftc`.
+  /// - A toolchain that contains only `swiftc`, `clangd` is not a superset of a toolchain that contains `swiftc` and
+  ///   `libIndexStore`. These toolchains are not comparable.
+  /// - Two toolchains that both contain `swiftc` and `clangd` are supersets of each other.
+  func isSuperset(of other: Toolchain) -> Bool {
+    func isSuperset(for tool: KeyPath<Toolchain, AbsolutePath?>) -> Bool {
+      if self[keyPath: tool] == nil && other[keyPath: tool] != nil {
+        // This toolchain doesn't contain the tool but the other toolchain does. It is not a superset.
+        return false
+      } else {
+        return true
+      }
+    }
+    return isSuperset(for: \.clang) && isSuperset(for: \.swift) && isSuperset(for: \.swiftc)
+      && isSuperset(for: \.clangd) && isSuperset(for: \.sourcekitd) && isSuperset(for: \.libIndexStore)
+  }
+
+  /// Same as `isSuperset` but returns `false` if both toolchains have the same set of tools.
+  func isProperSuperset(of other: Toolchain) -> Bool {
+    return self.isSuperset(of: other) && !other.isSuperset(of: self)
+  }
 }
 
 extension Toolchain {

--- a/Sources/SKCore/ToolchainRegistry.swift
+++ b/Sources/SKCore/ToolchainRegistry.swift
@@ -221,8 +221,13 @@ public final actor ToolchainRegistry {
       if let tc = toolchainsByIdentifier[darwinToolchainIdentifier]?.first {
         return tc
       }
-      // If neither of that worked, pick the first toolchain.
-      return toolchains.first
+      var result: Toolchain? = nil
+      for toolchain in toolchains {
+        if result == nil || toolchain.isProperSuperset(of: result!) {
+          result = toolchain
+        }
+      }
+      return result
     }
   }
 

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -556,6 +556,25 @@ final class ToolchainRegistryTests: XCTestCase {
     // Env variable wins.
     await assertEqual(tr.default?.path, try AbsolutePath(validating: "/t2/bin"))
   }
+
+  func testSupersetToolchains() async throws {
+    let onlySwiftcToolchain = Toolchain(
+      identifier: "onlySwiftc",
+      displayName: "onlySwiftc",
+      path: try AbsolutePath(validating: "/usr/local"),
+      swiftc: try AbsolutePath(validating: "/usr/local/bin/swiftc")
+    )
+    let swiftcAndSourcekitdToolchain = Toolchain(
+      identifier: "swiftcAndSourcekitd",
+      displayName: "swiftcAndSourcekitd",
+      path: try AbsolutePath(validating: "/usr"),
+      swiftc: try AbsolutePath(validating: "/usr/bin/swiftc"),
+      sourcekitd: try AbsolutePath(validating: "/usr/lib/sourcekitd.framework/sourcekitd")
+    )
+
+    let tr = ToolchainRegistry(toolchains: [onlySwiftcToolchain, swiftcAndSourcekitdToolchain])
+    await assertEqual(tr.default?.identifier, "swiftcAndSourcekitd")
+  }
 }
 
 private func makeXCToolchain(


### PR DESCRIPTION
This fixes the issue that you need to set the `PATH` environment variable to have `/usr/bin` as the first entry to test sourcekit-lsp on Linux.

rdar://78525669