### PR TITLE
Only check if a document has been modified while loading diagnostics during publishDiagnostics

### DIFF
--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -110,12 +110,6 @@ actor DiagnosticReportManager {
     let dict = try await self.sourcekitd.send(skreq, fileContents: snapshot.text)
 
     try Task.checkCancellation()
-    guard (try? documentManager.latestSnapshot(snapshot.uri).id) == snapshot.id else {
-      // Check that the document wasn't modified while we were getting diagnostics. This could happen because we are
-      // calling `fullDocumentDiagnosticReport` from `publishDiagnosticsIfNeeded` outside of `messageHandlingQueue`
-      // and thus a concurrent edit is possible while we are waiting for the sourcekitd request to return a result.
-      throw ResponseError.unknown("Document was modified while loading diagnostics")
-    }
 
     let diagnostics: [Diagnostic] =
       dict[keys.diagnostics]?.compactMap({ diag in


### PR DESCRIPTION
I was seeing some of these errors in VS Code, which uses the pull diagnostics request even though I couldn’t see any concurrent modifications to the document. Move the check up to `publishDiagnostics`, where it belongs, and log the version of the old and new document version so we can investiage what’s causing the issue.