### PR TITLE
Fix issue that caused the `Reloading Package` progress indicator to be stuck

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -205,6 +205,11 @@ extension SwiftPMWorkspace {
   /// dependencies.
   func reloadPackage() async throws {
     await reloadPackageStatusCallback(.start)
+    defer {
+      Task {
+        await reloadPackageStatusCallback(.end)
+      }
+    }
 
     let observabilitySystem = ObservabilitySystem({ scope, diagnostic in
       logger.log(level: diagnostic.severity.asLogLevel, "SwiftPM log: \(diagnostic.description)")
@@ -260,12 +265,10 @@ extension SwiftPMWorkspace {
     )
 
     guard let delegate = self.delegate else {
-      await reloadPackageStatusCallback(.end)
       return
     }
     await delegate.fileBuildSettingsChanged(self.watchedFiles)
     await delegate.fileHandlingCapabilityChanged()
-    await reloadPackageStatusCallback(.end)
   }
 }
 

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -395,7 +395,7 @@ public actor SourceKitServer {
 
   private var packageLoadingWorkDoneProgress = WorkDoneProgressState(
     "SourceKitLSP.SourceKitServer.reloadPackage",
-    title: "Reloading Package"
+    title: "SourceKit-LSP: Reloading Package"
   )
 
   /// **Public for testing**


### PR DESCRIPTION
If any method in `reloadPacakge` threw, the `Reloading Package` progress indicator was stuck.

Also, change the message of the indicator to `SourceKit-LSP: Reloading Package` to make it easier to differentiate from status generated by the VS Code extension.

Fixes #1050
rdar://122899093