### PR TITLE
Show message in the client if no compiler arguments could be found for a file

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -201,17 +201,28 @@ public final class TestSourceKitLSPClient: MessageHandler {
   public func nextDiagnosticsNotification(
     timeout: TimeInterval = defaultTimeout
   ) async throws -> PublishDiagnosticsNotification {
-    struct CastError: Error, CustomStringConvertible {
-      let actualType: any NotificationType.Type
+    return try await nextNotification(ofType: PublishDiagnosticsNotification.self, timeout: timeout)
+  }
 
-      var description: String { "Expected a publish diagnostics notification but got '\(actualType)'" }
-    }
+  private struct CastError: Error, CustomStringConvertible {
+    let expectedType: any NotificationType.Type
+    let actualType: any NotificationType.Type
 
+    var description: String { "Expected a \(expectedType) but got '\(actualType)'" }
+  }
+
+  /// Await the next diagnostic notification sent to the client.
+  ///
+  /// If the next notification is not of the expected type, this methods throws.
+  public func nextNotification<ExpectedNotificationType: NotificationType>(
+    ofType: ExpectedNotificationType.Type,
+    timeout: TimeInterval = defaultTimeout
+  ) async throws -> ExpectedNotificationType {
     let nextNotification = try await nextNotification(timeout: timeout)
-    guard let diagnostics = nextNotification as? PublishDiagnosticsNotification else {
-      throw CastError(actualType: type(of: nextNotification))
+    guard let notification = nextNotification as? ExpectedNotificationType else {
+      throw CastError(expectedType: ExpectedNotificationType.self, actualType: type(of: nextNotification))
     }
-    return diagnostics
+    return notification
   }
 
   /// Handle the next request that is sent to the client with the given handler.

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -249,6 +249,7 @@ final class BuildSystemTests: XCTestCase {
     let documentManager = await self.testClient.server._documentManager
 
     testClient.openDocument(text, uri: doc)
+    _ = try await testClient.nextNotification(ofType: ShowMessageNotification.self)
     let openDiags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openDiags.diagnostics.count, 1)
     XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)


### PR DESCRIPTION
This should help users debug issues when functionality is not working because compiler arguments are missing.

Note that when opening a standalone Swift file, we consider that file as having non-fallback build settings, even though the build settings are synthesized from the fallback build system. Thus, this will only pop up when the user is in a context that has some build system (like a compilation database or a Swift package) but the current file isn’t handled by that.

rdar://119741960