### PR TITLE
Pass `availableLibraries` when loading the package graph.

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -213,6 +213,7 @@ extension SwiftPMWorkspace {
     let packageGraph = try self.workspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [AbsolutePath(packageRoot)]),
       forceResolvedVersions: true,
+      availableLibraries: self.buildParameters.toolchain.providedLibraries,
       observabilityScope: observabilitySystem.topScope
     )
 


### PR DESCRIPTION
To match https://github.com/apple/swift-package-manager/pull/7337