### PR TITLE
Cancel the sourcekitd request to retrieve diagnostics if noone depends on it anymore

### DIFF
--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -99,9 +99,15 @@ final class LifecycleTests: XCTestCase {
       )
     )
 
+    let cursorInfoStartDate = Date()
     // Check that semantic functionality based on the AST is working again.
     let symbolInfo = try await testClient.send(
       SymbolInfoRequest(textDocument: TextDocumentIdentifier(uri), position: positions["3️⃣"])
+    )
+    XCTAssertLessThan(
+      Date().timeIntervalSince(cursorInfoStartDate),
+      2,
+      "Cursor info request wasn't fast. sourcekitd still blocked?"
     )
     XCTAssertGreaterThan(symbolInfo.count, 0)
   }


### PR DESCRIPTION
After a document has been modified, the corresponding publish diagnsotics request gets cancelled. But that cancellation didn’t propagate through `DiagnosticReportManager`.

rdar://121323969