### PR TITLE
Add a progress bar to the diagnose subcommand

### DIFF
--- a/Tests/DiagnoseTests/DiagnoseTests.swift
+++ b/Tests/DiagnoseTests/DiagnoseTests.swift
@@ -178,7 +178,14 @@ private func assertReduce(
       .replacingOccurrences(of: "$OFFSET", with: String(markerOffset))
 
     let requestInfo = try RequestInfo(request: request)
-    let reduced = try await requestInfo.reduceInputFile(using: requestExecutor)
+    var lastProgress = 0.0
+    let reduced = try await requestInfo.reduceInputFile(
+      using: requestExecutor,
+      progressUpdate: { progress, _ in
+        XCTAssertLessThanOrEqual(lastProgress, progress)
+        lastProgress = progress
+      }
+    )
 
     XCTAssertEqual(reduced.fileContents, expectedReducedFileContents, file: file, line: line)
   }


### PR DESCRIPTION
Gives some feedback about how long diagnostic bundle generation still takes. As always with progress indicators, everything is an estimate but I feel that giving some progress estimate gives some valuable feedback that something is happening. It also allows us to show the current state inline without accumulating a huge log of previous states.

<img width="1137" alt="Screenshot 2024-03-01 at 09 15 21" src="https://github.com/apple/sourcekit-lsp/assets/4062178/1edbe389-7a40-408e-b988-492c02fcbf23">
