### PR TITLE
Skip `testSwiftInterfaceAcrossModules` if the host SwiftPM doesn’t store the built modules in a subdirectory

### DIFF
--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -184,6 +184,7 @@ final class SwiftInterfaceTests: XCTestCase {
   }
 
   func testSwiftInterfaceAcrossModules() async throws {
+    try await SkipUnless.swiftpmStoresModulesInSubdirectory()
     let ws = try await SwiftPMTestWorkspace(
       files: [
         "MyLibrary/MyLibrary.swift": """


### PR DESCRIPTION
I missed this in https://github.com/apple/sourcekit-lsp/pull/1046.