### PR TITLE
Remove the “Run swift-format” task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,13 +37,6 @@
 				"$swiftc"
 			],
 			"type": "swift"
-		},
-		{
-			"allowWritingToPackageDirectory": true,
-			"args": [],
-			"command": "format-source-code",
-			"label": "Run swift-format",
-			"type": "swift-plugin",
 		}
 	],
 	"version": "2.0.0"


### PR DESCRIPTION
I just realized that the VS Code extension already provides it