### PR TITLE
Add some logging for `testRecomputeFileWorkspaceMembershipOnPackageSwiftChange`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -305,8 +305,20 @@ let package = Package(
     .testTarget(
       name: "SourceKitLSPTests",
       dependencies: [
+        "BuildServerProtocol",
+        "LSPLogging",
+        "LSPTestSupport",
+        "LanguageServerProtocol",
+        "SKCore",
+        "SKSupport",
         "SKTestSupport",
+        "SourceKitD",
         "SourceKitLSP",
+        .product(name: "IndexStoreDB", package: "indexstore-db"),
+        .product(name: "ISDBTestSupport", package: "indexstore-db"),
+        .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ]
     ),
   ]

--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -15,7 +15,9 @@
 ///  - Info: Helpful but not essential for troubleshooting (not persisted, logged to memory)
 ///  - Notice/log (Default): Essential for troubleshooting
 ///  - Error: Error seen during execution
+///    - Used eg. if the user sends an erroneous request or if a request fails
 ///  - Fault: Bug in program
+///    - Used eg. if invariants inside sourcekit-lsp are broken and the error is not due to user-provided input
 
 import Foundation
 

--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -363,6 +363,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
 
   public func filesDidChange(_ events: [FileEvent]) async {
     if events.contains(where: { self.fileEventShouldTriggerPackageReload(event: $0) }) {
+      logger.log("Reloading package because of file change")
       await orLog("Reloading package") {
         // TODO: It should not be necessary to reload the entire package just to get build settings for one file.
         try await self.reloadPackage()

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1051,6 +1051,7 @@ extension SourceKitServer: BuildSystemDelegate {
   }
 
   public func fileHandlingCapabilityChanged() {
+    logger.log("Resetting URI to workspace cache because file handling capability of a workspace changed")
     self.uriToWorkspaceCache = [:]
   }
 }


### PR DESCRIPTION
I just saw a failure of this test in CI, and can’t figure out what might have happened. Adding some logging that hopefully helps us if the failure happens again.