### PR TITLE
Fix a race condition in `TestMessageHandler`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -155,6 +155,7 @@ let package = Package(
       dependencies: [
         "LanguageServerProtocol",
         "LanguageServerProtocolJSONRPC",
+        "SKSupport",
       ]
     ),
 

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -19,8 +19,7 @@ class ConnectionTests: XCTestCase {
   var connection: TestLocalConnection! = nil
 
   override func setUp() {
-    connection = TestLocalConnection()
-    connection.client.allowUnexpectedNotification = false
+    connection = TestLocalConnection(allowUnexpectedNotification: false)
   }
 
   override func tearDown() {
@@ -61,17 +60,17 @@ class ConnectionTests: XCTestCase {
     waitForExpectations(timeout: defaultTimeout)
   }
 
-  func testEchoNote() {
+  func testEchoNote() async throws {
     let client = connection.client
     let expectation = self.expectation(description: "note received")
 
-    client.appendOneShotNotificationHandler { (note: EchoNotification) in
+    await client.appendOneShotNotificationHandler { (note: EchoNotification) in
       XCTAssertEqual(note.string, "hello!")
       expectation.fulfill()
     }
 
     client.send(EchoNotification(string: "hello!"))
 
-    waitForExpectations(timeout: defaultTimeout)
+    try await fulfillmentOfOrThrow([expectation])
   }
 }


### PR DESCRIPTION
Not entirely sure what introduced the race condition. Found by thread sanitizer. Probably wouldn’t have been an issue if we had migrated this code to strict concurrency checking.