### PR TITLE
Change `#if swift(<5.11)` to `#if compiler(<5.11)`

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -189,7 +189,7 @@ private let testMessageRegistry = MessageRegistry(
   notifications: [EchoNotification.self]
 )
 
-#if swift(<5.11)
+#if compiler(<5.11)
 extension String: ResponseType {}
 #else
 extension String: @retroactive ResponseType {}

--- a/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
+++ b/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
@@ -21,7 +21,7 @@ extension DocumentURI {
     return "<DocumentURI length=\(description.count) hash=\(description.hashForLogging)>"
   }
 }
-#if swift(<5.11)
+#if compiler(<5.11)
 extension DocumentURI: CustomLogStringConvertible {}
 #else
 extension DocumentURI: @retroactive CustomLogStringConvertible {}

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -31,7 +31,7 @@ extension IndexStoreDB {
   }
 }
 
-#if swift(<5.11)
+#if compiler(<5.11)
 extension IndexStoreDB: MainFilesProvider {}
 #else
 extension IndexStoreDB: @retroactive MainFilesProvider {}

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -49,7 +49,7 @@ extension AbsolutePath {
     .directory
   }
 }
-#if swift(<5.11)
+#if compiler(<5.11)
 extension AbsolutePath: ExpressibleByArgument {}
 #else
 extension AbsolutePath: @retroactive ExpressibleByArgument {}
@@ -66,7 +66,7 @@ extension RelativePath {
     self = path
   }
 }
-#if swift(<5.11)
+#if compiler(<5.11)
 extension RelativePath: ExpressibleByArgument {}
 #else
 extension RelativePath: @retroactive ExpressibleByArgument {}
@@ -81,19 +81,19 @@ extension PathPrefixMapping {
     )
   }
 }
-#if swift(<5.11)
+#if compiler(<5.11)
 extension PathPrefixMapping: ExpressibleByArgument {}
 #else
 extension PathPrefixMapping: @retroactive ExpressibleByArgument {}
 #endif
 
-#if swift(<5.11)
+#if compiler(<5.11)
 extension SKSupport.BuildConfiguration: ExpressibleByArgument {}
 #else
 extension SKSupport.BuildConfiguration: @retroactive ExpressibleByArgument {}
 #endif
 
-#if swift(<5.11)
+#if compiler(<5.11)
 extension SKSupport.WorkspaceType: ExpressibleByArgument {}
 #else
 extension SKSupport.WorkspaceType: @retroactive ExpressibleByArgument {}


### PR DESCRIPTION
We want to check the compiler version to decide whether to use `@retroactive`, not the effective language version (which is 5.10 for a Swift 6 compiler).