### PR TITLE
Add missing dependencies of `SKSwiftPMWorkspaceTests`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -225,8 +225,13 @@ let package = Package(
     .testTarget(
       name: "SKSwiftPMWorkspaceTests",
       dependencies: [
+        "LSPTestSupport",
+        "LanguageServerProtocol",
+        "SKCore",
         "SKSwiftPMWorkspace",
         "SKTestSupport",
+        "SourceKitLSP",
+        .product(name: "SwiftPM-auto", package: "swift-package-manager"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ]
     ),


### PR DESCRIPTION
Looks like these dependency declarations were simply missing.