### PR TITLE
Don’t log error if workspace root doesn’t contain Swift package manifest

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMWorkspace.swift
@@ -188,8 +188,7 @@ public actor SwiftPMWorkspace {
         buildSetup: buildSetup,
         reloadPackageStatusCallback: reloadPackageStatusCallback
       )
-    } catch Error.noManifest(let path) {
-      logger.error("could not find manifest, or not a SwiftPM package: \(path)")
+    } catch Error.noManifest {
       return nil
     } catch {
       logger.error("failed to create SwiftPMWorkspace at \(url.path): \(error.forLogging)")


### PR DESCRIPTION
We try creating a `SwiftPMWorkspace` on every workspace to check if it is a SwiftPM package. The workspace root not having a package manifest is not an error because it might contain compile_commands.json. Remove the log message.