### PR TITLE
Simplify `CapabilityRegistry`

### DIFF
--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -12,14 +12,17 @@
 
 import LSPLogging
 import LanguageServerProtocol
-
-/// Handler responsible for registering a capability with the client.
-public typealias ClientRegistrationHandler = (CapabilityRegistration) -> Void
+import SKSupport
 
 /// A class which tracks the client's capabilities as well as our dynamic
 /// capability registrations in order to avoid registering conflicting
 /// capabilities.
-public final class CapabilityRegistry {
+public final actor CapabilityRegistry {
+  /// The client's capabilities as they were reported when sourcekit-lsp was launched.
+  public let clientCapabilities: ClientCapabilities
+
+  // MARK: Tracking capabilities dynamically registered in the client
+
   /// Dynamically registered completion options.
   private var completion: [CapabilityRegistration: CompletionRegistrationOptions] = [:]
 
@@ -41,11 +44,7 @@ public final class CapabilityRegistry {
   /// Dynamically registered command IDs.
   private var commandIds: Set<String> = []
 
-  public let clientCapabilities: ClientCapabilities
-
-  public init(clientCapabilities: ClientCapabilities) {
-    self.clientCapabilities = clientCapabilities
-  }
+  // MARK: Query if client has dynamic registration
 
   public var clientHasDynamicCompletionRegistration: Bool {
     clientCapabilities.textDocument?.completion?.dynamicRegistration == true
@@ -75,266 +74,29 @@ public final class CapabilityRegistry {
     clientCapabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration == true
   }
 
+  // MARK: Other capability queries
+
   public var clientHasDiagnosticsCodeDescriptionSupport: Bool {
     clientCapabilities.textDocument?.publishDiagnostics?.codeDescriptionSupport == true
   }
 
-  /// Dynamically register completion capabilities if the client supports it and
-  /// we haven't yet registered any completion capabilities for the given
-  /// languages.
-  public func registerCompletionIfNeeded(
-    options: CompletionOptions,
-    for languages: [Language],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicCompletionRegistration else { return }
-    if let registration = registration(for: languages, in: completion) {
-      if options != registration.completionOptions {
-        logger.error(
-          """
-            Unable to register new completion options \(String(reflecting: options), privacy: .public) \
-            for \(languages, privacy: .public) \
-            due to pre-existing options \(String(reflecting: registration.completionOptions), privacy: .public)
-          """
-        )
-      }
-      return
-    }
-    let registrationOptions = CompletionRegistrationOptions(
-      documentSelector: self.documentSelector(for: languages),
-      completionOptions: options
-    )
-    let registration = CapabilityRegistration(
-      method: CompletionRequest.method,
-      registerOptions: self.encode(registrationOptions)
-    )
-
-    self.completion[registration] = registrationOptions
-
-    registerOnClient(registration)
+  /// Since LSP 3.17.0, diagnostics can be reported through pull-based requests in addition to the existing push-based
+  /// publish notifications.
+  ///
+  /// The `DiagnosticOptions` were added at the same time as the pull diagnostics request and allow specification of
+  /// options for the pull diagnostics request. If the client doesn't reject this dynamic capability registration,
+  /// it supports the pull diagnostics request.
+  public func clientSupportsPullDiagnostics(for language: Language) -> Bool {
+    registration(for: [language], in: pullDiagnostics) != nil
   }
 
-  public func registerDidChangeWatchedFiles(
-    watchers: [FileSystemWatcher],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicDidChangeWatchedFilesRegistration else { return }
-    if let registration = didChangeWatchedFiles {
-      if watchers != registration.watchers {
-        logger.error(
-          "Unable to register new file system watchers \(watchers) due to pre-existing options \(registration.watchers)"
-        )
-      }
-      return
-    }
-    let registrationOptions = DidChangeWatchedFilesRegistrationOptions(
-      watchers: watchers
-    )
-    let registration = CapabilityRegistration(
-      method: DidChangeWatchedFilesNotification.method,
-      registerOptions: self.encode(registrationOptions)
-    )
+  // MARK: Initializer
 
-    self.didChangeWatchedFiles = registrationOptions
-
-    registerOnClient(registration)
+  public init(clientCapabilities: ClientCapabilities) {
+    self.clientCapabilities = clientCapabilities
   }
 
-  /// Dynamically register folding range capabilities if the client supports it and
-  /// we haven't yet registered any folding range capabilities for the given
-  /// languages.
-  public func registerFoldingRangeIfNeeded(
-    options: FoldingRangeOptions,
-    for languages: [Language],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicFoldingRangeRegistration else { return }
-    if let registration = registration(for: languages, in: foldingRange) {
-      if options != registration.foldingRangeOptions {
-        logger.error(
-          """
-            Unable to register new folding range options \(String(reflecting: options), privacy: .public) \
-            for "\(languages, privacy: .public) \
-            due to pre-existing options \(String(reflecting: registration.foldingRangeOptions), privacy: .public)
-          """
-        )
-      }
-      return
-    }
-    let registrationOptions = FoldingRangeRegistrationOptions(
-      documentSelector: self.documentSelector(for: languages),
-      foldingRangeOptions: options
-    )
-    let registration = CapabilityRegistration(
-      method: FoldingRangeRequest.method,
-      registerOptions: self.encode(registrationOptions)
-    )
-
-    self.foldingRange[registration] = registrationOptions
-
-    registerOnClient(registration)
-  }
-
-  /// Dynamically register semantic tokens capabilities if the client supports
-  /// it and we haven't yet registered any semantic tokens capabilities for the
-  /// given languages.
-  public func registerSemanticTokensIfNeeded(
-    options: SemanticTokensOptions,
-    for languages: [Language],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicSemanticTokensRegistration else { return }
-    if let registration = registration(for: languages, in: semanticTokens) {
-      if options != registration.semanticTokenOptions {
-        logger.error(
-          """
-          Unable to register new semantic tokens options \(String(reflecting: options), privacy: .public) \
-          for \(languages, privacy: .public) \
-          due to pre-existing options \(String(reflecting: registration.semanticTokenOptions), privacy: .public)
-          """
-        )
-      }
-      return
-    }
-    let registrationOptions = SemanticTokensRegistrationOptions(
-      documentSelector: self.documentSelector(for: languages),
-      semanticTokenOptions: options
-    )
-    let registration = CapabilityRegistration(
-      method: SemanticTokensRegistrationOptions.method,
-      registerOptions: self.encode(registrationOptions)
-    )
-
-    self.semanticTokens[registration] = registrationOptions
-
-    registerOnClient(registration)
-  }
-
-  /// Dynamically register inlay hint capabilities if the client supports
-  /// it and we haven't yet registered any inlay hint capabilities for the
-  /// given languages.
-  public func registerInlayHintIfNeeded(
-    options: InlayHintOptions,
-    for languages: [Language],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicInlayHintRegistration else { return }
-    if let registration = registration(for: languages, in: inlayHint) {
-      if options != registration.inlayHintOptions {
-        logger.error(
-          """
-          Unable to register new inlay hint options \(String(reflecting: options), privacy: .public) \
-          for \(languages, privacy: .public) \
-          due to pre-existing options \(String(reflecting: registration.inlayHintOptions), privacy: .public)
-          """
-        )
-      }
-      return
-    }
-    let registrationOptions = InlayHintRegistrationOptions(
-      documentSelector: self.documentSelector(for: languages),
-      inlayHintOptions: options
-    )
-    let registration = CapabilityRegistration(
-      method: InlayHintRequest.method,
-      registerOptions: self.encode(registrationOptions)
-    )
-
-    self.inlayHint[registration] = registrationOptions
-
-    registerOnClient(registration)
-  }
-
-  /// Dynamically register (pull model) diagnostic capabilities,
-  /// if the client supports it.
-  public func registerDiagnosticIfNeeded(
-    options: DiagnosticOptions,
-    for languages: [Language],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicDocumentDiagnosticsRegistration else { return }
-    if let registration = registration(for: languages, in: pullDiagnostics) {
-      if options != registration.diagnosticOptions {
-        logger.error(
-          """
-          Unable to register new pull diagnostics options \(String(reflecting: options), privacy: .public) \
-          for \(languages, privacy: .public) \
-          due to pre-existing options \(String(reflecting: registration.diagnosticOptions), privacy: .public)
-          """
-        )
-      }
-      return
-    }
-    let registrationOptions = DiagnosticRegistrationOptions(
-      documentSelector: self.documentSelector(for: languages),
-      diagnosticOptions: options
-    )
-    let registration = CapabilityRegistration(
-      method: DocumentDiagnosticsRequest.method,
-      registerOptions: self.encode(registrationOptions)
-    )
-
-    self.pullDiagnostics[registration] = registrationOptions
-
-    registerOnClient(registration)
-  }
-
-  /// Dynamically register executeCommand with the given IDs if the client supports
-  /// it and we haven't yet registered the given command IDs yet.
-  public func registerExecuteCommandIfNeeded(
-    commands: [String],
-    registerOnClient: ClientRegistrationHandler
-  ) {
-    guard clientHasDynamicExecuteCommandRegistration else { return }
-    var newCommands = Set(commands)
-    newCommands.subtract(self.commandIds)
-
-    // We only want to send the registration with unregistered command IDs since
-    // clients such as VS Code only allow a command to be registered once. We could
-    // unregister all our commandIds first but this is simpler.
-    guard !newCommands.isEmpty else { return }
-    self.commandIds.formUnion(newCommands)
-
-    let registrationOptions = ExecuteCommandRegistrationOptions(commands: Array(newCommands))
-    let registration = CapabilityRegistration(
-      method: ExecuteCommandRequest.method,
-      registerOptions: self.encode(registrationOptions)
-    )
-
-    registerOnClient(registration)
-  }
-
-  /// Unregister a previously registered registration, e.g. if no longer needed
-  /// or if registration fails.
-  public func remove(registration: CapabilityRegistration) {
-    if registration.method == CompletionRequest.method {
-      completion.removeValue(forKey: registration)
-    }
-    if registration.method == FoldingRangeRequest.method {
-      foldingRange.removeValue(forKey: registration)
-    }
-    if registration.method == SemanticTokensRegistrationOptions.method {
-      semanticTokens.removeValue(forKey: registration)
-    }
-    if registration.method == InlayHintRequest.method {
-      inlayHint.removeValue(forKey: registration)
-    }
-    if registration.method == DocumentDiagnosticsRequest.method {
-      pullDiagnostics.removeValue(forKey: registration)
-    }
-  }
-
-  public func pullDiagnosticsRegistration(for language: Language) -> DiagnosticRegistrationOptions? {
-    registration(for: [language], in: pullDiagnostics)
-  }
-
-  private func documentSelector(for languages: [Language]) -> DocumentSelector {
-    return DocumentSelector(languages.map { DocumentFilter(language: $0.rawValue) })
-  }
-
-  private func encode<T: RegistrationOptions>(_ options: T) -> LSPAny {
-    options.encodeToLSPAny()
-  }
+  // MARK: Query registered capabilities
 
   /// Return a registration in `registrations` for one or more of the given
   /// `languages`.
@@ -358,5 +120,232 @@ public final class CapabilityRegistry {
       }
     }
     return nil
+  }
+
+  // MARK: Dynamic registration of server capabilities
+
+  /// Register a dynamic server capability with the client.
+  ///
+  /// If the registration of `options` for the given `method` and `languages` was successful, the capability will be
+  /// added to `registrationDict` by calling `setRegistrationDict`.
+  /// If registration failed, the capability won't be added to `registrationDict`.
+  private func registerLanguageSpecificCapability<
+    Options: RegistrationOptions & TextDocumentRegistrationOptionsProtocol & Equatable
+  >(
+    options: Options,
+    forMethod method: String,
+    languages: [Language],
+    in server: SourceKitServer,
+    registrationDict: [CapabilityRegistration: Options],
+    setRegistrationDict: (CapabilityRegistration, Options?) -> Void
+  ) async {
+    if let registration = registration(for: languages, in: registrationDict) {
+      if options != registration {
+        logger.error(
+          """
+          Failed to dynamically register for \(method, privacy: .public) for \(languages, privacy: .public) \
+          due to pre-existing options:
+          Existing options: \(String(reflecting: registration), privacy: .public)
+          New options: \(String(reflecting: options), privacy: .public)
+          """
+        )
+      }
+      return
+    }
+
+    let registration = CapabilityRegistration(
+      method: method,
+      registerOptions: options.encodeToLSPAny()
+    )
+
+    // Add the capability to the registration dictionary.
+    // This ensures that concurrent calls for the same capability don't register it as well.
+    // If the capability is rejected by the client, we remove it again.
+    setRegistrationDict(registration, options)
+
+    do {
+      _ = try await server.client.send(RegisterCapabilityRequest(registrations: [registration]))
+    } catch {
+      setRegistrationDict(registration, nil)
+    }
+  }
+
+  /// Dynamically register completion capabilities if the client supports it and
+  /// we haven't yet registered any completion capabilities for the given
+  /// languages.
+  public func registerCompletionIfNeeded(
+    options: CompletionOptions,
+    for languages: [Language],
+    server: SourceKitServer
+  ) async {
+    guard clientHasDynamicCompletionRegistration else { return }
+
+    await registerLanguageSpecificCapability(
+      options: CompletionRegistrationOptions(
+        documentSelector: DocumentSelector(for: languages),
+        completionOptions: options
+      ),
+      forMethod: CompletionRequest.method,
+      languages: languages,
+      in: server,
+      registrationDict: completion,
+      setRegistrationDict: { completion[$0] = $1 }
+    )
+  }
+
+  public func registerDidChangeWatchedFiles(
+    watchers: [FileSystemWatcher],
+    server: SourceKitServer
+  ) {
+    guard clientHasDynamicDidChangeWatchedFilesRegistration else { return }
+    if let registration = didChangeWatchedFiles {
+      if watchers != registration.watchers {
+        logger.error(
+          "Unable to register new file system watchers \(watchers) due to pre-existing options \(registration.watchers)"
+        )
+      }
+      return
+    }
+    let registrationOptions = DidChangeWatchedFilesRegistrationOptions(
+      watchers: watchers
+    )
+    let registration = CapabilityRegistration(
+      method: DidChangeWatchedFilesNotification.method,
+      registerOptions: registrationOptions.encodeToLSPAny()
+    )
+
+    self.didChangeWatchedFiles = registrationOptions
+
+    let _ = server.client.send(RegisterCapabilityRequest(registrations: [registration])) { result in
+      if let error = result.failure {
+        logger.error("Failed to dynamically register for watched files: \(error.forLogging)")
+        self.didChangeWatchedFiles = nil
+      }
+    }
+  }
+
+  /// Dynamically register folding range capabilities if the client supports it and
+  /// we haven't yet registered any folding range capabilities for the given
+  /// languages.
+  public func registerFoldingRangeIfNeeded(
+    options: FoldingRangeOptions,
+    for languages: [Language],
+    server: SourceKitServer
+  ) async {
+    guard clientHasDynamicFoldingRangeRegistration else { return }
+
+    await registerLanguageSpecificCapability(
+      options: FoldingRangeRegistrationOptions(
+        documentSelector: DocumentSelector(for: languages),
+        foldingRangeOptions: options
+      ),
+      forMethod: FoldingRangeRequest.method,
+      languages: languages,
+      in: server,
+      registrationDict: foldingRange,
+      setRegistrationDict: { foldingRange[$0] = $1 }
+    )
+  }
+
+  /// Dynamically register semantic tokens capabilities if the client supports
+  /// it and we haven't yet registered any semantic tokens capabilities for the
+  /// given languages.
+  public func registerSemanticTokensIfNeeded(
+    options: SemanticTokensOptions,
+    for languages: [Language],
+    server: SourceKitServer
+  ) async {
+    guard clientHasDynamicSemanticTokensRegistration else { return }
+
+    await registerLanguageSpecificCapability(
+      options: SemanticTokensRegistrationOptions(
+        documentSelector: DocumentSelector(for: languages),
+        semanticTokenOptions: options
+      ),
+      forMethod: SemanticTokensRegistrationOptions.method,
+      languages: languages,
+      in: server,
+      registrationDict: semanticTokens,
+      setRegistrationDict: { semanticTokens[$0] = $1 }
+    )
+  }
+
+  /// Dynamically register inlay hint capabilities if the client supports
+  /// it and we haven't yet registered any inlay hint capabilities for the
+  /// given languages.
+  public func registerInlayHintIfNeeded(
+    options: InlayHintOptions,
+    for languages: [Language],
+    server: SourceKitServer
+  ) async {
+    guard clientHasDynamicInlayHintRegistration else { return }
+    await registerLanguageSpecificCapability(
+      options: InlayHintRegistrationOptions(
+        documentSelector: DocumentSelector(for: languages),
+        inlayHintOptions: options
+      ),
+      forMethod: InlayHintRequest.method,
+      languages: languages,
+      in: server,
+      registrationDict: inlayHint,
+      setRegistrationDict: { inlayHint[$0] = $1 }
+    )
+  }
+
+  /// Dynamically register (pull model) diagnostic capabilities,
+  /// if the client supports it.
+  public func registerDiagnosticIfNeeded(
+    options: DiagnosticOptions,
+    for languages: [Language],
+    server: SourceKitServer
+  ) async {
+    guard clientHasDynamicDocumentDiagnosticsRegistration else { return }
+
+    await registerLanguageSpecificCapability(
+      options: DiagnosticRegistrationOptions(
+        documentSelector: DocumentSelector(for: languages),
+        diagnosticOptions: options
+      ),
+      forMethod: DocumentDiagnosticsRequest.method,
+      languages: languages,
+      in: server,
+      registrationDict: pullDiagnostics,
+      setRegistrationDict: { pullDiagnostics[$0] = $1 }
+    )
+  }
+
+  /// Dynamically register executeCommand with the given IDs if the client supports
+  /// it and we haven't yet registered the given command IDs yet.
+  public func registerExecuteCommandIfNeeded(
+    commands: [String],
+    server: SourceKitServer
+  ) {
+    guard clientHasDynamicExecuteCommandRegistration else { return }
+
+    var newCommands = Set(commands)
+    newCommands.subtract(self.commandIds)
+
+    // We only want to send the registration with unregistered command IDs since
+    // clients such as VS Code only allow a command to be registered once. We could
+    // unregister all our commandIds first but this is simpler.
+    guard !newCommands.isEmpty else { return }
+    self.commandIds.formUnion(newCommands)
+
+    let registration = CapabilityRegistration(
+      method: ExecuteCommandRequest.method,
+      registerOptions: ExecuteCommandRegistrationOptions(commands: Array(newCommands)).encodeToLSPAny()
+    )
+
+    let _ = server.client.send(RegisterCapabilityRequest(registrations: [registration])) { result in
+      if let error = result.failure {
+        logger.error("Failed to dynamically register commands: \(error.forLogging)")
+      }
+    }
+  }
+}
+
+fileprivate extension DocumentSelector {
+  init(for languages: [Language]) {
+    self.init(languages.map { DocumentFilter(language: $0.rawValue) })
   }
 }


### PR DESCRIPTION
Improve `CapabilityRegistry` and surrounding code in a couple of ways
- Make `CapabilityRegistry` an actor
- Refactor `CapabilityRegistry` to duplicate less code
- Ensure that `SourceKitServer` reports all capabilities of `SwiftLanguageServer` if the client doesn’t support dynamic capability registration. We were missing this for semantic tokens and inlay hits
- Add a few doc comments