### PR TITLE
Support rename of function parameters from variables that reference them

### DIFF
--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -60,9 +60,11 @@ struct RelatedIdentifiersResponse {
 }
 
 extension SwiftLanguageServer {
-  func relatedIdentifiers(at position: Position, in snapshot: DocumentSnapshot, includeNonEditableBaseNames: Bool)
-    async throws -> RelatedIdentifiersResponse
-  {
+  func relatedIdentifiers(
+    at position: Position,
+    in snapshot: DocumentSnapshot,
+    includeNonEditableBaseNames: Bool
+  ) async throws -> RelatedIdentifiersResponse {
     guard let offset = snapshot.utf8Offset(of: position) else {
       throw ResponseError.unknown("invalid position \(position)")
     }

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -825,4 +825,39 @@ final class RenameTests: XCTestCase {
       ]
     )
   }
+
+  func testRenameParameterInsideFunction() async throws {
+    try await assertSingleFileRename(
+      """
+      func test(myParam: Int) {
+        print(1️⃣myParam)
+      }
+      """,
+      newName: "other",
+      expectedPrepareRenamePlaceholder: "myParam",
+      expected: """
+        func test(myParam other: Int) {
+          print(other)
+        }
+        """
+    )
+  }
+
+  func testRenameParameterSecondNameInsideFunction() async throws {
+    try await assertSingleFileRename(
+      """
+      func test(myExternalName myParam: Int) {
+        print(1️⃣myParam)
+      }
+      """,
+      newName: "other",
+      expectedPrepareRenamePlaceholder: "myParam",
+      expected: """
+        func test(myExternalName other: Int) {
+          print(other)
+        }
+        """
+    )
+  }
+
 }


### PR DESCRIPTION
When renaming a function parameter from inside the function body, we expect that to be a local rename and thus we shouldn’t update the external parameter name. We should thus introduce the new renamed variable name as the parameter’s second name.

rdar://123536538