### PR TITLE
Support rename of a function’s name started from a parameter or argument label

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -127,7 +127,7 @@ public enum SkipUnless {
     ) {
       let testClient = try await TestSourceKitLSPClient()
       let uri = DocumentURI.for(.swift)
-      let positions = testClient.openDocument("void 1️⃣test() {}", uri: uri)
+      let positions = testClient.openDocument("func 1️⃣test() {}", uri: uri)
       do {
         _ = try await testClient.send(
           RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"], newName: "test2")

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -1037,6 +1037,9 @@ extension sourcekitd_uid_t {
       return .namespace
     case vals.refModule:
       return .module
+    case vals.refConstructor,
+      vals.declConstructor:
+      return .constructor
     default:
       return nil
     }

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -163,7 +163,9 @@ public protocol ToolchainLanguageServer: AnyObject {
   ) async throws -> [TextEdit]
 
   /// Return compound decl name that will be used as a placeholder for a rename request at a specific position.
-  func prepareRename(_ request: PrepareRenameRequest) async throws -> PrepareRenameResponse?
+  func prepareRename(
+    _ request: PrepareRenameRequest
+  ) async throws -> (prepareRename: PrepareRenameResponse, usr: String?)?
 
   func indexedRename(_ request: IndexedRenameRequest) async throws -> WorkspaceEdit?
 


### PR DESCRIPTION
When starting rename from a function parameter’s label, we should be performing a rename of the function signature. To do that, we need to do some adjustments of th rename positions in order to get the position of the function’s base name and use that for the rename requests sent to sourcekitd.

rdar://119875277