### PR TITLE
Use pull diagnostics by default in tests

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -633,6 +633,11 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
 
     /// Whether the clients supports related documents for document diagnostic pulls.
     public var relatedDocumentSupport: Bool?
+
+    public init(dynamicRegistration: Bool? = nil, relatedDocumentSupport: Bool? = nil) {
+      self.dynamicRegistration = dynamicRegistration
+      self.relatedDocumentSupport = relatedDocumentSupport
+    }
   }
 
   // MARK: Properties

--- a/Sources/SKTestSupport/MultiFileTestWorkspace.swift
+++ b/Sources/SKTestSupport/MultiFileTestWorkspace.swift
@@ -70,6 +70,7 @@ public class MultiFileTestWorkspace {
   public init(
     files: [RelativeFileLocation: String],
     workspaces: (URL) -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
+    usePullDiagnostics: Bool = true,
     testName: String = #function
   ) async throws {
     scratchDirectory = try testScratchDir(testName: testName)
@@ -103,6 +104,7 @@ public class MultiFileTestWorkspace {
     self.fileData = fileData
 
     self.testClient = try await TestSourceKitLSPClient(
+      usePullDiagnostics: usePullDiagnostics,
       workspaceFolders: workspaces(scratchDirectory),
       cleanUp: { [scratchDirectory] in
         if cleanScratchDirectories {

--- a/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
+++ b/Sources/SKTestSupport/SwiftPMTestWorkspace.swift
@@ -40,6 +40,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
     manifest: String = SwiftPMTestWorkspace.defaultPackageManifest,
     workspaces: (URL) -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
     build: Bool = false,
+    usePullDiagnostics: Bool = true,
     testName: String = #function
   ) async throws {
     var filesByPath: [RelativeFileLocation: String] = [:]
@@ -60,6 +61,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
     try await super.init(
       files: filesByPath,
       workspaces: workspaces,
+      usePullDiagnostics: usePullDiagnostics,
       testName: testName
     )
 

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -48,7 +48,7 @@ final class CrashRecoveryTests: XCTestCase {
     try SkipUnless.platformIsDarwin("Linux and Windows use in-process sourcekitd")
     try SkipUnless.longTestsEnabled()
 
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI.for(.swift)
 
     let positions = testClient.openDocument(

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -90,7 +90,7 @@ final class BuildSystemTests: XCTestCase {
   private var haveClangd: Bool = false
 
   override func setUp() async throws {
-    testClient = try await TestSourceKitLSPClient()
+    testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     buildSystem = TestBuildSystem()
 
     let server = testClient.server

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -340,7 +340,10 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testCodeActionsRemovePlaceholders() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: clientCapabilitiesWithCodeActionSupport(),
+      usePullDiagnostics: false
+    )
     let uri = DocumentURI.for(.swift)
 
     let positions = testClient.openDocument(

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -41,7 +41,8 @@ final class DependencyTrackingTests: XCTestCase {
            .target(name: "LibB", dependencies: ["LibA"]),
           ]
         )
-        """
+        """,
+      usePullDiagnostics: false
     )
 
     let (libBUri, _) = try ws.openDocument("LibB.swift")
@@ -69,21 +70,24 @@ final class DependencyTrackingTests: XCTestCase {
   }
 
   func testDependenciesUpdatedCXX() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
-      "lib.c": """
-      int libX(int value) {
-        return value ? 22 : 0;
-      }
-      """,
-      "main.c": """
-      #include "lib-generated.h"
+    let ws = try await MultiFileTestWorkspace(
+      files: [
+        "lib.c": """
+        int libX(int value) {
+          return value ? 22 : 0;
+        }
+        """,
+        "main.c": """
+        #include "lib-generated.h"
 
-      int main(int argc, const char *argv[]) {
-        return libX(argc);
-      }
-      """,
-      "compile_flags.txt": "",
-    ])
+        int main(int argc, const char *argv[]) {
+          return libX(argc);
+        }
+        """,
+        "compile_flags.txt": "",
+      ],
+      usePullDiagnostics: false
+    )
 
     let generatedHeaderURL = try ws.uri(for: "main.c").fileURL!.deletingLastPathComponent()
       .appendingPathComponent("lib-generated.h", isDirectory: false)

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -34,7 +34,7 @@ final class LocalSwiftTests: XCTestCase {
   // MARK: - Tests
 
   func testEditing() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI.for(.swift)
 
     let documentManager = await testClient.server._documentManager
@@ -157,7 +157,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testEditingNonURL() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI(string: "urn:uuid:A1B08909-E791-469E-BF0F-F5790977E051")
 
     let documentManager = await testClient.server._documentManager
@@ -281,7 +281,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testExcludedDocumentSchemeDiagnostics() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let includedURL = URL(fileURLWithPath: "/a.swift")
     let includedURI = DocumentURI(includedURL)
 
@@ -297,7 +297,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testCrossFileDiagnostics() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let urlB = URL(fileURLWithPath: "/\(UUID())/b.swift")
     let uriA = DocumentURI(urlA)
@@ -335,7 +335,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testDiagnosticsReopen() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let urlA = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uriA = DocumentURI(urlA)
 
@@ -366,7 +366,8 @@ final class LocalSwiftTests: XCTestCase {
         textDocument: TextDocumentClientCapabilities(
           publishDiagnostics: .init(codeDescriptionSupport: true)
         )
-      )
+      ),
+      usePullDiagnostics: false
     )
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
@@ -381,7 +382,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnostics() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -419,7 +420,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreIncludedInPublishDiagnosticsNotes() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -483,7 +484,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitInsert() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -527,7 +528,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActions() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities, usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -585,7 +586,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testFixitsAreReturnedFromCodeActionsNotes() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities, usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -644,7 +645,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionPrimary() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities, usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -691,7 +692,7 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testMuliEditFixitCodeActionNote() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities)
+    let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities, usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 
@@ -1659,7 +1660,7 @@ final class LocalSwiftTests: XCTestCase {
     serverOptions.swiftPublishDiagnosticsDebounceDuration = 1 /* 1s */
 
     // Construct our own  `TestSourceKitLSPClient` instead of the one from set up because we want a higher debounce interval.
-    let testClient = try await TestSourceKitLSPClient(serverOptions: serverOptions)
+    let testClient = try await TestSourceKitLSPClient(serverOptions: serverOptions, usePullDiagnostics: false)
 
     let uri = DocumentURI(URL(fileURLWithPath: "/\(UUID())/a.swift"))
     testClient.openDocument("foo", uri: uri)

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -46,7 +46,8 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: false
+      build: false,
+      usePullDiagnostics: false
     )
 
     // Use the definition of `VARIABLE_NAME` together with `-Wunused-variable` to check that we are getting compiler
@@ -86,7 +87,8 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: false
+      build: false,
+      usePullDiagnostics: false
     )
 
     _ = try ws.openDocument("shared.h", language: .c)
@@ -142,7 +144,8 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      build: true,
+      usePullDiagnostics: false
     )
 
     _ = try ws.openDocument("shared.h", language: .c)
@@ -190,7 +193,8 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      build: true,
+      usePullDiagnostics: false
     )
 
     _ = try ws.openDocument("shared.h", language: .c)

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 final class PublishDiagnosticsTests: XCTestCase {
   func testUnknownIdentifierDiagnostic() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(
@@ -38,7 +38,7 @@ final class PublishDiagnosticsTests: XCTestCase {
   }
 
   func testRangeShiftAfterNewlineAdded() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(
@@ -79,7 +79,7 @@ final class PublishDiagnosticsTests: XCTestCase {
   }
 
   func testRangeShiftAfterNewlineRemoved() async throws {
-    let testClient = try await TestSourceKitLSPClient()
+    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI.for(.swift)
 
     testClient.openDocument(

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -58,7 +58,8 @@ final class SemanticTokensTests: XCTestCase {
             formats: [.relative]
           )
         )
-      )
+      ),
+      usePullDiagnostics: false
     )
   }
 

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -184,7 +184,8 @@ final class WorkspaceTests: XCTestCase {
           WorkspaceFolder(uri: DocumentURI(scratchDir.appendingPathComponent("WorkspaceA"))),
           WorkspaceFolder(uri: DocumentURI(scratchDir.appendingPathComponent("WorkspaceB"))),
         ]
-      }
+      },
+      usePullDiagnostics: false
     )
 
     _ = try ws.openDocument("test.m")


### PR DESCRIPTION
Currently, all tests send publish diagnostics notifications, which is noise in the logs for most tests. Change the tests to use the pull diagnostics model by default and make the push diagnostic model opt-in.

rdar://123241539