### PR TITLE
Increase test timeout

### DIFF
--- a/Sources/LSPTestSupport/Timeouts.swift
+++ b/Sources/LSPTestSupport/Timeouts.swift
@@ -14,4 +14,4 @@ import Foundation
 
 /// The default duration how long tests should wait for responses from
 /// SourceKit-LSP / sourcekitd / clangd.
-public let defaultTimeout: TimeInterval = 120
+public let defaultTimeout: TimeInterval = 180


### PR DESCRIPTION
In some CI environments, some tests exceed the 2 min timeout.