### PR TITLE
Support cross-language rename between Swift and clang languages

### DIFF
--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -35,9 +35,9 @@ public final class SKDResponseArray {
 
   /// If the `applier` returns `false`, iteration terminates.
   @discardableResult
-  public func forEach(_ applier: (Int, SKDResponseDictionary) -> Bool) -> Bool {
+  public func forEach(_ applier: (Int, SKDResponseDictionary) throws -> Bool) rethrows -> Bool {
     for i in 0..<count {
-      if !applier(i, SKDResponseDictionary(sourcekitd.api.variant_array_get_value(array, i), response: resp)) {
+      if try !applier(i, SKDResponseDictionary(sourcekitd.api.variant_array_get_value(array, i), response: resp)) {
         return false
       }
     }
@@ -46,29 +46,29 @@ public final class SKDResponseArray {
 
   /// If the `applier` returns `false`, iteration terminates.
   @discardableResult
-  public func forEachUID(_ applier: (Int, sourcekitd_uid_t) -> Bool) -> Bool {
+  public func forEachUID(_ applier: (Int, sourcekitd_uid_t) throws -> Bool) rethrows -> Bool {
     for i in 0..<count {
-      if let uid = sourcekitd.api.variant_array_get_uid(array, i), !applier(i, uid) {
+      if let uid = sourcekitd.api.variant_array_get_uid(array, i), try !applier(i, uid) {
         return false
       }
     }
     return true
   }
 
-  public func map<T>(_ transform: (SKDResponseDictionary) -> T) -> [T] {
+  public func map<T>(_ transform: (SKDResponseDictionary) throws -> T) rethrows -> [T] {
     var result: [T] = []
     result.reserveCapacity(self.count)
-    self.forEach { _, element in
-      result.append(transform(element))
+    try self.forEach { _, element in
+      result.append(try transform(element))
       return true
     }
     return result
   }
 
-  public func compactMap<T>(_ transform: (SKDResponseDictionary) -> T?) -> [T] {
+  public func compactMap<T>(_ transform: (SKDResponseDictionary) throws -> T?) rethrows -> [T] {
     var result: [T] = []
-    self.forEach { _, element in
-      if let transformed = transform(element) {
+    try self.forEach { _, element in
+      if let transformed = try transform(element) {
         result.append(transformed)
       }
       return true

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -18,7 +18,9 @@ public struct sourcekitd_keys {
   public let annotated_decl: sourcekitd_uid_t
   public let annotations: sourcekitd_uid_t
   public let argindex: sourcekitd_uid_t
+  public let argNames: sourcekitd_uid_t
   public let associated_usrs: sourcekitd_uid_t
+  public let baseName: sourcekitd_uid_t
   public let bodylength: sourcekitd_uid_t
   public let bodyoffset: sourcekitd_uid_t
   public let cancelOnSubsequentRequest: sourcekitd_uid_t
@@ -50,12 +52,14 @@ public struct sourcekitd_keys {
   public let includeNonEditableBaseNames: sourcekitd_uid_t
   public let is_system: sourcekitd_uid_t
   public let isDynamic: sourcekitd_uid_t
+  public let isZeroArgSelector: sourcekitd_uid_t
   public let kind: sourcekitd_uid_t
   public let length: sourcekitd_uid_t
   public let line: sourcekitd_uid_t
   public let locations: sourcekitd_uid_t
   public let modulename: sourcekitd_uid_t
   public let name: sourcekitd_uid_t
+  public let namekind: sourcekitd_uid_t
   public let namelength: sourcekitd_uid_t
   public let nameoffset: sourcekitd_uid_t
   public let nameType: sourcekitd_uid_t
@@ -80,6 +84,7 @@ public struct sourcekitd_keys {
   public let results: sourcekitd_uid_t
   public let retrieve_refactor_actions: sourcekitd_uid_t
   public let secondarySymbols: sourcekitd_uid_t
+  public let selectorPieces: sourcekitd_uid_t
   public let semantic_tokens: sourcekitd_uid_t
   public let severity: sourcekitd_uid_t
   public let sourceEditKindActive: sourcekitd_uid_t
@@ -126,14 +131,16 @@ public struct sourcekitd_keys {
     annotated_decl = api.uid_get_from_cstr("key.annotated_decl")!
     annotations = api.uid_get_from_cstr("key.annotations")!
     argindex = api.uid_get_from_cstr("key.argindex")!
+    argNames = api.uid_get_from_cstr("key.argnames")!
     associated_usrs = api.uid_get_from_cstr("key.associated_usrs")!
+    baseName = api.uid_get_from_cstr("key.basename")!
     bodylength = api.uid_get_from_cstr("key.bodylength")!
     bodyoffset = api.uid_get_from_cstr("key.bodyoffset")!
     cancelOnSubsequentRequest = api.uid_get_from_cstr("key.cancel_on_subsequent_request")!
     categories = api.uid_get_from_cstr("key.categories")!
-    category = api.uid_get_from_cstr("key.category")!
     categorizededits = api.uid_get_from_cstr("key.categorizededits")!
     categorizedranges = api.uid_get_from_cstr("key.categorizedranges")!
+    category = api.uid_get_from_cstr("key.category")!
     column = api.uid_get_from_cstr("key.column")!
     compilerargs = api.uid_get_from_cstr("key.compilerargs")!
     context = api.uid_get_from_cstr("key.context")!
@@ -158,12 +165,14 @@ public struct sourcekitd_keys {
     includeNonEditableBaseNames = api.uid_get_from_cstr("key.include_non_editable_base_names")!
     is_system = api.uid_get_from_cstr("key.is_system")!
     isDynamic = api.uid_get_from_cstr("key.is_dynamic")!
+    isZeroArgSelector = api.uid_get_from_cstr("key.is_zero_arg_selector")!
     kind = api.uid_get_from_cstr("key.kind")!
     length = api.uid_get_from_cstr("key.length")!
     line = api.uid_get_from_cstr("key.line")!
     locations = api.uid_get_from_cstr("key.locations")!
     modulename = api.uid_get_from_cstr("key.modulename")!
     name = api.uid_get_from_cstr("key.name")!
+    namekind = api.uid_get_from_cstr("key.namekind")!
     namelength = api.uid_get_from_cstr("key.namelength")!
     nameoffset = api.uid_get_from_cstr("key.nameoffset")!
     nameType = api.uid_get_from_cstr("key.nametype")!
@@ -188,6 +197,7 @@ public struct sourcekitd_keys {
     results = api.uid_get_from_cstr("key.results")!
     retrieve_refactor_actions = api.uid_get_from_cstr("key.retrieve_refactor_actions")!
     secondarySymbols = api.uid_get_from_cstr("key.secondary_symbols")!
+    selectorPieces = api.uid_get_from_cstr("key.selectorpieces")!
     semantic_tokens = api.uid_get_from_cstr("key.semantic_tokens")!
     severity = api.uid_get_from_cstr("key.severity")!
     sourceEditKindActive = api.uid_get_from_cstr("source.edit.kind.active")!
@@ -231,44 +241,46 @@ public struct sourcekitd_keys {
 }
 
 public struct sourcekitd_requests {
-  public let crash_exit: sourcekitd_uid_t
-  public let editor_open: sourcekitd_uid_t
-  public let editor_open_interface: sourcekitd_uid_t
-  public let editor_close: sourcekitd_uid_t
-  public let editor_replacetext: sourcekitd_uid_t
-  public let codecomplete: sourcekitd_uid_t
+  public let codecomplete_close: sourcekitd_uid_t
   public let codecomplete_open: sourcekitd_uid_t
   public let codecomplete_update: sourcekitd_uid_t
-  public let codecomplete_close: sourcekitd_uid_t
+  public let codecomplete: sourcekitd_uid_t
+  public let crash_exit: sourcekitd_uid_t
   public let cursorinfo: sourcekitd_uid_t
   public let diagnostics: sourcekitd_uid_t
-  public let semantic_tokens: sourcekitd_uid_t
+  public let editor_close: sourcekitd_uid_t
+  public let editor_open_interface: sourcekitd_uid_t
+  public let editor_open: sourcekitd_uid_t
+  public let editor_replacetext: sourcekitd_uid_t
   public let expression_type: sourcekitd_uid_t
+  public let find_syntactic_rename_ranges: sourcekitd_uid_t
   public let find_usr: sourcekitd_uid_t
-  public let variable_type: sourcekitd_uid_t
+  public let nameTranslation: sourcekitd_uid_t
   public let relatedidents: sourcekitd_uid_t
   public let semantic_refactoring: sourcekitd_uid_t
-  public let find_syntactic_rename_ranges: sourcekitd_uid_t
+  public let semantic_tokens: sourcekitd_uid_t
+  public let variable_type: sourcekitd_uid_t
 
   public init(api: sourcekitd_functions_t) {
-    crash_exit = api.uid_get_from_cstr("source.request.crash_exit")!
-    editor_open = api.uid_get_from_cstr("source.request.editor.open")!
-    editor_open_interface = api.uid_get_from_cstr("source.request.editor.open.interface")!
-    editor_close = api.uid_get_from_cstr("source.request.editor.close")!
-    editor_replacetext = api.uid_get_from_cstr("source.request.editor.replacetext")!
     codecomplete = api.uid_get_from_cstr("source.request.codecomplete")!
+    codecomplete_close = api.uid_get_from_cstr("source.request.codecomplete.close")!
     codecomplete_open = api.uid_get_from_cstr("source.request.codecomplete.open")!
     codecomplete_update = api.uid_get_from_cstr("source.request.codecomplete.update")!
-    codecomplete_close = api.uid_get_from_cstr("source.request.codecomplete.close")!
+    crash_exit = api.uid_get_from_cstr("source.request.crash_exit")!
     cursorinfo = api.uid_get_from_cstr("source.request.cursorinfo")!
     diagnostics = api.uid_get_from_cstr("source.request.diagnostics")!
-    semantic_tokens = api.uid_get_from_cstr("source.request.semantic_tokens")!
+    editor_close = api.uid_get_from_cstr("source.request.editor.close")!
+    editor_open = api.uid_get_from_cstr("source.request.editor.open")!
+    editor_open_interface = api.uid_get_from_cstr("source.request.editor.open.interface")!
+    editor_replacetext = api.uid_get_from_cstr("source.request.editor.replacetext")!
     expression_type = api.uid_get_from_cstr("source.request.expression.type")!
+    find_syntactic_rename_ranges = api.uid_get_from_cstr("source.request.find-syntactic-rename-ranges")!
     find_usr = api.uid_get_from_cstr("source.request.editor.find_usr")!
-    variable_type = api.uid_get_from_cstr("source.request.variable.type")!
+    nameTranslation = api.uid_get_from_cstr("source.request.name.translation")!
     relatedidents = api.uid_get_from_cstr("source.request.relatedidents")!
     semantic_refactoring = api.uid_get_from_cstr("source.request.semantic.refactoring")!
-    find_syntactic_rename_ranges = api.uid_get_from_cstr("source.request.find-syntactic-rename-ranges")!
+    semantic_tokens = api.uid_get_from_cstr("source.request.semantic_tokens")!
+    variable_type = api.uid_get_from_cstr("source.request.variable.type")!
   }
 }
 
@@ -375,6 +387,8 @@ public struct sourcekitd_values {
   public let syntaxtype_identifier: sourcekitd_uid_t
   public let expr_object_literal: sourcekitd_uid_t
   public let expr_call: sourcekitd_uid_t
+  public let namekindSwift: sourcekitd_uid_t
+  public let namekindObjC: sourcekitd_uid_t
 
   public let kind_keyword: sourcekitd_uid_t
 
@@ -487,6 +501,8 @@ public struct sourcekitd_values {
     syntaxtype_identifier = api.uid_get_from_cstr("source.lang.swift.syntaxtype.identifier")!
     expr_object_literal = api.uid_get_from_cstr("source.lang.swift.expr.object_literal")!
     expr_call = api.uid_get_from_cstr("source.lang.swift.expr.call")!
+    namekindSwift = api.uid_get_from_cstr("source.lang.name.kind.swift")!
+    namekindObjC = api.uid_get_from_cstr("source.lang.name.kind.objc")!
 
     kind_keyword = api.uid_get_from_cstr("source.lang.swift.keyword")!
   }

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -28,6 +28,9 @@ import var TSCBasic.localFileSystem
 
 public typealias URL = Foundation.URL
 
+/// Disambiguate LanguageServerProtocol.Language and IndexstoreDB.Language
+public typealias Language = LanguageServerProtocol.Language
+
 /// Exhaustive enumeration of all toolchain language servers known to SourceKit-LSP.
 enum LanguageServerType: Hashable {
   case clangd

--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -54,7 +54,8 @@ struct RelatedIdentifiersResponse {
   /// The compound decl name at the requested location. This can be used as `name` parameter to a
   /// `find-syntactic-rename-ranges` request.
   ///
-  /// `nil` if `sourcekitd` is too old and doesn't return the `name` as part of the related identifiers request.
+  /// `nil` if `sourcekitd` is too old and doesn't return the `name` as part of the related identifiers request or
+  /// `relatedIdentifiers` is empty (eg. when performing a related identifiers request on `self`).
   let name: String?
 }
 

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -151,15 +151,15 @@ public protocol ToolchainLanguageServer: AnyObject {
   /// symbol to be renamed so that `SourceKitServer` can perform an index lookup to discover more locations to rename
   /// within the entire workspace. `SourceKitServer` will transform those into edits by calling
   /// `editsToRename(locations:in:oldName:newName:)` on the toolchain server to perform the actual rename.
-  func rename(_ request: RenameRequest) async throws -> (edits: WorkspaceEdit, usr: String?, oldName: String?)
+  func rename(_ request: RenameRequest) async throws -> (edits: WorkspaceEdit, usr: String?)
 
   /// Given a list of `locations``, return the list of edits that need to be performed to rename these occurrences from
   /// `oldName` to `newName`.
   func editsToRename(
     locations renameLocations: [RenameLocation],
     in snapshot: DocumentSnapshot,
-    oldName: String,
-    newName: String
+    oldName: TranslatableName,
+    newName: TranslatableName
   ) async throws -> [TextEdit]
 
   /// Return compound decl name that will be used as a placeholder for a rename request at a specific position.

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -158,8 +158,8 @@ public protocol ToolchainLanguageServer: AnyObject {
   func editsToRename(
     locations renameLocations: [RenameLocation],
     in snapshot: DocumentSnapshot,
-    oldName: TranslatableName,
-    newName: TranslatableName
+    oldName: CrossLanguageName,
+    newName: CrossLanguageName
   ) async throws -> [TextEdit]
 
   /// Return compound decl name that will be used as a placeholder for a rename request at a specific position.

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -17,6 +17,8 @@ import SKTestSupport
 import SourceKitLSP
 import XCTest
 
+import enum PackageLoading.Platform
+
 private func apply(edits: [TextEdit], to source: String) -> String {
   var lineTable = LineTable(source)
   let edits = edits.sorted(by: { $0.range.lowerBound < $1.range.lowerBound })
@@ -112,8 +114,9 @@ private func assertRenamedSourceMatches(
 /// to be placed in a state where there are in-memory changes that haven't been written to disk yet.
 private func assertMultiFileRename(
   files: [RelativeFileLocation: String],
-  language: Language? = nil,
+  headerFileLanguage: Language? = nil,
   newName: String,
+  expectedPrepareRenamePlaceholder: String,
   expected: [RelativeFileLocation: String],
   manifest: String = SwiftPMTestWorkspace.defaultPackageManifest,
   preRenameActions: (SwiftPMTestWorkspace) throws -> Void = { _ in },
@@ -133,11 +136,34 @@ private func assertMultiFileRename(
     if markers.isEmpty {
       continue
     }
-    let (uri, positions) = try ws.openDocument(fileLocation.fileName, language: language)
+    let (uri, positions) = try ws.openDocument(
+      fileLocation.fileName,
+      language: fileLocation.fileName.hasSuffix(".h") ? headerFileLanguage : nil
+    )
     defer {
       ws.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
     }
     for marker in markers {
+      let prepareRenameResponse: PrepareRenameResponse?
+      do {
+        prepareRenameResponse = try await ws.testClient.send(
+          PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions[marker])
+        )
+      } catch let error as ResponseError {
+        if error.message == "Running sourcekit-lsp with a version of sourcekitd that does not support rename" {
+          throw XCTSkip(error.message)
+        } else {
+          throw error
+        }
+      }
+      XCTAssertEqual(
+        prepareRenameResponse?.placeholder,
+        expectedPrepareRenamePlaceholder,
+        "Prepare rename placeholder does not match while performing rename at \(marker)",
+        file: file,
+        line: line
+      )
+
       let response: WorkspaceEdit?
       do {
         response = try await ws.testClient.send(
@@ -150,7 +176,7 @@ private func assertMultiFileRename(
           throw error
         }
       }
-      let changes = try XCTUnwrap(response?.changes)
+      let changes = try XCTUnwrap(response?.changes, "Did not receive any edits", file: file, line: line)
       try assertRenamedSourceMatches(
         originalFiles: files,
         changes: changes,
@@ -163,6 +189,20 @@ private func assertMultiFileRename(
     }
   }
 }
+
+private let libAlibBPackageManifest = """
+  // swift-tools-version: 5.7
+
+  import PackageDescription
+
+  let package = Package(
+    name: "MyLibrary",
+    targets: [
+     .target(name: "LibA"),
+     .target(name: "LibB", dependencies: ["LibA"]),
+    ]
+  )
+  """
 
 final class RenameTests: XCTestCase {
   func testRenameVariableBaseName() async throws {
@@ -546,9 +586,10 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameInsidePoundSelector() async throws {
-    #if !canImport(Darwin)
-    throw XCTSkip("#selector in test case doesn't compile without Objective-C runtime.")
-    #endif
+    try XCTSkipUnless(
+      Platform.current == .darwin,
+      "#selector in test case doesn't compile without Objective-C runtime."
+    )
     try await assertSingleFileRename(
       """
       import Foundation
@@ -581,6 +622,7 @@ final class RenameTests: XCTestCase {
         """,
       ],
       newName: "bar",
+      expectedPrepareRenamePlaceholder: "foo()",
       expected: [
         "a.swift": """
         func bar() {}
@@ -608,6 +650,7 @@ final class RenameTests: XCTestCase {
         """,
       ],
       newName: "bar(new:)",
+      expectedPrepareRenamePlaceholder: "foo(argLabel:)",
       expected: [
         "LibA/LibA.swift": """
         public func bar(new: Int) {}
@@ -619,19 +662,7 @@ final class RenameTests: XCTestCase {
         }
         """,
       ],
-      manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
-        let package = Package(
-          name: "MyLibrary",
-          targets: [
-           .target(name: "LibA"),
-           .target(name: "LibB", dependencies: ["LibA"]),
-          ]
-        )
-        """
+      manifest: libAlibBPackageManifest
     )
   }
 
@@ -648,6 +679,7 @@ final class RenameTests: XCTestCase {
         """,
       ],
       newName: "bar",
+      expectedPrepareRenamePlaceholder: "foo()",
       expected: [
         "a.swift": """
         func bar() {}
@@ -658,6 +690,21 @@ final class RenameTests: XCTestCase {
         }
         """,
       ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(
+              name: "MyLibrary", 
+              swiftSettings: [.unsafeFlags(["-Xfrontend", "-disable-objc-attr-requires-foundation-module"])]
+            )
+          ]
+        )
+        """,
       preRenameActions: { ws in
         let (bUri, bPositions) = try ws.openDocument("b.swift")
         ws.testClient.send(
@@ -683,6 +730,7 @@ final class RenameTests: XCTestCase {
         """,
       ],
       newName: "bar",
+      expectedPrepareRenamePlaceholder: "foo()",
       expected: [
         "a.swift": """
         func bar() {}
@@ -693,6 +741,21 @@ final class RenameTests: XCTestCase {
         }
         """,
       ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(
+              name: "MyLibrary", 
+              swiftSettings: [.unsafeFlags(["-Xfrontend", "-disable-objc-attr-requires-foundation-module"])]
+            )
+          ]
+        )
+        """,
       preRenameActions: { ws in
         let (bUri, bPositions) = try ws.openDocument("b.swift")
         ws.testClient.send(
@@ -776,8 +839,9 @@ final class RenameTests: XCTestCase {
         }
         """,
       ],
-      language: .c,
+      headerFileLanguage: .c,
       newName: "doRecursiveStuff",
+      expectedPrepareRenamePlaceholder: "doStuff",
       expected: [
         "Sources/MyLibrary/include/lib.h": """
         void doRecursiveStuff();
@@ -811,8 +875,9 @@ final class RenameTests: XCTestCase {
         @end
         """,
       ],
-      language: .objective_c,
+      headerFileLanguage: .objective_c,
       newName: "performNewAction:by:",
+      expectedPrepareRenamePlaceholder: "performAction:with:",
       expected: [
         "Sources/MyLibrary/include/lib.h": """
         @interface Foo
@@ -829,6 +894,718 @@ final class RenameTests: XCTestCase {
         @end
         """,
       ]
+    )
+  }
+}
+
+final class CrossLanguageRenameTests: XCTestCase {
+  func testZeroArgCFunction() async throws {
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        void 1️⃣cFunc();
+        """,
+        "LibA/LibA.c": """
+        #include "LibA.h"
+
+        void 2️⃣cFunc() {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          3️⃣cFunc()
+        }
+        """,
+      ],
+      headerFileLanguage: .c,
+      newName: "dFunc",
+      expectedPrepareRenamePlaceholder: "cFunc",
+      expected: [
+        "LibA/include/LibA.h": """
+        void dFunc();
+        """,
+        "LibA/LibA.c": """
+        #include "LibA.h"
+
+        void dFunc() {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          dFunc()
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testMultiArgCFunction() async throws {
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        void 1️⃣cFunc(int x, int y);
+        """,
+        "LibA/LibA.c": """
+        #include "LibA.h"
+
+        void 2️⃣cFunc(int x, int y) {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          3️⃣cFunc(1, 2)
+        }
+        """,
+      ],
+      newName: "dFunc",
+      expectedPrepareRenamePlaceholder: "cFunc",
+      expected: [
+        "LibA/include/LibA.h": """
+        void dFunc(int x, int y);
+        """,
+        "LibA/LibA.c": """
+        #include "LibA.h"
+
+        void dFunc(int x, int y) {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          dFunc(1, 2)
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testCFunctionWithSwiftNameAnnotation() async throws {
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        void 1️⃣cFunc(int x, int y) __attribute__((swift_name("cFunc(x:y:)")));
+        """,
+        "LibA/LibA.c": """
+        #include "LibA.h"
+
+        void 2️⃣cFunc(int x, int y) {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          3️⃣cFunc(x: 1, y: 2)
+        }
+        """,
+      ],
+      headerFileLanguage: .c,
+      newName: "dFunc",
+      expectedPrepareRenamePlaceholder: "cFunc",
+      expected: [
+        "LibA/include/LibA.h": """
+        void dFunc(int x, int y) __attribute__((swift_name("cFunc(x:y:)")));
+        """,
+        "LibA/LibA.c": """
+        #include "LibA.h"
+
+        void dFunc(int x, int y) {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          cFunc(x: 1, y: 2)
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testZeroArgObjCSelector() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)1️⃣performAction;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)performAction {
+          return [self 2️⃣performAction];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣performAction()
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "performNewAction",
+      expectedPrepareRenamePlaceholder: "performAction",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)performNewAction;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)performNewAction {
+          return [self performNewAction];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.performNewAction()
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testZeroArgObjCClassSelector() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        + (int)1️⃣performAction;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        + (int)performAction {
+          return [Foo 2️⃣performAction];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          Foo.3️⃣performAction()
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "performNewAction",
+      expectedPrepareRenamePlaceholder: "performAction",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        + (int)performNewAction;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        + (int)performNewAction {
+          return [Foo performNewAction];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          Foo.performNewAction()
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testOneArgObjCSelector() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)1️⃣performAction:(int)action;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)2️⃣performAction:(int)action {
+          return [self performAction:action];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣performAction(1)
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "performNewAction:",
+      expectedPrepareRenamePlaceholder: "performAction:",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)performNewAction:(int)action;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)performNewAction:(int)action {
+          return [self performNewAction:action];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.performNewAction(1)
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testMultiArgObjCSelector() async throws {
+    try XCTSkipUnless(
+      Platform.current == .darwin,
+      "Objective-C imported to Swift fails to build on Linux rdar://121689798"
+    )
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)1️⃣performAction:(int)action with:(int)value;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)2️⃣performAction:(int)action with:(int)value {
+          return [self performAction:action with:value];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣performAction(1, with: 2)
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "performNewAction:by:",
+      expectedPrepareRenamePlaceholder: "performAction:with:",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)performNewAction:(int)action by:(int)value;
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)performNewAction:(int)action by:(int)value {
+          return [self performNewAction:action by:value];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.performNewAction(1, by: 2)
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testObjCSelectorWithSwiftNameAnnotation() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)1️⃣performAction:(int)action withValue:(int)value __attribute__((swift_name("perform(action:with:)")));
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)2️⃣performAction:(int)action withValue:(int)value {
+          return [self performAction:action withValue:value];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣perform(action: 1, with: 2)
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "performNewAction:by:",
+      expectedPrepareRenamePlaceholder: "performAction:withValue:",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        - (int)performNewAction:(int)action by:(int)value __attribute__((swift_name("perform(action:with:)")));
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Foo
+        - (int)performNewAction:(int)action by:(int)value {
+          return [self performNewAction:action by:value];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.perform(action: 1, with: 2)
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testObjCClass() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface 1️⃣Foo
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation 2️⃣Foo
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: 3️⃣Foo) {
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "Bar",
+      expectedPrepareRenamePlaceholder: "Foo",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Bar
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation Bar
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Bar) {
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testObjCClassWithSwiftNameAnnotation() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        __attribute__((swift_name("Foo")))
+        @interface 1️⃣AHFoo
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation 2️⃣AHFoo
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: 3️⃣Foo) {
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_c,
+      newName: "AHBar",
+      expectedPrepareRenamePlaceholder: "AHFoo",
+      expected: [
+        "LibA/include/LibA.h": """
+        __attribute__((swift_name("Foo")))
+        @interface AHBar
+        @end
+        """,
+        "LibA/LibA.m": """
+        #include "LibA.h"
+
+        @implementation AHBar
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testCppMethod() async throws {
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          void 1️⃣doStuff() const;
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        void Foo::2️⃣doStuff() const {};
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣doStuff()
+        }
+        """,
+      ],
+      headerFileLanguage: .cpp,
+      newName: "doCoolStuff",
+      expectedPrepareRenamePlaceholder: "doStuff",
+      expected: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          void doCoolStuff() const;
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        void Foo::doCoolStuff() const {};
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.doCoolStuff()
+        }
+        """,
+      ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+           .target(name: "LibA"),
+           .target(name: "LibB", dependencies: ["LibA"], swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default"])]),
+          ]
+        )
+        """
+    )
+  }
+
+  func testCppMethodWithSwiftName() async throws {
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          void 1️⃣doStuff(int x) const __attribute__((swift_name("do(stuff:)")));
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        void Foo::2️⃣doStuff(int x) const {};
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣do(stuff: 1)
+        }
+        """,
+      ],
+      headerFileLanguage: .cpp,
+      newName: "doCoolStuff",
+      expectedPrepareRenamePlaceholder: "doStuff",
+      expected: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          void doCoolStuff(int x) const __attribute__((swift_name("do(stuff:)")));
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        void Foo::doCoolStuff(int x) const {};
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.do(stuff: 1)
+        }
+        """,
+      ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+           .target(name: "LibA"),
+           .target(name: "LibB", dependencies: ["LibA"], swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default"])]),
+          ]
+        )
+        """
+    )
+  }
+
+  func testCppMethodInObjCpp() async throws {
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          void 1️⃣doStuff() const;
+        };
+        """,
+        "LibA/LibA.mm": """
+        #include "LibA.h"
+
+        void Foo::2️⃣doStuff() const {};
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.3️⃣doStuff()
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_cpp,
+      newName: "doCoolStuff",
+      expectedPrepareRenamePlaceholder: "doStuff",
+      expected: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          void doCoolStuff() const;
+        };
+        """,
+        "LibA/LibA.mm": """
+        #include "LibA.h"
+
+        void Foo::doCoolStuff() const {};
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test(foo: Foo) {
+          foo.doCoolStuff()
+        }
+        """,
+      ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+           .target(name: "LibA"),
+           .target(name: "LibB", dependencies: ["LibA"], swiftSettings: [.unsafeFlags(["-cxx-interoperability-mode=default"])]),
+          ]
+        )
+        """
+    )
+  }
+
+  func testZeroArgObjCClassSelectorInObjCpp() async throws {
+    try XCTSkipUnless(Platform.current == .darwin, "Linux and Windows use in-process sourcekitd")
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        + (int)1️⃣performAction;
+        @end
+        """,
+        "LibA/LibA.mm": """
+        #include "LibA.h"
+
+        @implementation Foo
+        + (int)performAction {
+          return [Foo 2️⃣performAction];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          Foo.3️⃣performAction()
+        }
+        """,
+      ],
+      headerFileLanguage: .objective_cpp,
+      newName: "performNewAction",
+      expectedPrepareRenamePlaceholder: "performAction",
+      expected: [
+        "LibA/include/LibA.h": """
+        @interface Foo
+        + (int)performNewAction;
+        @end
+        """,
+        "LibA/LibA.mm": """
+        #include "LibA.h"
+
+        @implementation Foo
+        + (int)performNewAction {
+          return [Foo performNewAction];
+        }
+        @end
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func test() {
+          Foo.performNewAction()
+        }
+        """,
+      ],
+      manifest: libAlibBPackageManifest
     )
   }
 }


### PR DESCRIPTION
This adds support for name translation between Swift anc clang languages to allow renaming across those language boundaries.

Rename is always initiated at the symbol’s definition, so when renaming an Objective-C symbol from Swift, the user is prompeted to enter the new Objective-C method name.

rdar://118996461