### PR TITLE
Expand trailing closures of code completion items

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -296,6 +296,7 @@ let package = Package(
         .product(name: "SwiftIDEUtils", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftRefactor", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(SourceKitLSP PUBLIC
   SwiftSyntax::SwiftIDEUtils
   SwiftSyntax::SwiftParser
   SwiftSyntax::SwiftParserDiagnostics
+  SwiftSyntax::SwiftRefactor
   SwiftSyntax::SwiftSyntax)
 target_link_libraries(SourceKitLSP PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -46,6 +46,7 @@ extension SwiftLanguageServer {
     return try await CodeCompletionSession.completionList(
       sourcekitd: sourcekitd,
       snapshot: snapshot,
+      syntaxTreeParseResult: syntaxTreeManager.incrementalParseResult(for: snapshot),
       completionPosition: completionPos,
       completionUtf8Offset: offset,
       cursorPosition: req.position,

--- a/Sources/SourceKitLSP/Swift/SyntaxTreeManager.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxTreeManager.swift
@@ -71,14 +71,19 @@ actor SyntaxTreeManager {
 
   /// Get the SwiftSyntax tree for the given document snapshot.
   func syntaxTree(for snapshot: DocumentSnapshot) async -> SourceFileSyntax {
+    return await incrementalParseResult(for: snapshot).tree
+  }
+
+  /// Get the `IncrementalParseResult` for the given document snapshot.
+  func incrementalParseResult(for snapshot: DocumentSnapshot) async -> IncrementalParseResult {
     if let syntaxTreeComputation = computation(for: snapshot.id) {
-      return await syntaxTreeComputation.value.tree
+      return await syntaxTreeComputation.value
     }
     let task = Task {
       return Parser.parseIncrementally(source: snapshot.text, parseTransition: nil)
     }
     setComputation(for: snapshot.id, computation: task)
-    return await task.value.tree
+    return await task.value
   }
 
   /// Register that we have made an edit to an old document snapshot.


### PR DESCRIPTION
Editors other than Xcode don’t have a notion of editor placeholders or their expansion, so we can’t produce results with editor placeholders and expect the user to expand them while completing the function arguments.

Instead, expand all trailing closure placeholders when producing the code completion results.

The generated expansion is currently not formatted with respect to the file’s indentaiton. Since we don’t want to launch `swift-format` for every completion item, this formatting will need to be done using `BasicFormat` which needs to infer the file’s indentation. Doing so will be non-trivial work on its own and will be done in a follow-up PR (rdar://123287930).

rdar://121130170