### PR TITLE
Show calls to satisfied protocol requirements in call hierarchy

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -2080,7 +2080,14 @@ extension SourceKitServer {
     else {
       return []
     }
-    let callableUsrs = [data.usr] + index.occurrences(relatedToUSR: data.usr, roles: .accessorOf).map(\.symbol.usr)
+    var callableUsrs = [data.usr]
+    // Calls to the accessors of a property count as calls to the property
+    callableUsrs += index.occurrences(relatedToUSR: data.usr, roles: .accessorOf).map(\.symbol.usr)
+    // Also show calls to the functions that this method overrides. This includes overridden class methods and
+    // satisfied protocol requirements.
+    callableUsrs += index.occurrences(ofUSR: data.usr, roles: .overrideOf).flatMap { occurrence in
+      occurrence.relations.filter { $0.roles.contains(.overrideOf) }.map(\.symbol.usr)
+    }
     let callOccurrences = callableUsrs.flatMap { index.occurrences(ofUSR: $0, roles: .calledBy) }
     let calls = callOccurrences.flatMap { occurrence -> [CallHierarchyIncomingCall] in
       guard let location = indexToLSPLocation(occurrence.location) else {


### PR DESCRIPTION
For example in the following, we should show `proto.foo()` as a call when computing the call hierarchy of `MyStruct.foo`. Otherwise `MyStruct.foo` does not have any calls, which is misleading.

```swift
protocol MyProtocol {
  func foo()
}
struct MyStruct: MyProtocol {
  func foo() {}
}
func test(proto: MyProtocol) {
  proto.foo()
}
```

rdar://123837232