### PR TITLE
Add a subcommand to sourcekit-lsp that automatically reduces sourcekitd issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ if forceNonDarwinLogger {
 
 let package = Package(
   name: "SourceKitLSP",
-  platforms: [.macOS("12.0")],
+  platforms: [.macOS(.v13)],
   products: [
     .executable(name: "sourcekit-lsp", targets: ["sourcekit-lsp"]),
     .library(name: "_SourceKitLSP", targets: ["SourceKitLSP"]),
@@ -60,6 +60,7 @@ let package = Package(
     .executableTarget(
       name: "sourcekit-lsp",
       dependencies: [
+        "Diagnose",
         "LanguageServerProtocol",
         "LanguageServerProtocolJSONRPC",
         "SKCore",
@@ -94,6 +95,19 @@ let package = Package(
     .target(
       name: "Csourcekitd",
       dependencies: [],
+      exclude: ["CMakeLists.txt"]
+    ),
+
+    .target(
+      name: "Diagnose",
+      dependencies: [
+        "SourceKitD",
+        "SKCore",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ],
       exclude: ["CMakeLists.txt"]
     ),
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(BuildServerProtocol)
 add_subdirectory(Csourcekitd)
+add_subdirectory(Diagnose)
 add_subdirectory(LanguageServerProtocol)
 add_subdirectory(LanguageServerProtocolJSONRPC)
 add_subdirectory(LSPLogging)

--- a/Sources/Diagnose/CMakeLists.txt
+++ b/Sources/Diagnose/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(Diagnose STATIC
+  CommandLineArgumentsReducer.swift
+  DiagnoseCommand.swift
+  FileReducer.swift
+  FixItApplier.swift
+  OSLogScraper.swift
+  ReductionError.swift
+  ReproducerBundle.swift
+  RequestInfo.swift
+  SourceKitDRequestExecutor.swift
+  SourcekitdRequestCommand.swift)
+
+set_target_properties(Diagnose PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+target_link_libraries(Diagnose PUBLIC
+  SKCore
+  SourceKitD
+  ArgumentParser
+  SwiftSyntax::SwiftSyntax
+  SwiftSyntax::SwiftParser
+  TSCBasic
+)

--- a/Sources/Diagnose/CommandLineArgumentsReducer.swift
+++ b/Sources/Diagnose/CommandLineArgumentsReducer.swift
@@ -90,7 +90,7 @@ class CommandLineArgumentReducer {
     reducedRequestInfo.compilerArgs.removeSubrange(argumentsToRemove)
 
     let result = try await sourcekitdExecutor.run(request: reducedRequestInfo.request(for: temporarySourceFile))
-    if result == .crashed {
+    if case .reproducesIssue = result {
       logSuccessfulReduction(reducedRequestInfo)
       return reducedRequestInfo
     } else {

--- a/Sources/Diagnose/CommandLineArgumentsReducer.swift
+++ b/Sources/Diagnose/CommandLineArgumentsReducer.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Reduces the compiler arguments needed to reproduce a sourcekitd crash.
+class CommandLineArgumentReducer {
+  /// The executor that is used to run a sourcekitd request and check whether it
+  /// still crashes.
+  private let sourcekitdExecutor: SourceKitRequestExecutor
+
+  /// The file to which we write the reduced source code.
+  private let temporarySourceFile: URL
+
+  init(sourcekitdExecutor: SourceKitRequestExecutor) {
+    self.sourcekitdExecutor = sourcekitdExecutor
+    temporarySourceFile = FileManager.default.temporaryDirectory.appendingPathComponent("reduce.swift")
+  }
+
+  func logSuccessfulReduction(_ requestInfo: RequestInfo) {
+    print("Reduced compiler arguments to \(requestInfo.compilerArgs.count)")
+  }
+
+  func run(initialRequestInfo: RequestInfo) async throws -> RequestInfo {
+    try initialRequestInfo.fileContents.write(to: temporarySourceFile, atomically: true, encoding: .utf8)
+    var requestInfo = initialRequestInfo
+
+    var argumentIndexToRemove = requestInfo.compilerArgs.count - 1
+    while argumentIndexToRemove >= 0 {
+      var numberOfArgumentsToRemove = 1
+      // If the argument is preceded by -Xswiftc or -Xcxx, we need to remove the `-X` flag as well.
+      if argumentIndexToRemove - numberOfArgumentsToRemove >= 0
+        && requestInfo.compilerArgs[argumentIndexToRemove - numberOfArgumentsToRemove].hasPrefix("-X")
+      {
+        numberOfArgumentsToRemove += 1
+      }
+
+      if let reduced = try await tryRemoving(
+        (argumentIndexToRemove - numberOfArgumentsToRemove + 1)...argumentIndexToRemove,
+        from: requestInfo
+      ) {
+        requestInfo = reduced
+        argumentIndexToRemove -= numberOfArgumentsToRemove
+        continue
+      }
+
+      // If removing the argument failed and the argument is preceded by an argument starting with `-`, try removing that as well.
+      // E.g. removing `-F` followed by a search path.
+      if argumentIndexToRemove - numberOfArgumentsToRemove >= 0
+        && requestInfo.compilerArgs[argumentIndexToRemove - numberOfArgumentsToRemove].hasPrefix("-")
+      {
+        numberOfArgumentsToRemove += 1
+      }
+
+      // If the argument is preceded by -Xswiftc or -Xcxx, we need to remove the `-X` flag as well.
+      if argumentIndexToRemove - numberOfArgumentsToRemove >= 0
+        && requestInfo.compilerArgs[argumentIndexToRemove - numberOfArgumentsToRemove].hasPrefix("-X")
+      {
+        numberOfArgumentsToRemove += 1
+      }
+
+      if let reduced = try await tryRemoving(
+        (argumentIndexToRemove - numberOfArgumentsToRemove + 1)...argumentIndexToRemove,
+        from: requestInfo
+      ) {
+        requestInfo = reduced
+        argumentIndexToRemove -= numberOfArgumentsToRemove
+        continue
+      }
+      argumentIndexToRemove -= 1
+    }
+
+    return requestInfo
+  }
+
+  private func tryRemoving(
+    _ argumentsToRemove: ClosedRange<Int>,
+    from requestInfo: RequestInfo
+  ) async throws -> RequestInfo? {
+    var reducedRequestInfo = requestInfo
+    reducedRequestInfo.compilerArgs.removeSubrange(argumentsToRemove)
+
+    let result = try await sourcekitdExecutor.run(request: reducedRequestInfo.request(for: temporarySourceFile))
+    if result == .crashed {
+      logSuccessfulReduction(reducedRequestInfo)
+      return reducedRequestInfo
+    } else {
+      // The reduced request did not crash. We did not find a reduced test case, so return `nil`.
+      return nil
+    }
+  }
+}

--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+import SKCore
+
+import struct TSCBasic.AbsolutePath
+
+public struct DiagnoseCommand: AsyncParsableCommand {
+  public static var configuration: CommandConfiguration = CommandConfiguration(
+    commandName: "diagnose",
+    abstract: "Reduce sourcekitd crashes",
+    shouldDisplay: false
+  )
+
+  @Option(
+    name: .customLong("request-file"),
+    help:
+      "Path to a sourcekitd request. If not specified, the command will look for crashed sourcekitd requests and have been logged to OSLog"
+  )
+  var sourcekitdRequestPath: String?
+
+  @Option(
+    name: .customLong("os-log-history"),
+    help: "If now request file is passed, how many minutes of OS Log history should be scraped for a crash."
+  )
+  var osLogScrapeDuration: Int = 60
+
+  @Option(
+    name: .customLong("sourcekitd"),
+    help:
+      "Path to sourcekitd.framework/sourcekitd. If not specified, the toolchain is found in the same way that sourcekit-lsp finds it"
+  )
+  var sourcekitdOverride: String?
+
+  var sourcekitd: String? {
+    get async throws {
+      if let sourcekitdOverride {
+        return sourcekitdOverride
+      }
+
+      let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
+      let toolchainRegistry = ToolchainRegistry(installPath: installPath)
+      return await toolchainRegistry.default?.sourcekitd?.pathString
+    }
+  }
+
+  /// Request infos of crashes that should be diagnosed.
+  func requestInfos() throws -> [(name: String, info: RequestInfo)] {
+    if let sourcekitdRequestPath {
+      let request = try String(contentsOfFile: sourcekitdRequestPath)
+      return [(sourcekitdRequestPath, try RequestInfo(request: request))]
+    }
+    #if canImport(OSLog)
+    return try OSLogScraper(searchDuration: TimeInterval(osLogScrapeDuration * 60)).getCrashedRequests()
+    #else
+    throw ReductionError("--request-file must be specified on all platforms other than macOS")
+    #endif
+  }
+
+  public init() {}
+
+  public func run() async throws {
+    guard let sourcekitd = try await sourcekitd else {
+      throw ReductionError("Unable to find sourcekitd.framework")
+    }
+
+    for (name, requestInfo) in try requestInfos() {
+      print("-- Diagnosing \(name)")
+      do {
+        var requestInfo = requestInfo
+        let executor = SourceKitRequestExecutor(sourcekitd: URL(fileURLWithPath: sourcekitd))
+        let fileReducer = FileReducer(sourcekitdExecutor: executor)
+        requestInfo = try await fileReducer.run(initialRequestInfo: requestInfo)
+
+        let commandLineReducer = CommandLineArgumentReducer(sourcekitdExecutor: executor)
+        requestInfo = try await commandLineReducer.run(initialRequestInfo: requestInfo)
+
+        let reproducerBundle = try makeReproducerBundle(for: requestInfo)
+
+        print("----------------------------------------")
+        print(
+          "Reduced SourceKit crash and created a bundle that contains information to reproduce the issue at the following path."
+        )
+        print("Please file an issue at https://github.com/apple/sourcekit-lsp/issues/new and attach this bundle")
+        print()
+        print(reproducerBundle.path)
+
+        // We have found a reproducer. Stop. Looking further probably won't help because other crashes are likely the same cause.
+        return
+      } catch {
+        // Reducing this request failed. Continue reducing the next one, maybe that one succeeds.
+        print(error)
+      }
+    }
+
+    print("No reducible crashes found")
+    throw ExitCode(1)
+  }
+}

--- a/Sources/Diagnose/FileReducer.swift
+++ b/Sources/Diagnose/FileReducer.swift
@@ -1,0 +1,306 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SourceKitD
+import SwiftParser
+import SwiftSyntax
+
+/// Reduces an input source file while continuing to reproduce the crash
+class FileReducer {
+  /// The executor that is used to run a sourcekitd request and check whether it
+  /// still crashes.
+  private let sourcekitdExecutor: SourceKitRequestExecutor
+
+  /// The file to which we write the reduced source code.
+  private let temporarySourceFile: URL
+
+  init(sourcekitdExecutor: SourceKitRequestExecutor) {
+    self.sourcekitdExecutor = sourcekitdExecutor
+    temporarySourceFile = FileManager.default.temporaryDirectory.appendingPathComponent("reduce.swift")
+  }
+
+  /// Reduce the file contents in `initialRequest` to a smaller file that still reproduces a crash.
+  func run(initialRequestInfo: RequestInfo) async throws -> RequestInfo {
+    var requestInfo = initialRequestInfo
+    try await validateRequestInfoCrashes(requestInfo: requestInfo)
+
+    requestInfo = try await runReductionStep(requestInfo: requestInfo, reduce: removeComments) ?? requestInfo
+
+    requestInfo = try await runStatefulReductionStep(
+      requestInfo: requestInfo,
+      reducer: ReplaceFunctionBodiesByFatalError()
+    )
+
+    // Run removal of members and code block items in a loop. Sometimes the removal of a code block item further down in the
+    // file can remove the last reference to a member which can then be removed as well.
+    while true {
+      let reducedRequestInfo = try await runStatefulReductionStep(
+        requestInfo: requestInfo,
+        reducer: RemoveMembersAndCodeBlockItems()
+      )
+      if reducedRequestInfo.fileContents == requestInfo.fileContents {
+        // No changes were made during reduction. We are done.
+        break
+      }
+      requestInfo = reducedRequestInfo
+    }
+
+    return requestInfo
+  }
+
+  func logSuccessfulReduction(_ requestInfo: RequestInfo) {
+    print("Reduced source file to \(requestInfo.fileContents.utf8.count) bytes")
+  }
+
+  // MARK: - Running reduction steps
+
+  private func validateRequestInfoCrashes(requestInfo: RequestInfo) async throws {
+    let initialReproducer = try await runReductionStep(requestInfo: requestInfo) { tree in [] }
+    if initialReproducer == nil {
+      throw ReductionError("Initial request info did not crash")
+    }
+  }
+
+  /// Run a single reduction step.
+  ///
+  /// If the request still crashes after applying the edits computed by `reduce`, return the reduced request info.
+  /// Otherwise, return `nil`
+  private func runReductionStep(
+    requestInfo: RequestInfo,
+    reduce: (_ tree: SourceFileSyntax) throws -> [SourceEdit]
+  ) async throws -> RequestInfo? {
+    let tree = Parser.parse(source: requestInfo.fileContents)
+    let edits = try reduce(tree)
+    let reducedSource = FixItApplier.apply(edits: edits, to: tree)
+
+    var adjustedOffset = requestInfo.offset
+    for edit in edits {
+      if edit.range.upperBound < AbsolutePosition(utf8Offset: requestInfo.offset) {
+        adjustedOffset -= (edit.range.upperBound.utf8Offset - edit.range.lowerBound.utf8Offset)
+        adjustedOffset += edit.replacement.utf8.count
+      }
+    }
+
+    let reducedRequestInfo = RequestInfo(
+      requestTemplate: requestInfo.requestTemplate,
+      offset: adjustedOffset,
+      compilerArgs: requestInfo.compilerArgs,
+      fileContents: reducedSource
+    )
+
+    try reducedSource.write(to: temporarySourceFile, atomically: false, encoding: .utf8)
+    let result = try await sourcekitdExecutor.run(request: reducedRequestInfo.request(for: temporarySourceFile))
+    if result == .crashed {
+      logSuccessfulReduction(reducedRequestInfo)
+      return reducedRequestInfo
+    } else {
+      // The reduced request did not crash. We did not find a reduced test case, so return `nil`.
+      return nil
+    }
+  }
+
+  /// Run a reducer that can carry state between reduction steps.
+  ///
+  /// This invokes `reduce(tree:)` on `reducer` as long as the `reduce` method returns non-empty edits.
+  /// When `reducer.reduce(tree:)` returns empty edits, it indicates that it can't reduce the file any further
+  /// and this method return the reduced request info.
+  func runStatefulReductionStep(
+    requestInfo: RequestInfo,
+    reducer: any StatefulReducer
+  ) async throws -> RequestInfo {
+    /// Error to indicate that `reducer.reduce(tree:)` did not produce any edits.
+    /// Will always be caught within the function.
+    struct StatefulReducerFinishedReducing: Error {}
+
+    var reproducer = requestInfo
+    while true {
+      do {
+        let reduced = try await runReductionStep(requestInfo: reproducer) { tree in
+          let edits = reducer.reduce(tree: tree)
+          if edits.isEmpty {
+            throw StatefulReducerFinishedReducing()
+          }
+          return edits
+        }
+        if let reduced {
+          reproducer = reduced
+        }
+      } catch is StatefulReducerFinishedReducing {
+        return reproducer
+      }
+    }
+  }
+}
+
+// MARK: - Reduce functions
+
+/// See `FileReducer.runReductionStep`
+protocol StatefulReducer {
+  func reduce(tree: SourceFileSyntax) -> [SourceEdit]
+}
+
+/// Tries replacing one function body by `fatalError()` at a time.
+class ReplaceFunctionBodiesByFatalError: StatefulReducer {
+  /// The function bodies that should not be replaced by `fatalError()`.
+  ///
+  /// When we tried replacing a function body by `fatalError`, it gets added to this list.
+  /// That way, if replacing it did not result in a reduced reproducer, we won't try replacing it again
+  /// on the next invocation of `reduce(tree:)`.
+  ///
+  /// `fatalError()` is in here from the start to mark functions that we have replaced by `fatalError()` as done.
+  /// There's no point replacing a `fatalError()` function by `fatalError()` again.
+  var keepFunctionBodies: [String] = ["fatalError()"]
+
+  func reduce(tree: SourceFileSyntax) -> [SourceEdit] {
+    let visitor = Visitor(keepFunctionBodies: keepFunctionBodies)
+    visitor.walk(tree)
+    keepFunctionBodies = visitor.keepFunctionBodies
+    return visitor.edits
+  }
+
+  private class Visitor: SyntaxAnyVisitor {
+    var keepFunctionBodies: [String]
+    var edits: [SourceEdit] = []
+
+    init(keepFunctionBodies: [String]) {
+      self.keepFunctionBodies = keepFunctionBodies
+      super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+      if !edits.isEmpty {
+        // We already produced an edit. We only want to replace one function at a time.
+        return .skipChildren
+      }
+      return .visitChildren
+    }
+
+    override func visit(_ node: CodeBlockSyntax) -> SyntaxVisitorContinueKind {
+      if !edits.isEmpty {
+        return .skipChildren
+      }
+      if keepFunctionBodies.contains(node.statements.description.trimmingCharacters(in: .whitespacesAndNewlines)) {
+        return .visitChildren
+      } else {
+        keepFunctionBodies.append(node.statements.description.trimmingCharacters(in: .whitespacesAndNewlines))
+        edits.append(
+          SourceEdit(
+            range: node.statements.position..<node.statements.endPosition,
+            replacement: "\(node.statements.leadingTrivia)fatalError()"
+          )
+        )
+        return .skipChildren
+      }
+    }
+  }
+}
+
+/// Tries removing `MemberBlockItemSyntax` and `CodeBlockItemSyntax` one at a time.
+class RemoveMembersAndCodeBlockItems: StatefulReducer {
+  /// The code block items / members that shouldn't be removed.
+  ///
+  /// See `ReplaceFunctionBodiesByFatalError.keepFunctionBodies`.
+  var keepItems: [String] = []
+
+  func reduce(tree: SourceFileSyntax) -> [SourceEdit] {
+    let visitor = Visitor(keepMembers: keepItems)
+    visitor.walk(tree)
+    keepItems = visitor.keepItems
+    return visitor.edits
+  }
+
+  private class Visitor: SyntaxAnyVisitor {
+    var keepItems: [String]
+    var edits: [SourceEdit] = []
+
+    init(keepMembers: [String]) {
+      self.keepItems = keepMembers
+      super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+      if !edits.isEmpty {
+        return .skipChildren
+      }
+      return .visitChildren
+    }
+
+    override func visit(_ node: MemberBlockItemSyntax) -> SyntaxVisitorContinueKind {
+      if !edits.isEmpty {
+        return .skipChildren
+      }
+      if keepItems.contains(node.description.trimmingCharacters(in: .whitespacesAndNewlines)) {
+        return .visitChildren
+      } else {
+        keepItems.append(node.description.trimmingCharacters(in: .whitespacesAndNewlines))
+        edits.append(SourceEdit(range: node.position..<node.endPosition, replacement: ""))
+        return .skipChildren
+      }
+    }
+
+    override func visit(_ node: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
+      if !edits.isEmpty {
+        return .skipChildren
+      }
+      if keepItems.contains(node.description.trimmingCharacters(in: .whitespacesAndNewlines)) {
+        return .visitChildren
+      } else {
+        keepItems.append(node.description.trimmingCharacters(in: .whitespacesAndNewlines))
+        edits.append(SourceEdit(range: node.position..<node.endPosition, replacement: ""))
+        return .skipChildren
+      }
+    }
+  }
+}
+
+/// Removes all comments from the source file.
+func removeComments(from tree: SourceFileSyntax) -> [SourceEdit] {
+  class CommentRemover: SyntaxVisitor {
+    var edits: [SourceEdit] = []
+
+    private func removeComments(from trivia: Trivia, startPosition: AbsolutePosition) {
+      var position = startPosition
+      var previousTriviaPiece: TriviaPiece?
+      for triviaPiece in trivia {
+        defer {
+          previousTriviaPiece = triviaPiece
+          position += triviaPiece.sourceLength
+        }
+        if triviaPiece.isComment || (triviaPiece.isNewline && previousTriviaPiece?.isComment ?? false) {
+          edits.append(SourceEdit(range: position..<(position + triviaPiece.sourceLength), replacement: ""))
+        }
+      }
+    }
+
+    override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+      removeComments(from: node.leadingTrivia, startPosition: node.position)
+      removeComments(from: node.trailingTrivia, startPosition: node.endPositionBeforeTrailingTrivia)
+      return .skipChildren
+    }
+  }
+
+  let remover = CommentRemover(viewMode: .sourceAccurate)
+  remover.walk(tree)
+  return remover.edits
+}
+
+fileprivate extension TriviaPiece {
+  var isComment: Bool {
+    switch self {
+    case .blockComment, .docBlockComment, .docLineComment, .lineComment:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/Diagnose/FixItApplier.swift
+++ b/Sources/Diagnose/FixItApplier.swift
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Copy of `FixItApplier` in `_SwiftSyntaxTestSupport`.
+/// We should use the copy from swift-syntax once it's available as public API.
+public enum FixItApplier {
+  /// Apply the given edits to the syntax tree.
+  ///
+  /// - Parameters:
+  ///   - edits: The edits to apply to the syntax tree
+  ///   - tree: he syntax tree to which the edits should be applied.
+  /// - Returns: A `String` representation of the modified syntax tree after applying the edits.
+  public static func apply(
+    edits: [SourceEdit],
+    to tree: any SyntaxProtocol
+  ) -> String {
+    var edits = edits
+    var source = tree.description
+
+    while let edit = edits.first {
+      edits = Array(edits.dropFirst())
+
+      let startIndex = source.utf8.index(source.utf8.startIndex, offsetBy: edit.startUtf8Offset)
+      let endIndex = source.utf8.index(source.utf8.startIndex, offsetBy: edit.endUtf8Offset)
+
+      source.replaceSubrange(startIndex..<endIndex, with: edit.replacement)
+
+      edits = edits.compactMap { remainingEdit -> SourceEdit? in
+        if remainingEdit.replacementRange.overlaps(edit.replacementRange) {
+          // The edit overlaps with the previous edit. We can't apply both
+          // without conflicts. Apply the one that's listed first and drop the
+          // later edit.
+          return nil
+        }
+
+        // If the remaining edit starts after or at the end of the edit that we just applied,
+        // shift it by the current edit's difference in length.
+        if edit.endUtf8Offset <= remainingEdit.startUtf8Offset {
+          let startPosition = AbsolutePosition(
+            utf8Offset: remainingEdit.startUtf8Offset - edit.replacementRange.count + edit.replacementLength
+          )
+          let endPosition = AbsolutePosition(
+            utf8Offset: remainingEdit.endUtf8Offset - edit.replacementRange.count + edit.replacementLength
+          )
+          return SourceEdit(range: startPosition..<endPosition, replacement: remainingEdit.replacement)
+        }
+
+        return remainingEdit
+      }
+    }
+
+    return source
+  }
+}
+
+private extension SourceEdit {
+  var startUtf8Offset: Int {
+    return range.lowerBound.utf8Offset
+  }
+
+  var endUtf8Offset: Int {
+    return range.upperBound.utf8Offset
+  }
+
+  var replacementLength: Int {
+    return replacement.utf8.count
+  }
+
+  var replacementRange: Range<Int> {
+    return startUtf8Offset..<endUtf8Offset
+  }
+}

--- a/Sources/Diagnose/OSLogScraper.swift
+++ b/Sources/Diagnose/OSLogScraper.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(OSLog)
+import OSLog
+
+/// Reads oslog messages to find recent sourcekitd crashes.
+struct OSLogScraper {
+  /// How far into the past we should search for crashes in OSLog.
+  var searchDuration: TimeInterval
+
+  private func getLogEntries(matching predicate: NSPredicate) throws -> [any OSLogEntryWithPayload & OSLogEntry] {
+    let logStore = try OSLogStore.local()
+    let startPoint = logStore.position(date: Date().addingTimeInterval(-searchDuration))
+    return
+      try logStore
+      .getEntries(
+        at: startPoint,
+        matching: predicate
+      ).compactMap { $0 as? (OSLogEntryWithPayload & OSLogEntry) }
+  }
+
+  private func crashedSourceKitLSPRequests() throws -> [(name: String, logCategory: String)] {
+    let predicate = NSPredicate(
+      format: #"subsystem CONTAINS "sourcekit-lsp" AND composedMessage CONTAINS "sourcekitd crashed (1/""#
+    )
+    return try getLogEntries(matching: predicate).map {
+      (name: "Crash at \($0.date)", logCategory: $0.category)
+    }
+  }
+
+  /// Get the `RequestInfo` for a crash that was logged in `logCategory`.
+  private func requestInfo(for logCategory: String) throws -> RequestInfo {
+    let predicate = NSPredicate(
+      format:
+        #"subsystem CONTAINS "sourcekit-lsp" AND composedMessage CONTAINS "sourcekitd crashed" AND category = %@"#,
+      logCategory
+    )
+    var isInFileContentSection = false
+    var request = ""
+    var fileContents = ""
+    for entry in try getLogEntries(matching: predicate) {
+      for line in entry.composedMessage.components(separatedBy: "\n") {
+        if line.starts(with: "sourcekitd crashed (") {
+          continue
+        }
+        if line == "Request:" {
+          continue
+        }
+        if line == "File contents:" {
+          isInFileContentSection = true
+          continue
+        }
+        if line == "--- End Chunk" {
+          continue
+        }
+        if isInFileContentSection {
+          fileContents += line + "\n"
+        } else {
+          request += line + "\n"
+        }
+      }
+    }
+
+    var requestInfo = try RequestInfo(request: request)
+    requestInfo.fileContents = fileContents
+    return requestInfo
+  }
+
+  /// Get information about sourcekitd crashes that haven logged to OSLog.
+  /// This information can be used to reduce the crash.
+  ///
+  /// Name is a human readable name that identifies the crash.
+  func getCrashedRequests() throws -> [(name: String, info: RequestInfo)] {
+    let crashedReqeusts = try crashedSourceKitLSPRequests().reversed()
+    return try crashedReqeusts.map { ($0.name, try requestInfo(for: $0.logCategory)) }
+  }
+}
+#endif

--- a/Sources/Diagnose/ReductionError.swift
+++ b/Sources/Diagnose/ReductionError.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Generic error that can be thrown if reducing the crash failed in a non-recoverable way.
+struct ReductionError: Error, CustomStringConvertible {
+  let description: String
+
+  init(_ description: String) {
+    self.description = description
+  }
+}

--- a/Sources/Diagnose/ReproducerBundle.swift
+++ b/Sources/Diagnose/ReproducerBundle.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Create a folder that contains all files that should be necessary to reproduce a sourcekitd crash.
+func makeReproducerBundle(for requestInfo: RequestInfo) throws -> URL {
+  let date = ISO8601DateFormatter().string(from: Date()).replacingOccurrences(of: ":", with: "-")
+  let bundlePath = FileManager.default.temporaryDirectory
+    .appendingPathComponent("sourcekitd-reproducer-\(date)")
+  try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+
+  try requestInfo.fileContents.write(
+    to: bundlePath.appendingPathComponent("input.swift"),
+    atomically: true,
+    encoding: .utf8
+  )
+  let request = try requestInfo.request(for: URL(fileURLWithPath: "/input.swift"))
+  try request.write(
+    to: bundlePath.appendingPathComponent("request.json"),
+    atomically: true,
+    encoding: .utf8
+  )
+  for compilerArg in requestInfo.compilerArgs {
+    // Copy all files from the compiler arguments into the reproducer bundle.
+    // Don't include files in Xcode (.app), Xcode toolchains or usr because they are most likely binary files that aren't user specific and would bloat the reproducer bundle.
+    if compilerArg.hasPrefix("/"), !compilerArg.contains(".app"), !compilerArg.contains(".xctoolchain"),
+      !compilerArg.contains("/usr/")
+    {
+      let dest = URL(fileURLWithPath: bundlePath.path + compilerArg)
+      try? FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try? FileManager.default.copyItem(at: URL(fileURLWithPath: compilerArg), to: dest)
+    }
+  }
+  return bundlePath
+}

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import RegexBuilder
+
+/// All the information necessary to replay a sourcektid request.
+struct RequestInfo {
+  /// The JSON request object. Contains the following dynamic placeholders:
+  ///  - `$OFFSET`: To be replaced by `offset` before running the request
+  ///  - `$FILE`: Will be replaced with a path to the file that contains the reduced source code.
+  ///  - `$COMPILERARGS`: Will be replaced by the compiler arguments of the request
+  var requestTemplate: String
+
+  /// The offset at which the sourcekitd request should be run. Replaces the
+  /// `$OFFSET` placeholder in the request template.
+  var offset: Int
+
+  /// The compiler arguments of the request. Replaces the `$COMPILERARGS`placeholder in the request template.
+  var compilerArgs: [String]
+
+  /// The contents of the file that the sourcekitd request operates on.
+  var fileContents: String
+
+  func request(for file: URL) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+    guard var compilerArgs = String(data: try encoder.encode(compilerArgs), encoding: .utf8) else {
+      throw ReductionError("Failed to encode compiler arguments")
+    }
+    // Drop the opening `[` and `]`. The request template already contains them
+    compilerArgs = String(compilerArgs.dropFirst().dropLast())
+    return
+      requestTemplate
+      .replacingOccurrences(of: "$OFFSET", with: String(offset))
+      .replacingOccurrences(of: "$COMPILERARGS", with: compilerArgs)
+      .replacingOccurrences(of: "$FILE", with: file.path)
+
+  }
+
+  init(requestTemplate: String, offset: Int, compilerArgs: [String], fileContents: String) {
+    self.requestTemplate = requestTemplate
+    self.offset = offset
+    self.compilerArgs = compilerArgs
+    self.fileContents = fileContents
+  }
+
+  /// Creates `RequestInfo` from the contents of the JSON sourcekitd request at `requestPath`.
+  ///
+  /// The contents of the source file are read from disk.
+  init(request: String) throws {
+    var requestTemplate = request
+
+    // Extract offset
+    let offsetRegex = Regex {
+      "key.offset: "
+      Capture(ZeroOrMore(.digit))
+    }
+    guard let offsetMatch = requestTemplate.matches(of: offsetRegex).only else {
+      throw ReductionError("Failed to find key.offset in the request")
+    }
+    offset = Int(offsetMatch.1)!
+    requestTemplate.replace(offsetRegex, with: "key.offset: $OFFSET")
+
+    // Extract source file
+    let sourceFileRegex = Regex {
+      #"key.sourcefile: ""#
+      Capture(ZeroOrMore(#/[^"]/#))
+      "\""
+    }
+    guard let sourceFileMatch = requestTemplate.matches(of: sourceFileRegex).only else {
+      throw ReductionError("Failed to find key.sourcefile in the request")
+    }
+    let sourceFilePath = String(sourceFileMatch.1)
+    requestTemplate.replace(sourceFileMatch.1, with: "$FILE")
+
+    // Extract compiler arguments
+    let compilerArgsExtraction = try extractCompilerArguments(from: requestTemplate)
+    requestTemplate = compilerArgsExtraction.template
+    compilerArgs = compilerArgsExtraction.compilerArgs
+
+    self.requestTemplate = requestTemplate
+
+    fileContents = try String(contentsOf: URL(fileURLWithPath: sourceFilePath))
+  }
+}
+
+private func extractCompilerArguments(
+  from requestTemplate: String
+) throws -> (template: String, compilerArgs: [String]) {
+  let lines = requestTemplate.components(separatedBy: "\n")
+  guard
+    let compilerArgsStartIndex = lines.firstIndex(where: { $0.contains("key.compilerargs: [") }),
+    let compilerArgsEndIndex = lines[compilerArgsStartIndex...].firstIndex(where: {
+      $0.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("]")
+    })
+  else {
+    return (requestTemplate, [])
+  }
+  let template = lines[...compilerArgsStartIndex] + ["$COMPILERARGS"] + lines[compilerArgsEndIndex...]
+  let compilerArgsJson = "[" + lines[(compilerArgsStartIndex + 1)..<compilerArgsEndIndex].joined(separator: "\n") + "]"
+  let compilerArgs = try JSONDecoder().decode([String].self, from: compilerArgsJson)
+  return (template.joined(separator: "\n"), compilerArgs)
+}

--- a/Sources/Diagnose/SourceKitDRequestExecutor.swift
+++ b/Sources/Diagnose/SourceKitDRequestExecutor.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SourceKitD
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+
+/// The different states in which a sourcektid request can finish.
+enum SourceKitDRequestResult {
+  /// The request succeeded.
+  case success
+
+  /// The request failed but did not crash.
+  case error
+
+  /// Running the request crashed
+  case crashed
+}
+
+fileprivate extension String {
+  init?(bytes: [UInt8], encoding: Encoding) {
+    let data = bytes.withUnsafeBytes { buffer in
+      guard let baseAddress = buffer.baseAddress else {
+        return Data()
+      }
+      return Data(bytes: baseAddress, count: buffer.count)
+    }
+    self.init(data: data, encoding: encoding)
+  }
+}
+
+/// Runs `sourcekit-lsp run-sourcekitd-request` to check if a sourcekit-request crashes.
+struct SourceKitRequestExecutor {
+  /// The path to `sourcekitd.framework/sourcekitd`.
+  private let sourcekitd: URL
+
+  /// The file to which we write the JSON request that we want to run.
+  private let temporarySourceFile: URL
+
+  init(sourcekitd: URL) {
+    self.sourcekitd = sourcekitd
+    temporarySourceFile = FileManager.default.temporaryDirectory.appendingPathComponent("request.json")
+  }
+
+  func run(request requestString: String) async throws -> SourceKitDRequestResult {
+    try requestString.write(to: temporarySourceFile, atomically: true, encoding: .utf8)
+
+    let process = Process(
+      arguments: [
+        ProcessInfo.processInfo.arguments[0],
+        "run-sourcekitd-request",
+        "--sourcekitd",
+        sourcekitd.path,
+        "--request-file",
+        temporarySourceFile.path,
+      ]
+    )
+    try process.launch()
+    let result = try await process.waitUntilExit()
+    switch result.exitStatus {
+    case .terminated(code: 0):
+      return .success
+    case .terminated(code: 4):
+      return .crashed
+    default:
+      return .error
+    }
+  }
+}

--- a/Sources/Diagnose/SourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/SourcekitdRequestCommand.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+import SourceKitD
+
+import struct TSCBasic.AbsolutePath
+
+public struct SourceKitdRequestCommand: AsyncParsableCommand {
+  public static var configuration = CommandConfiguration(
+    commandName: "run-sourcekitd-request",
+    abstract: "Run a sourcekitd request and print its result",
+    shouldDisplay: false
+  )
+
+  @Option(
+    name: .customLong("sourcekitd"),
+    help: "Path to sourcekitd.framework/sourcekitd"
+  )
+  var sourcekitdPath: String
+
+  @Option(
+    name: .customLong("request-file"),
+    help: "Path to a JSON sourcekitd request"
+  )
+  var sourcekitdRequestPath: String
+
+  public init() {}
+
+  public func run() async throws {
+    let requestString = try String(contentsOf: URL(fileURLWithPath: sourcekitdRequestPath))
+
+    let sourcekitd = try SourceKitDImpl.getOrCreate(
+      dylibPath: try! AbsolutePath(validating: sourcekitdPath)
+    )
+
+    let request = try requestString.cString(using: .utf8)?.withUnsafeBufferPointer { buffer in
+      var error: UnsafeMutablePointer<CChar>?
+      let req = sourcekitd.api.request_create_from_yaml(buffer.baseAddress, &error)
+      if let error {
+        throw ReductionError("Failed to parse sourcekitd request from JSON: \(String(cString: error))")
+      }
+      precondition(req != nil)
+      return req
+    }
+    let response: SKDResponse = await withCheckedContinuation { continuation in
+      var handle: sourcekitd_request_handle_t? = nil
+      sourcekitd.api.send_request(request, &handle) { resp in
+        continuation.resume(returning: SKDResponse(resp, sourcekitd: sourcekitd))
+      }
+    }
+
+    switch response.error {
+    case .requestFailed:
+      throw ExitCode(1)
+    case .requestInvalid:
+      throw ExitCode(2)
+    case .requestCancelled:
+      throw ExitCode(3)
+    case .connectionInterrupted:
+      throw ExitCode(4)
+    case .missingRequiredSymbol:
+      throw ExitCode(5)
+    case nil:
+      return
+    }
+  }
+}

--- a/Sources/Diagnose/SourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/SourcekitdRequestCommand.swift
@@ -61,18 +61,12 @@ public struct SourceKitdRequestCommand: AsyncParsableCommand {
     }
 
     switch response.error {
-    case .requestFailed:
+    case .requestFailed, .requestInvalid, .requestCancelled, .missingRequiredSymbol:
       throw ExitCode(1)
-    case .requestInvalid:
-      throw ExitCode(2)
-    case .requestCancelled:
-      throw ExitCode(3)
     case .connectionInterrupted:
-      throw ExitCode(4)
-    case .missingRequiredSymbol:
-      throw ExitCode(5)
+      throw ExitCode(255)
     case nil:
-      return
+      print(response.description)
     }
   }
 }

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(SKCore STATIC
   XCToolchainPlist.swift)
 set_target_properties(SKCore PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-target_link_libraries(SKCore PRIVATE
+target_link_libraries(SKCore PUBLIC
   BuildServerProtocol
   LanguageServerProtocol
   LanguageServerProtocolJSONRPC

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(sourcekit-lsp
   SourceKitLSP.swift)
 target_link_libraries(sourcekit-lsp PRIVATE
+  Diagnose
   LanguageServerProtocol
   LanguageServerProtocolJSONRPC
   SKCore


### PR DESCRIPTION
Essentially, this is adding three pieces of functionality:
1. `sourcekit-lsp run-sourcekitd-request` takes a JSON sourcekitd request and a path to `sourcekitd.framework` and executes that request using that sourcekitd. This is basically equivalent to `sourcekitd-test -json-request-path` but it works even if the toolchain with `sourcekitd.framework` doesn’t have a `sourcekitd-test`.
2. `sourcekit-lsp diagnose --request-file` takes a path to a JSON sourcekitd request, gets the source file’s contents from disk and reduces the source file + compiler arguments to create a reduced reproducer. It then copies all files referenced from the compiler arguments to a temporary folder and asks the user to file an issue with that information. To reproduce non-crashes an `NSPredicate` can be passed via the `--predicate` parameter. Any sourcekitd response that satisfies the predicate is considered a reproducer.
3. `sourcekit-lsp diagnose` without arguments is similar to (2) but looks in OSLog for the last sourcekitd crash.

---

So far, this tool has been able to automatically reduce a crash I found while working on `sourcekit-lsp` to the following input file and reduced the compiler arguments to only include the input file itself.
```swift


public actor TranslatableName {

  init(
    definitionName: String,
    definitionDocumentUri: DocumentURI,
    definitionPosition: Position,
    definitionLanguageService: any ToolchainLanguageServer,
    isObjectiveCSelector: Bool
  ) {
    self.isObjectiveCSelector = isObjectiveCSelector
  }
}

```