### PR TITLE
Add more information to the diagnostic bundle

### DIFF
--- a/Sources/Diagnose/OSLogScraper.swift
+++ b/Sources/Diagnose/OSLogScraper.swift
@@ -81,8 +81,8 @@ struct OSLogScraper {
   ///
   /// Name is a human readable name that identifies the crash.
   func getCrashedRequests() throws -> [(name: String, info: RequestInfo)] {
-    let crashedReqeusts = try crashedSourceKitLSPRequests().reversed()
-    return try crashedReqeusts.map { ($0.name, try requestInfo(for: $0.logCategory)) }
+    let crashedRequests = try crashedSourceKitLSPRequests().reversed()
+    return try crashedRequests.map { ($0.name, try requestInfo(for: $0.logCategory)) }
   }
 }
 #endif

--- a/Sources/Diagnose/ReproducerBundle.swift
+++ b/Sources/Diagnose/ReproducerBundle.swift
@@ -13,12 +13,7 @@
 import Foundation
 
 /// Create a folder that contains all files that should be necessary to reproduce a sourcekitd crash.
-func makeReproducerBundle(for requestInfo: RequestInfo) throws -> URL {
-  let date = ISO8601DateFormatter().string(from: Date()).replacingOccurrences(of: ":", with: "-")
-  let bundlePath = FileManager.default.temporaryDirectory
-    .appendingPathComponent("sourcekitd-reproducer-\(date)")
-  try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
-
+func makeReproducerBundle(for requestInfo: RequestInfo, bundlePath: URL) throws {
   try requestInfo.fileContents.write(
     to: bundlePath.appendingPathComponent("input.swift"),
     atomically: true,
@@ -41,5 +36,4 @@ func makeReproducerBundle(for requestInfo: RequestInfo) throws -> URL {
       try? FileManager.default.copyItem(at: URL(fileURLWithPath: compilerArg), to: dest)
     }
   }
-  return bundlePath
 }


### PR DESCRIPTION
Add the following information to the diagnose bundle:
- OSLog output of sourcekit-lsp
- Any sourcekit-lsp or SourceKitService crash logs
- The versions of the swift toolchains installed on the system

rdar://123479769