### PR TITLE
Don’t include parentheses in Prepare Rename result if function has no parameters

### DIFF
--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -1227,8 +1227,11 @@ extension SwiftLanguageServer {
       in: snapshot,
       includeNonEditableBaseNames: true
     )
-    guard let name = response.name else {
+    guard var name = response.name else {
       throw ResponseError.unknown("Running sourcekit-lsp with a version of sourcekitd that does not support rename")
+    }
+    if name.hasSuffix("()") {
+      name = String(name.dropLast(2))
     }
     guard let range = response.relatedIdentifiers.first(where: { $0.range.contains(renamePosition) })?.range
     else {

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -37,8 +37,8 @@ final class RenameTests: XCTestCase {
       2️⃣foo()
       _ = 3️⃣foo
       """,
-      newName: "bar()",
-      expectedPrepareRenamePlaceholder: "foo()",
+      newName: "bar",
+      expectedPrepareRenamePlaceholder: "foo",
       expected: """
         func bar() {}
         bar()


### PR DESCRIPTION
rdar://121864405
Fixes #1041