### PR TITLE
Add swift-format to the dependencies so the `Format Swift Code` command plugin can be used to format the codebase

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,6 +37,13 @@
 				"$swiftc"
 			],
 			"type": "swift"
+		},
+		{
+			"allowWritingToPackageDirectory": true,
+			"args": [],
+			"command": "format-source-code",
+			"label": "Run swift-format",
+			"type": "swift-plugin",
 		}
 	],
 	"version": "2.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -358,6 +358,8 @@ var dependencies: [Package.Dependency] {
       .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
       .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+      // Not a build dependency. Used so the "Format Source Code" command plugin can be used to format sourcekit-lsp
+      .package(url: "https://github.com/apple/swift-format.git", branch: relatedDependenciesBranch),
     ]
   }
 }


### PR DESCRIPTION
I deliberately didn’t add it to the local dependencies so we notice when a build dependency on swift-format is being introduced.