### PR TITLE
Improvements to the diagnose subcommands

### DIFF
--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -70,11 +70,12 @@ public struct RequestInfo {
       "key.offset: "
       Capture(ZeroOrMore(.digit))
     }
-    guard let offsetMatch = requestTemplate.matches(of: offsetRegex).only else {
-      throw ReductionError("Failed to find key.offset in the request")
+    if let offsetMatch = requestTemplate.matches(of: offsetRegex).only {
+      offset = Int(offsetMatch.1)!
+      requestTemplate.replace(offsetRegex, with: "key.offset: $OFFSET")
+    } else {
+      offset = 0
     }
-    offset = Int(offsetMatch.1)!
-    requestTemplate.replace(offsetRegex, with: "key.offset: $OFFSET")
 
     // Extract source file
     let sourceFileRegex = Regex {

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -77,6 +77,10 @@ public struct RequestInfo {
       offset = 0
     }
 
+    // If the request contained source text, remove it. We want to pick it up from the file on disk and most (possibly
+    // all) sourcekitd requests use key.sourcefile if key.sourcetext is missing.
+    requestTemplate.replace(#/ *key.sourcetext: .*\n/#, with: "")
+
     // Extract source file
     let sourceFileRegex = Regex {
       #"key.sourcefile: ""#

--- a/Sources/Diagnose/SourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/SourcekitdRequestCommand.swift
@@ -60,7 +60,17 @@ public struct SourceKitdRequestCommand: AsyncParsableCommand {
     }
 
     switch response.error {
-    case .requestFailed, .requestInvalid, .requestCancelled, .missingRequiredSymbol:
+    case .requestFailed(let message):
+      print(message)
+      throw ExitCode(1)
+    case .requestInvalid(let message):
+      print(message)
+      throw ExitCode(1)
+    case .requestCancelled:
+      print("request cancelled")
+      throw ExitCode(1)
+    case .missingRequiredSymbol:
+      print("missing required symbol")
       throw ExitCode(1)
     case .connectionInterrupted:
       throw ExitCode(255)

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -147,8 +147,12 @@ extension LineTable {
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
   @inlinable
   public func stringIndexOf(line: Int, utf8Column: Int) -> String.Index? {
-    guard line < count else {
+    guard 0 <= line, line < count else {
       // Line out of range.
+      return nil
+    }
+    guard 0 <= utf8Column else {
+      // Column out of range.
       return nil
     }
     let lineSlice = self[line]


### PR DESCRIPTION
- Support reduction of requests that don’t have an offset
-  Remove key.sourcetext from the request
  - If the request contained source text, remove it. We want to pick it up from the file on disk and most (possibly all) sourcekitd requests use key.sourcefile if key.sourcetext is missing.
- Print error message if `sourcekit-lsp run-sourcekitd-request` fails
- Allow passing `--position` to `sourcekit-lsp run-sourcekitd-request`
  - When doing the final manual reduction steps of a sourcekitd request, this eliminates laborious adjustment of key.offset in the request while lines that don’t contain the offset are being modified.
