### PR TITLE
Add Sendable annotations to LanguageServerProtocol, LSPLogging and SKSupport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 
 import Foundation
 import PackageDescription
@@ -97,7 +97,8 @@ let package = Package(
     .target(
       name: "LanguageServerProtocol",
       dependencies: [],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
     ),
 
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -197,7 +197,8 @@ let package = Package(
         "LanguageServerProtocol",
         "LSPLogging",
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
     ),
 
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -138,7 +138,7 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto")
       ],
       exclude: ["CMakeLists.txt"],
-      swiftSettings: lspLoggingSwiftSettings
+      swiftSettings: lspLoggingSwiftSettings + [.enableExperimentalFeature("StrictConcurrency")]
     ),
 
     .testTarget(

--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -185,7 +185,7 @@ extension String: @retroactive ResponseType {}
 #endif
 
 public struct EchoRequest: RequestType {
-  public static var method: String = "test_server/echo"
+  public static let method: String = "test_server/echo"
   public typealias Response = String
 
   public var string: String
@@ -196,7 +196,7 @@ public struct EchoRequest: RequestType {
 }
 
 public struct EchoError: RequestType {
-  public static var method: String = "test_server/echo_error"
+  public static let method: String = "test_server/echo_error"
   public typealias Response = VoidResponse
 
   public var code: ErrorCode?
@@ -209,7 +209,7 @@ public struct EchoError: RequestType {
 }
 
 public struct EchoNotification: NotificationType {
-  public static var method: String = "test_server/echo_note"
+  public static let method: String = "test_server/echo_note"
 
   public var string: String
 

--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -13,7 +13,7 @@
 import Dispatch
 
 /// An abstract connection, allow messages to be sent to a (potentially remote) `MessageHandler`.
-public protocol Connection: AnyObject {
+public protocol Connection: AnyObject, Sendable {
 
   /// Send a notification without a reply.
   func send(_ notification: some NotificationType)
@@ -61,7 +61,9 @@ public protocol MessageHandler: AnyObject {
 /// conn.send(...) // handled by server
 /// conn.close()
 /// ```
-public final class LocalConnection {
+///
+/// - Note: Unchecked sendable conformance because shared state is guarded by `queue`.
+public final class LocalConnection: @unchecked Sendable {
 
   enum State {
     case ready, started, closed

--- a/Sources/LanguageServerProtocol/CustomCodable.swift
+++ b/Sources/LanguageServerProtocol/CustomCodable.swift
@@ -51,6 +51,8 @@ public struct CustomCodable<CustomCoder: CustomCodableWrapper> {
   }
 }
 
+extension CustomCodable: Sendable where CustomCoder.WrappedValue: Sendable {}
+
 extension CustomCodable: Codable {
   public init(from decoder: Decoder) throws {
     self.wrappedValue = try CustomCoder(from: decoder).wrappedValue

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -14,7 +14,7 @@
 public typealias LSPResult<T> = Swift.Result<T, ResponseError>
 
 /// Error code suitable for use between language server and client.
-public struct ErrorCode: RawRepresentable, Codable, Hashable {
+public struct ErrorCode: RawRepresentable, Codable, Hashable, Sendable {
 
   public var rawValue: Int
 
@@ -100,9 +100,9 @@ public struct ResponseError: Error, Codable, Hashable {
 extension ResponseError {
   // MARK: Convenience properties for common errors.
 
-  public static var cancelled: ResponseError = ResponseError(code: .cancelled, message: "request cancelled by client")
+  public static let cancelled: ResponseError = ResponseError(code: .cancelled, message: "request cancelled by client")
 
-  public static var serverCancelled: ResponseError = ResponseError(
+  public static let serverCancelled: ResponseError = ResponseError(
     code: .serverCancelled,
     message: "request cancelled by server"
   )
@@ -136,7 +136,7 @@ public struct MessageDecodingError: Error, Hashable {
   /// If it was possible to recover the request id, it is stored here. This can be used e.g. to reply with a `ResponseError` to invalid requests.
   public var id: RequestID?
 
-  public enum MessageKind {
+  public enum MessageKind: Sendable {
     case request
     case response
     case notification

--- a/Sources/LanguageServerProtocol/Message.swift
+++ b/Sources/LanguageServerProtocol/Message.swift
@@ -12,7 +12,7 @@
 
 import Dispatch
 
-public protocol MessageType: Codable {}
+public protocol MessageType: Codable, Sendable {}
 
 /// `RequestType` with no associated type or same-type requirements. Most users should prefer
 /// `RequestType`.

--- a/Sources/LanguageServerProtocol/MessageRegistry.swift
+++ b/Sources/LanguageServerProtocol/MessageRegistry.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class MessageRegistry {
+public final class MessageRegistry: Sendable {
 
   public static let lspProtocol: MessageRegistry =
     MessageRegistry(requests: builtinRequests, notifications: builtinNotifications)

--- a/Sources/LanguageServerProtocol/Notifications/CancelWorkDoneProgressNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/CancelWorkDoneProgressNotification.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct CancelWorkDoneProgressNotification: NotificationType {
-  public static var method: String = "window/workDoneProgress/cancel"
+  public static let method: String = "window/workDoneProgress/cancel"
 
   public var token: ProgressToken
 

--- a/Sources/LanguageServerProtocol/Notifications/DidChangeFileNotifications.swift
+++ b/Sources/LanguageServerProtocol/Notifications/DidChangeFileNotifications.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct DidCreateFilesNotification: NotificationType {
-  public static var method: String = "workspace/didCreateFiles"
+  public static let method: String = "workspace/didCreateFiles"
 
   /// An array of all files/folders created in this operation.
   public var files: [FileCreate]
@@ -22,7 +22,7 @@ public struct DidCreateFilesNotification: NotificationType {
 }
 
 public struct DidRenameFilesNotification: NotificationType {
-  public static var method: String = "workspace/didRenameFiles"
+  public static let method: String = "workspace/didRenameFiles"
 
   /// An array of all files/folders renamed in this operation. When a folder
   /// is renamed, only the folder will be included, and not its children.
@@ -34,7 +34,7 @@ public struct DidRenameFilesNotification: NotificationType {
 }
 
 public struct DidDeleteFilesNotification: NotificationType {
-  public static var method: String = "workspace/didDeleteFiles"
+  public static let method: String = "workspace/didDeleteFiles"
 
   /// An array of all files/folders created in this operation.
   public var files: [FileDelete]

--- a/Sources/LanguageServerProtocol/Notifications/DidChangeWorkspaceFoldersNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/DidChangeWorkspaceFoldersNotification.swift
@@ -27,7 +27,7 @@ public struct DidChangeWorkspaceFoldersNotification: NotificationType {
 }
 
 /// The workspace folder change event.
-public struct WorkspaceFoldersChangeEvent: Codable, Hashable {
+public struct WorkspaceFoldersChangeEvent: Codable, Hashable, Sendable {
 
   /// The array of added workspace folders
   public var added: [WorkspaceFolder]?

--- a/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
+++ b/Sources/LanguageServerProtocol/Notifications/TextSynchronizationNotifications.swift
@@ -169,7 +169,7 @@ public struct DidOpenNotebookDocumentNotification: NotificationType, Hashable {
 
 /// The change notification is sent from the client to the server when a notebook document changes. It is only sent by a client if the server requested the synchronization mode `notebook` in its `notebookDocumentSync` capability.
 public struct DidChangeNotebookDocumentNotification: NotificationType, Hashable {
-  public static var method: String = "notebookDocument/didChange"
+  public static let method: String = "notebookDocument/didChange"
 
   /// The notebook document that did change. The version number points
   /// to the version after all provided changes have been applied.
@@ -196,7 +196,7 @@ public struct DidChangeNotebookDocumentNotification: NotificationType, Hashable 
 
 /// The save notification is sent from the client to the server when a notebook document is saved. It is only sent by a client if the server requested the synchronization mode `notebook` in its `notebookDocumentSync` capability.
 public struct DidSaveNotebookDocumentNotification: NotificationType {
-  public static var method: String = "notebookDocument/didSave"
+  public static let method: String = "notebookDocument/didSave"
 
   /// The notebook document that got saved.
   public var notebookDocument: NotebookDocumentIdentifier
@@ -208,7 +208,7 @@ public struct DidSaveNotebookDocumentNotification: NotificationType {
 
 /// The close notification is sent from the client to the server when a notebook document is closed. It is only sent by a client if the server requested the synchronization mode `notebook` in its `notebookDocumentSync` capability.
 public struct DidCloseNotebookDocumentNotification: NotificationType {
-  public static var method: String = "notebookDocument/didClose"
+  public static let method: String = "notebookDocument/didClose"
 
   /// The notebook document that got closed.
   public var notebookDocument: NotebookDocumentIdentifier

--- a/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
+++ b/Sources/LanguageServerProtocol/Notifications/WorkDoneProgress.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct WorkDoneProgress: NotificationType, Hashable {
-  public static var method: String = "$/progress"
+  public static let method: String = "$/progress"
 
   /// The progress token provided by the client or server.
   public var token: ProgressToken
@@ -25,7 +25,7 @@ public struct WorkDoneProgress: NotificationType, Hashable {
   }
 }
 
-public enum WorkDoneProgressKind: Codable, Hashable {
+public enum WorkDoneProgressKind: Codable, Hashable, Sendable {
   case begin(WorkDoneProgressBegin)
   case report(WorkDoneProgressReport)
   case end(WorkDoneProgressEnd)
@@ -58,7 +58,7 @@ public enum WorkDoneProgressKind: Codable, Hashable {
   }
 }
 
-public struct WorkDoneProgressBegin: Codable, Hashable {
+public struct WorkDoneProgressBegin: Codable, Hashable, Sendable {
   /// Mandatory title of the progress operation. Used to briefly inform about
   /// the kind of operation being performed.
   ///
@@ -127,7 +127,7 @@ public struct WorkDoneProgressBegin: Codable, Hashable {
   }
 }
 
-public struct WorkDoneProgressReport: Codable, Hashable {
+public struct WorkDoneProgressReport: Codable, Hashable, Sendable {
   /// Controls enablement state of a cancel button. This property is only valid
   /// if a cancel button got requested in the `WorkDoneProgressBegin` payload.
   ///
@@ -188,7 +188,7 @@ public struct WorkDoneProgressReport: Codable, Hashable {
   }
 }
 
-public struct WorkDoneProgressEnd: Codable, Hashable {
+public struct WorkDoneProgressEnd: Codable, Hashable, Sendable {
   /// Optional, a final message indicating to for example indicate the outcome
   /// of the operation.
   public var message: String?

--- a/Sources/LanguageServerProtocol/RequestID.swift
+++ b/Sources/LanguageServerProtocol/RequestID.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum RequestID: Hashable {
+public enum RequestID: Hashable, Sendable {
   case string(String)
   case number(Int)
 }

--- a/Sources/LanguageServerProtocol/Requests/BarrierRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/BarrierRequest.swift
@@ -13,7 +13,7 @@
 /// A no-op request that ensures all previous notifications and requests have been handled before any message
 /// after the barrier request is handled.
 public struct BarrierRequest: RequestType {
-  public static var method: String = "workspace/_barrier"
+  public static let method: String = "workspace/_barrier"
   public typealias Response = VoidResponse
 
   public init() {}

--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -89,7 +89,7 @@ public enum CodeActionRequestResponse: ResponseType, Codable, Equatable {
 }
 
 /// The reason why code actions were requested.
-public struct CodeActionTriggerKind: RawRepresentable, Codable, Hashable {
+public struct CodeActionTriggerKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {
@@ -106,7 +106,7 @@ public struct CodeActionTriggerKind: RawRepresentable, Codable, Hashable {
   public static let automatic = CodeActionTriggerKind(rawValue: 2)
 }
 
-public struct CodeActionContext: Codable, Hashable {
+public struct CodeActionContext: Codable, Hashable, Sendable {
 
   /// An array of diagnostics.
   public var diagnostics: [Diagnostic]

--- a/Sources/LanguageServerProtocol/Requests/CodeActionResolveRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionResolveRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct CodeActionResolveRequest: RequestType {
-  public static var method: String = "codeAction/resolve"
+  public static let method: String = "codeAction/resolve"
   public typealias Response = CodeAction
 
   public var codeAction: CodeAction

--- a/Sources/LanguageServerProtocol/Requests/CodeLensRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeLensRefreshRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct CodeLensRefreshRequest: RequestType {
-  public static var method: String = "workspace/codeLens/refresh"
+  public static let method: String = "workspace/codeLens/refresh"
 
   public typealias Response = VoidResponse
 

--- a/Sources/LanguageServerProtocol/Requests/CodeLensRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeLensRequest.swift
@@ -12,7 +12,7 @@
 
 /// The code lens request is sent from the client to the server to compute code lenses for a given text document.
 public struct CodeLensRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/codeLens"
+  public static let method: String = "textDocument/codeLens"
   public typealias Response = [CodeLens]?
 
   /// The document to request code lens for.

--- a/Sources/LanguageServerProtocol/Requests/CodeLensResolveRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeLensResolveRequest.swift
@@ -12,7 +12,7 @@
 
 /// The code lens resolve request is sent from the client to the server to resolve the command for a given code lens item.
 public struct CodeLensResolveRequest: RequestType {
-  public static var method: String = "codeLens/resolve"
+  public static let method: String = "codeLens/resolve"
   public typealias Response = CodeLens
 
   public var codeLens: CodeLens

--- a/Sources/LanguageServerProtocol/Requests/CompletionItemResolveRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CompletionItemResolveRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct CompletionItemResolveRequest: RequestType {
-  public static var method: String = "completionItem/resolve"
+  public static let method: String = "completionItem/resolve"
   public typealias Response = CompletionItem
 
   public var item: CompletionItem

--- a/Sources/LanguageServerProtocol/Requests/CompletionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CompletionRequest.swift
@@ -52,7 +52,7 @@ public struct CompletionRequest: TextDocumentRequest, Hashable {
 }
 
 /// How a completion was triggered
-public struct CompletionTriggerKind: RawRepresentable, Codable, Hashable {
+public struct CompletionTriggerKind: RawRepresentable, Codable, Hashable, Sendable {
   /// Completion was triggered by typing an identifier (24x7 code complete), manual invocation (e.g Ctrl+Space) or via API.
   public static let invoked = CompletionTriggerKind(rawValue: 1)
 
@@ -69,7 +69,7 @@ public struct CompletionTriggerKind: RawRepresentable, Codable, Hashable {
 }
 
 /// Contains additional information about the context in which a completion request is triggered.
-public struct CompletionContext: Codable, Hashable {
+public struct CompletionContext: Codable, Hashable, Sendable {
   /// How the completion was triggered.
   public var triggerKind: CompletionTriggerKind
 
@@ -85,7 +85,7 @@ public struct CompletionContext: Codable, Hashable {
 /// List of completion items. If this list has been filtered already, the `isIncomplete` flag
 /// indicates that the client should re-query code-completions if the filter text changes.
 public struct CompletionList: ResponseType, Hashable {
-  public struct InsertReplaceRanges: Codable, Hashable {
+  public struct InsertReplaceRanges: Codable, Hashable, Sendable {
     @CustomCodable<PositionRange>
     var insert: Range<Position>
 
@@ -98,7 +98,7 @@ public struct CompletionList: ResponseType, Hashable {
     }
   }
 
-  public enum ItemDefaultsEditRange: Codable, Hashable {
+  public enum ItemDefaultsEditRange: Codable, Hashable, Sendable {
     case range(Range<Position>)
     case insertReplaceRanges(InsertReplaceRanges)
 
@@ -126,7 +126,7 @@ public struct CompletionList: ResponseType, Hashable {
     }
   }
 
-  public struct ItemDefaults: Codable, Hashable {
+  public struct ItemDefaults: Codable, Hashable, Sendable {
     /// A default commit character set.
     public var commitCharacters: [String]?
 

--- a/Sources/LanguageServerProtocol/Requests/CreateWorkDoneProgressRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CreateWorkDoneProgressRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct CreateWorkDoneProgressRequest: RequestType {
-  public static var method: String = "window/workDoneProgress/create"
+  public static let method: String = "window/workDoneProgress/create"
   public typealias Response = VoidResponse
 
   /// The token to be used to report progress.

--- a/Sources/LanguageServerProtocol/Requests/DiagnosticsRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DiagnosticsRefreshRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct DiagnosticsRefreshRequest: RequestType {
-  public static var method: String = "workspace/diagnostic/refresh"
+  public static let method: String = "workspace/diagnostic/refresh"
   public typealias Response = VoidResponse
 
   public init() {}

--- a/Sources/LanguageServerProtocol/Requests/DocumentColorRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentColorRequest.swift
@@ -46,7 +46,7 @@ public struct ColorInformation: ResponseType, Hashable {
 }
 
 /// Represents a color in RGBA space.
-public struct Color: Hashable, Codable {
+public struct Color: Hashable, Codable, Sendable {
   /// The red component of this color in the range [0-1].
   public var red: Double
   /// The green component of this color in the range [0-1].

--- a/Sources/LanguageServerProtocol/Requests/DocumentDiagnosticsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentDiagnosticsRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct DocumentDiagnosticsRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/diagnostic"
+  public static let method: String = "textDocument/diagnostic"
   public typealias Response = DocumentDiagnosticReport
 
   /// The text document.
@@ -64,7 +64,7 @@ public enum DocumentDiagnosticReport: ResponseType, Codable, Hashable {
 }
 
 /// The document diagnostic report kinds.
-public struct DocumentDiagnosticReportKind: RawRepresentable, Codable, Hashable {
+public struct DocumentDiagnosticReportKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: String
 
   public init(rawValue: String) {
@@ -81,7 +81,7 @@ public struct DocumentDiagnosticReportKind: RawRepresentable, Codable, Hashable 
 }
 
 /// A diagnostic report with a full set of problems.
-public struct RelatedFullDocumentDiagnosticReport: Codable, Hashable {
+public struct RelatedFullDocumentDiagnosticReport: Codable, Hashable, Sendable {
   /// An optional result id. If provided it will
   /// be sent on the next diagnostic request for the
   /// same document.
@@ -143,7 +143,7 @@ public struct RelatedFullDocumentDiagnosticReport: Codable, Hashable {
 
 /// A diagnostic report indicating that the last returned
 /// report is still accurate.
-public struct RelatedUnchangedDocumentDiagnosticReport: Codable, Hashable {
+public struct RelatedUnchangedDocumentDiagnosticReport: Codable, Hashable, Sendable {
   /// A result id which will be sent on the next
   /// diagnostic request for the same document.
   public var resultId: String

--- a/Sources/LanguageServerProtocol/Requests/DocumentHighlightRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentHighlightRequest.swift
@@ -41,7 +41,7 @@ public struct DocumentHighlightRequest: TextDocumentRequest, Hashable {
 }
 
 /// The kind of document highlight - read, write, or text (fuzzy).
-public enum DocumentHighlightKind: Int, Codable, Hashable {
+public enum DocumentHighlightKind: Int, Codable, Hashable, Sendable {
 
   /// Textual match.
   case text = 1

--- a/Sources/LanguageServerProtocol/Requests/DocumentSemanticTokensDeltaRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentSemanticTokensDeltaRequest.swift
@@ -55,7 +55,7 @@ public enum DocumentSemanticTokensDeltaResponse: ResponseType, Codable, Equatabl
   }
 }
 
-public struct SemanticTokensDelta: Codable, Hashable {
+public struct SemanticTokensDelta: Codable, Hashable, Sendable {
   /// An optional result identifier which enables supporting clients to request semantic token deltas
   /// subsequent requests.
   public var resultId: String?
@@ -69,7 +69,7 @@ public struct SemanticTokensDelta: Codable, Hashable {
   }
 }
 
-public struct SemanticTokensEdit: Codable, Hashable {
+public struct SemanticTokensEdit: Codable, Hashable, Sendable {
   /// Start offset of the edit.
   public var start: Int
 

--- a/Sources/LanguageServerProtocol/Requests/DocumentSymbolRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/DocumentSymbolRequest.swift
@@ -65,7 +65,7 @@ public enum DocumentSymbolResponse: ResponseType, Hashable {
 /// Represents programming constructs like variables, classes, interfaces etc. that appear
 /// in a document. Document symbols can be hierarchical and they have two ranges: one that encloses
 /// its definition and one that points to its most interesting range, e.g. the range of an identifier.
-public struct DocumentSymbol: Hashable, Codable {
+public struct DocumentSymbol: Hashable, Codable, Sendable {
 
   /// The name of this symbol. Will be displayed in the user interface and therefore must not be
   /// an empty string or a string only consisting of white spaces.

--- a/Sources/LanguageServerProtocol/Requests/FormattingRequests.swift
+++ b/Sources/LanguageServerProtocol/Requests/FormattingRequests.swift
@@ -108,7 +108,7 @@ public struct DocumentOnTypeFormattingRequest: TextDocumentRequest, Hashable {
 }
 
 /// Options to customize how document formatting requests are performed.
-public struct FormattingOptions: Codable, Hashable {
+public struct FormattingOptions: Codable, Hashable, Sendable {
 
   /// The number of space characters in a tab.
   public var tabSize: Int

--- a/Sources/LanguageServerProtocol/Requests/HoverRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/HoverRequest.swift
@@ -55,7 +55,7 @@ public struct HoverResponse: ResponseType, Hashable {
   }
 }
 
-public enum HoverResponseContents: Hashable {
+public enum HoverResponseContents: Hashable, Sendable {
   case markedStrings([MarkedString])
   case markupContent(MarkupContent)
 }
@@ -70,7 +70,7 @@ public enum MarkedString: Hashable {
   case codeBlock(language: String, value: String)
 }
 
-extension MarkedString: Codable {
+extension MarkedString: Codable, Sendable {
   public init(from decoder: Decoder) throws {
     if let value = try? decoder.singleValueContainer().decode(String.self) {
       self = .markdown(value: value)

--- a/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InitializeRequest.swift
@@ -29,7 +29,7 @@
 /// - Returns:
 public struct InitializeRequest: RequestType, Hashable {
   /// Information about the client
-  public struct ClientInfo: Codable, Hashable {
+  public struct ClientInfo: Codable, Hashable, Sendable {
     // The name of the client as defined by the client.
     public var name: String
 

--- a/Sources/LanguageServerProtocol/Requests/InlayHintRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlayHintRefreshRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct InlayHintRefreshRequest: RequestType {
-  public static var method: String = "workspace/inlayHint/refresh"
+  public static let method: String = "workspace/inlayHint/refresh"
   public typealias Response = VoidResponse
 
   public init() {}

--- a/Sources/LanguageServerProtocol/Requests/InlayHintResolveRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlayHintResolveRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct InlayHintResolveRequest: RequestType {
-  public static var method: String = "inlayHint/resolve"
+  public static let method: String = "inlayHint/resolve"
   public typealias Response = InlayHint
 
   public var inlayHint: InlayHint

--- a/Sources/LanguageServerProtocol/Requests/InlineValueRefreshRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlineValueRefreshRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct InlineValueRefreshRequest: RequestType {
-  public static var method: String = "workspace/inlineValue/refresh"
+  public static let method: String = "workspace/inlineValue/refresh"
   public typealias Response = VoidResponse
 
   public init() {}

--- a/Sources/LanguageServerProtocol/Requests/InlineValueRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/InlineValueRequest.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct InlineValueContext: Codable, Hashable {
+public struct InlineValueContext: Codable, Hashable, Sendable {
   /// The stack frame (as a DAP Id) where the execution has stopped.
   public var frameId: Int
 
@@ -28,7 +28,7 @@ public struct InlineValueContext: Codable, Hashable {
 
 /// The inline value request is sent from the client to the server to compute inline values for a given text document that may be rendered in the editor at the end of lines.
 public struct InlineValueRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/inlineValue"
+  public static let method: String = "textDocument/inlineValue"
   public typealias Response = [InlineValue]?
 
   /// The text document.
@@ -50,7 +50,7 @@ public struct InlineValueRequest: TextDocumentRequest {
 }
 
 /// Provide inline value as text.
-public struct InlineValueText: Codable, Hashable {
+public struct InlineValueText: Codable, Hashable, Sendable {
   /// The document range for which the inline value applies.
   @CustomCodable<PositionRange>
   public var range: Range<Position>
@@ -70,7 +70,7 @@ public struct InlineValueText: Codable, Hashable {
 /// the underlying document.
 ///
 /// An optional variable name can be used to override the extracted name.
-public struct InlineValueVariableLookup: Codable, Hashable {
+public struct InlineValueVariableLookup: Codable, Hashable, Sendable {
   /// The document range for which the inline value applies.
   /// The range is used to extract the variable name from the underlying
   /// document.
@@ -96,7 +96,7 @@ public struct InlineValueVariableLookup: Codable, Hashable {
 /// underlying document.
 ///
 /// An optional expression can be used to override the extracted expression.
-public struct InlineValueEvaluatableExpression: Codable, Hashable {
+public struct InlineValueEvaluatableExpression: Codable, Hashable, Sendable {
   /// The document range for which the inline value applies.
   /// The range is used to extract the evaluatable expression from the
   /// underlying document.
@@ -117,7 +117,7 @@ public struct InlineValueEvaluatableExpression: Codable, Hashable {
 /// - as a name to use for a variable lookup (class InlineValueVariableLookup)
 /// - as an evaluatable expression (class InlineValueEvaluatableExpression)
 /// The InlineValue types combines all inline value types into one type.
-public enum InlineValue: ResponseType, Hashable {
+public enum InlineValue: ResponseType, Hashable, Sendable {
   case text(InlineValueText)
   case variableLookup(InlineValueVariableLookup)
   case evaluatableExpression(InlineValueEvaluatableExpression)

--- a/Sources/LanguageServerProtocol/Requests/LinkedEditingRangeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/LinkedEditingRangeRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct LinkedEditingRangeRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/linkedEditingRange"
+  public static let method: String = "textDocument/linkedEditingRange"
   public typealias Response = LinkedEditingRanges?
 
   /// The document in which the given symbol is located.

--- a/Sources/LanguageServerProtocol/Requests/MonikersRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/MonikersRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct MonikersRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/moniker"
+  public static let method: String = "textDocument/moniker"
   public typealias Response = [Moniker]?
 
   /// The document in which to lookup the symbol location.
@@ -29,7 +29,7 @@ public struct MonikersRequest: TextDocumentRequest {
 /// Moniker definition to match LSIF 0.5 moniker definition.
 public struct Moniker: ResponseType, Hashable {
   /// Moniker uniqueness level to define scope of the moniker.
-  public struct UniquenessLevel: RawRepresentable, Codable, Hashable {
+  public struct UniquenessLevel: RawRepresentable, Codable, Hashable, Sendable {
     public var rawValue: String
 
     public init(rawValue: String) {
@@ -53,7 +53,7 @@ public struct Moniker: ResponseType, Hashable {
   }
 
   /// The moniker kind.
-  public struct Kind: RawRepresentable, Codable, Hashable {
+  public struct Kind: RawRepresentable, Codable, Hashable, Sendable {
     public var rawValue: String
 
     public init(rawValue: String) {

--- a/Sources/LanguageServerProtocol/Requests/PollIndexRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/PollIndexRequest.swift
@@ -16,7 +16,7 @@
 /// Users of PollIndex should set `"initializationOptions": { "listenToUnitEvents": false }` during
 /// the `initialize` request.
 public struct PollIndexRequest: RequestType {
-  public static var method: String = "workspace/_pollIndex"
+  public static let method: String = "workspace/_pollIndex"
   public typealias Response = VoidResponse
 
   public init() {}

--- a/Sources/LanguageServerProtocol/Requests/ReferencesRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ReferencesRequest.swift
@@ -42,7 +42,7 @@ public struct ReferencesRequest: TextDocumentRequest, Hashable {
   }
 }
 
-public struct ReferencesContext: Codable, Hashable {
+public struct ReferencesContext: Codable, Hashable, Sendable {
   /// Whether to include the declaration in the list of symbols, or just the references.
   public var includeDeclaration: Bool
 

--- a/Sources/LanguageServerProtocol/Requests/RegisterCapabilityRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/RegisterCapabilityRequest.swift
@@ -35,7 +35,7 @@ public struct RegisterCapabilityRequest: RequestType, Hashable {
 }
 
 /// General parameters to register a capability.
-public struct CapabilityRegistration: Codable, Hashable {
+public struct CapabilityRegistration: Codable, Hashable, Sendable {
   /// The id used to register the capability which may be used to unregister support.
   public var id: String
 

--- a/Sources/LanguageServerProtocol/Requests/SelectionRangeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SelectionRangeRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct SelectionRangeRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/selectionRange"
+  public static let method: String = "textDocument/selectionRange"
   public typealias Response = [SelectionRange]
 
   /// The text document.
@@ -28,8 +28,8 @@ public struct SelectionRangeRequest: TextDocumentRequest {
 
 public struct SelectionRange: ResponseType, Codable, Hashable {
   /// Indirect reference to a `SelectionRange`.
-  final class SelectionRangeBox: Codable, Hashable {
-    var selectionRange: SelectionRange
+  final class SelectionRangeBox: Codable, Hashable, Sendable {
+    let selectionRange: SelectionRange
 
     init(selectionRange: SelectionRange) {
       self.selectionRange = selectionRange

--- a/Sources/LanguageServerProtocol/Requests/SignatureHelpRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SignatureHelpRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct SignatureHelpRequest: TextDocumentRequest {
-  public static var method: String = "textDocument/signatureHelp"
+  public static let method: String = "textDocument/signatureHelp"
   public typealias Response = SignatureHelp?
 
   /// The document in which the given symbol is located.
@@ -33,7 +33,7 @@ public struct SignatureHelpRequest: TextDocumentRequest {
 }
 
 /// How a signature help was triggered.
-public struct SignatureHelpTriggerKind: RawRepresentable, Codable, Hashable {
+public struct SignatureHelpTriggerKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {
@@ -53,7 +53,7 @@ public struct SignatureHelpTriggerKind: RawRepresentable, Codable, Hashable {
 
 /// Additional information about the context in which a signature help request
 /// was triggered.
-public struct SignatureHelpContext: Codable, Hashable {
+public struct SignatureHelpContext: Codable, Hashable, Sendable {
   /// Action that caused signature help to be triggered.
   public var triggerKind: SignatureHelpTriggerKind
 
@@ -127,7 +127,7 @@ public struct SignatureHelp: ResponseType, Hashable {
 /// Represents the signature of something callable. A signature
 /// can have a label, like a function-name, a doc-comment, and
 /// a set of parameters.
-public struct SignatureInformation: Codable, Hashable {
+public struct SignatureInformation: Codable, Hashable, Sendable {
   /// The label of this signature. Will be shown in
   /// the UI.
   public var label: String
@@ -159,8 +159,8 @@ public struct SignatureInformation: Codable, Hashable {
 
 /// Represents a parameter of a callable-signature. A parameter can
 /// have a label and a doc-comment.
-public struct ParameterInformation: Codable, Hashable {
-  public enum Label: Codable, Hashable {
+public struct ParameterInformation: Codable, Hashable, Sendable {
+  public enum Label: Codable, Hashable, Sendable {
     case string(String)
     case offsets(start: Int, end: Int)
 

--- a/Sources/LanguageServerProtocol/Requests/UnregisterCapabilityRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/UnregisterCapabilityRequest.swift
@@ -33,7 +33,7 @@ extension UnregisterCapabilityRequest: Codable {
 }
 
 /// General parameters to unregister a capability.
-public struct Unregistration: Codable, Hashable {
+public struct Unregistration: Codable, Hashable, Sendable {
   /// The id used to unregister the capability, usually provided through the
   /// register request.
   public var id: String

--- a/Sources/LanguageServerProtocol/Requests/WillChangeFilesRequests.swift
+++ b/Sources/LanguageServerProtocol/Requests/WillChangeFilesRequests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents information on a file/folder create.
-public struct FileCreate: Codable, Hashable {
+public struct FileCreate: Codable, Hashable, Sendable {
   /// A file:// URI for the location of the file/folder being created.
   public var uri: DocumentURI
 
@@ -21,7 +21,7 @@ public struct FileCreate: Codable, Hashable {
 }
 
 public struct WillCreateFilesRequest: RequestType {
-  public static var method: String = "workspace/willCreateFiles"
+  public static let method: String = "workspace/willCreateFiles"
   public typealias Response = WorkspaceEdit?
 
   /// An array of all files/folders created in this operation.
@@ -33,7 +33,7 @@ public struct WillCreateFilesRequest: RequestType {
 }
 
 /// Represents information on a file/folder rename.
-public struct FileRename: Codable, Hashable {
+public struct FileRename: Codable, Hashable, Sendable {
 
   /// A file:// URI for the original location of the file/folder being renamed.
   public var oldUri: DocumentURI
@@ -48,7 +48,7 @@ public struct FileRename: Codable, Hashable {
 }
 
 public struct WillRenameFilesRequest: RequestType {
-  public static var method: String = "workspace/willRenameFiles"
+  public static let method: String = "workspace/willRenameFiles"
   public typealias Response = WorkspaceEdit?
 
   /// An array of all files/folders renamed in this operation. When a folder
@@ -61,7 +61,7 @@ public struct WillRenameFilesRequest: RequestType {
 }
 
 /// Represents information on a file/folder delete.
-public struct FileDelete: Codable, Hashable {
+public struct FileDelete: Codable, Hashable, Sendable {
   /// A file:// URI for the location of the file/folder being deleted.
   public var uri: DocumentURI
 
@@ -71,7 +71,7 @@ public struct FileDelete: Codable, Hashable {
 }
 
 public struct WillDeleteFilesRequest: RequestType {
-  public static var method: String = "workspace/willDeleteFiles"
+  public static let method: String = "workspace/willDeleteFiles"
   public typealias Response = WorkspaceEdit?
 
   /// An array of all files/folders deleted in this operation.

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceDiagnosticsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceDiagnosticsRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A previous result id in a workspace pull request.
-public struct PreviousResultId: Codable {
+public struct PreviousResultId: Codable, Sendable {
   /// The URI for which the client knows a result id.
   public var uri: DocumentURI
 
@@ -25,7 +25,7 @@ public struct PreviousResultId: Codable {
 }
 
 public struct WorkspaceDiagnosticsRequest: RequestType {
-  public static var method: String = "workspace/diagnostic"
+  public static let method: String = "workspace/diagnostic"
   public typealias Response = WorkspaceDiagnosticReport
 
   /// The additional identifier provided during registration.
@@ -51,7 +51,7 @@ public struct WorkspaceDiagnosticReport: ResponseType {
 }
 
 /// A full document diagnostic report for a workspace diagnostic result.
-public struct WorkspaceFullDocumentDiagnosticReport: Codable, Hashable {
+public struct WorkspaceFullDocumentDiagnosticReport: Codable, Hashable, Sendable {
   /// An optional result id. If provided it will
   /// be sent on the next diagnostic request for the
   /// same document.
@@ -109,7 +109,7 @@ public struct WorkspaceFullDocumentDiagnosticReport: Codable, Hashable {
 }
 
 /// An unchanged document diagnostic report for a workspace diagnostic result.
-public struct WorkspaceUnchangedDocumentDiagnosticReport: Codable, Hashable {
+public struct WorkspaceUnchangedDocumentDiagnosticReport: Codable, Hashable, Sendable {
   /// A result id which will be sent on the next
   /// diagnostic request for the same document.
   public var resultId: String
@@ -159,7 +159,7 @@ public struct WorkspaceUnchangedDocumentDiagnosticReport: Codable, Hashable {
 }
 
 /// A workspace diagnostic document report.
-public enum WorkspaceDocumentDiagnosticReport: Codable, Hashable {
+public enum WorkspaceDocumentDiagnosticReport: Codable, Hashable, Sendable {
   case full(WorkspaceFullDocumentDiagnosticReport)
   case unchanged(WorkspaceUnchangedDocumentDiagnosticReport)
 

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolResolveRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolResolveRequest.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct WorkspaceSymbolResolveRequest: RequestType {
-  public static var method: String = "workspaceSymbol/resolve"
+  public static let method: String = "workspaceSymbol/resolve"
   public typealias Response = WorkspaceSymbol
 
   public var workspaceSymbol: WorkspaceSymbol

--- a/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/WorkspaceSymbolsRequest.swift
@@ -12,7 +12,7 @@
 
 /// Request for all symbols that match a certain query string.
 ///
-/// This request looks up the canonical occurence of each symbol which has a name that contains the query string.
+/// This request looks up the canonical occurrence of each symbol which has a name that contains the query string.
 /// The list of symbol information is returned
 ///
 /// Servers that provide workspace symbol queries should set the `workspaceSymbolProvider` server capability.
@@ -94,8 +94,8 @@ public struct SymbolInformation: Hashable, ResponseType {
 
 /// A special workspace symbol that supports locations without a range
 public struct WorkspaceSymbol: ResponseType, Hashable {
-  public enum WorkspaceSymbolLocation: Codable, Hashable {
-    public struct URI: Codable, Hashable {
+  public enum WorkspaceSymbolLocation: Codable, Hashable, Sendable {
+    public struct URI: Codable, Hashable, Sendable {
       public var uri: DocumentURI
 
       public init(uri: DocumentURI) {

--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Capabilities provided by the client editor/IDE.
-public struct ClientCapabilities: Hashable, Codable {
+public struct ClientCapabilities: Hashable, Codable, Sendable {
 
   /// Workspace-specific client capabilities.
   public var workspace: WorkspaceClientCapabilities?
@@ -49,8 +49,8 @@ public struct ClientCapabilities: Hashable, Codable {
 }
 
 /// Helper capability wrapper for structs that only have a `dynamicRegistration` member.
-public struct DynamicRegistrationCapability: Hashable, Codable {
-  /// Whether the client supports dynamic registaration of this feature.
+public struct DynamicRegistrationCapability: Hashable, Codable, Sendable {
+  /// Whether the client supports dynamic registration of this feature.
   public var dynamicRegistration: Bool? = nil
 
   public init(dynamicRegistration: Bool? = nil) {
@@ -59,7 +59,7 @@ public struct DynamicRegistrationCapability: Hashable, Codable {
 }
 
 /// Helper capability wrapper for structs that only have a `refreshSupport` member.
-public struct RefreshRegistrationCapability: Hashable, Codable {
+public struct RefreshRegistrationCapability: Hashable, Codable, Sendable {
   /// Whether the client implementation supports a refresh request sent from the
   /// server to the client.
   public var refreshSupport: Bool?
@@ -71,10 +71,10 @@ public struct RefreshRegistrationCapability: Hashable, Codable {
 
 /// Capabilities of the client editor/IDE related to managing the workspace.
 // FIXME: Instead of making all of these optional, provide default values and make the deserialization handle missing values.
-public struct WorkspaceClientCapabilities: Hashable, Codable {
+public struct WorkspaceClientCapabilities: Hashable, Codable, Sendable {
 
   /// Capabilities specific to `WorkspaceEdit`.
-  public struct WorkspaceEdit: Hashable, Codable {
+  public struct WorkspaceEdit: Hashable, Codable, Sendable {
     /// Whether the client supports the `documentChanges` field of `WorkspaceEdit`.
     public var documentChanges: Bool? = nil
 
@@ -84,10 +84,10 @@ public struct WorkspaceClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to the `workspace/symbol` request.
-  public struct Symbol: Hashable, Codable {
+  public struct Symbol: Hashable, Codable, Sendable {
 
     /// Capabilities specific to `SymbolKind`.
-    public struct SymbolKind: Hashable, Codable {
+    public struct SymbolKind: Hashable, Codable, Sendable {
 
       /// The symbol kind values that the client can support.
       ///
@@ -101,7 +101,7 @@ public struct WorkspaceClientCapabilities: Hashable, Codable {
       }
     }
 
-    /// Whether the client supports dynamic registaration of this request.
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
 
     public var symbolKind: SymbolKind? = nil
@@ -112,7 +112,7 @@ public struct WorkspaceClientCapabilities: Hashable, Codable {
     }
   }
 
-  public struct FileOperations: Hashable, Codable {
+  public struct FileOperations: Hashable, Codable, Sendable {
     /// Whether the client supports dynamic registration for file
     /// requests/notifications.
     public var dynamicRegistration: Bool?
@@ -224,12 +224,12 @@ public struct WorkspaceClientCapabilities: Hashable, Codable {
 
 /// Capabilities of the client editor/IDE related to the document.
 // FIXME: Instead of making all of these optional, provide default values and make the deserialization handle missing values.
-public struct TextDocumentClientCapabilities: Hashable, Codable {
+public struct TextDocumentClientCapabilities: Hashable, Codable, Sendable {
 
   /// Capabilities specific to the `textDocument/...` change notifications.
-  public struct Synchronization: Hashable, Codable {
+  public struct Synchronization: Hashable, Codable, Sendable {
 
-    /// Whether the client supports dynamic registaration of these notifications.
+    /// Whether the client supports dynamic registration of these notifications.
     public var dynamicRegistration: Bool? = nil
 
     /// Whether the client supports the will-save notification.
@@ -255,10 +255,10 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to the `textDocument/...` change notifications.
-  public struct Completion: Hashable, Codable {
+  public struct Completion: Hashable, Codable, Sendable {
 
     /// Capabilities specific to `CompletionItem`.
-    public struct CompletionItem: Hashable, Codable {
+    public struct CompletionItem: Hashable, Codable, Sendable {
 
       /// Whether the client supports rich snippets using placeholders, etc.
       public var snippetSupport: Bool? = nil
@@ -291,7 +291,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     }
 
     /// Capabilities specific to `CompletionItemKind`.
-    public struct CompletionItemKind: Hashable, Codable {
+    public struct CompletionItemKind: Hashable, Codable, Sendable {
 
       /// The completion kind values that the client can support.
       ///
@@ -307,7 +307,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
 
     // MARK: Properties
 
-    /// Whether the client supports dynamic registaration of these capabilities.
+    /// Whether the client supports dynamic registration of these capabilities.
     public var dynamicRegistration: Bool? = nil
 
     public var completionItem: CompletionItem? = nil
@@ -331,9 +331,9 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to the `textDocument/hover` request.
-  public struct Hover: Hashable, Codable {
+  public struct Hover: Hashable, Codable, Sendable {
 
-    /// Whether the client supports dynamic registaration of this request.
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
 
     /// Formats supported by the client for the `Hover.content` property from most to least preferred.
@@ -346,11 +346,11 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to the `textDocument/signatureHelp` request.
-  public struct SignatureHelp: Hashable, Codable {
+  public struct SignatureHelp: Hashable, Codable, Sendable {
 
     /// Capabilities specific to `SignatureInformation`.
-    public struct SignatureInformation: Hashable, Codable {
-      public struct ParameterInformation: Hashable, Codable {
+    public struct SignatureInformation: Hashable, Codable, Sendable {
+      public struct ParameterInformation: Hashable, Codable, Sendable {
         /// The client supports processing label offsets instead of a simple label string.
         var labelOffsetSupport: Bool? = nil
 
@@ -370,7 +370,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
       }
     }
 
-    /// Whether the client supports dynamic registaration of this request.
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
 
     public var signatureInformation: SignatureInformation? = nil
@@ -382,10 +382,10 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to the `textDocument/documentSymbol` request.
-  public struct DocumentSymbol: Hashable, Codable {
+  public struct DocumentSymbol: Hashable, Codable, Sendable {
 
     /// Capabilities specific to `SymbolKind`.
-    public struct SymbolKind: Hashable, Codable {
+    public struct SymbolKind: Hashable, Codable, Sendable {
 
       /// The symbol kind values that the client can support.
       ///
@@ -399,7 +399,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
       }
     }
 
-    /// Whether the client supports dynamic registaration of this request.
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
 
     public var symbolKind: SymbolKind? = nil
@@ -417,8 +417,8 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     }
   }
 
-  public struct DynamicRegistrationLinkSupportCapability: Hashable, Codable {
-    /// Whether the client supports dynamic registaration of this request.
+  public struct DynamicRegistrationLinkSupportCapability: Hashable, Codable, Sendable {
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
 
     /// The client supports additional metadata in the form of declaration links.
@@ -431,12 +431,12 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to the `textDocument/codeAction` request.
-  public struct CodeAction: Hashable, Codable {
+  public struct CodeAction: Hashable, Codable, Sendable {
 
-    /// Liteals accepted by the client in response to a `textDocument/codeAction` request.
-    public struct CodeActionLiteralSupport: Hashable, Codable {
+    /// Literals accepted by the client in response to a `textDocument/codeAction` request.
+    public struct CodeActionLiteralSupport: Hashable, Codable, Sendable {
       /// Accepted code action kinds.
-      public struct CodeActionKind: Hashable, Codable {
+      public struct CodeActionKind: Hashable, Codable, Sendable {
 
         /// The code action kind values that the client can support.
         ///
@@ -455,7 +455,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
       }
     }
 
-    /// Whether the client supports dynamic registaration of this request.
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool?
 
     public var codeActionLiteralSupport: CodeActionLiteralSupport? = nil
@@ -466,9 +466,9 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to `textDocument/rename`.
-  public struct Rename: Hashable, Codable {
+  public struct Rename: Hashable, Codable, Sendable {
 
-    /// Whether the client supports dynamic registaration of this request.
+    /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool?
 
     /// The client supports testing for validity of rename operations before execution.
@@ -481,7 +481,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to `textDocument/publishDiagnostics`.
-  public struct PublishDiagnostics: Hashable, Codable {
+  public struct PublishDiagnostics: Hashable, Codable, Sendable {
     /// Whether the client accepts diagnostics with related information.
     public var relatedInformation: Bool? = nil
 
@@ -504,7 +504,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to `textDocument/foldingRange`.
-  public struct FoldingRange: Equatable, Hashable, Codable {
+  public struct FoldingRange: Equatable, Hashable, Codable, Sendable {
 
     /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
@@ -523,12 +523,12 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     }
   }
 
-  public struct SemanticTokensRangeClientCapabilities: Equatable, Hashable, Codable {
+  public struct SemanticTokensRangeClientCapabilities: Equatable, Hashable, Codable, Sendable {
     // Empty in the LSP 3.16 spec.
     public init() {}
   }
 
-  public struct SemanticTokensFullClientCapabilities: Equatable, Hashable, Codable {
+  public struct SemanticTokensFullClientCapabilities: Equatable, Hashable, Codable, Sendable {
     /// The client will also send the `textDocument/semanticTokens/full/delta`
     /// request if the server provides a corresponding handler.
     public var delta: Bool?
@@ -538,7 +538,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
     }
   }
 
-  public struct SemanticTokensRequestsClientCapabilities: Equatable, Hashable, Codable {
+  public struct SemanticTokensRequestsClientCapabilities: Equatable, Hashable, Codable, Sendable {
     /// The client will send the `textDocument/semanticTokens/range` request
     /// if the server provides a corresponding handler.
     public var range: ValueOrBool<SemanticTokensRangeClientCapabilities>?
@@ -557,7 +557,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to `textDocument/semanticTokens`.
-  public struct SemanticTokens: Equatable, Hashable, Codable {
+  public struct SemanticTokens: Equatable, Hashable, Codable, Sendable {
 
     /// Whether the client supports dynamic registration of this request.
     public var dynamicRegistration: Bool? = nil
@@ -599,9 +599,9 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to 'textDocument/inlayHint'.
-  public struct InlayHint: Hashable, Codable {
+  public struct InlayHint: Hashable, Codable, Sendable {
     /// Properties a client can resolve lazily.
-    public struct ResolveSupport: Hashable, Codable {
+    public struct ResolveSupport: Hashable, Codable, Sendable {
       /// The properties that a client can resolve lazily.
       public var properties: [String]
 
@@ -626,7 +626,7 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
   }
 
   /// Capabilities specific to 'textDocument/diagnostic'. Since LSP 3.17.0.
-  public struct Diagnostic: Equatable, Hashable, Codable {
+  public struct Diagnostic: Equatable, Hashable, Codable, Sendable {
 
     /// Whether implementation supports dynamic registration.
     public var dynamicRegistration: Bool?
@@ -768,8 +768,8 @@ public struct TextDocumentClientCapabilities: Hashable, Codable {
 }
 
 /// Capabilities specific to the notebook document support.
-public struct NotebookDocumentClientCapabilities: Hashable, Codable {
-  public struct NotebookDocumentSync: Hashable, Codable {
+public struct NotebookDocumentClientCapabilities: Hashable, Codable, Sendable {
+  public struct NotebookDocumentSync: Hashable, Codable, Sendable {
     /// Whether implementation supports dynamic registration. If this is
     /// set to `true` the client supports the new
     /// `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
@@ -797,10 +797,10 @@ public struct NotebookDocumentClientCapabilities: Hashable, Codable {
 }
 
 /// Window specific client capabilities.
-public struct WindowClientCapabilities: Hashable, Codable {
+public struct WindowClientCapabilities: Hashable, Codable, Sendable {
   /// Show message request client capabilities
-  public struct ShowMessageRequest: Hashable, Codable {
-    public struct MessageActionItem: Hashable, Codable {
+  public struct ShowMessageRequest: Hashable, Codable, Sendable {
+    public struct MessageActionItem: Hashable, Codable, Sendable {
       /// Whether the client supports additional attributes which
       /// are preserved and sent back to the server in the
       /// request's response.
@@ -820,7 +820,7 @@ public struct WindowClientCapabilities: Hashable, Codable {
   }
 
   /// Client capabilities for the show document request.
-  public struct ShowDocument: Hashable, Codable {
+  public struct ShowDocument: Hashable, Codable, Sendable {
     /// The client has support for the show document
     /// request.
     public var support: Bool
@@ -856,8 +856,8 @@ public struct WindowClientCapabilities: Hashable, Codable {
 }
 
 /// General client capabilities.
-public struct GeneralClientCapabilities: Hashable, Codable {
-  public struct StaleRequestSupport: Hashable, Codable {
+public struct GeneralClientCapabilities: Hashable, Codable, Sendable {
+  public struct StaleRequestSupport: Hashable, Codable, Sendable {
     /// The client will actively cancel the request.
     public var cancel: Bool
 
@@ -873,7 +873,7 @@ public struct GeneralClientCapabilities: Hashable, Codable {
   }
 
   /// Client capabilities specific to regular expressions.
-  public struct RegularExpressions: Hashable, Codable {
+  public struct RegularExpressions: Hashable, Codable, Sendable {
     /// The engine's name.
     public var engine: String
 
@@ -887,7 +887,7 @@ public struct GeneralClientCapabilities: Hashable, Codable {
   }
 
   /// Client capabilities specific to the used markdown parser.
-  public struct Markdown: Hashable, Codable {
+  public struct Markdown: Hashable, Codable, Sendable {
     /// The name of the parser.
     public var parser: String
 
@@ -906,7 +906,7 @@ public struct GeneralClientCapabilities: Hashable, Codable {
 
   /// A type indicating how positions are encoded,
   /// specifically what column offsets mean.
-  public enum PositionEncodingKind: String, Hashable, Codable {
+  public enum PositionEncodingKind: String, Hashable, Codable, Sendable {
 
     /// Character offsets count UTF-8 code units (e.g bytes).
     case utf8 = "utf-8"

--- a/Sources/LanguageServerProtocol/SupportTypes/CodeActionKind.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CodeActionKind.swift
@@ -13,7 +13,7 @@
 /// A code action kind.
 ///
 /// In LSP, this is a string, so we don't use a closed set.
-public struct CodeActionKind: RawRepresentable, Codable, Hashable {
+public struct CodeActionKind: RawRepresentable, Codable, Hashable, Sendable {
 
   public var rawValue: String
 

--- a/Sources/LanguageServerProtocol/SupportTypes/Command.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Command.swift
@@ -13,7 +13,7 @@
 /// Represents a reference to a command identified by a string. Used as the result of
 /// requests that returns actions to the user, later used as the parameter of
 /// workspace/executeCommand if the user wishes to execute said command.
-public struct Command: Codable, Hashable {
+public struct Command: Codable, Hashable, Sendable {
 
   /// The title of this command.
   public var title: String

--- a/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CompletionItem.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Additional details for a completion item label.
-public struct CompletionItemLabelDetails: Codable, Hashable {
+public struct CompletionItemLabelDetails: Codable, Hashable, Sendable {
 
   /// An optional string which is rendered less prominently directly after
   /// {@link CompletionItem.label label}, without any spacing. Should be
@@ -31,7 +31,7 @@ public struct CompletionItemLabelDetails: Codable, Hashable {
 
 /// Completion item tags are extra annotations that tweak the rendering of a
 /// completion item.
-public struct CompletionItemTag: RawRepresentable, Codable, Hashable {
+public struct CompletionItemTag: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {
@@ -42,7 +42,7 @@ public struct CompletionItemTag: RawRepresentable, Codable, Hashable {
   public static let deprecated = CompletionItemTag(rawValue: 1)
 }
 
-public enum CompletionItemEdit: Codable, Hashable {
+public enum CompletionItemEdit: Codable, Hashable, Sendable {
   case textEdit(TextEdit)
   case insertReplaceEdit(InsertReplaceEdit)
 
@@ -71,7 +71,7 @@ public enum CompletionItemEdit: Codable, Hashable {
 }
 
 /// A single completion result.
-public struct CompletionItem: ResponseType, Codable, Hashable {
+public struct CompletionItem: ResponseType, Codable, Hashable, Sendable {
 
   /// The display name of the completion.
   public var label: String
@@ -205,7 +205,7 @@ public struct CompletionItem: ResponseType, Codable, Hashable {
 }
 
 /// The format of the returned insertion text - either literal plain text or a snippet.
-public enum InsertTextFormat: Int, Codable, Hashable {
+public enum InsertTextFormat: Int, Codable, Hashable, Sendable {
 
   /// The text to insert is plain text.
   case plain = 1
@@ -216,7 +216,7 @@ public enum InsertTextFormat: Int, Codable, Hashable {
 
 /// How whitespace and indentation is handled during completion
 /// item insertion.
-public struct InsertTextMode: RawRepresentable, Codable, Hashable {
+public struct InsertTextMode: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {

--- a/Sources/LanguageServerProtocol/SupportTypes/CompletionItemKind.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CompletionItemKind.swift
@@ -13,7 +13,7 @@
 /// A completion kind.
 ///
 /// In LSP, this is an integer, so we don't use a closed set.
-public struct CompletionItemKind: RawRepresentable, Codable, Hashable {
+public struct CompletionItemKind: RawRepresentable, Codable, Hashable, Sendable {
 
   public var rawValue: Int
 

--- a/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Diagnostic.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The serverity level of a Diagnostic, between hint and error.
-public enum DiagnosticSeverity: Int, Codable, Hashable {
+/// The severity level of a Diagnostic, between hint and error.
+public enum DiagnosticSeverity: Int, Codable, Hashable, Sendable {
   case error = 1
   case warning = 2
   case information = 3
@@ -19,13 +19,13 @@ public enum DiagnosticSeverity: Int, Codable, Hashable {
 }
 
 /// A unique diagnostic code, which may be used identifier the diagnostic in e.g. documentation.
-public enum DiagnosticCode: Hashable {
+public enum DiagnosticCode: Hashable, Sendable {
   case number(Int)
   case string(String)
 }
 
 /// Captures a description of a diagnostic error code.
-public struct CodeDescription: Codable, Hashable {
+public struct CodeDescription: Codable, Hashable, Sendable {
 
   /// A URI to open with more information about the diagnostic.
   public var href: DocumentURI
@@ -36,7 +36,7 @@ public struct CodeDescription: Codable, Hashable {
 }
 
 /// A diagnostic message such a compiler error or warning.
-public struct Diagnostic: Codable, Hashable {
+public struct Diagnostic: Codable, Hashable, Sendable {
 
   /// The primary position/range of the diagnostic.
   @CustomCodable<PositionRange>
@@ -100,7 +100,7 @@ public struct Diagnostic: Codable, Hashable {
 
 /// A small piece of metadata about a diagnostic that lets editors e.g. style the diagnostic
 /// in a special way.
-public struct DiagnosticTag: RawRepresentable, Codable, Hashable {
+public struct DiagnosticTag: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {
@@ -119,8 +119,8 @@ public struct DiagnosticTag: RawRepresentable, Codable, Hashable {
   public static let deprecated: DiagnosticTag = DiagnosticTag(rawValue: 2)
 }
 
-/// A 'note' diagnostic attached to a primary diagonstic that provides additional information.
-public struct DiagnosticRelatedInformation: Codable, Hashable {
+/// A 'note' diagnostic attached to a primary diagnostic that provides additional information.
+public struct DiagnosticRelatedInformation: Codable, Hashable, Sendable {
 
   /// The location of this related diagnostic information.
   public var location: Location

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-public struct DocumentURI: Codable, Hashable {
+public struct DocumentURI: Codable, Hashable, Sendable {
   /// The URL that store the URIs value
   private let storage: URL
 

--- a/Sources/LanguageServerProtocol/SupportTypes/FileEvent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/FileEvent.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// An event describing a file change.
-public struct FileEvent: Codable, Hashable {
+public struct FileEvent: Codable, Hashable, Sendable {
   public var uri: DocumentURI
   public var type: FileChangeType
 
@@ -23,7 +23,7 @@ public struct FileEvent: Codable, Hashable {
 /// The type of file event.
 ///
 /// In LSP, this is an integer, so we don't use a closed set.
-public struct FileChangeType: RawRepresentable, Codable, Hashable {
+public struct FileChangeType: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {

--- a/Sources/LanguageServerProtocol/SupportTypes/FileSystemWatcher.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/FileSystemWatcher.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Defines a watcher interested in specific file system change events.
-public struct FileSystemWatcher: Codable, Hashable {
+public struct FileSystemWatcher: Codable, Hashable, Sendable {
   /// The glob pattern to watch.
   public var globPattern: String
 
@@ -55,7 +55,7 @@ extension FileSystemWatcher: LSPAnyCodable {
 /// The type of file event a watcher is interested in.
 ///
 /// In LSP, this is an integer, so we don't use a closed set.
-public struct WatchKind: OptionSet, Codable, Hashable {
+public struct WatchKind: OptionSet, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {

--- a/Sources/LanguageServerProtocol/SupportTypes/FoldingRangeKind.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/FoldingRangeKind.swift
@@ -13,7 +13,7 @@
 /// A folding range kind.
 ///
 /// In LSP, this is a string, so we don't use a closed set.
-public struct FoldingRangeKind: RawRepresentable, Codable, Hashable {
+public struct FoldingRangeKind: RawRepresentable, Codable, Hashable, Sendable {
 
   public var rawValue: String
 

--- a/Sources/LanguageServerProtocol/SupportTypes/InlayHint.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/InlayHint.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents an inline annotation displayed by the editor in a source file.
-public struct InlayHint: ResponseType, Codable, Hashable {
+public struct InlayHint: ResponseType, Codable, Hashable, Sendable {
   /// The position within the code that this hint is attached to.
   public var position: Position
 
@@ -59,7 +59,7 @@ public struct InlayHint: ResponseType, Codable, Hashable {
 }
 
 /// A hint's kind, used for more flexible client-side styling.
-public struct InlayHintKind: RawRepresentable, Codable, Hashable {
+public struct InlayHintKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {
@@ -74,7 +74,7 @@ public struct InlayHintKind: RawRepresentable, Codable, Hashable {
 }
 
 /// A hint's label, either being a single string or a composition of parts.
-public enum InlayHintLabel: Codable, Hashable {
+public enum InlayHintLabel: Codable, Hashable, Sendable {
   case parts([InlayHintLabelPart])
   case string(String)
 
@@ -115,7 +115,7 @@ extension InlayHintLabel: ExpressibleByStringInterpolation {
 }
 
 /// A part of an interactive or composite inlay hint label.
-public struct InlayHintLabelPart: Codable, Hashable {
+public struct InlayHintLabelPart: Codable, Hashable, Sendable {
   /// The value of this label part.
   public let value: String
 

--- a/Sources/LanguageServerProtocol/SupportTypes/InsertReplaceEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/InsertReplaceEdit.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A special text edit to provide an insert and a replace operation.
-public struct InsertReplaceEdit: Codable, Hashable {
+public struct InsertReplaceEdit: Codable, Hashable, Sendable {
   /// The string to be inserted.
   public var newText: String
 

--- a/Sources/LanguageServerProtocol/SupportTypes/LSPAny.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LSPAny.swift
@@ -12,7 +12,7 @@
 
 /// Representation of 'any' in the Language Server Protocol, which is equivalent
 /// to an arbitrary JSON value.
-public enum LSPAny: Hashable {
+public enum LSPAny: Hashable, Sendable {
   case null
   case int(Int)
   case bool(Bool)

--- a/Sources/LanguageServerProtocol/SupportTypes/Language.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Language.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A source code language identifier, such as "swift", or "objective-c".
-public struct Language: RawRepresentable, Codable, Equatable, Hashable {
+public struct Language: RawRepresentable, Codable, Equatable, Hashable, Sendable {
   public typealias LanguageId = String
 
   public let rawValue: LanguageId

--- a/Sources/LanguageServerProtocol/SupportTypes/Location.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Location.swift
@@ -13,7 +13,7 @@
 /// Range within a particular document.
 ///
 /// For a location where the document is implied, use `Position` or `Range<Position>`.
-public struct Location: ResponseType, Hashable, Codable, CustomDebugStringConvertible, Comparable {
+public struct Location: ResponseType, Hashable, Codable, CustomDebugStringConvertible, Comparable, Sendable {
   public static func < (lhs: Location, rhs: Location) -> Bool {
     if lhs.uri != rhs.uri {
       return lhs.uri.stringValue < rhs.uri.stringValue

--- a/Sources/LanguageServerProtocol/SupportTypes/LocationLink.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LocationLink.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct LocationLink: Codable, Hashable {
+public struct LocationLink: Codable, Hashable, Sendable {
   /// Span of the origin of this link.
   ///
   /// Used as the underlined span for mouse interaction. Defaults to the word range at the mouse position.

--- a/Sources/LanguageServerProtocol/SupportTypes/LocationsOrLocationLinksResponse.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/LocationsOrLocationLinksResponse.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum LocationsOrLocationLinksResponse: ResponseType, Hashable {
+public enum LocationsOrLocationLinksResponse: ResponseType, Hashable, Sendable {
   case locations([Location])
   case locationLinks([LocationLink])
 

--- a/Sources/LanguageServerProtocol/SupportTypes/MarkupContent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/MarkupContent.swift
@@ -13,7 +13,7 @@
 /// The kind of markup (plaintext or markdown).
 ///
 /// In LSP, this is a string, so we don't use a closed set.
-public struct MarkupKind: RawRepresentable, Codable, Hashable {
+public struct MarkupKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: String
   public init(rawValue: String) {
     self.rawValue = rawValue
@@ -23,7 +23,7 @@ public struct MarkupKind: RawRepresentable, Codable, Hashable {
   public static let markdown: MarkupKind = MarkupKind(rawValue: "markdown")
 }
 
-public struct MarkupContent: Codable, Hashable {
+public struct MarkupContent: Codable, Hashable, Sendable {
 
   public var kind: MarkupKind
 

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookCellTextDocumentFilter.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookCellTextDocumentFilter.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A notebook document filter denotes a notebook document by different properties.
-public struct NotebookDocumentFilter: Codable, Hashable {
+public struct NotebookDocumentFilter: Codable, Hashable, Sendable {
   /// The type of the enclosing notebook.
   public var notebookType: String?
 
@@ -30,8 +30,8 @@ public struct NotebookDocumentFilter: Codable, Hashable {
 
 /// A notebook cell text document filter denotes a cell text
 /// document by different properties.
-public struct NotebookCellTextDocumentFilter: Codable, Hashable {
-  public enum NotebookFilter: Codable, Hashable {
+public struct NotebookCellTextDocumentFilter: Codable, Hashable, Sendable {
+  public enum NotebookFilter: Codable, Hashable, Sendable {
     case string(String)
     case notebookDocumentFilter(NotebookDocumentFilter)
 

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookDocument.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookDocument.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct NotebookDocument: Codable, Hashable {
+public struct NotebookDocument: Codable, Hashable, Sendable {
 
   /// The notebook document's URI.
   public var uri: DocumentURI
@@ -39,7 +39,7 @@ public struct NotebookDocument: Codable, Hashable {
 }
 
 /// A notebook cell kind.
-public struct NotebookCellKind: RawRepresentable, Codable, Hashable {
+public struct NotebookCellKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {
@@ -47,13 +47,13 @@ public struct NotebookCellKind: RawRepresentable, Codable, Hashable {
   }
 
   /// A markup-cell is formatted source that is used for display.
-  public static var markup = NotebookCellKind(rawValue: 1)
+  public static let markup = NotebookCellKind(rawValue: 1)
 
   /// A code-cell is source code.
-  public static var code = NotebookCellKind(rawValue: 2)
+  public static let code = NotebookCellKind(rawValue: 2)
 }
 
-public struct ExecutionSummary: Codable, Hashable {
+public struct ExecutionSummary: Codable, Hashable, Sendable {
   /// A strict monotonically increasing value
   /// indicating the execution order of a cell
   /// inside a notebook.
@@ -74,7 +74,7 @@ public struct ExecutionSummary: Codable, Hashable {
 /// A cell's document URI must be unique across ALL notebook
 /// cells and can therefore be used to uniquely identify a
 /// notebook cell or the cell's text document.
-public struct NotebookCell: Codable, Hashable {
+public struct NotebookCell: Codable, Hashable, Sendable {
 
   /// The cell's kind
   public var kind: NotebookCellKind

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookDocumentChangeEvent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookDocumentChangeEvent.swift
@@ -12,7 +12,7 @@
 
 /// A change describing how to move a `NotebookCell`
 /// array from state S to S'.
-public struct NotebookCellArrayChange: Codable, Hashable {
+public struct NotebookCellArrayChange: Codable, Hashable, Sendable {
   /// The start offset of the cell that changed.
   public var start: Int
 
@@ -30,8 +30,8 @@ public struct NotebookCellArrayChange: Codable, Hashable {
 }
 
 /// A change event for a notebook document.
-public struct NotebookDocumentChangeEvent: Codable, Hashable {
-  public struct CellsStructure: Codable, Hashable {
+public struct NotebookDocumentChangeEvent: Codable, Hashable, Sendable {
+  public struct CellsStructure: Codable, Hashable, Sendable {
     /// The change to the cell array.
     public var array: NotebookCellArrayChange
 
@@ -52,7 +52,7 @@ public struct NotebookDocumentChangeEvent: Codable, Hashable {
     }
   }
 
-  public struct CellsTextContent: Codable, Hashable {
+  public struct CellsTextContent: Codable, Hashable, Sendable {
     public var document: VersionedTextDocumentIdentifier
     public var changes: [TextDocumentContentChangeEvent]
 
@@ -62,7 +62,7 @@ public struct NotebookDocumentChangeEvent: Codable, Hashable {
     }
   }
 
-  public struct Cells: Codable, Hashable {
+  public struct Cells: Codable, Hashable, Sendable {
     /// Changes to the cell structure to add or
     /// remove cells.
     public var structure: CellsStructure?

--- a/Sources/LanguageServerProtocol/SupportTypes/NotebookDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/NotebookDocumentIdentifier.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A literal to identify a notebook document in the client.
-public struct NotebookDocumentIdentifier: Hashable, Codable {
+public struct NotebookDocumentIdentifier: Hashable, Codable, Sendable {
 
   /// The notebook document's URI.
   public var uri: DocumentURI

--- a/Sources/LanguageServerProtocol/SupportTypes/Position.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Position.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Position within a text document, expressed as a zero-based line and column (utf-16 code unit offset).
-public struct Position: Hashable {
+public struct Position: Hashable, Codable, Sendable {
 
   /// Line number within a document (zero-based).
   public var line: Int
@@ -25,7 +25,7 @@ public struct Position: Hashable {
   }
 }
 
-extension Position: Codable {
+extension Position {
   private enum CodingKeys: String, CodingKey {
     case line
     case utf16index = "character"

--- a/Sources/LanguageServerProtocol/SupportTypes/PositionEncoding.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/PositionEncoding.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A set of predefined position encoding kinds.
-public struct PositionEncodingKind: RawRepresentable, Codable, Hashable {
+public struct PositionEncodingKind: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: String
 
   public init(rawValue: String) {

--- a/Sources/LanguageServerProtocol/SupportTypes/ProgressToken.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ProgressToken.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum ProgressToken: Codable, Hashable {
+public enum ProgressToken: Codable, Hashable, Sendable {
   case integer(Int)
   case string(String)
 

--- a/Sources/LanguageServerProtocol/SupportTypes/SKCompletionOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SKCompletionOptions.swift
@@ -14,7 +14,7 @@
 ///
 /// **(LSP Extension)**: This is used as part of an extension to the
 /// code-completion request.
-public struct SKCompletionOptions: Codable, Hashable {
+public struct SKCompletionOptions: Codable, Hashable, Sendable {
   /// The maximum number of completion results to return, or `nil` for unlimited.
   public var maxResults: Int?
 

--- a/Sources/LanguageServerProtocol/SupportTypes/SemanticTokenModifiers.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SemanticTokenModifiers.swift
@@ -16,7 +16,7 @@ import Foundation
 ///
 /// Similar to `SemanticTokenTypes`, the bit indices should
 /// be numbered starting at 0.
-public struct SemanticTokenModifiers: OptionSet, Hashable {
+public struct SemanticTokenModifiers: OptionSet, Hashable, Sendable {
   public let rawValue: UInt32
 
   public init(rawValue: UInt32) {

--- a/Sources/LanguageServerProtocol/SupportTypes/SemanticTokenTypes.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SemanticTokenTypes.swift
@@ -17,7 +17,7 @@ import Foundation
 /// The protocol defines a set of token types and modifiers but clients are
 /// allowed to extend these and announce the values they support in the
 /// corresponding client capability.
-public struct SemanticTokenTypes: Hashable {
+public struct SemanticTokenTypes: Hashable, Sendable {
   public let name: String
   public init(_ name: String) {
     self.name = name
@@ -50,7 +50,7 @@ public struct SemanticTokenTypes: Hashable {
   /// since 3.17.0
   public static let decorator = Self("decorator")
 
-  public static var predefined: [Self] = [
+  public static let predefined: [Self] = [
     .namespace,
     .type,
     .class,

--- a/Sources/LanguageServerProtocol/SupportTypes/SemanticTokens.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SemanticTokens.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The legend for a server's encoding of semantic tokens.
-public struct SemanticTokensLegend: Codable, Hashable, LSPAnyCodable {
+public struct SemanticTokensLegend: Codable, Hashable, LSPAnyCodable, Sendable {
   /// The token types for a server.
   ///
   /// Token types are looked up by indexing into this array, e.g. a `tokenType`
@@ -57,7 +57,7 @@ public struct SemanticTokensLegend: Codable, Hashable, LSPAnyCodable {
 }
 
 /// The encoding format for semantic tokens. Currently only `relative` is supported.
-public struct TokenFormat: RawRepresentable, Codable, Hashable {
+public struct TokenFormat: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: String
   public init(rawValue: String) {
     self.rawValue = rawValue

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Capabilities provided by the language server.
-public struct ServerCapabilities: Codable, Hashable {
+public struct ServerCapabilities: Codable, Hashable, Sendable {
 
   /// The position encoding the server picked from the encodings offered
   /// by the client via the client capability `general.positionEncodings`.
@@ -238,7 +238,9 @@ public enum ValueOrBool<ValueType: Codable>: Codable, Hashable where ValueType: 
   }
 }
 
-public enum TextDocumentSync: Codable, Hashable {
+extension ValueOrBool: Sendable where ValueType: Sendable {}
+
+public enum TextDocumentSync: Codable, Hashable, Sendable {
   case options(TextDocumentSyncOptions)
   case kind(TextDocumentSyncKind)
 
@@ -270,7 +272,7 @@ public enum TextDocumentSync: Codable, Hashable {
 /// with `willSave` etc. and one that only contains `openClose` and `change`.
 /// Based on the VSCode implementation, the definition that contains `willSave`
 /// appears to be the correct one, so we use that one as well.
-public struct TextDocumentSyncOptions: Codable, Hashable {
+public struct TextDocumentSyncOptions: Codable, Hashable, Sendable {
 
   /// Open and close notifications are sent to the server.
   /// If omitted open close notifications should not be sent.
@@ -290,7 +292,7 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
   /// Whether will-save-wait-until notifications should be sent to the server.
   public var willSaveWaitUntil: Bool?
 
-  public struct SaveOptions: Codable, Hashable {
+  public struct SaveOptions: Codable, Hashable, Sendable {
 
     /// Whether the client should include the file content in save notifications.
     public var includeText: Bool?
@@ -340,7 +342,7 @@ public struct TextDocumentSyncOptions: Codable, Hashable {
   }
 }
 
-public enum TextDocumentSyncKind: Int, Codable, Hashable {
+public enum TextDocumentSyncKind: Int, Codable, Hashable, Sendable {
 
   /// Documents should not be synced at all.
   case none = 0
@@ -353,7 +355,7 @@ public enum TextDocumentSyncKind: Int, Codable, Hashable {
   case incremental = 2
 }
 
-public enum NotebookFilter: Codable, Hashable {
+public enum NotebookFilter: Codable, Hashable, Sendable {
   case string(String)
   case documentFilter(DocumentFilter)
 
@@ -382,7 +384,7 @@ public enum NotebookFilter: Codable, Hashable {
 }
 public typealias NotebookSelector = [NotebookFilter]
 
-public struct NotebookDocumentSyncAndStaticRegistrationOptions: Codable, Hashable {
+public struct NotebookDocumentSyncAndStaticRegistrationOptions: Codable, Hashable, Sendable {
   /// The notebooks to be synced
   public var notebookSelector: NotebookSelector
 
@@ -408,7 +410,7 @@ public protocol WorkDoneProgressOptions {
   var workDoneProgress: Bool? { get }
 }
 
-public struct HoverOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct HoverOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -418,7 +420,7 @@ public struct HoverOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct CompletionItemOptions: LSPAnyCodable, Codable, Hashable {
+public struct CompletionItemOptions: LSPAnyCodable, Codable, Hashable, Sendable {
   /// The server has support for completion item label
   /// details (see also `CompletionItemLabelDetails`) when receiving
   /// a completion item in a resolve call.
@@ -447,7 +449,7 @@ public struct CompletionItemOptions: LSPAnyCodable, Codable, Hashable {
   }
 }
 
-public struct CompletionOptions: WorkDoneProgressOptions, Codable, LSPAnyCodable, Hashable {
+public struct CompletionOptions: WorkDoneProgressOptions, Codable, LSPAnyCodable, Hashable, Sendable {
   /// Whether to use `textDocument/resolveCompletion`
   public var resolveProvider: Bool?
 
@@ -525,7 +527,7 @@ public struct CompletionOptions: WorkDoneProgressOptions, Codable, LSPAnyCodable
   }
 }
 
-public struct DefinitionOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct DefinitionOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -535,7 +537,7 @@ public struct DefinitionOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct ReferenceOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct ReferenceOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -545,7 +547,7 @@ public struct ReferenceOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct DocumentHighlightOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct DocumentHighlightOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -555,7 +557,7 @@ public struct DocumentHighlightOptions: WorkDoneProgressOptions, Codable, Hashab
   }
 }
 
-public struct DocumentSymbolOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct DocumentSymbolOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -565,7 +567,7 @@ public struct DocumentSymbolOptions: WorkDoneProgressOptions, Codable, Hashable 
   }
 }
 
-public struct DocumentFormattingOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct DocumentFormattingOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -575,7 +577,7 @@ public struct DocumentFormattingOptions: WorkDoneProgressOptions, Codable, Hasha
   }
 }
 
-public struct DocumentRangeFormattingOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct DocumentRangeFormattingOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   public var workDoneProgress: Bool?
 
   public init(
@@ -590,7 +592,7 @@ public struct FoldingRangeOptions: Codable, Hashable {
   public init() {}
 }
 
-public struct SignatureHelpOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct SignatureHelpOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// The characters that trigger signature help automatically.
   public var triggerCharacters: [String]?
 
@@ -612,7 +614,7 @@ public struct SignatureHelpOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct DocumentFilter: Codable, Hashable {
+public struct DocumentFilter: Codable, Hashable, Sendable {
   /// A language id, like `typescript`.
   public var language: String?
 
@@ -675,7 +677,7 @@ extension DocumentFilter: LSPAnyCodable {
 
 public typealias DocumentSelector = [DocumentFilter]
 
-public struct TextDocumentAndStaticRegistrationOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct TextDocumentAndStaticRegistrationOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// A document selector to identify the scope of the registration. If set to null the document selector provided on the client side will be used.
   public var documentSelector: DocumentSelector?
 
@@ -695,9 +697,9 @@ public struct TextDocumentAndStaticRegistrationOptions: WorkDoneProgressOptions,
   }
 }
 
-public struct DocumentOnTypeFormattingOptions: Codable, Hashable {
+public struct DocumentOnTypeFormattingOptions: Codable, Hashable, Sendable {
 
-  /// A character that sould trigger formatting (e.g. '}').
+  /// A character that should trigger formatting (e.g. '}').
   public var firstTriggerCharacter: String
 
   /// Additional triggers.
@@ -714,7 +716,7 @@ public struct DocumentOnTypeFormattingOptions: Codable, Hashable {
 /// Wrapper type for a server's CodeActions' capabilities.
 /// If the client supports CodeAction literals, the server can return specific information about
 /// how CodeActions will be sent. Otherwise, the server's capabilities are determined by a boolean.
-public enum CodeActionServerCapabilities: Codable, Hashable {
+public enum CodeActionServerCapabilities: Codable, Hashable, Sendable {
 
   case supportsCodeActionRequests(Bool)
   case supportsCodeActionRequestsWithLiterals(CodeActionOptions)
@@ -754,7 +756,7 @@ public enum CodeActionServerCapabilities: Codable, Hashable {
   }
 }
 
-public struct CodeActionOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct CodeActionOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
 
   /// CodeActionKinds that this server may return.
   public var codeActionKinds: [CodeActionKind]?
@@ -776,7 +778,7 @@ public struct CodeActionOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct CodeLensOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct CodeLensOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// Code lens has a resolve provider as well.
   public var resolveProvider: Bool?
 
@@ -791,7 +793,7 @@ public struct CodeLensOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct ExecuteCommandOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct ExecuteCommandOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
 
   /// The commands to be executed on this server.
   public var commands: [String]
@@ -807,7 +809,7 @@ public struct ExecuteCommandOptions: WorkDoneProgressOptions, Codable, Hashable 
   }
 }
 
-public struct RenameOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct RenameOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// Renames should be checked and tested before being executed.
   public var prepareProvider: Bool?
 
@@ -822,7 +824,7 @@ public struct RenameOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct DocumentLinkOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct DocumentLinkOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// Document links have a resolve provider as well.
   public var resolveProvider: Bool?
 
@@ -837,9 +839,9 @@ public struct DocumentLinkOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct SemanticTokensOptions: WorkDoneProgressOptions, Codable, Hashable, LSPAnyCodable {
+public struct SemanticTokensOptions: WorkDoneProgressOptions, Codable, Hashable, LSPAnyCodable, Sendable {
 
-  public struct SemanticTokensRangeOptions: Equatable, Hashable, Codable, LSPAnyCodable {
+  public struct SemanticTokensRangeOptions: Equatable, Hashable, Codable, LSPAnyCodable, Sendable {
     public init() {
       // Empty in the LSP 3.16 spec.
     }
@@ -853,7 +855,7 @@ public struct SemanticTokensOptions: WorkDoneProgressOptions, Codable, Hashable,
     }
   }
 
-  public struct SemanticTokensFullOptions: Equatable, Hashable, Codable, LSPAnyCodable {
+  public struct SemanticTokensFullOptions: Equatable, Hashable, Codable, LSPAnyCodable, Sendable {
     /// The server supports deltas for full documents.
     public var delta: Bool?
 
@@ -972,7 +974,7 @@ public struct SemanticTokensOptions: WorkDoneProgressOptions, Codable, Hashable,
 
 }
 
-public struct InlayHintOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct InlayHintOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// The server provides support to resolve additional information
   /// for an inlay hint item.
   public var resolveProvider: Bool?
@@ -998,7 +1000,7 @@ public struct InlayHintOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct WorkspaceSymbolOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct WorkspaceSymbolOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// The server provides support to resolve additional information
   /// for an inlay hint item.
   public var resolveProvider: Bool?
@@ -1014,7 +1016,7 @@ public struct WorkspaceSymbolOptions: WorkDoneProgressOptions, Codable, Hashable
   }
 }
 
-public struct MonikerOptions: WorkDoneProgressOptions, Codable, Hashable {
+public struct MonikerOptions: WorkDoneProgressOptions, Codable, Hashable, Sendable {
   /// A document selector to identify the scope of the registration. If set to null the document selector provided on the client side will be used.
   public var documentSelector: DocumentSelector?
 
@@ -1029,7 +1031,7 @@ public struct MonikerOptions: WorkDoneProgressOptions, Codable, Hashable {
   }
 }
 
-public struct DiagnosticOptions: WorkDoneProgressOptions, LSPAnyCodable, Codable, Hashable {
+public struct DiagnosticOptions: WorkDoneProgressOptions, LSPAnyCodable, Codable, Hashable, Sendable {
   /// An optional identifier under which the diagnostics are managed by the client.
   public var identifier: String?
 
@@ -1107,8 +1109,8 @@ public struct DiagnosticOptions: WorkDoneProgressOptions, LSPAnyCodable, Codable
   }
 }
 
-public struct WorkspaceServerCapabilities: Codable, Hashable {
-  public struct WorkspaceFolders: Codable, Hashable {
+public struct WorkspaceServerCapabilities: Codable, Hashable, Sendable {
+  public struct WorkspaceFolders: Codable, Hashable, Sendable {
     /// The server has support for workspace folders
     public var supported: Bool?
 

--- a/Sources/LanguageServerProtocol/SupportTypes/StringOrMarkupContent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/StringOrMarkupContent.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum StringOrMarkupContent: Codable, Hashable {
+public enum StringOrMarkupContent: Codable, Hashable, Sendable {
   case string(String)
   case markupContent(MarkupContent)
 

--- a/Sources/LanguageServerProtocol/SupportTypes/SymbolKind.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/SymbolKind.swift
@@ -13,7 +13,7 @@
 /// A symbol kind.
 ///
 /// In LSP, this is an integer, so we don't use a closed set.
-public struct SymbolKind: RawRepresentable, Codable, Hashable {
+public struct SymbolKind: RawRepresentable, Codable, Hashable, Sendable {
 
   public var rawValue: Int
 
@@ -57,7 +57,7 @@ public struct SymbolKind: RawRepresentable, Codable, Hashable {
 /// Symbol tags are extra annotations that tweak the rendering of a symbol.
 ///
 /// In LSP, this is an integer, so we don't use a closed set.
-public struct SymbolTag: RawRepresentable, Codable, Hashable {
+public struct SymbolTag: RawRepresentable, Codable, Hashable, Sendable {
   public var rawValue: Int
 
   public init(rawValue: Int) {

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentContentChangeEvent.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentContentChangeEvent.swift
@@ -15,7 +15,7 @@
 /// If `range` and `rangeLength` are unspecified, the whole document content is replaced.
 ///
 /// The `range.end` and `rangeLength` are potentially redundant. Based on https://github.com/Microsoft/language-server-protocol/issues/9, servers should be lenient and accept either.
-public struct TextDocumentContentChangeEvent: Codable, Hashable {
+public struct TextDocumentContentChangeEvent: Codable, Hashable, Sendable {
 
   @CustomCodable<PositionRange?>
   public var range: Range<Position>?

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
@@ -13,8 +13,8 @@
 /// Edit within a particular document.
 ///
 /// For an edit where the document is implied, use `TextEdit`.
-public struct TextDocumentEdit: Hashable, Codable {
-  public enum Edit: Codable, Hashable {
+public struct TextDocumentEdit: Hashable, Codable, Sendable {
+  public enum Edit: Codable, Hashable, Sendable {
     case textEdit(TextEdit)
     case annotatedTextEdit(AnnotatedTextEdit)
 

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentIdentifier.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Unique identifier for a document.
-public struct TextDocumentIdentifier: Hashable, Codable {
+public struct TextDocumentIdentifier: Hashable, Codable, Sendable {
 
   /// A URI that uniquely identifies the document.
   public var uri: DocumentURI

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentItem.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The content and metadata of a text document.
-public struct TextDocumentItem: Hashable {
+public struct TextDocumentItem: Hashable, Sendable {
 
   public var uri: DocumentURI
 

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentSaveReason.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentSaveReason.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum TextDocumentSaveReason: Int, Codable, Hashable {
+public enum TextDocumentSaveReason: Int, Codable, Hashable, Sendable {
 
   case manual = 1
 

--- a/Sources/LanguageServerProtocol/SupportTypes/TextEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextEdit.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Edit to a text document, replacing the contents of `range` with `text`.
-public struct TextEdit: ResponseType, Hashable {
+public struct TextEdit: ResponseType, Hashable, Sendable {
 
   /// The range of text to be replaced.
   @CustomCodable<PositionRange>
@@ -49,7 +49,7 @@ extension TextEdit: LSPAnyCodable {
 }
 
 /// Additional information that describes document changes.
-public struct ChangeAnnotation: Codable, Hashable {
+public struct ChangeAnnotation: Codable, Hashable, Sendable {
   /// A human-readable string describing the actual change. The string
   /// is rendered prominent in the user interface.
   public var label: String
@@ -76,7 +76,7 @@ public typealias ChangeAnnotationIdentifier = String
 /// A special text edit with an additional change annotation.
 ///
 /// Notionally a subtype of `TextEdit`.
-public struct AnnotatedTextEdit: ResponseType, Hashable {
+public struct AnnotatedTextEdit: ResponseType, Hashable, Sendable {
 
   /// The range of text to be replaced.
   @CustomCodable<PositionRange>

--- a/Sources/LanguageServerProtocol/SupportTypes/Tracing.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/Tracing.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum Tracing: String, Codable {
+public enum Tracing: String, Codable, Sendable {
   case off
   case messages
   case verbose

--- a/Sources/LanguageServerProtocol/SupportTypes/TypeHierarchyItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TypeHierarchyItem.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A single type hierarchy item.
-public struct TypeHierarchyItem: ResponseType, Hashable {
+public struct TypeHierarchyItem: ResponseType, Hashable, Sendable {
   /// Name of this item.
   public var name: String
   /// The kind of this item.

--- a/Sources/LanguageServerProtocol/SupportTypes/VersionedNotebookDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/VersionedNotebookDocumentIdentifier.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Unique identifier for a document.
-public struct VersionedNotebookDocumentIdentifier: Codable, Hashable {
+public struct VersionedNotebookDocumentIdentifier: Codable, Hashable, Sendable {
 
   /// The version number of this notebook document.
   public var version: Int

--- a/Sources/LanguageServerProtocol/SupportTypes/VersionedTextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/VersionedTextDocumentIdentifier.swift
@@ -13,7 +13,7 @@
 /// A document identifier representing a specific version of the document.
 ///
 /// Notionally a subtype of `TextDocumentIdentifier`.
-public struct VersionedTextDocumentIdentifier: Hashable, Codable {
+public struct VersionedTextDocumentIdentifier: Hashable, Codable, Sendable {
 
   /// A URI that uniquely identifies the document.
   public var uri: DocumentURI
@@ -33,7 +33,7 @@ public struct VersionedTextDocumentIdentifier: Hashable, Codable {
 /// An identifier which optionally denotes a specific version of a text document. This information usually flows from the server to the client.
 ///
 /// Notionally a subtype of `TextDocumentIdentifier`.
-public struct OptionalVersionedTextDocumentIdentifier: Hashable, Codable {
+public struct OptionalVersionedTextDocumentIdentifier: Hashable, Codable, Sendable {
 
   /// A URI that uniquely identifies the document.
   public var uri: DocumentURI

--- a/Sources/LanguageServerProtocol/SupportTypes/WindowMessageType.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WindowMessageType.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The type of message (error, etc.) for a ShowMessage or LogMessage request. Corresponds to `MessageType` in LSP.
-public enum WindowMessageType: Int, Codable, Hashable {
+public enum WindowMessageType: Int, Codable, Hashable, Sendable {
 
   case error = 1
   case warning = 2

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceEdit.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A workspace edit represents changes to many resources managed in the workspace.
-public struct WorkspaceEdit: Hashable, ResponseType {
+public struct WorkspaceEdit: Hashable, ResponseType, Sendable {
 
   /// The edits to be applied to existing resources.
   public var changes: [DocumentURI: [TextEdit]]?
@@ -72,7 +72,7 @@ extension WorkspaceEdit: Codable {
   }
 }
 
-public enum WorkspaceEditDocumentChange: Codable, Hashable {
+public enum WorkspaceEditDocumentChange: Codable, Hashable, Sendable {
   case textDocumentEdit(TextDocumentEdit)
   case createFile(CreateFile)
   case renameFile(RenameFile)
@@ -111,7 +111,7 @@ public enum WorkspaceEditDocumentChange: Codable, Hashable {
 }
 
 /// Options to create a file.
-public struct CreateFileOptions: Codable, Hashable {
+public struct CreateFileOptions: Codable, Hashable, Sendable {
   /// Overwrite existing file. Overwrite wins over `ignoreIfExists`
   public var overwrite: Bool?
   /// Ignore if exists.
@@ -124,7 +124,7 @@ public struct CreateFileOptions: Codable, Hashable {
 }
 
 /// Create file operation
-public struct CreateFile: Codable, Hashable {
+public struct CreateFile: Codable, Hashable, Sendable {
   /// The resource to create.
   public var uri: DocumentURI
   /// Additional options
@@ -172,7 +172,7 @@ public struct CreateFile: Codable, Hashable {
 }
 
 /// Rename file options
-public struct RenameFileOptions: Codable, Hashable {
+public struct RenameFileOptions: Codable, Hashable, Sendable {
   /// Overwrite target if existing. Overwrite wins over `ignoreIfExists`
   public var overwrite: Bool?
   /// Ignores if target exists.
@@ -185,7 +185,7 @@ public struct RenameFileOptions: Codable, Hashable {
 }
 
 /// Rename file operation
-public struct RenameFile: Codable, Hashable {
+public struct RenameFile: Codable, Hashable, Sendable {
   /// The old (existing) location.
   public var oldUri: DocumentURI
   /// The new location.
@@ -244,7 +244,7 @@ public struct RenameFile: Codable, Hashable {
 }
 
 /// Delete file options
-public struct DeleteFileOptions: Codable, Hashable {
+public struct DeleteFileOptions: Codable, Hashable, Sendable {
   /// Delete the content recursively if a folder is denoted.
   public var recursive: Bool?
   /// Ignore the operation if the file doesn't exist.
@@ -257,7 +257,7 @@ public struct DeleteFileOptions: Codable, Hashable {
 }
 
 /// Delete file operation
-public struct DeleteFile: Codable, Hashable {
+public struct DeleteFile: Codable, Hashable, Sendable {
   /// The file to delete.
   public var uri: DocumentURI
   /// Delete options.

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceFolder.swift
@@ -13,7 +13,7 @@
 /// The configuration to build a workspace in.
 ///
 /// **(LSP Extension)**
-public enum BuildConfiguration: Hashable, Codable {
+public enum BuildConfiguration: Hashable, Codable, Sendable {
   case debug
   case release
 }
@@ -21,14 +21,14 @@ public enum BuildConfiguration: Hashable, Codable {
 /// The type of workspace; default workspace type selection logic can be overridden.
 ///
 /// **(LSP Extension)**
-public enum WorkspaceType: Hashable, Codable {
+public enum WorkspaceType: Hashable, Codable, Sendable {
   case buildServer, compilationDatabase, swiftPM
 }
 
 /// Build settings that should be used for a workspace.
 ///
 /// **(LSP Extension)**
-public struct WorkspaceBuildSetup: Hashable, Codable {
+public struct WorkspaceBuildSetup: Hashable, Codable, Sendable {
   /// The configuration that the workspace should be built in.
   public let buildConfiguration: BuildConfiguration?
 
@@ -70,7 +70,7 @@ public struct WorkspaceBuildSetup: Hashable, Codable {
 }
 
 /// Unique identifier for a document.
-public struct WorkspaceFolder: ResponseType, Hashable, Codable {
+public struct WorkspaceFolder: ResponseType, Hashable, Codable, Sendable {
 
   /// A URI that uniquely identifies the workspace.
   public var uri: DocumentURI

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceSettings.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceSettings.swift
@@ -13,7 +13,7 @@
 /// The `settings` field of a `workspace/didChangeConfiguration`.
 ///
 /// This is typed as `Any` in the protocol, and this enum contains the formats we support.
-public enum WorkspaceSettingsChange: Codable, Hashable {
+public enum WorkspaceSettingsChange: Codable, Hashable, Sendable {
 
   case clangd(ClangWorkspaceSettings)
   case unknown(LSPAny)
@@ -41,7 +41,7 @@ public enum WorkspaceSettingsChange: Codable, Hashable {
 ///
 /// Clangd will accept *either* a path to a compilation database on disk, or the contents of a
 /// compilation database to be managed in-memory, but they cannot be mixed.
-public struct ClangWorkspaceSettings: Codable, Hashable {
+public struct ClangWorkspaceSettings: Codable, Hashable, Sendable {
 
   /// The path to a json compilation database.
   public var compilationDatabasePath: String?
@@ -66,7 +66,7 @@ public struct ClangWorkspaceSettings: Codable, Hashable {
 }
 
 /// A single compile command for use in a clangd workspace settings.
-public struct ClangCompileCommand: Codable, Hashable {
+public struct ClangCompileCommand: Codable, Hashable, Sendable {
 
   /// The command (executable + compiler arguments).
   public var compilationCommand: [String]

--- a/Sources/SKSupport/ThreadSafeBox.swift
+++ b/Sources/SKSupport/ThreadSafeBox.swift
@@ -22,7 +22,9 @@ extension NSLock {
 }
 
 /// A thread safe container that contains a value of type `T`.
-public class ThreadSafeBox<T> {
+///
+/// - Note: Unchecked sendable conformance because value is guarded by a lock.
+public class ThreadSafeBox<T>: @unchecked Sendable {
   /// Lock guarding `_value`.
   private let lock = NSLock()
 

--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -57,7 +57,7 @@ public final class DLHandle {
   }
 }
 
-public struct DLOpenFlags: RawRepresentable, OptionSet {
+public struct DLOpenFlags: RawRepresentable, OptionSet, Sendable {
 
   #if !os(Windows)
   public static let lazy: DLOpenFlags = DLOpenFlags(rawValue: RTLD_LAZY)

--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -1363,7 +1363,10 @@ extension SourceKitServer {
     cancellationMessageHandlingQueue.async(priority: .high) {
       guard let task = await self.inProgressRequests[notification.id] else {
         logger.error(
-          "Cannot cancel request \(notification.id, privacy: .public) because it hasn't been scheduled for execution yet"
+          """
+          Cannot cancel request \(notification.id, privacy: .public) because it hasn't been scheduled for execution \
+          yet or because the request already returned a response
+          """
         )
         return
       }


### PR DESCRIPTION
- LanguageServerProtocol was just about slapping `Sendable` on basically everything because all the request and response types are value types and sendable
- LSPLogging was also pretty trivial
- SKSupport required a little bit of restructuring in `AsyncQueue` to get sendable checks to pass. The change actually localize potential races, so it’s for the better.

The most controversial change might be that I’m raising the package description version to 5.8 and adding `.enableExperimentalFeature("StrictConcurrency")` to the audited modules. But I think it’s fine. I checked that the package still builds with Xcode 15.0.