### PR TITLE
De-dupe locations returned from the defintions request

### DIFF
--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -362,4 +362,32 @@ class DefinitionTests: XCTestCase {
       )
     )
   }
+
+  func testDefinitionOfImplicitInitializer() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      class 1️⃣Foo {}
+
+      func test() {
+        2️⃣Foo()
+      }
+      """,
+      uri: uri
+    )
+
+    let response = try await testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    guard case .locations(let locations) = response else {
+      XCTFail("Expected locations response")
+      return
+    }
+    XCTAssertEqual(
+      locations,
+      [Location(uri: uri, range: Range(positions["1️⃣"]))]
+    )
+  }
 }


### PR DESCRIPTION
We might end up with duplicate locations when performing a definition request on eg. `MyStruct()` when no explicit initializer is declared. In this case we get two symbol infos, one for the declaration of the `MyStruct` type and one for the initializer, which is implicit and thus has the location of  the `MyStruct` declaration itself.

rdar://123036565
Fixes #1055