### PR TITLE
Teach `sourcekit-lsp diagnose` how to reduce `swift-frontend` crashes

### DIFF
--- a/Sources/Diagnose/CMakeLists.txt
+++ b/Sources/Diagnose/CMakeLists.txt
@@ -1,15 +1,21 @@
 add_library(Diagnose STATIC
   CommandLineArgumentsReducer.swift
   DiagnoseCommand.swift
+  MergeSwiftFiles.swift
   OSLogScraper.swift
   ReduceCommand.swift
+  ReduceFrontendCommand.swift
+  ReduceSourceKitDRequest.swift
+  ReduceSwiftFrontend.swift
   ReductionError.swift
   ReproducerBundle.swift
   RequestInfo.swift
   SourceKitD+RunWithYaml.swift
   SourceKitDRequestExecutor.swift
+  SourceReducer.swift
   SourcekitdRequestCommand.swift
-  SourceReducer.swift)
+  SwiftFrontendCrashScraper.swift
+  Toolchain+SwiftFrontend.swift)
 
 set_target_properties(Diagnose PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/Diagnose/CommandLineArgumentsReducer.swift
+++ b/Sources/Diagnose/CommandLineArgumentsReducer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import LSPLogging
 
 // MARK: - Entry point
 
@@ -48,60 +49,65 @@ fileprivate class CommandLineArgumentReducer {
     self.progressUpdate = progressUpdate
   }
 
-  func logSuccessfulReduction(_ requestInfo: RequestInfo) {
-    progressUpdate(
-      1 - (Double(requestInfo.compilerArgs.count) / Double(initialCommandLineCount)),
-      "Reduced compiler arguments to \(requestInfo.compilerArgs.count)"
-    )
+  func run(initialRequestInfo: RequestInfo) async throws -> RequestInfo {
+    var requestInfo = initialRequestInfo
+    requestInfo = try await reduce(initialRequestInfo: requestInfo, simultaneousRemove: 10)
+    requestInfo = try await reduce(initialRequestInfo: requestInfo, simultaneousRemove: 1)
+    return requestInfo
   }
 
-  func run(initialRequestInfo: RequestInfo) async throws -> RequestInfo {
+  /// Reduce the command line arguments of the given `RequestInfo`.
+  ///
+  /// If `simultaneousRemove` is set, the reducer will try to remove that many arguments at once. This is useful to
+  /// quickly remove multiple arguments from the request.
+  private func reduce(initialRequestInfo: RequestInfo, simultaneousRemove: Int) async throws -> RequestInfo {
+    guard initialRequestInfo.compilerArgs.count > simultaneousRemove else {
+      // Trying to remove more command line arguments than we have. This isn't going to work.
+      return initialRequestInfo
+    }
+
     var requestInfo = initialRequestInfo
     self.initialCommandLineCount = requestInfo.compilerArgs.count
 
     var argumentIndexToRemove = requestInfo.compilerArgs.count - 1
-    while argumentIndexToRemove >= 0 {
-      var numberOfArgumentsToRemove = 1
+    while argumentIndexToRemove + 1 >= simultaneousRemove {
+      defer {
+        // argumentIndexToRemove can become negative by being decremented in the code below
+        let progress = 1 - (Double(max(argumentIndexToRemove, 0)) / Double(initialCommandLineCount))
+        progressUpdate(progress, "Reduced compiler arguments to \(requestInfo.compilerArgs.count)")
+      }
+      var numberOfArgumentsToRemove = simultaneousRemove
       // If the argument is preceded by -Xswiftc or -Xcxx, we need to remove the `-X` flag as well.
-      if argumentIndexToRemove - numberOfArgumentsToRemove >= 0
-        && requestInfo.compilerArgs[argumentIndexToRemove - numberOfArgumentsToRemove].hasPrefix("-X")
-      {
+      if requestInfo.compilerArgs[safe: argumentIndexToRemove - numberOfArgumentsToRemove]?.hasPrefix("-X") ?? false {
         numberOfArgumentsToRemove += 1
       }
 
-      if let reduced = try await tryRemoving(
-        (argumentIndexToRemove - numberOfArgumentsToRemove + 1)...argumentIndexToRemove,
-        from: requestInfo
-      ) {
+      let rangeToRemove = (argumentIndexToRemove - numberOfArgumentsToRemove + 1)...argumentIndexToRemove
+      if let reduced = try await tryRemoving(rangeToRemove, from: requestInfo) {
         requestInfo = reduced
         argumentIndexToRemove -= numberOfArgumentsToRemove
         continue
       }
 
-      // If removing the argument failed and the argument is preceded by an argument starting with `-`, try removing that as well.
-      // E.g. removing `-F` followed by a search path.
-      if argumentIndexToRemove - numberOfArgumentsToRemove >= 0
-        && requestInfo.compilerArgs[argumentIndexToRemove - numberOfArgumentsToRemove].hasPrefix("-")
-      {
+      // If removing the argument failed and the argument is preceded by an argument starting with `-`, try removing
+      // that as well. E.g. removing `-F` followed by a search path.
+      if requestInfo.compilerArgs[safe: argumentIndexToRemove - numberOfArgumentsToRemove]?.hasPrefix("-") ?? false {
         numberOfArgumentsToRemove += 1
+
+        // If the argument is preceded by -Xswiftc or -Xcxx, we need to remove the `-X` flag as well.
+        if requestInfo.compilerArgs[safe: argumentIndexToRemove - numberOfArgumentsToRemove]?.hasPrefix("-X") ?? false {
+          numberOfArgumentsToRemove += 1
+        }
+
+        let rangeToRemove = (argumentIndexToRemove - numberOfArgumentsToRemove + 1)...argumentIndexToRemove
+        if let reduced = try await tryRemoving(rangeToRemove, from: requestInfo) {
+          requestInfo = reduced
+          argumentIndexToRemove -= numberOfArgumentsToRemove
+          continue
+        }
       }
 
-      // If the argument is preceded by -Xswiftc or -Xcxx, we need to remove the `-X` flag as well.
-      if argumentIndexToRemove - numberOfArgumentsToRemove >= 0
-        && requestInfo.compilerArgs[argumentIndexToRemove - numberOfArgumentsToRemove].hasPrefix("-X")
-      {
-        numberOfArgumentsToRemove += 1
-      }
-
-      if let reduced = try await tryRemoving(
-        (argumentIndexToRemove - numberOfArgumentsToRemove + 1)...argumentIndexToRemove,
-        from: requestInfo
-      ) {
-        requestInfo = reduced
-        argumentIndexToRemove -= numberOfArgumentsToRemove
-        continue
-      }
-      argumentIndexToRemove -= 1
+      argumentIndexToRemove -= simultaneousRemove
     }
 
     return requestInfo
@@ -111,16 +117,28 @@ fileprivate class CommandLineArgumentReducer {
     _ argumentsToRemove: ClosedRange<Int>,
     from requestInfo: RequestInfo
   ) async throws -> RequestInfo? {
+    logger.debug("Try removing the following compiler arguments:\n\(requestInfo.compilerArgs[argumentsToRemove])")
     var reducedRequestInfo = requestInfo
     reducedRequestInfo.compilerArgs.removeSubrange(argumentsToRemove)
 
     let result = try await sourcekitdExecutor.run(request: reducedRequestInfo)
     if case .reproducesIssue = result {
-      logSuccessfulReduction(reducedRequestInfo)
+      logger.debug("Reduction successful")
       return reducedRequestInfo
     } else {
       // The reduced request did not crash. We did not find a reduced test case, so return `nil`.
+      logger.debug("Reduction did not reproduce the issue")
       return nil
     }
+  }
+}
+
+fileprivate extension Array {
+  /// Access index in the array if it's in bounds or return `nil` if `index` is outside of the array's bounds.
+  subscript(safe index: Int) -> Element? {
+    if index < 0 || index >= count {
+      return nil
+    }
+    return self[index]
   }
 }

--- a/Sources/Diagnose/MergeSwiftFiles.swift
+++ b/Sources/Diagnose/MergeSwiftFiles.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LSPLogging
+
+extension RequestInfo {
+  /// Check if the issue reproduces when merging all `.swift` input files into a single file.
+  ///
+  /// Returns `nil` if the issue didn't reproduce with all `.swift` files merged.
+  func mergeSwiftFiles(
+    using executor: SourceKitRequestExecutor,
+    progressUpdate: (_ progress: Double, _ message: String) -> Void
+  ) async throws -> RequestInfo? {
+    let swiftFilePaths = compilerArgs.filter { $0.hasSuffix(".swift") }
+    let mergedFile = try swiftFilePaths.map { try String(contentsOfFile: $0) }.joined(separator: "\n\n\n\n")
+
+    progressUpdate(0, "Merging all .swift files into a single file")
+
+    let mergedRequestInfo = RequestInfo(
+      requestTemplate: requestTemplate,
+      offset: offset,
+      compilerArgs: compilerArgs.filter { !$0.hasSuffix(".swift") } + ["$FILE"],
+      fileContents: mergedFile
+    )
+
+    let result = try await executor.run(request: mergedRequestInfo)
+    if case .reproducesIssue = result {
+      logger.debug("Successfully merged all .swift input files")
+      return mergedRequestInfo
+    } else {
+      logger.debug("Merging .swift files did not reproduce the issue")
+      return nil
+    }
+  }
+}

--- a/Sources/Diagnose/ReduceSourceKitDRequest.swift
+++ b/Sources/Diagnose/ReduceSourceKitDRequest.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension RequestInfo {
+  /// Reduce the input file of this request and the command line arguments.
+  func reduce(
+    using executor: SourceKitRequestExecutor,
+    progressUpdate: (_ progress: Double, _ message: String) -> Void
+  ) async throws -> RequestInfo {
+    var requestInfo = self
+
+    // How much time of the reduction is expected to be spent reducing the source compared to command line argument
+    // reduction.
+    let sourceReductionPercentage = 0.7
+
+    requestInfo = try await requestInfo.reduceInputFile(using: executor) { progress, message in
+      let progress = progress * sourceReductionPercentage
+      progressUpdate(progress, message)
+    }
+    requestInfo = try await requestInfo.reduceCommandLineArguments(using: executor) { progress, message in
+      let progress = sourceReductionPercentage + progress * (1 - sourceReductionPercentage)
+      progressUpdate(progress, message)
+    }
+    return requestInfo
+  }
+}

--- a/Sources/Diagnose/ReduceSwiftFrontend.swift
+++ b/Sources/Diagnose/ReduceSwiftFrontend.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing)
+public func reduceFrontendIssue(
+  frontendArgs: [String],
+  using executor: SourceKitRequestExecutor,
+  progressUpdate: (_ progress: Double, _ message: String) -> Void
+) async throws -> RequestInfo {
+  let requestInfo = try RequestInfo(frontendArgs: frontendArgs)
+  let initialResult = try await executor.run(request: requestInfo)
+  guard case .reproducesIssue = initialResult else {
+    throw ReductionError("Unable to reproduce the swift-frontend issue")
+  }
+  let mergedSwiftFilesRequestInfo = try await requestInfo.mergeSwiftFiles(using: executor) { progress, message in
+    progressUpdate(0, message)
+  }
+  guard let mergedSwiftFilesRequestInfo else {
+    throw ReductionError("Merging all .swift files did not reproduce the issue. Unable to reduce it.")
+  }
+  return try await mergedSwiftFilesRequestInfo.reduce(using: executor, progressUpdate: progressUpdate)
+}

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -48,8 +48,17 @@ public struct RequestInfo {
       .replacingOccurrences(of: "$OFFSET", with: String(offset))
       .replacingOccurrences(of: "$COMPILER_ARGS", with: compilerArgs)
       .replacingOccurrences(of: "$FILE", with: file.path)
-
   }
+
+  /// A fake value that is used to indicate that we are reducing a `swift-frontend` issue instead of a sourcekitd issue.
+  static var fakeRequestTemplateForFrontendIssues = """
+    {
+      key.request: sourcekit-lsp-fake-request-for-frontend-crash
+      key.compilerargs: [
+        $COMPILER_ARGS
+      ]
+    }
+    """
 
   @_spi(Testing)
   public init(requestTemplate: String, offset: Int, compilerArgs: [String], fileContents: String) {
@@ -102,6 +111,41 @@ public struct RequestInfo {
     self.requestTemplate = requestTemplate
 
     fileContents = try String(contentsOf: URL(fileURLWithPath: sourceFilePath))
+  }
+
+  /// Create a `RequestInfo` that is used to reduce a `swift-frontend issue`
+  init(frontendArgs: [String]) throws {
+    var frontendArgsWithFilelistInlined: [String] = []
+
+    var iterator = frontendArgs.makeIterator()
+
+    // Inline the file list so we can reduce the compiler arguments by removing individual source files.
+    // A couple `output-filelist`-related compiler arguments don't work with the file list inlined. Remove them as they
+    // are unlikely to be responsible for the swift-frontend cache
+    while let frontendArg = iterator.next() {
+      switch frontendArg {
+      case "-supplementary-output-file-map", "-output-filelist", "-index-unit-output-path-filelist":
+        _ = iterator.next()
+      case "-filelist":
+        guard let fileList = iterator.next() else {
+          throw ReductionError("Expected file path after -filelist command line argument")
+        }
+        frontendArgsWithFilelistInlined += try String(contentsOfFile: fileList)
+          .split(separator: "\n")
+          .map { String($0) }
+      default:
+        frontendArgsWithFilelistInlined.append(frontendArg)
+      }
+    }
+
+    // File contents are not known because there are multiple input files. Will usually be set after running
+    // `mergeSwiftFiles`.
+    self.init(
+      requestTemplate: Self.fakeRequestTemplateForFrontendIssues,
+      offset: 0,
+      compilerArgs: frontendArgsWithFilelistInlined,
+      fileContents: ""
+    )
   }
 }
 

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -34,7 +34,8 @@ public struct RequestInfo {
   @_spi(Testing)
   public var fileContents: String
 
-  func request(for file: URL) throws -> String {
+  @_spi(Testing)
+  public func request(for file: URL) throws -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
     guard var compilerArgs = String(data: try encoder.encode(compilerArgs), encoding: .utf8) else {

--- a/Sources/Diagnose/SourceKitDRequestExecutor.swift
+++ b/Sources/Diagnose/SourceKitDRequestExecutor.swift
@@ -15,6 +15,7 @@ import SourceKitD
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
 
 /// The different states in which a sourcekitd request can finish.
 @_spi(Testing)
@@ -45,13 +46,28 @@ fileprivate extension String {
 /// An executor that can run a sourcekitd request and indicate whether the request reprodes a specified issue.
 @_spi(Testing)
 public protocol SourceKitRequestExecutor {
-  func run(request: RequestInfo) async throws -> SourceKitDRequestResult
+  func runSourceKitD(request: RequestInfo) async throws -> SourceKitDRequestResult
+  func runSwiftFrontend(request: RequestInfo) async throws -> SourceKitDRequestResult
+}
+
+extension SourceKitRequestExecutor {
+  func run(request: RequestInfo) async throws -> SourceKitDRequestResult {
+    if request.requestTemplate == RequestInfo.fakeRequestTemplateForFrontendIssues {
+      return try await runSwiftFrontend(request: request)
+    } else {
+      return try await runSourceKitD(request: request)
+    }
+  }
 }
 
 /// Runs `sourcekit-lsp run-sourcekitd-request` to check if a sourcekit-request crashes.
-class OutOfProcessSourceKitRequestExecutor: SourceKitRequestExecutor {
+@_spi(Testing)
+public class OutOfProcessSourceKitRequestExecutor: SourceKitRequestExecutor {
   /// The path to `sourcekitd.framework/sourcekitd`.
   private let sourcekitd: URL
+
+  /// The path to `swift-frontend`.
+  private let swiftFrontend: URL
 
   /// The file to which we write the reduce source file.
   private let temporarySourceFile: URL
@@ -63,8 +79,10 @@ class OutOfProcessSourceKitRequestExecutor: SourceKitRequestExecutor {
   /// considered to reproduce the issue.
   private let reproducerPredicate: NSPredicate?
 
-  init(sourcekitd: URL, reproducerPredicate: NSPredicate?) {
+  @_spi(Testing)
+  public init(sourcekitd: URL, swiftFrontend: URL, reproducerPredicate: NSPredicate?) {
     self.sourcekitd = sourcekitd
+    self.swiftFrontend = swiftFrontend
     self.reproducerPredicate = reproducerPredicate
     temporaryRequestFile = FileManager.default.temporaryDirectory.appendingPathComponent("request-\(UUID()).yml")
     temporarySourceFile = FileManager.default.temporaryDirectory.appendingPathComponent("recude-\(UUID()).swift")
@@ -75,7 +93,66 @@ class OutOfProcessSourceKitRequestExecutor: SourceKitRequestExecutor {
     try? FileManager.default.removeItem(at: temporarySourceFile)
   }
 
-  func run(request: RequestInfo) async throws -> SourceKitDRequestResult {
+  /// The `SourceKitDRequestResult` for the given process result, evaluating the reproducer predicate, if it was
+  /// specified.
+  private func requestResult(for result: ProcessResult) -> SourceKitDRequestResult {
+    if let reproducerPredicate {
+      if let outputStr = try? String(bytes: result.output.get(), encoding: .utf8),
+        let stderrStr = try? String(bytes: result.stderrOutput.get(), encoding: .utf8)
+      {
+        let exitCode: Int32? =
+          switch result.exitStatus {
+          case .terminated(code: let exitCode): exitCode
+          default: nil
+          }
+
+        let dict: [String: Any] = [
+          "stdout": outputStr,
+          "stderr": stderrStr,
+          "exitCode": exitCode as Any,
+        ]
+
+        if reproducerPredicate.evaluate(with: dict) {
+          return .reproducesIssue
+        } else {
+          return .error
+        }
+      } else {
+        return .error
+      }
+    }
+
+    switch result.exitStatus {
+    case .terminated(code: 0):
+      if let outputStr = try? String(bytes: result.output.get(), encoding: .utf8) {
+        return .success(response: outputStr)
+      } else {
+        return .error
+      }
+    case .terminated(code: 1):
+      // The request failed but did not crash. It doesn't reproduce the issue.
+      return .error
+    default:
+      // Exited with a non-zero and non-one exit code. Looks like it crashed, so reproduces a crasher.
+      return .reproducesIssue
+    }
+  }
+
+  @_spi(Testing)
+  public func runSwiftFrontend(request: RequestInfo) async throws -> SourceKitDRequestResult {
+    try request.fileContents.write(to: temporarySourceFile, atomically: true, encoding: .utf8)
+
+    let arguments = request.compilerArgs.replacing(["$FILE"], with: [temporarySourceFile.path])
+
+    let process = Process(arguments: [swiftFrontend.path] + arguments)
+    try process.launch()
+    let result = try await process.waitUntilExit()
+
+    return requestResult(for: result)
+  }
+
+  @_spi(Testing)
+  public func runSourceKitD(request: RequestInfo) async throws -> SourceKitDRequestResult {
     try request.fileContents.write(to: temporarySourceFile, atomically: true, encoding: .utf8)
     let requestString = try request.request(for: temporarySourceFile)
     try requestString.write(to: temporaryRequestFile, atomically: true, encoding: .utf8)
@@ -92,22 +169,7 @@ class OutOfProcessSourceKitRequestExecutor: SourceKitRequestExecutor {
     )
     try process.launch()
     let result = try await process.waitUntilExit()
-    switch result.exitStatus {
-    case .terminated(code: 0):
-      if let outputStr = try? String(bytes: result.output.get(), encoding: .utf8) {
-        if let reproducerPredicate, reproducerPredicate.evaluate(with: outputStr) {
-          return .reproducesIssue
-        }
-        return .success(response: outputStr)
-      } else {
-        return .error
-      }
-    case .terminated(code: 1):
-      // The request failed but did not crash. It doesn't reproduce the issue.
-      return .error
-    default:
-      // Exited with a non-zero and non-one exit code. Looks like it crashed, so reproduces a crasher.
-      return .reproducesIssue
-    }
+
+    return requestResult(for: result)
   }
 }

--- a/Sources/Diagnose/SwiftFrontendCrashScraper.swift
+++ b/Sources/Diagnose/SwiftFrontendCrashScraper.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SKCore
+
+struct SwiftFrontendCrashScraper {
+  /// Information we care about in a `.ips` crash report.
+  private struct IpsCrashReport: Decodable {
+    struct Asi: Decodable {
+      let swiftFrontend: [String]
+      enum CodingKeys: CodingKey {
+        case swiftFrontend
+
+        var stringValue: String {
+          switch self {
+          case .swiftFrontend: "swift-frontend"
+          }
+        }
+      }
+    }
+    let procLaunch: Date
+    let asi: Asi
+  }
+
+  struct SwiftFrontendCrash {
+    let date: Date
+    let swiftFrontend: URL
+    let frontendArgs: [String]
+  }
+
+  private var directoriesToScanForCrashReports: [String]
+
+  init(directoriesToScanForCrashReports: [String]) {
+    self.directoriesToScanForCrashReports = directoriesToScanForCrashReports
+  }
+
+  private func crashReports() -> [URL] {
+    var crashReports: [URL] = []
+    for directoryToScan in directoriesToScanForCrashReports {
+      let diagnosticReports = URL(fileURLWithPath: (directoryToScan as NSString).expandingTildeInPath)
+      let enumerator = FileManager.default.enumerator(at: diagnosticReports, includingPropertiesForKeys: nil)
+      while let fileUrl = enumerator?.nextObject() as? URL {
+        if fileUrl.lastPathComponent.hasPrefix("swift-frontend"), fileUrl.pathExtension == "ips" {
+          crashReports.append(fileUrl)
+        }
+      }
+    }
+    return crashReports
+  }
+
+  /// Find `swift-frontend` crashes
+  func findSwiftFrontendCrashes() -> [SwiftFrontendCrash] {
+    return crashReports().compactMap { (crashReportUrl) -> SwiftFrontendCrash? in
+      guard let fileContents = try? String(contentsOf: crashReportUrl, encoding: .utf8) else {
+        return nil
+      }
+      // The first line contains some summary data that we're not interested in. Remove it
+      guard let firstNewline = fileContents.firstIndex(of: "\n") else {
+        return nil
+      }
+      let interestingString = fileContents[firstNewline...]
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .formatted(dateFormatter)
+      guard let decoded = try? decoder.decode(IpsCrashReport.self, from: interestingString.data(using: .utf8)!) else {
+        return nil
+      }
+
+      let commandLineString = decoded.asi.swiftFrontend
+        .compactMap { (entry) -> Substring? in
+          guard let range = entry.firstRange(of: "Program arguments: ") else {
+            return nil
+          }
+          return entry[range.upperBound...]
+        }
+        .first
+
+      guard let commandLineString else {
+        return nil
+      }
+
+      let commandLine = splitShellEscapedCommand(String(commandLineString))
+      guard let swiftFrontendPath = commandLine.first else {
+        return nil
+      }
+      let swiftFrontendUrl = URL(fileURLWithPath: swiftFrontendPath)
+
+      return SwiftFrontendCrash(
+        date: decoded.procLaunch,
+        swiftFrontend: swiftFrontendUrl,
+        frontendArgs: Array(commandLine.dropFirst())
+      )
+    }
+  }
+}

--- a/Sources/Diagnose/Toolchain+SwiftFrontend.swift
+++ b/Sources/Diagnose/Toolchain+SwiftFrontend.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SKCore
+
+extension Toolchain {
+  /// The path to `swift-frontend` in the toolchain, found relative to `swift`.
+  ///
+  /// - Note: Not discovered as part of the toolchain because `swift-frontend` is only needed in the diagnose commands.
+  @_spi(Testing)
+  public var swiftFrontend: URL? {
+    return swift?.asURL.deletingLastPathComponent().appendingPathComponent("swift-frontend")
+  }
+}

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -106,6 +106,7 @@ struct SourceKitLSP: AsyncParsableCommand {
     subcommands: [
       DiagnoseCommand.self,
       ReduceCommand.self,
+      ReduceFrontendCommand.self,
       SourceKitdRequestCommand.self,
     ]
   )
@@ -116,7 +117,7 @@ struct SourceKitLSP: AsyncParsableCommand {
   var syncRequests = false
 
   @Option(
-    name: [.customLong("configuration"), .customShort("c")],
+    name: [.customLong("configuration")],
     help: "Build with configuration [debug|release]"
   )
   var buildConfiguration = BuildConfiguration.debug


### PR DESCRIPTION
`sourcekit-lsp diagnose` tries to automatically scrape crash reports on the user’s machine for compiler arguments. If it finds any, it tries to reduce that swift-frontend crash.

Alternatively, a swift-frontend crash can be reduced by running 
```bash
sourcekit-lsp reduce-frontend [--toolchain /path/to/toolchain] --frontend-args -all -the frontend --args
```

rdar://124795084