### PR TITLE
Report whether sourcekit-lsp supports the `workspace/tests` and `textDocument/tests` requests

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/DocumentTestsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentTestsRequest.swift
@@ -14,7 +14,7 @@
 ///
 /// **(LSP Extension)**
 public struct DocumentTestsRequest: TextDocumentRequest, Hashable {
-  public static let method: String = "document/tests"
+  public static let method: String = "textDocument/tests"
   public typealias Response = [WorkspaceSymbolItem]?
 
   public var textDocument: TextDocumentIdentifier

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1288,7 +1288,11 @@ extension SourceKitServer {
       callHierarchyProvider: .bool(true),
       typeHierarchyProvider: .bool(true),
       semanticTokensProvider: semanticTokensOptions,
-      inlayHintProvider: inlayHintOptions
+      inlayHintProvider: inlayHintOptions,
+      experimental: .dictionary([
+        "workspace/tests": .dictionary(["version": .int(1)]),
+        "textDocument/tests": .dictionary(["version": .int(1)]),
+      ])
     )
   }
 


### PR DESCRIPTION
I also renamed the `document/tests` request to `textDocument/tests` to be consistent with other document requests in LSP.

Fixes #1098
rdar://123771703