### PR TITLE
Fix jumbled formatting results

### DIFF
--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -116,7 +116,7 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
     // Adjust the index offset based on changes that `Collection.difference` expects to already have been applied.
     var adjustment: Int = 0
     for edit in edits {
-      if edit.range.upperBound < change.offset {
+      if edit.range.upperBound < change.offset + adjustment {
         adjustment = adjustment + edit.range.count - edit.replacement.count
       }
     }

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -215,4 +215,36 @@ final class FormattingTests: XCTestCase {
       )
     )
   }
+
+  func testInsertAndRemove() async throws {
+    try await SkipUnless.toolchainContainsSwiftFormat()
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      1️⃣public 2️⃣extension Example {
+        3️⃣func function() {}
+      }
+
+      """,
+      uri: uri
+    )
+
+    let response = try await testClient.send(
+      DocumentFormattingRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        options: FormattingOptions(tabSize: 2, insertSpaces: true)
+      )
+    )
+
+    let edits = try XCTUnwrap(response)
+    XCTAssertEqual(
+      edits,
+      [
+        TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: ""),
+        TextEdit(range: Range(positions["3️⃣"]), newText: "public "),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Fixing an error that computes the edits to perform to get from unformatted to the formatted source.

Fixes #1059
rdar://123108170