### PR TITLE
A couple of renames for clarity

### DIFF
--- a/Sources/SKSwiftPMWorkspace/CMakeLists.txt
+++ b/Sources/SKSwiftPMWorkspace/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_library(SKSwiftPMWorkspace STATIC
-  SwiftPMWorkspace.swift)
+  SwiftPMBuildSystem.swift)
 set_target_properties(SKSwiftPMWorkspace PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SKSwiftPMWorkspace PRIVATE

--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -63,7 +63,7 @@ private func getDefaultToolchain(_ toolchainRegistry: ToolchainRegistry) async -
 /// This class implements the `BuildSystem` interface to provide the build settings for a Swift
 /// Package Manager (SwiftPM) package. The settings are determined by loading the Package.swift
 /// manifest using `libSwiftPM` and constructing a build plan using the default (debug) parameters.
-public actor SwiftPMWorkspace {
+public actor SwiftPMBuildSystem {
 
   public enum Error: Swift.Error {
 
@@ -197,7 +197,7 @@ public actor SwiftPMWorkspace {
   }
 }
 
-extension SwiftPMWorkspace {
+extension SwiftPMBuildSystem {
 
   /// (Re-)load the package settings by parsing the manifest and resolving all the targets and
   /// dependencies.
@@ -270,7 +270,7 @@ extension SwiftPMWorkspace {
   }
 }
 
-extension SwiftPMWorkspace: SKCore.BuildSystem {
+extension SwiftPMBuildSystem: SKCore.BuildSystem {
 
   public var buildPath: TSCAbsolutePath {
     return TSCAbsolutePath(buildParameters.buildPath)
@@ -382,7 +382,7 @@ extension SwiftPMWorkspace: SKCore.BuildSystem {
   }
 }
 
-extension SwiftPMWorkspace {
+extension SwiftPMBuildSystem {
 
   // MARK: Implementation details
 

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -17,7 +17,7 @@ import LanguageServerProtocol
 import SourceKitLSP
 import TSCBasic
 
-public struct IndexedSingleSwiftFileWorkspace {
+public struct IndexedSingleSwiftFileTestProject {
   enum Error: Swift.Error {
     case swiftcNotFound
   }

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileWorkspace.swift
@@ -95,7 +95,7 @@ public struct IndexedSingleSwiftFileWorkspace {
     }
 
     // Create the test client
-    var options = SourceKitServer.Options.testDefault
+    var options = SourceKitLSPServer.Options.testDefault
     options.indexOptions = IndexOptions(
       indexStorePath: try AbsolutePath(validating: indexURL.path),
       indexDatabasePath: try AbsolutePath(validating: indexDBURL.path)

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -33,11 +33,11 @@ public struct RelativeFileLocation: Hashable, ExpressibleByStringLiteral {
   }
 }
 
-/// A workspace that writes multiple files to disk and opens a `TestSourceKitLSPClient` client with a workspace pointing
-/// to a temporary directory containing those files.
+/// A test project that writes multiple files to disk and opens a `TestSourceKitLSPClient` client with a workspace
+/// pointing to a temporary directory containing those files.
 ///
 /// The temporary files will be deleted when the `TestSourceKitLSPClient` is destructed.
-public class MultiFileTestWorkspace {
+public class MultiFileTestProject {
   /// Information necessary to open a file in the LSP server by its filename.
   private struct FileData {
     /// The URI at which the file is stored on disk.
@@ -53,7 +53,7 @@ public class MultiFileTestWorkspace {
   private let fileData: [String: FileData]
 
   enum Error: Swift.Error {
-    /// No file with the given filename is known to the `SwiftPMTestWorkspace`.
+    /// No file with the given filename is known to the `MultiFileTestProject`.
     case fileNotFound
   }
 

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -180,7 +180,7 @@ public enum SkipUnless {
     line: UInt = #line
   ) async throws {
     try await skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(5, 11), file: file, line: line) {
-      let workspace = try await SwiftPMTestWorkspace(
+      let workspace = try await SwiftPMTestProject(
         files: ["test.swift": ""],
         build: true
       )

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -15,7 +15,7 @@ import LanguageServerProtocol
 @_spi(Testing) import SKCore
 import TSCBasic
 
-public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
+public class SwiftPMTestProject: MultiFileTestProject {
   enum Error: Swift.Error {
     /// The `swift` executable could not be found.
     case swiftNotFound
@@ -37,7 +37,7 @@ public class SwiftPMTestWorkspace: MultiFileTestWorkspace {
   /// If `index` is `true`, then the package will be built, indexing all modules within the package.
   public init(
     files: [RelativeFileLocation: String],
-    manifest: String = SwiftPMTestWorkspace.defaultPackageManifest,
+    manifest: String = SwiftPMTestProject.defaultPackageManifest,
     workspaces: (URL) -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
     build: Bool = false,
     usePullDiagnostics: Bool = true,

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -20,8 +20,8 @@ import SourceKitLSP
 import SwiftSyntax
 import XCTest
 
-extension SourceKitServer.Options {
-  /// The default SourceKitServer options for testing.
+extension SourceKitLSPServer.Options {
+  /// The default SourceKitLSPServer options for testing.
   public static var testDefault = Self(swiftPublishDiagnosticsDebounceDuration: 0)
 }
 
@@ -44,7 +44,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
   private let moduleCache: URL?
 
   /// The server that handles the requests.
-  public let server: SourceKitServer
+  public let server: SourceKitLSPServer
 
   /// Whether pull or push-model diagnostics should be used.
   ///
@@ -87,7 +87,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
   ///     This allows e.g. a `IndexedSingleSwiftFileWorkspace` to delete its temporary files when they are no longer
   ///     needed.
   public init(
-    serverOptions: SourceKitServer.Options = .testDefault,
+    serverOptions: SourceKitLSPServer.Options = .testDefault,
     useGlobalModuleCache: Bool = true,
     initialize: Bool = true,
     initializationOptions: LSPAny? = nil,
@@ -114,7 +114,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
 
     let serverToClientConnection = LocalConnection()
     self.serverToClientConnection = serverToClientConnection
-    server = SourceKitServer(
+    server = SourceKitLSPServer(
       client: serverToClientConnection,
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: serverOptions,
@@ -262,26 +262,25 @@ public final class TestSourceKitLSPClient: MessageHandler {
 
   /// Handle the next request that is sent to the client with the given handler.
   ///
-  /// By default, `TestSourceKitServer` emits an `XCTFail` if a request is sent
+  /// By default, `TestSourceKitLSPClient` emits an `XCTFail` if a request is sent
   /// to the client, since it doesn't know how to handle it. This allows the
   /// simulation of a single request's handling on the client.
   ///
   /// If the next request that is sent to the client is of a different kind than
-  /// the given handler, `TestSourceKitServer` will emit an `XCTFail`.
+  /// the given handler, `TestSourceKitLSPClient` will emit an `XCTFail`.
   public func handleNextRequest<R: RequestType>(_ requestHandler: @escaping RequestHandler<R>) {
     requestHandlers.append(requestHandler)
   }
 
   // MARK: - Conformance to MessageHandler
 
-  /// - Important: Implementation detail of `TestSourceKitServer`. Do not call
+  /// - Important: Implementation detail of `TestSourceKitLSPServer`. Do not call
   ///   from tests.
   public func handle(_ params: some NotificationType) {
     notificationYielder.yield(params)
   }
 
-  /// - Important: Implementation detail of `TestSourceKitServer`. Do not call
-  ///   from tests.
+  /// - Important: Implementation detail of `TestSourceKitLSPClient`. Do not call from tests.
   public func handle<Request: RequestType>(
     _ params: Request,
     id: LanguageServerProtocol.RequestID,
@@ -393,8 +392,8 @@ public struct DocumentPositions {
 
 /// Wrapper around a weak `MessageHandler`.
 ///
-/// This allows us to set the ``TestSourceKitServer`` as the message handler of
-/// `SourceKitServer` without retaining it.
+/// This allows us to set the ``TestSourceKitLSPClient`` as the message handler of
+/// `SourceKitLSPServer` without retaining it.
 private class WeakMessageHandler: MessageHandler {
   private weak var handler: (any MessageHandler)?
 

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -70,7 +70,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
 
   /// A closure that is called when the `TestSourceKitLSPClient` is destructed.
   ///
-  /// This allows e.g. a `IndexedSingleSwiftFileWorkspace` to delete its temporary files when they are no longer needed.
+  /// This allows e.g. a `IndexedSingleSwiftFileTestProject` to delete its temporary files when they are no longer needed.
   private let cleanUp: () -> Void
 
   /// - Parameters:
@@ -84,7 +84,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
   ///   - usePullDiagnostics: Whether to use push diagnostics or use push-based diagnostics
   ///   - workspaceFolders: Workspace folders to open.
   ///   - cleanUp: A closure that is called when the `TestSourceKitLSPClient` is destructed.
-  ///     This allows e.g. a `IndexedSingleSwiftFileWorkspace` to delete its temporary files when they are no longer
+  ///     This allows e.g. a `IndexedSingleSwiftFileTestProject` to delete its temporary files when they are no longer
   ///     needed.
   public init(
     serverOptions: SourceKitLSPServer.Options = .testDefault,

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -8,8 +8,8 @@ add_library(SourceKitLSP STATIC
   Sequence+AsyncMap.swift
   SourceKitIndexDelegate.swift
   SourceKitLSPCommandMetadata.swift
-  SourceKitServer.swift
-  SourceKitServer+Options.swift
+  SourceKitLSPServer.swift
+  SourceKitLSPServer+Options.swift
   TestDiscovery.swift
   ToolchainLanguageServer.swift
   WorkDoneProgressManager.swift

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -3,20 +3,20 @@ add_library(SourceKitLSP STATIC
   CapabilityRegistry.swift
   DocumentManager.swift
   IndexStoreDB+MainFilesProvider.swift
-  ResponseError+Init.swift
+  LanguageService.swift
   Rename.swift
+  ResponseError+Init.swift
   Sequence+AsyncMap.swift
   SourceKitIndexDelegate.swift
   SourceKitLSPCommandMetadata.swift
   SourceKitLSPServer.swift
   SourceKitLSPServer+Options.swift
   TestDiscovery.swift
-  ToolchainLanguageServer.swift
   WorkDoneProgressManager.swift
   Workspace.swift
 )
 target_sources(SourceKitLSP PRIVATE
-  Clang/ClangLanguageServer.swift)
+  Clang/ClangLanguageService.swift)
 target_sources(SourceKitLSP PRIVATE
   Swift/AdjustPositionToStartOfIdentifier.swift
   Swift/CodeCompletion.swift
@@ -36,7 +36,7 @@ target_sources(SourceKitLSP PRIVATE
   Swift/SemanticTokens.swift
   Swift/SourceKitD+ResponseError.swift
   Swift/SwiftCommand.swift
-  Swift/SwiftLanguageServer.swift
+  Swift/SwiftLanguageService.swift
   Swift/SymbolInfo.swift
   Swift/SyntaxHighlightingToken.swift
   Swift/SyntaxHighlightingTokenParser.swift

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -135,7 +135,7 @@ public final actor CapabilityRegistry {
     options: Options,
     forMethod method: String,
     languages: [Language],
-    in server: SourceKitServer,
+    in server: SourceKitLSPServer,
     registrationDict: [CapabilityRegistration: Options],
     setRegistrationDict: (CapabilityRegistration, Options?) -> Void
   ) async {
@@ -176,7 +176,7 @@ public final actor CapabilityRegistry {
   public func registerCompletionIfNeeded(
     options: CompletionOptions,
     for languages: [Language],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) async {
     guard clientHasDynamicCompletionRegistration else { return }
 
@@ -195,7 +195,7 @@ public final actor CapabilityRegistry {
 
   public func registerDidChangeWatchedFiles(
     watchers: [FileSystemWatcher],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) async {
     guard clientHasDynamicDidChangeWatchedFilesRegistration else { return }
     if let registration = didChangeWatchedFiles {
@@ -230,7 +230,7 @@ public final actor CapabilityRegistry {
   public func registerFoldingRangeIfNeeded(
     options: FoldingRangeOptions,
     for languages: [Language],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) async {
     guard clientHasDynamicFoldingRangeRegistration else { return }
 
@@ -253,7 +253,7 @@ public final actor CapabilityRegistry {
   public func registerSemanticTokensIfNeeded(
     options: SemanticTokensOptions,
     for languages: [Language],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) async {
     guard clientHasDynamicSemanticTokensRegistration else { return }
 
@@ -276,7 +276,7 @@ public final actor CapabilityRegistry {
   public func registerInlayHintIfNeeded(
     options: InlayHintOptions,
     for languages: [Language],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) async {
     guard clientHasDynamicInlayHintRegistration else { return }
     await registerLanguageSpecificCapability(
@@ -297,7 +297,7 @@ public final actor CapabilityRegistry {
   public func registerDiagnosticIfNeeded(
     options: DiagnosticOptions,
     for languages: [Language],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) async {
     guard clientHasDynamicDocumentDiagnosticsRegistration else { return }
 
@@ -318,7 +318,7 @@ public final actor CapabilityRegistry {
   /// it and we haven't yet registered the given command IDs yet.
   public func registerExecuteCommandIfNeeded(
     commands: [String],
-    server: SourceKitServer
+    server: SourceKitLSPServer
   ) {
     guard clientHasDynamicExecuteCommandRegistration else { return }
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -60,7 +60,7 @@ fileprivate class ClangdStderrLogForwarder {
 /// ``ClangLanguageServerShim`` conforms to ``MessageHandler`` to receive
 /// requests and notifications **from** clangd, not from the editor, and it will
 /// forward these requests and notifications to the editor.
-actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
+actor ClangLanguageService: LanguageService, MessageHandler {
   /// The queue on which all messages that originate from clangd are handled.
   ///
   /// These are requests and notifications sent *from* clangd, not replies from
@@ -71,7 +71,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
   /// requests and notifications sent from clangd to the client is quite small.
   public let clangdMessageHandlingQueue = AsyncQueue<Serial>()
 
-  /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageServerShim`.
+  /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageService`.
   ///
   /// Used to send requests and notifications to the editor.
   private weak var sourceKitServer: SourceKitLSPServer?
@@ -191,7 +191,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
     }
   }
 
-  /// Start the `clangd` process, either on creation of the `ClangLanguageServerShim` or after `clangd` has crashed.
+  /// Start the `clangd` process, either on creation of the `ClangLanguageService` or after `clangd` has crashed.
   private func startClangdProcess() throws {
     // Since we are starting a new clangd process, reset the list of open document
     openDocuments = [:]
@@ -387,7 +387,7 @@ actor ClangLanguageServerShim: ToolchainLanguageServer, MessageHandler {
 
 // MARK: - LanguageServer
 
-extension ClangLanguageServerShim {
+extension ClangLanguageService {
 
   /// Intercept clangd's `PublishDiagnosticsNotification` to withold it if we're using fallback
   /// build settings.
@@ -424,9 +424,9 @@ extension ClangLanguageServerShim {
 
 }
 
-// MARK: - ToolchainLanguageServer
+// MARK: - LanguageService
 
-extension ClangLanguageServerShim {
+extension ClangLanguageService {
 
   func initialize(_ initialize: InitializeRequest) async throws -> InitializeResult {
     // Store the initialize request so we can replay it in case clangd crashes
@@ -521,7 +521,6 @@ extension ClangLanguageServerShim {
 
   // MARK: - Text Document
 
-  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
   public func definition(_ req: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
     // We handle it to provide jump-to-header support for #import/#include.
     return try await self.forwardRequestToClangd(req)

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -69,7 +69,7 @@ public protocol LanguageService: AnyObject {
   // MARK: - Creation
 
   init?(
-    sourceKitServer: SourceKitLSPServer,
+    sourceKitLSPServer: SourceKitLSPServer,
     toolchain: Toolchain,
     options: SourceKitLSPServer.Options,
     workspace: Workspace

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -60,8 +60,11 @@ public struct RenameLocation {
   let usage: Usage
 }
 
-/// A `LanguageServer` that exists within the context of the current process.
-public protocol ToolchainLanguageServer: AnyObject {
+/// Provides language specific functionality to sourcekit-lsp from a specific toolchain.
+///
+/// For example, we may have a language service that provides semantic functionality for c-family using a clangd server,
+/// launched from a specific toolchain or from sourcekitd.
+public protocol LanguageService: AnyObject {
 
   // MARK: - Creation
 

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -310,7 +310,7 @@ private extension IndexSymbolKind {
 
 // MARK: - Name translation
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   enum NameTranslationError: Error, CustomStringConvertible {
     case cannotComputeOffset(SymbolLocation)
     case malformedSwiftToClangTranslateNameResponse(SKDResponseDictionary)
@@ -515,7 +515,7 @@ extension SourceKitLSPServer {
     usr: String,
     index: IndexStoreDB,
     workspace: Workspace
-  ) async -> (languageServer: SwiftLanguageServer, snapshot: DocumentSnapshot, location: SymbolLocation)? {
+  ) async -> (swiftLanguageService: SwiftLanguageService, snapshot: DocumentSnapshot, location: SymbolLocation)? {
     var reference: SymbolOccurrence? = nil
     index.forEachSymbolOccurrence(byUSR: usr, roles: renameRoles) {
       if index.symbolProvider(for: $0.location.path) == .swift {
@@ -533,11 +533,11 @@ extension SourceKitLSPServer {
     guard let snapshot = self.documentManager.latestSnapshotOrDisk(uri, language: .swift) else {
       return nil
     }
-    let swiftLanguageServer = await self.languageService(for: uri, .swift, in: workspace) as? SwiftLanguageServer
-    guard let swiftLanguageServer else {
+    let swiftLanguageService = await self.languageService(for: uri, .swift, in: workspace) as? SwiftLanguageService
+    guard let swiftLanguageService else {
       return nil
     }
-    return (swiftLanguageServer, snapshot, reference.location)
+    return (swiftLanguageService, snapshot, reference.location)
   }
 
   /// Returns a `CrossLanguageName` for the symbol with the given USR.
@@ -612,11 +612,11 @@ extension SourceKitLSPServer {
     let definitionName = overrideName ?? definitionSymbol.name
 
     switch definitionLanguageService {
-    case is ClangLanguageServerShim:
+    case is ClangLanguageService:
       let swiftName: String?
       if let swiftReference = await getReferenceFromSwift(usr: usr, index: index, workspace: workspace) {
         let isObjectiveCSelector = definitionLanguage == .objective_c && definitionSymbol.kind.isMethod
-        swiftName = try await swiftReference.languageServer.translateClangNameToSwift(
+        swiftName = try await swiftReference.swiftLanguageService.translateClangNameToSwift(
           at: swiftReference.location,
           in: swiftReference.snapshot,
           isObjectiveCSelector: isObjectiveCSelector,
@@ -627,7 +627,7 @@ extension SourceKitLSPServer {
         swiftName = nil
       }
       return CrossLanguageName(clangName: definitionName, swiftName: swiftName, definitionLanguage: definitionLanguage)
-    case let swiftLanguageServer as SwiftLanguageServer:
+    case let swiftLanguageService as SwiftLanguageService:
       // Continue iteration if the symbol provider is not clang.
       // If we terminate early by returning `false` from the closure, `forEachSymbolOccurrence` returns `true`,
       // indicating that we have found a reference from clang.
@@ -636,7 +636,7 @@ extension SourceKitLSPServer {
       }
       let clangName: String?
       if hasReferenceFromClang {
-        clangName = try await swiftLanguageServer.translateSwiftNameToClang(
+        clangName = try await swiftLanguageService.translateSwiftNameToClang(
           at: definitionOccurrence.location,
           in: definitionDocumentUri,
           name: CompoundDeclName(definitionName)
@@ -845,7 +845,7 @@ extension SourceKitLSPServer {
   func prepareRename(
     _ request: PrepareRenameRequest,
     workspace: Workspace,
-    languageService: ToolchainLanguageServer
+    languageService: LanguageService
   ) async throws -> PrepareRenameResponse? {
     guard let languageServicePrepareRename = try await languageService.prepareRename(request) else {
       return nil
@@ -874,7 +874,7 @@ extension SourceKitLSPServer {
   func indexedRename(
     _ request: IndexedRenameRequest,
     workspace: Workspace,
-    languageService: ToolchainLanguageServer
+    languageService: LanguageService
   ) async throws -> WorkspaceEdit? {
     return try await languageService.indexedRename(request)
   }
@@ -882,7 +882,7 @@ extension SourceKitLSPServer {
 
 // MARK: - Swift
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   /// From a list of rename locations compute the list of `SyntacticRenameName`s that define which ranges need to be
   /// edited to rename a compound decl name.
   ///
@@ -1368,7 +1368,7 @@ extension SwiftLanguageServer {
 
 // MARK: - Clang
 
-extension ClangLanguageServerShim {
+extension ClangLanguageService {
   func rename(_ renameRequest: RenameRequest) async throws -> (edits: WorkspaceEdit, usr: String?) {
     async let edits = forwardRequestToClangd(renameRequest)
     let symbolInfoRequest = SymbolInfoRequest(

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -495,7 +495,7 @@ public struct CrossLanguageName {
   }
 }
 
-// MARK: - SourceKitServer
+// MARK: - SourceKitLSPServer
 
 /// The kinds of symbol occurrence roles that should be renamed.
 fileprivate let renameRoles: SymbolRole = [.declaration, .definition, .reference]
@@ -508,7 +508,7 @@ extension DocumentManager {
   }
 }
 
-extension SourceKitServer {
+extension SourceKitLSPServer {
   /// Returns a `DocumentSnapshot`, a position and the corresponding language service that references
   /// `usr` from a Swift file. If `usr` is not referenced from Swift, returns `nil`.
   private func getReferenceFromSwift(

--- a/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
@@ -18,7 +18,7 @@ import SKSupport
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
 
-extension SourceKitServer {
+extension SourceKitLSPServer {
 
   /// Configuration options for the SourceKitServer.
   public struct Options {

--- a/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
@@ -42,8 +42,8 @@ extension SourceKitLSPServer {
     /// Override the default directory where generated interfaces will be stored
     public var generatedInterfacesPath: AbsolutePath
 
-    /// The time that `SwiftLanguageServer` should wait after an edit before starting to compute diagnostics and sending
-    /// a `PublishDiagnosticsNotification`.
+    /// The time that `SwiftLanguageService` should wait after an edit before starting to compute diagnostics and
+    /// sending a `PublishDiagnosticsNotification`.
     ///
     /// This is mostly intended for testing purposes so we don't need to wait the debouncing time to get a diagnostics
     /// notification when running unit tests.

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -700,7 +700,7 @@ public actor SourceKitLSPServer {
     // Start a new service.
     return await orLog("failed to start language service", level: .error) {
       let service = try await serverType.serverType.init(
-        sourceKitServer: self,
+        sourceKitLSPServer: self,
         toolchain: toolchain,
         options: options,
         workspace: workspace

--- a/Sources/SourceKitLSP/Swift/AdjustPositionToStartOfIdentifier.swift
+++ b/Sources/SourceKitLSP/Swift/AdjustPositionToStartOfIdentifier.swift
@@ -40,7 +40,7 @@ fileprivate class StartOfIdentifierFinder: SyntaxAnyVisitor {
   }
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   /// VS Code considers the position after an identifier as part of an identifier. Ie. if you have `let foo| = 1`, then
   /// it considers the cursor to be positioned at the identifier. This scenario is hit, when selecting an identifier by
   /// double-clicking it and then eg. performing jump-to-definition. In that case VS Code will send the position after

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -16,8 +16,7 @@ import LanguageServerProtocol
 import SourceKitD
 import SwiftBasicFormat
 
-extension SwiftLanguageServer {
-
+extension SwiftLanguageService {
   public func completion(_ req: CompletionRequest) async throws -> CompletionList {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
 

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -115,8 +115,7 @@ extension CursorInfoError: CustomStringConvertible {
   }
 }
 
-extension SwiftLanguageServer {
-
+extension SwiftLanguageService {
   /// Provides detailed information about a symbol under the cursor, if any.
   ///
   /// Wraps the information returned by sourcekitd's `cursor_info` request, such as symbol name,

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -136,7 +136,7 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
   }
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   public func documentFormatting(_ req: DocumentFormattingRequest) async throws -> [TextEdit]? {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
 

--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -15,7 +15,7 @@ import LSPLogging
 import LanguageServerProtocol
 import SwiftSyntax
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   public func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse? {
     let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
 

--- a/Sources/SourceKitLSP/Swift/FoldingRange.swift
+++ b/Sources/SourceKitLSP/Swift/FoldingRange.swift
@@ -234,7 +234,7 @@ fileprivate final class FoldingRangeFinder: SyntaxAnyVisitor {
   }
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   public func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]? {
     let foldingRangeCapabilities = capabilityRegistry.clientCapabilities.textDocument?.foldingRange
     let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -20,7 +20,7 @@ struct InterfaceInfo {
   var contents: String
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   public func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails? {
     let uri = request.textDocument.uri
     let moduleName = request.moduleName

--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -59,7 +59,7 @@ struct RelatedIdentifiersResponse {
   let name: String?
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   func relatedIdentifiers(
     at position: Position,
     in snapshot: DocumentSnapshot,

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -112,8 +112,7 @@ extension SemanticRefactoringError: CustomStringConvertible {
   }
 }
 
-extension SwiftLanguageServer {
-
+extension SwiftLanguageService {
   /// Provides detailed information about the result of a specific refactoring operation.
   ///
   /// Wraps the information returned by sourcekitd's `semantic_refactoring` request, such as the necessary edits and placeholder locations.

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -17,7 +17,7 @@ import SwiftIDEUtils
 import SwiftParser
 import SwiftSyntax
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   /// Requests the semantic highlighting tokens for the given snapshot from sourcekitd.
   private func semanticHighlightingTokens(for snapshot: DocumentSnapshot) async throws -> [SyntaxHighlightingToken]? {
     guard let buildSettings = await self.buildSettings(for: snapshot.uri), !buildSettings.isFallback else {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -91,8 +91,8 @@ public struct SwiftCompileCommand: Equatable {
 }
 
 public actor SwiftLanguageServer: ToolchainLanguageServer {
-  /// The ``SourceKitServer`` instance that created this `ClangLanguageServerShim`.
-  weak var sourceKitServer: SourceKitServer?
+  /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageServerShim`.
+  weak var sourceKitServer: SourceKitLSPServer?
 
   let sourcekitd: SourceKitD
 
@@ -105,7 +105,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
 
   let capabilityRegistry: CapabilityRegistry
 
-  let serverOptions: SourceKitServer.Options
+  let serverOptions: SourceKitLSPServer.Options
 
   /// Directory where generated Swift interfaces will be stored.
   let generatedInterfacesPath: URL
@@ -172,9 +172,9 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
   /// `reopenDocuments` is a closure that will be called if sourcekitd crashes and the `SwiftLanguageServer` asks its parent server to reopen all of its documents.
   /// Returns `nil` if `sourcekitd` couldn't be found.
   public init?(
-    sourceKitServer: SourceKitServer,
+    sourceKitServer: SourceKitLSPServer,
     toolchain: Toolchain,
-    options: SourceKitServer.Options,
+    options: SourceKitLSPServer.Options,
     workspace: Workspace
   ) async throws {
     guard let sourcekitd = toolchain.sourcekitd else { return nil }
@@ -203,7 +203,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
 
   func buildSettings(for document: DocumentURI) async -> SwiftCompileCommand? {
     guard let sourceKitServer else {
-      logger.fault("Cannot retrieve build settings because SourceKitServer is no longer alive")
+      logger.fault("Cannot retrieve build settings because SourceKitLSPServer is no longer alive")
       return nil
     }
     guard let workspace = await sourceKitServer.workspaceForDocument(uri: document) else {
@@ -861,7 +861,7 @@ extension SwiftLanguageServer {
   public func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
     // TODO: If there's support for several types of commands, we might need to structure this similarly to the code actions request.
     guard let sourceKitServer else {
-      // `SourceKitServer` has been destructed. We are tearing down the language
+      // `SourceKitLSPServer` has been destructed. We are tearing down the language
       // server. Nothing left to do.
       throw ResponseError.unknown("Connection to the editor closed")
     }
@@ -913,7 +913,7 @@ extension SwiftLanguageServer: SKDNotificationHandler {
       if let sourceKitServer {
         await sourceKitServer.reopenDocuments(for: self)
       } else {
-        logger.fault("Cannot reopen documents because SourceKitServer is no longer alive")
+        logger.fault("Cannot reopen documents because SourceKitLSPServer is no longer alive")
       }
     }
 

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -90,8 +90,8 @@ public struct SwiftCompileCommand: Equatable {
   }
 }
 
-public actor SwiftLanguageServer: ToolchainLanguageServer {
-  /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageServerShim`.
+public actor SwiftLanguageService: LanguageService {
+  /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageService`.
   weak var sourceKitServer: SourceKitLSPServer?
 
   let sourcekitd: SourceKitD
@@ -169,7 +169,8 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
   }
 
   /// Creates a language server for the given client using the sourcekitd dylib specified in `toolchain`.
-  /// `reopenDocuments` is a closure that will be called if sourcekitd crashes and the `SwiftLanguageServer` asks its parent server to reopen all of its documents.
+  /// `reopenDocuments` is a closure that will be called if sourcekitd crashes and the `SwiftLanguageService` asks its
+  /// parent server to reopen all of its documents.
   /// Returns `nil` if `sourcekitd` couldn't be found.
   public init?(
     sourceKitServer: SourceKitLSPServer,
@@ -231,7 +232,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
   }
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
 
   public func initialize(_ initialize: InitializeRequest) async throws -> InitializeResult {
     await sourcekitd.addNotificationHandler(self)
@@ -549,7 +550,6 @@ extension SwiftLanguageServer {
 
   // MARK: - Language features
 
-  /// Returns true if the `ToolchainLanguageServer` will take ownership of the request.
   public func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
     throw ResponseError.unknown("unsupported method")
   }
@@ -885,7 +885,7 @@ extension SwiftLanguageServer {
   }
 }
 
-extension SwiftLanguageServer: SKDNotificationHandler {
+extension SwiftLanguageService: SKDNotificationHandler {
   public nonisolated func notification(_ notification: SKDResponse) {
     sourcekitdNotificationHandlingQueue.async {
       await self.notificationImpl(notification)

--- a/Sources/SourceKitLSP/Swift/SymbolInfo.swift
+++ b/Sources/SourceKitLSP/Swift/SymbolInfo.swift
@@ -12,7 +12,7 @@
 
 import LanguageServerProtocol
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   public func symbolInfo(_ req: SymbolInfoRequest) async throws -> [SymbolDetails] {
     let uri = req.textDocument.uri
     let snapshot = try documentManager.latestSnapshot(uri)

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -76,7 +76,7 @@ struct VariableTypeInfo {
   }
 }
 
-extension SwiftLanguageServer {
+extension SwiftLanguageService {
   /// Provides typed variable declarations in a document.
   ///
   /// - Parameters:

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -31,7 +31,7 @@ fileprivate extension SymbolOccurrence {
   }
 }
 
-extension SourceKitServer {
+extension SourceKitLSPServer {
   func workspaceTests(_ req: WorkspaceTestsRequest) async throws -> [WorkspaceSymbolItem]? {
     let testSymbols = workspaces.flatMap { (workspace) -> [SymbolOccurrence] in
       return workspace.index?.unitTests() ?? []

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -46,7 +46,7 @@ extension SourceKitLSPServer {
   func documentTests(
     _ req: DocumentTestsRequest,
     workspace: Workspace,
-    languageService: ToolchainLanguageServer
+    languageService: LanguageService
   ) async throws -> [WorkspaceSymbolItem]? {
     let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
     let mainFileUri = await workspace.buildSystemManager.mainFile(

--- a/Sources/SourceKitLSP/ToolchainLanguageServer.swift
+++ b/Sources/SourceKitLSP/ToolchainLanguageServer.swift
@@ -66,9 +66,9 @@ public protocol ToolchainLanguageServer: AnyObject {
   // MARK: - Creation
 
   init?(
-    sourceKitServer: SourceKitServer,
+    sourceKitServer: SourceKitLSPServer,
     toolchain: Toolchain,
-    options: SourceKitServer.Options,
+    options: SourceKitLSPServer.Options,
     workspace: Workspace
   ) async throws
 
@@ -148,8 +148,8 @@ public protocol ToolchainLanguageServer: AnyObject {
   ///
   /// Rename is implemented as a two-step process:  This function returns all the edits it knows need to be performed.
   /// For Swift these edits are those within the current file. In addition, it can return a USR + the old name of the
-  /// symbol to be renamed so that `SourceKitServer` can perform an index lookup to discover more locations to rename
-  /// within the entire workspace. `SourceKitServer` will transform those into edits by calling
+  /// symbol to be renamed so that `SourceKitLSPServer` can perform an index lookup to discover more locations to rename
+  /// within the entire workspace. `SourceKitLSPServer` will transform those into edits by calling
   /// `editsToRename(locations:in:oldName:newName:)` on the toolchain server to perform the actual rename.
   func rename(_ request: RenameRequest) async throws -> (edits: WorkspaceEdit, usr: String?)
 

--- a/Sources/SourceKitLSP/WorkDoneProgressManager.swift
+++ b/Sources/SourceKitLSP/WorkDoneProgressManager.swift
@@ -21,9 +21,9 @@ import SKSupport
 final class WorkDoneProgressManager {
   private let token: ProgressToken
   private let queue = AsyncQueue<Serial>()
-  private let server: SourceKitServer
+  private let server: SourceKitLSPServer
 
-  init?(server: SourceKitServer, capabilityRegistry: CapabilityRegistry, title: String, message: String? = nil) {
+  init?(server: SourceKitLSPServer, capabilityRegistry: CapabilityRegistry, title: String, message: String? = nil) {
     guard capabilityRegistry.clientCapabilities.window?.workDoneProgress ?? false else {
       return nil
     }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -111,8 +111,8 @@ public final class Workspace {
   ) async throws {
     var buildSystem: BuildSystem? = nil
 
-    func buildSwiftPMWorkspace(rootUrl: URL) async -> SwiftPMWorkspace? {
-      return await SwiftPMWorkspace(
+    func createSwiftPMBuildSystem(rootUrl: URL) async -> SwiftPMBuildSystem? {
+      return await SwiftPMBuildSystem(
         url: rootUrl,
         toolchainRegistry: toolchainRegistry,
         buildSetup: buildSetup,
@@ -120,32 +120,32 @@ public final class Workspace {
       )
     }
 
-    func buildCompDBWorkspace(rootPath: AbsolutePath) -> CompilationDatabaseBuildSystem? {
+    func createCompilationDatabaseBuildSystem(rootPath: AbsolutePath) -> CompilationDatabaseBuildSystem? {
       return CompilationDatabaseBuildSystem(
         projectRoot: rootPath,
         searchPaths: compilationDatabaseSearchPaths
       )
     }
 
-    func buildBuildServerWorkspace(rootPath: AbsolutePath) async -> BuildServerBuildSystem? {
+    func createBuildServerBuildSystem(rootPath: AbsolutePath) async -> BuildServerBuildSystem? {
       return await BuildServerBuildSystem(projectRoot: rootPath, buildSetup: buildSetup)
     }
 
     if let rootUrl = rootUri.fileURL, let rootPath = try? AbsolutePath(validating: rootUrl.path) {
       let defaultBuildSystem: BuildSystem? =
         switch buildSetup.defaultWorkspaceType {
-        case .buildServer: await buildBuildServerWorkspace(rootPath: rootPath)
-        case .compilationDatabase: buildCompDBWorkspace(rootPath: rootPath)
-        case .swiftPM: await buildSwiftPMWorkspace(rootUrl: rootUrl)
+        case .buildServer: await createBuildServerBuildSystem(rootPath: rootPath)
+        case .compilationDatabase: createCompilationDatabaseBuildSystem(rootPath: rootPath)
+        case .swiftPM: await createSwiftPMBuildSystem(rootUrl: rootUrl)
         case nil: nil
         }
       if let defaultBuildSystem {
         buildSystem = defaultBuildSystem
-      } else if let buildServer = await buildBuildServerWorkspace(rootPath: rootPath) {
+      } else if let buildServer = await createBuildServerBuildSystem(rootPath: rootPath) {
         buildSystem = buildServer
-      } else if let swiftpm = await buildSwiftPMWorkspace(rootUrl: rootUrl) {
+      } else if let swiftpm = await createSwiftPMBuildSystem(rootUrl: rootUrl) {
         buildSystem = swiftpm
-      } else if let compdb = buildCompDBWorkspace(rootPath: rootPath) {
+      } else if let compdb = createCompilationDatabaseBuildSystem(rootPath: rootPath) {
         buildSystem = compdb
       } else {
         buildSystem = nil

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -62,7 +62,7 @@ public final class Workspace {
   /// The source code index, if available.
   public var index: IndexStoreDB? = nil
 
-  /// Documents open in the SourceKitServer. This may include open documents from other workspaces.
+  /// Documents open in the SourceKitLSPServer. This may include open documents from other workspaces.
   private let documentManager: DocumentManager
 
   /// Language service for an open document, if available.

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -66,7 +66,7 @@ public final class Workspace {
   private let documentManager: DocumentManager
 
   /// Language service for an open document, if available.
-  var documentService: [DocumentURI: ToolchainLanguageServer] = [:]
+  var documentService: [DocumentURI: LanguageService] = [:]
 
   public init(
     documentManager: DocumentManager,

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -205,8 +205,8 @@ struct SourceKitLSP: AsyncParsableCommand {
   )
   var completionMaxResults = 200
 
-  func mapOptions() -> SourceKitServer.Options {
-    var serverOptions = SourceKitServer.Options()
+  func mapOptions() -> SourceKitLSPServer.Options {
+    var serverOptions = SourceKitLSPServer.Options()
 
     serverOptions.buildSetup.configuration = buildConfiguration
     serverOptions.buildSetup.defaultWorkspaceType = defaultWorkspaceType
@@ -249,7 +249,7 @@ struct SourceKitLSP: AsyncParsableCommand {
 
     let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
 
-    let server = SourceKitServer(
+    let server = SourceKitLSPServer(
       client: clientConnection,
       toolchainRegistry: ToolchainRegistry(installPath: installPath, localFileSystem),
       options: mapOptions(),

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -1347,7 +1347,7 @@ func with<T>(_ value: T, mutate: (inout T) -> Void) -> T {
 
 extension String {
   func indented(_ spaces: Int, skipFirstLine: Bool = false) -> String {
-    let ws = String(repeating: " ", count: spaces)
-    return (skipFirstLine ? "" : ws) + self.replacingOccurrences(of: "\n", with: "\n" + ws)
+    let spaces = String(repeating: " ", count: spaces)
+    return (skipFirstLine ? "" : spaces) + self.replacingOccurrences(of: "\n", with: "\n" + spaces)
   }
 }

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
@@ -41,7 +41,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
       await assertThrowsError(
-        try await SwiftPMWorkspace(
+        try await SwiftPMBuildSystem(
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
@@ -68,7 +68,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
       await assertThrowsError(
-        try await SwiftPMWorkspace(
+        try await SwiftPMBuildSystem(
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
@@ -95,7 +95,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = tempDir.appending(component: "pkg")
       await assertThrowsError(
-        try await SwiftPMWorkspace(
+        try await SwiftPMBuildSystem(
           workspacePath: packageRoot,
           toolchainRegistry: ToolchainRegistry(toolchains: []),
           fileSystem: fs,
@@ -122,7 +122,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -130,12 +130,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let hostTriple = await ws.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
-      assertEqual(await ws.buildPath, build)
-      assertNotNil(await ws.indexStorePath)
-      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      assertEqual(await swiftpmBuildSystem.buildPath, build)
+      assertNotNil(await swiftpmBuildSystem.indexStorePath)
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
 
       assertArgumentsContain("-module-name", "lib", arguments: arguments)
       assertArgumentsContain("-emit-dependencies", arguments: arguments)
@@ -190,7 +190,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         flags: BuildFlags(cCompilerFlags: ["-m32"], swiftCompilerFlags: ["-typecheck"])
       )
 
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -198,11 +198,11 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let hostTriple = await ws.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
       let build = buildPath(root: packageRoot, config: config, platform: hostTriple.platformBuildPathComponent)
 
-      assertEqual(await ws.buildPath, build)
-      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      assertEqual(await swiftpmBuildSystem.buildPath, build)
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
 
       assertArgumentsContain("-typecheck", arguments: arguments)
       assertArgumentsContain("-Xcc", "-m32", arguments: arguments)
@@ -227,7 +227,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -235,7 +235,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
-      let arguments = try await ws.buildSettings(for: source.asURI, language: .swift)!.compilerArguments
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: source.asURI, language: .swift)!.compilerArguments
 
       assertArgumentsContain("-swift-version", "4.2", arguments: arguments)
       assertArgumentsContain(source.pathString, arguments: arguments)
@@ -260,7 +260,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -270,10 +270,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
 
-      let argumentsA = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      let argumentsA = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!
+        .compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: argumentsA)
       assertArgumentsContain(bswift.pathString, arguments: argumentsA)
-      let argumentsB = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      let argumentsB = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!
+        .compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: argumentsB)
       assertArgumentsContain(bswift.pathString, arguments: argumentsB)
     }
@@ -303,7 +305,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -312,7 +314,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: arguments)
       assertArgumentsDoNotContain(bswift.pathString, arguments: arguments)
       // Temporary conditional to work around revlock between SourceKit-LSP and SwiftPM
@@ -333,7 +335,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         )
       }
 
-      let argumentsB = try await ws.buildSettings(for: bswift.asURI, language: .swift)!.compilerArguments
+      let argumentsB = try await swiftpmBuildSystem.buildSettings(for: bswift.asURI, language: .swift)!
+        .compilerArguments
       assertArgumentsContain(bswift.pathString, arguments: argumentsB)
       assertArgumentsDoNotContain(aswift.pathString, arguments: argumentsB)
       assertArgumentsDoNotContain(
@@ -364,7 +367,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -373,9 +376,14 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      assertNotNil(try await ws.buildSettings(for: aswift.asURI, language: .swift))
-      assertNil(try await ws.buildSettings(for: bswift.asURI, language: .swift))
-      assertNil(try await ws.buildSettings(for: DocumentURI(URL(string: "https://www.apple.com")!), language: .swift))
+      assertNotNil(try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift))
+      assertNil(try await swiftpmBuildSystem.buildSettings(for: bswift.asURI, language: .swift))
+      assertNil(
+        try await swiftpmBuildSystem.buildSettings(
+          for: DocumentURI(URL(string: "https://www.apple.com")!),
+          language: .swift
+        )
+      )
     }
   }
 
@@ -399,7 +407,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -409,14 +417,14 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let bcxx = packageRoot.appending(components: "Sources", "lib", "b.cpp")
       let header = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
-      let hostTriple = await ws.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
-      assertEqual(await ws.buildPath, build)
-      assertNotNil(await ws.indexStorePath)
+      assertEqual(await swiftpmBuildSystem.buildPath, build)
+      assertNotNil(await swiftpmBuildSystem.indexStorePath)
 
       for file in [acxx, header] {
-        let args = try await ws.buildSettings(for: file.asURI, language: .cpp)!.compilerArguments
+        let args = try await swiftpmBuildSystem.buildSettings(for: file.asURI, language: .cpp)!.compilerArguments
 
         assertArgumentsContain("-std=c++14", arguments: args)
 
@@ -478,7 +486,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
@@ -486,9 +494,9 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       assertArgumentsContain("-target", arguments: arguments)  // Only one!
-      let hostTriple = await ws.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
 
       #if os(macOS)
       assertArgumentsContain(
@@ -525,7 +533,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -539,8 +547,10 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         .appending(components: "Sources", "lib", "a.swift")
       let manifest = packageRoot.appending(components: "Package.swift")
 
-      let arguments1 = try await ws.buildSettings(for: aswift1.asURI, language: .swift)?.compilerArguments
-      let arguments2 = try await ws.buildSettings(for: aswift2.asURI, language: .swift)?.compilerArguments
+      let arguments1 = try await swiftpmBuildSystem.buildSettings(for: aswift1.asURI, language: .swift)?
+        .compilerArguments
+      let arguments2 = try await swiftpmBuildSystem.buildSettings(for: aswift2.asURI, language: .swift)?
+        .compilerArguments
       XCTAssertNotNil(arguments1)
       XCTAssertNotNil(arguments2)
       XCTAssertEqual(arguments1, arguments2)
@@ -548,7 +558,8 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       assertArgumentsDoNotContain(aswift1.pathString, arguments: arguments1 ?? [])
       assertArgumentsContain(try resolveSymlinks(aswift1).pathString, arguments: arguments1 ?? [])
 
-      let argsManifest = try await ws.buildSettings(for: manifest.asURI, language: .swift)?.compilerArguments
+      let argsManifest = try await swiftpmBuildSystem.buildSettings(for: manifest.asURI, language: .swift)?
+        .compilerArguments
       XCTAssertNotNil(argsManifest)
 
       assertArgumentsDoNotContain(manifest.pathString, arguments: argsManifest ?? [])
@@ -586,7 +597,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appending(component: "pkg_real").pathString)
       )
 
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: symlinkRoot,
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
@@ -595,7 +606,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
 
       for file in [acpp, ah] {
         let args = try unwrap(
-          await ws.buildSettings(for: symlinkRoot.appending(components: file).asURI, language: .cpp)?
+          await swiftpmBuildSystem.buildSettings(for: symlinkRoot.appending(components: file).asURI, language: .cpp)?
             .compilerArguments
         )
         assertArgumentsContain(realRoot.appending(components: file).pathString, arguments: args)
@@ -626,7 +637,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -634,7 +645,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: arguments)
       XCTAssertNotNil(
         arguments.firstIndex(where: {
@@ -662,14 +673,14 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
-      assertEqual(await ws.projectRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
+      assertEqual(await swiftpmBuildSystem.projectRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
     }
   }
 
@@ -698,7 +709,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
-      let ws = try await SwiftPMWorkspace(
+      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
@@ -706,12 +717,12 @@ final class SwiftPMWorkspaceTests: XCTestCase {
       )
 
       let aswift = packageRoot.appending(components: "Plugins", "MyPlugin", "a.swift")
-      let hostTriple = await ws.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
-      assertEqual(await ws.buildPath, build)
-      assertNotNil(await ws.indexStorePath)
-      let arguments = try await ws.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
+      assertEqual(await swiftpmBuildSystem.buildPath, build)
+      assertNotNil(await swiftpmBuildSystem.indexStorePath)
+      let arguments = try await swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift)!.compilerArguments
 
       // Plugins get compiled with the same compiler arguments as the package manifest
       assertArgumentsContain("-package-description-version", "5.7.0", arguments: arguments)

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMWorkspaceTests.swift
@@ -45,7 +45,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
-          buildSetup: SourceKitServer.Options.testDefault.buildSetup
+          buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
         )
       )
     }
@@ -72,7 +72,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: tr,
           fileSystem: fs,
-          buildSetup: SourceKitServer.Options.testDefault.buildSetup
+          buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
         )
       )
     }
@@ -99,7 +99,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
           workspacePath: packageRoot,
           toolchainRegistry: ToolchainRegistry(toolchains: []),
           fileSystem: fs,
-          buildSetup: SourceKitServer.Options.testDefault.buildSetup
+          buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
         )
       )
     }
@@ -126,7 +126,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -231,7 +231,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
@@ -264,7 +264,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -307,7 +307,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
@@ -368,7 +368,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
@@ -403,7 +403,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
@@ -482,7 +482,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -529,7 +529,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift1 = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -590,7 +590,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: symlinkRoot,
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       for file in [acpp, ah] {
@@ -630,7 +630,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
@@ -666,7 +666,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       assertEqual(await ws.projectRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
@@ -702,7 +702,7 @@ final class SwiftPMWorkspaceTests: XCTestCase {
         workspacePath: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
-        buildSetup: SourceKitServer.Options.testDefault.buildSetup
+        buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup
       )
 
       let aswift = packageRoot.appending(components: "Plugins", "MyPlugin", "a.swift")
@@ -759,7 +759,7 @@ private func assertArgumentsContain(
 
 private func buildPath(
   root: AbsolutePath,
-  config: BuildSetup = SourceKitServer.Options.testDefault.buildSetup,
+  config: BuildSetup = SourceKitLSPServer.Options.testDefault.buildSetup,
   platform: String
 ) -> AbsolutePath {
   let buildPath = config.path ?? root.appending(component: ".build")

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -81,14 +81,14 @@ final class CrashRecoveryTests: XCTestCase {
 
     // Crash sourcekitd
 
-    let sourcekitdServer =
+    let swiftLanguageService =
       await testClient.server._languageService(
         for: uri,
         .swift,
         in: testClient.server.workspaceForDocument(uri: uri)!
-      ) as! SwiftLanguageServer
+      ) as! SwiftLanguageService
 
-    await sourcekitdServer._crash()
+    await swiftLanguageService._crash()
 
     let crashedNotification = try await testClient.nextNotification(ofType: WorkDoneProgress.self, timeout: 5)
     XCTAssertEqual(

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -202,7 +202,7 @@ final class CrashRecoveryTests: XCTestCase {
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "main.cpp": """
       #if FOO
       void 1️⃣foo2️⃣() {}

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -202,7 +202,7 @@ final class CrashRecoveryTests: XCTestCase {
   func testClangdCrashRecoveryReopensWithCorrectBuildSettings() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       "main.cpp": """
       #if FOO
       void 1️⃣foo2️⃣() {}
@@ -219,7 +219,7 @@ final class CrashRecoveryTests: XCTestCase {
       """,
     ])
 
-    let (mainUri, positions) = try ws.openDocument("main.cpp")
+    let (mainUri, positions) = try project.openDocument("main.cpp")
 
     // Do a sanity check and verify that we get the expected result from a hover response before crashing clangd.
 
@@ -232,7 +232,7 @@ final class CrashRecoveryTests: XCTestCase {
       textDocument: TextDocumentIdentifier(mainUri),
       position: positions["3️⃣"]
     )
-    let preCrashHighlightResponse = try await ws.testClient.send(highlightRequest)
+    let preCrashHighlightResponse = try await project.testClient.send(highlightRequest)
     precondition(
       preCrashHighlightResponse == expectedHighlightResponse,
       "Sanity check failed. The Hover response was not what we expected, even before crashing sourcekitd"
@@ -240,14 +240,14 @@ final class CrashRecoveryTests: XCTestCase {
 
     // Crash clangd
 
-    try await crashClangd(for: ws.testClient, document: mainUri)
+    try await crashClangd(for: project.testClient, document: mainUri)
 
     // Check that we have re-opened the document with the correct build settings
     // If we did not recover the correct build settings, document highlight would
     // pick the definition of foo() in the #else branch.
 
     await assertNoThrow {
-      let postCrashHighlightResponse = try await ws.testClient.send(highlightRequest)
+      let postCrashHighlightResponse = try await project.testClient.send(highlightRequest)
       XCTAssertEqual(postCrashHighlightResponse, expectedHighlightResponse)
     }
   }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -19,7 +19,7 @@ import SKTestSupport
 import TSCBasic
 import XCTest
 
-/// Build system to be used for testing BuildSystem and BuildSystemDelegate functionality with SourceKitServer
+/// Build system to be used for testing BuildSystem and BuildSystemDelegate functionality with SourceKitLSPServer
 /// and other components.
 final class TestBuildSystem: BuildSystem {
   var projectRoot: AbsolutePath = try! AbsolutePath(validating: "/")
@@ -74,7 +74,7 @@ final class BuildSystemTests: XCTestCase {
   /// - Note: Set before each test run in `setUp`.
   private var workspace: Workspace! = nil
 
-  /// The build system that we use to verify SourceKitServer behavior.
+  /// The build system that we use to verify SourceKitLSPServer behavior.
   ///
   /// - Note: Set before each test run in `setUp`.
   private var buildSystem: TestBuildSystem! = nil
@@ -95,7 +95,7 @@ final class BuildSystemTests: XCTestCase {
       rootUri: nil,
       capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
       toolchainRegistry: ToolchainRegistry.forTesting,
-      buildSetup: SourceKitServer.Options.testDefault.buildSetup,
+      buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
       underlyingBuildSystem: buildSystem,
       index: nil,
       indexDelegate: nil

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class CallHierarchyTests: XCTestCase {
   func testCallHierarchy() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣a() {}
 
@@ -46,8 +46,11 @@ final class CallHierarchyTests: XCTestCase {
     )
 
     func callHierarchy(at position: Position) async throws -> [CallHierarchyItem] {
-      let request = CallHierarchyPrepareRequest(textDocument: TextDocumentIdentifier(ws.fileURI), position: position)
-      return try await ws.testClient.send(request) ?? []
+      let request = CallHierarchyPrepareRequest(
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: position
+      )
+      return try await project.testClient.send(request) ?? []
     }
 
     func incomingCalls(at position: Position) async throws -> [CallHierarchyIncomingCall] {
@@ -56,7 +59,7 @@ final class CallHierarchyTests: XCTestCase {
         return []
       }
       let request = CallHierarchyIncomingCallsRequest(item: item)
-      return try await ws.testClient.send(request) ?? []
+      return try await project.testClient.send(request) ?? []
     }
 
     func outgoingCalls(at position: Position) async throws -> [CallHierarchyOutgoingCall] {
@@ -65,7 +68,7 @@ final class CallHierarchyTests: XCTestCase {
         return []
       }
       let request = CallHierarchyOutgoingCallsRequest(item: item)
-      return try await ws.testClient.send(request) ?? []
+      return try await project.testClient.send(request) ?? []
     }
 
     func usr(at position: Position) async throws -> String {
@@ -96,55 +99,55 @@ final class CallHierarchyTests: XCTestCase {
         kind: kind,
         tags: nil,
         detail: detail,
-        uri: ws.fileURI,
+        uri: project.fileURI,
         range: Range(position),
         selectionRange: Range(position),
         data: .dictionary([
           "usr": .string(usr),
-          "uri": .string(ws.fileURI.stringValue),
+          "uri": .string(project.fileURI.stringValue),
         ])
       )
     }
 
-    let aUsr = try await usr(at: ws.positions["1️⃣"])
-    let bUsr = try await usr(at: ws.positions["2️⃣"])
-    let cUsr = try await usr(at: ws.positions["6️⃣"])
-    let dUsr = try await usr(at: ws.positions["🔟"])
+    let aUsr = try await usr(at: project.positions["1️⃣"])
+    let bUsr = try await usr(at: project.positions["2️⃣"])
+    let cUsr = try await usr(at: project.positions["6️⃣"])
+    let dUsr = try await usr(at: project.positions["🔟"])
 
     // Test outgoing call hierarchy
 
-    assertEqual(try await outgoingCalls(at: ws.positions["1️⃣"]), [])
+    assertEqual(try await outgoingCalls(at: project.positions["1️⃣"]), [])
     assertEqual(
-      try await outgoingCalls(at: ws.positions["2️⃣"]),
+      try await outgoingCalls(at: project.positions["2️⃣"]),
       [
         CallHierarchyOutgoingCall(
-          to: item("a()", .function, usr: aUsr, at: ws.positions["1️⃣"]),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          to: item("a()", .function, usr: aUsr, at: project.positions["1️⃣"]),
+          fromRanges: [Range(project.positions["3️⃣"])]
         ),
         CallHierarchyOutgoingCall(
-          to: item("b(x:)", .function, usr: bUsr, at: ws.positions["2️⃣"]),
-          fromRanges: [Range(ws.positions["5️⃣"])]
+          to: item("b(x:)", .function, usr: bUsr, at: project.positions["2️⃣"]),
+          fromRanges: [Range(project.positions["5️⃣"])]
         ),
         CallHierarchyOutgoingCall(
-          to: item("c()", .function, usr: cUsr, at: ws.positions["6️⃣"]),
-          fromRanges: [Range(ws.positions["4️⃣"])]
+          to: item("c()", .function, usr: cUsr, at: project.positions["6️⃣"]),
+          fromRanges: [Range(project.positions["4️⃣"])]
         ),
       ]
     )
     assertEqual(
-      try await outgoingCalls(at: ws.positions["6️⃣"]),
+      try await outgoingCalls(at: project.positions["6️⃣"]),
       [
         CallHierarchyOutgoingCall(
-          to: item("a()", .function, usr: aUsr, at: ws.positions["1️⃣"]),
-          fromRanges: [Range(ws.positions["7️⃣"])]
+          to: item("a()", .function, usr: aUsr, at: project.positions["1️⃣"]),
+          fromRanges: [Range(project.positions["7️⃣"])]
         ),
         CallHierarchyOutgoingCall(
-          to: item("c()", .function, usr: cUsr, at: ws.positions["6️⃣"]),
-          fromRanges: [Range(ws.positions["9️⃣"])]
+          to: item("c()", .function, usr: cUsr, at: project.positions["6️⃣"]),
+          fromRanges: [Range(project.positions["9️⃣"])]
         ),
         CallHierarchyOutgoingCall(
-          to: item("d()", .function, usr: dUsr, at: ws.positions["🔟"]),
-          fromRanges: [Range(ws.positions["8️⃣"])]
+          to: item("d()", .function, usr: dUsr, at: project.positions["🔟"]),
+          fromRanges: [Range(project.positions["8️⃣"])]
         ),
       ]
     )
@@ -152,40 +155,40 @@ final class CallHierarchyTests: XCTestCase {
     // Test incoming call hierarchy
 
     assertEqual(
-      try await incomingCalls(at: ws.positions["1️⃣"]),
+      try await incomingCalls(at: project.positions["1️⃣"]),
       [
         CallHierarchyIncomingCall(
-          from: item("b(x:)", .function, usr: bUsr, at: ws.positions["2️⃣"]),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          from: item("b(x:)", .function, usr: bUsr, at: project.positions["2️⃣"]),
+          fromRanges: [Range(project.positions["3️⃣"])]
         ),
         CallHierarchyIncomingCall(
-          from: item("c()", .function, usr: cUsr, at: ws.positions["6️⃣"]),
-          fromRanges: [Range(ws.positions["7️⃣"])]
+          from: item("c()", .function, usr: cUsr, at: project.positions["6️⃣"]),
+          fromRanges: [Range(project.positions["7️⃣"])]
         ),
       ]
     )
     assertEqual(
-      try await incomingCalls(at: ws.positions["2️⃣"]),
+      try await incomingCalls(at: project.positions["2️⃣"]),
       [
         CallHierarchyIncomingCall(
-          from: item("b(x:)", .function, usr: bUsr, at: ws.positions["2️⃣"]),
-          fromRanges: [Range(ws.positions["5️⃣"])]
+          from: item("b(x:)", .function, usr: bUsr, at: project.positions["2️⃣"]),
+          fromRanges: [Range(project.positions["5️⃣"])]
         )
       ]
     )
     assertEqual(
-      try await incomingCalls(at: ws.positions["🔟"]),
+      try await incomingCalls(at: project.positions["🔟"]),
       [
         CallHierarchyIncomingCall(
-          from: item("c()", .function, usr: cUsr, at: ws.positions["6️⃣"]),
-          fromRanges: [Range(ws.positions["8️⃣"])]
+          from: item("c()", .function, usr: cUsr, at: project.positions["6️⃣"]),
+          fromRanges: [Range(project.positions["8️⃣"])]
         )
       ]
     )
   }
 
   func testReportSingleItemInPrepareCallHierarchy() async throws {
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "MyLibrary/include/lib.h": """
         struct FilePathIndex {
@@ -199,8 +202,8 @@ final class CallHierarchyTests: XCTestCase {
       ],
       build: true
     )
-    let (uri, positions) = try ws.openDocument("lib.h", language: .cpp)
-    let result = try await ws.testClient.send(
+    let (uri, positions) = try project.openDocument("lib.h", language: .cpp)
+    let result = try await project.testClient.send(
       CallHierarchyPrepareRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
 
@@ -213,12 +216,12 @@ final class CallHierarchyTests: XCTestCase {
           kind: .method,
           tags: nil,
           detail: "",
-          uri: try ws.uri(for: "lib.cpp"),
-          range: try Range(ws.position(of: "2️⃣", in: "lib.cpp")),
-          selectionRange: try Range(ws.position(of: "2️⃣", in: "lib.cpp")),
+          uri: try project.uri(for: "lib.cpp"),
+          range: try Range(project.position(of: "2️⃣", in: "lib.cpp")),
+          selectionRange: try Range(project.position(of: "2️⃣", in: "lib.cpp")),
           data: LSPAny.dictionary([
             "usr": .string("c:@S@FilePathIndex@F@foo#"),
-            "uri": .string(try ws.uri(for: "lib.cpp").stringValue),
+            "uri": .string(try project.uri(for: "lib.cpp").stringValue),
           ])
         )
       ]
@@ -227,7 +230,7 @@ final class CallHierarchyTests: XCTestCase {
 
   func testIncomingCallHierarchyShowsSurroundingFunctionCall() async throws {
     // We used to show `myVar` as the caller here
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣foo() {}
 
@@ -236,14 +239,14 @@ final class CallHierarchyTests: XCTestCase {
       }
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["1️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -253,22 +256,22 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["2️⃣"]),
-            selectionRange: Range(ws.positions["2️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["2️⃣"]),
+            selectionRange: Range(project.positions["2️⃣"]),
             data: .dictionary([
               "usr": .string("s:4test0A4Func1xySS_tF"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         )
       ]
     )
   }
 
   func testIncomingCallHierarchyFromComputedProperty() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣foo() {}
 
@@ -278,14 +281,14 @@ final class CallHierarchyTests: XCTestCase {
       }
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["1️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -295,22 +298,22 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["2️⃣"]),
-            selectionRange: Range(ws.positions["2️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["2️⃣"]),
+            selectionRange: Range(project.positions["2️⃣"]),
             data: .dictionary([
               "usr": .string("s:4test0A3VarSivg"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         )
       ]
     )
   }
 
   func testIncomingCallHierarchyShowsAccessToVariables() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       var 1️⃣foo: Int
       func 2️⃣testFunc() {
@@ -320,14 +323,14 @@ final class CallHierarchyTests: XCTestCase {
 
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["1️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -337,15 +340,15 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["2️⃣"]),
-            selectionRange: Range(ws.positions["2️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["2️⃣"]),
+            selectionRange: Range(project.positions["2️⃣"]),
             data: .dictionary([
               "usr": .string("s:4test0A4FuncyyF"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         ),
         CallHierarchyIncomingCall(
           from: CallHierarchyItem(
@@ -353,22 +356,22 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["2️⃣"]),
-            selectionRange: Range(ws.positions["2️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["2️⃣"]),
+            selectionRange: Range(project.positions["2️⃣"]),
             data: .dictionary([
               "usr": .string("s:4test0A4FuncyyF"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["4️⃣"])]
+          fromRanges: [Range(project.positions["4️⃣"])]
         ),
       ]
     )
   }
 
   func testOutgoingCallHierarchyShowsAccessesToVariable() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       var 1️⃣foo: Int
       func 2️⃣testFunc() {
@@ -377,14 +380,14 @@ final class CallHierarchyTests: XCTestCase {
 
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["2️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["2️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyOutgoingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyOutgoingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -394,22 +397,22 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["1️⃣"]),
-            selectionRange: Range(ws.positions["1️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["1️⃣"]),
+            selectionRange: Range(project.positions["1️⃣"]),
             data: .dictionary([
               "usr": .string("s:4test3fooSivg"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         )
       ]
     )
   }
 
   func testOutgoingCallHierarchyFromVariableAccessor() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣testFunc() -> Int { 0 }
       var 2️⃣foo: Int {
@@ -417,14 +420,14 @@ final class CallHierarchyTests: XCTestCase {
       }
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["2️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["2️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyOutgoingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyOutgoingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -434,22 +437,22 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["1️⃣"]),
-            selectionRange: Range(ws.positions["1️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["1️⃣"]),
+            selectionRange: Range(project.positions["1️⃣"]),
             data: .dictionary([
               "usr": .string("s:4test0A4FuncSiyF"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         )
       ]
     )
   }
 
   func testIncomingCallHierarchyLooksThroughProtocols() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       protocol MyProtocol {
         func foo()
@@ -466,14 +469,14 @@ final class CallHierarchyTests: XCTestCase {
       }
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["1️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -483,22 +486,22 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["2️⃣"]),
-            selectionRange: Range(ws.positions["2️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["2️⃣"]),
+            selectionRange: Range(project.positions["2️⃣"]),
             data: .dictionary([
               "usr": .string("s:4testAA5protoyAA10MyProtocol_p_tF"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         )
       ]
     )
   }
 
   func testIncomingCallHierarchyLooksThroughSuperclasses() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       class Base {
         func foo() {}
@@ -515,14 +518,14 @@ final class CallHierarchyTests: XCTestCase {
       }
       """
     )
-    let prepare = try await ws.testClient.send(
+    let prepare = try await project.testClient.send(
       CallHierarchyPrepareRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["1️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
     let initialItem = try XCTUnwrap(prepare?.only)
-    let calls = try await ws.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
+    let calls = try await project.testClient.send(CallHierarchyIncomingCallsRequest(item: initialItem))
     XCTAssertEqual(
       calls,
       [
@@ -532,15 +535,15 @@ final class CallHierarchyTests: XCTestCase {
             kind: .function,
             tags: nil,
             detail: "test",  // test is the module name because the file is called test.swift
-            uri: ws.fileURI,
-            range: Range(ws.positions["2️⃣"]),
-            selectionRange: Range(ws.positions["2️⃣"]),
+            uri: project.fileURI,
+            range: Range(project.positions["2️⃣"]),
+            selectionRange: Range(project.positions["2️⃣"]),
             data: .dictionary([
               "usr": .string("s:4testAA4baseyAA4BaseC_tF"),
-              "uri": .string(ws.fileURI.stringValue),
+              "uri": .string(project.fileURI.stringValue),
             ])
           ),
-          fromRanges: [Range(ws.positions["3️⃣"])]
+          fromRanges: [Range(project.positions["3️⃣"])]
         )
       ]
     )

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class CallHierarchyTests: XCTestCase {
   func testCallHierarchy() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣a() {}
 
@@ -185,7 +185,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testReportSingleItemInPrepareCallHierarchy() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "MyLibrary/include/lib.h": """
         struct FilePathIndex {
@@ -227,7 +227,7 @@ final class CallHierarchyTests: XCTestCase {
 
   func testIncomingCallHierarchyShowsSurroundingFunctionCall() async throws {
     // We used to show `myVar` as the caller here
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣foo() {}
 
@@ -268,7 +268,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testIncomingCallHierarchyFromComputedProperty() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣foo() {}
 
@@ -310,7 +310,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testIncomingCallHierarchyShowsAccessToVariables() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       var 1️⃣foo: Int
       func 2️⃣testFunc() {
@@ -368,7 +368,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testOutgoingCallHierarchyShowsAccessesToVariable() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       var 1️⃣foo: Int
       func 2️⃣testFunc() {
@@ -409,7 +409,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testOutgoingCallHierarchyFromVariableAccessor() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣testFunc() -> Int { 0 }
       var 2️⃣foo: Int {
@@ -449,7 +449,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testIncomingCallHierarchyLooksThroughProtocols() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       protocol MyProtocol {
         func foo()
@@ -498,7 +498,7 @@ final class CallHierarchyTests: XCTestCase {
   }
 
   func testIncomingCallHierarchyLooksThroughSuperclasses() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       class Base {
         func foo() {}

--- a/Tests/SourceKitLSPTests/ClangdTests.swift
+++ b/Tests/SourceKitLSPTests/ClangdTests.swift
@@ -16,20 +16,20 @@ import XCTest
 
 final class ClangdTests: XCTestCase {
   func testClangdGoToInclude() async throws {
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       "Object.h": "",
       "main.c": """
       #include 1️⃣"Object.h"
       """,
     ])
-    let (mainUri, positions) = try ws.openDocument("main.c")
-    let headerUri = try ws.uri(for: "Object.h")
+    let (mainUri, positions) = try project.openDocument("main.c")
+    let headerUri = try project.uri(for: "Object.h")
 
     let goToInclude = DefinitionRequest(
       textDocument: TextDocumentIdentifier(mainUri),
       position: positions["1️⃣"]
     )
-    let resp = try await ws.testClient.send(goToInclude)
+    let resp = try await project.testClient.send(goToInclude)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-#include")
     switch locationsOrLinks {
@@ -47,7 +47,7 @@ final class ClangdTests: XCTestCase {
   }
 
   func testClangdGoToDefinitionWithoutIndex() async throws {
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       "Object.h": """
       struct Object {
         int field;
@@ -62,14 +62,14 @@ final class ClangdTests: XCTestCase {
       """,
     ])
 
-    let (mainUri, positions) = try ws.openDocument("main.c")
-    let headerUri = try ws.uri(for: "Object.h")
+    let (mainUri, positions) = try project.openDocument("main.c")
+    let headerUri = try project.uri(for: "Object.h")
 
     let goToDefinition = DefinitionRequest(
       textDocument: TextDocumentIdentifier(mainUri),
       position: positions["1️⃣"]
     )
-    let resp = try await ws.testClient.send(goToDefinition)
+    let resp = try await project.testClient.send(goToDefinition)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-definition")
     switch locationsOrLinks {
@@ -87,7 +87,7 @@ final class ClangdTests: XCTestCase {
   }
 
   func testClangdGoToDeclaration() async throws {
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       "Object.h": """
       struct Object {
         int field;
@@ -104,14 +104,14 @@ final class ClangdTests: XCTestCase {
       """,
     ])
 
-    let (mainUri, positions) = try ws.openDocument("main.c")
-    let headerUri = try ws.uri(for: "Object.h")
+    let (mainUri, positions) = try project.openDocument("main.c")
+    let headerUri = try project.uri(for: "Object.h")
 
     let goToInclude = DeclarationRequest(
       textDocument: TextDocumentIdentifier(mainUri),
       position: positions["1️⃣"]
     )
-    let resp = try await ws.testClient.send(goToInclude)
+    let resp = try await project.testClient.send(goToInclude)
 
     let locationsOrLinks = try XCTUnwrap(resp, "No response for go-to-declaration")
     switch locationsOrLinks {

--- a/Tests/SourceKitLSPTests/ClangdTests.swift
+++ b/Tests/SourceKitLSPTests/ClangdTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 final class ClangdTests: XCTestCase {
   func testClangdGoToInclude() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "Object.h": "",
       "main.c": """
       #include 1️⃣"Object.h"
@@ -47,7 +47,7 @@ final class ClangdTests: XCTestCase {
   }
 
   func testClangdGoToDefinitionWithoutIndex() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "Object.h": """
       struct Object {
         int field;
@@ -87,7 +87,7 @@ final class ClangdTests: XCTestCase {
   }
 
   func testClangdGoToDeclaration() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "Object.h": """
       struct Object {
         int field;

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -430,14 +430,16 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testCodeActionForFixItsProducedBySwiftSyntax() async throws {
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       "test.swift": "protocol 1️⃣Multi 2️⃣ident 3️⃣{}",
       "compile_commands.json": "[]",
     ])
 
-    let (uri, positions) = try ws.openDocument("test.swift")
+    let (uri, positions) = try project.openDocument("test.swift")
 
-    let report = try await ws.testClient.send(DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri)))
+    let report = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
     guard case .full(let fullReport) = report else {
       XCTFail("Expected full diagnostics report")
       return

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -430,7 +430,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testCodeActionForFixItsProducedBySwiftSyntax() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "test.swift": "protocol 1️⃣Multi 2️⃣ident 3️⃣{}",
       "compile_commands.json": "[]",
     ])

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class CompilationDatabaseTests: XCTestCase {
   func testModifyCompilationDatabase() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "main.cpp": """
       #if FOO
       void 1️⃣foo2️⃣() {}

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -40,7 +40,7 @@ class DefinitionTests: XCTestCase {
   }
 
   func testJumpToDefinitionIncludesOverrides() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       protocol TestProtocol {
         func 1️⃣doThing()
@@ -73,7 +73,7 @@ class DefinitionTests: XCTestCase {
   }
 
   func testJumpToDefinitionFiltersByReceiver() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       class A {
         func 1️⃣doThing() {}
@@ -109,7 +109,7 @@ class DefinitionTests: XCTestCase {
   }
 
   func testDynamicJumpToDefinitionInClang() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Sources/MyLibrary/include/dummy.h": "",
         "test.cpp": """
@@ -147,7 +147,7 @@ class DefinitionTests: XCTestCase {
   }
 
   func testJumpToCDefinitionFromSwift() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Sources/MyLibrary/include/test.h": """
         void myFunc(void);
@@ -226,7 +226,7 @@ class DefinitionTests: XCTestCase {
   func testAmbiguousDefinition() async throws {
     // FIXME: This shouldn't have to be an indexed workspace but solver-based cursor info currently fails if the file
     // does not exist on disk.
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣foo() -> Int { 1 }
       func 2️⃣foo() -> String { "" }
@@ -251,7 +251,7 @@ class DefinitionTests: XCTestCase {
 
   func testDefinitionOfClassBetweenModulesObjC() async throws {
     try SkipUnless.platformIsDarwin("@import in Objective-C is not enabled on non-Darwin")
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "LibA/include/LibA.h": """
         @interface 1️⃣LibAClass2️⃣
@@ -308,7 +308,7 @@ class DefinitionTests: XCTestCase {
 
   func testDefinitionOfMethodBetweenModulesObjC() async throws {
     try SkipUnless.platformIsDarwin("@import in Objective-C is not enabled on non-Darwin")
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "LibA/include/LibA.h": """
         @interface LibAClass

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -17,7 +17,7 @@ import XCTest
 final class DependencyTrackingTests: XCTestCase {
   func testDependenciesUpdatedSwift() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
         public func aaa() {}
@@ -60,7 +60,7 @@ final class DependencyTrackingTests: XCTestCase {
       )
     }
 
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory)
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory)
 
     await ws.testClient.server.filesDependenciesUpdated([libBUri])
 
@@ -70,7 +70,7 @@ final class DependencyTrackingTests: XCTestCase {
   }
 
   func testDependenciesUpdatedCXX() async throws {
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "lib.c": """
         int libX(int value) {

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -17,7 +17,7 @@ import XCTest
 final class DependencyTrackingTests: XCTestCase {
   func testDependenciesUpdatedSwift() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
         public func aaa() {}
@@ -45,9 +45,9 @@ final class DependencyTrackingTests: XCTestCase {
       usePullDiagnostics: false
     )
 
-    let (libBUri, _) = try ws.openDocument("LibB.swift")
+    let (libBUri, _) = try project.openDocument("LibB.swift")
 
-    let initialDiags = try await ws.testClient.nextDiagnosticsNotification()
+    let initialDiags = try await project.testClient.nextDiagnosticsNotification()
     // Semantic analysis: expect module import error.
     XCTAssertEqual(initialDiags.diagnostics.count, 1)
     if let diagnostic = initialDiags.diagnostics.first {
@@ -60,17 +60,17 @@ final class DependencyTrackingTests: XCTestCase {
       )
     }
 
-    try await SwiftPMTestProject.build(at: ws.scratchDirectory)
+    try await SwiftPMTestProject.build(at: project.scratchDirectory)
 
-    await ws.testClient.server.filesDependenciesUpdated([libBUri])
+    await project.testClient.server.filesDependenciesUpdated([libBUri])
 
-    let updatedDiags = try await ws.testClient.nextDiagnosticsNotification()
+    let updatedDiags = try await project.testClient.nextDiagnosticsNotification()
     // Semantic analysis: no more errors expected, import should resolve since we built.
     XCTAssertEqual(updatedDiags.diagnostics.count, 0)
   }
 
   func testDependenciesUpdatedCXX() async throws {
-    let ws = try await MultiFileTestProject(
+    let project = try await MultiFileTestProject(
       files: [
         "lib.c": """
         int libX(int value) {
@@ -89,15 +89,15 @@ final class DependencyTrackingTests: XCTestCase {
       usePullDiagnostics: false
     )
 
-    let generatedHeaderURL = try ws.uri(for: "main.c").fileURL!.deletingLastPathComponent()
+    let generatedHeaderURL = try project.uri(for: "main.c").fileURL!.deletingLastPathComponent()
       .appendingPathComponent("lib-generated.h", isDirectory: false)
 
     // Write an empty header file first since clangd doesn't handle missing header
     // files without a recently upstreamed extension.
     try "".write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
-    let (mainUri, _) = try ws.openDocument("main.c")
+    let (mainUri, _) = try project.openDocument("main.c")
 
-    let openDiags = try await ws.testClient.nextDiagnosticsNotification()
+    let openDiags = try await project.testClient.nextDiagnosticsNotification()
     // Expect one error:
     // - Implicit declaration of function invalid
     XCTAssertEqual(openDiags.diagnostics.count, 1)
@@ -106,9 +106,9 @@ final class DependencyTrackingTests: XCTestCase {
     let contents = "int libX(int value);"
     try contents.write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
 
-    await ws.testClient.server.filesDependenciesUpdated([mainUri])
+    await project.testClient.server.filesDependenciesUpdated([mainUri])
 
-    let updatedDiags = try await ws.testClient.nextDiagnosticsNotification()
+    let updatedDiags = try await project.testClient.nextDiagnosticsNotification()
     // No more errors expected, import should resolve since we the generated header file
     // now has the proper contents.
     XCTAssertEqual(updatedDiags.diagnostics.count, 0)

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -81,7 +81,7 @@ final class FormattingTests: XCTestCase {
   func testConfigFileOnDisk() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       ".swift-format": """
       {
         "version": 1,
@@ -116,7 +116,7 @@ final class FormattingTests: XCTestCase {
   func testConfigFileInParentDirectory() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       ".swift-format": """
       {
         "version": 1,
@@ -151,7 +151,7 @@ final class FormattingTests: XCTestCase {
   func testConfigFileInNestedDirectory() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       ".swift-format": """
       {
         "version": 1,
@@ -195,7 +195,7 @@ final class FormattingTests: XCTestCase {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     // The swift-format default is 2 spaces.
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       ".swift-format": "",
       "test.swift": """
       struct Root {

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -81,7 +81,7 @@ final class FormattingTests: XCTestCase {
   func testConfigFileOnDisk() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       ".swift-format": """
       {
         "version": 1,
@@ -97,9 +97,9 @@ final class FormattingTests: XCTestCase {
 
       """,
     ])
-    let (uri, positions) = try ws.openDocument("test.swift")
+    let (uri, positions) = try project.openDocument("test.swift")
 
-    let response = try await ws.testClient.send(
+    let response = try await project.testClient.send(
       DocumentFormattingRequest(
         textDocument: TextDocumentIdentifier(uri),
         options: FormattingOptions(tabSize: 2, insertSpaces: true)
@@ -116,7 +116,7 @@ final class FormattingTests: XCTestCase {
   func testConfigFileInParentDirectory() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       ".swift-format": """
       {
         "version": 1,
@@ -132,9 +132,9 @@ final class FormattingTests: XCTestCase {
 
       """,
     ])
-    let (uri, positions) = try ws.openDocument("test.swift")
+    let (uri, positions) = try project.openDocument("test.swift")
 
-    let response = try await ws.testClient.send(
+    let response = try await project.testClient.send(
       DocumentFormattingRequest(
         textDocument: TextDocumentIdentifier(uri),
         options: FormattingOptions(tabSize: 2, insertSpaces: true)
@@ -151,7 +151,7 @@ final class FormattingTests: XCTestCase {
   func testConfigFileInNestedDirectory() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       ".swift-format": """
       {
         "version": 1,
@@ -175,9 +175,9 @@ final class FormattingTests: XCTestCase {
 
       """,
     ])
-    let (uri, positions) = try ws.openDocument("test.swift")
+    let (uri, positions) = try project.openDocument("test.swift")
 
-    let response = try await ws.testClient.send(
+    let response = try await project.testClient.send(
       DocumentFormattingRequest(
         textDocument: TextDocumentIdentifier(uri),
         options: FormattingOptions(tabSize: 2, insertSpaces: true)
@@ -195,7 +195,7 @@ final class FormattingTests: XCTestCase {
     try await SkipUnless.toolchainContainsSwiftFormat()
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     // The swift-format default is 2 spaces.
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       ".swift-format": "",
       "test.swift": """
       struct Root {
@@ -204,10 +204,10 @@ final class FormattingTests: XCTestCase {
 
       """,
     ])
-    let (uri, _) = try ws.openDocument("test.swift")
+    let (uri, _) = try project.openDocument("test.swift")
 
     await assertThrowsError(
-      try await ws.testClient.send(
+      try await project.testClient.send(
         DocumentFormattingRequest(
           textDocument: TextDocumentIdentifier(uri),
           options: FormattingOptions(tabSize: 3, insertSpaces: true)

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -26,11 +26,11 @@ final class ImplementationTests: XCTestCase {
     testName: String = #function,
     line: UInt = #line
   ) async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(markedText, testName: testName)
-    let response = try await ws.testClient.send(
+    let project = try await IndexedSingleSwiftFileTestProject(markedText, testName: testName)
+    let response = try await project.testClient.send(
       ImplementationRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["1️⃣"]
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
     guard case .locations(let implementations) = response else {
@@ -38,7 +38,7 @@ final class ImplementationTests: XCTestCase {
       return
     }
     let expectedLocations = expectedLocationMarkers.map {
-      Location(uri: ws.fileURI, range: Range(ws.positions[$0]))
+      Location(uri: project.fileURI, range: Range(project.positions[$0]))
     }
     XCTAssertEqual(implementations, expectedLocations, line: line)
   }
@@ -287,7 +287,7 @@ final class ImplementationTests: XCTestCase {
   }
 
   func testCrossFile() async throws {
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "a.swift": """
         protocol 1️⃣MyProto {}
@@ -299,9 +299,9 @@ final class ImplementationTests: XCTestCase {
       build: true
     )
 
-    let (aUri, aPositions) = try ws.openDocument("a.swift")
+    let (aUri, aPositions) = try project.openDocument("a.swift")
 
-    let response = try await ws.testClient.send(
+    let response = try await project.testClient.send(
       ImplementationRequest(
         textDocument: TextDocumentIdentifier(aUri),
         position: aPositions["1️⃣"]
@@ -313,7 +313,7 @@ final class ImplementationTests: XCTestCase {
     }
     XCTAssertEqual(
       implementations,
-      [Location(uri: try ws.uri(for: "b.swift"), range: Range(try ws.position(of: "2️⃣", in: "b.swift")))]
+      [Location(uri: try project.uri(for: "b.swift"), range: Range(try project.position(of: "2️⃣", in: "b.swift")))]
     )
   }
 }

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -26,7 +26,7 @@ final class ImplementationTests: XCTestCase {
     testName: String = #function,
     line: UInt = #line
   ) async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(markedText, testName: testName)
+    let ws = try await IndexedSingleSwiftFileTestProject(markedText, testName: testName)
     let response = try await ws.testClient.send(
       ImplementationRequest(
         textDocument: TextDocumentIdentifier(ws.fileURI),
@@ -287,7 +287,7 @@ final class ImplementationTests: XCTestCase {
   }
 
   func testCrossFile() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "a.swift": """
         protocol 1️⃣MyProto {}

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -17,7 +17,7 @@ import XCTest
 final class IndexTests: XCTestCase {
   func testIndexSwiftModules() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
         public func 1️⃣aaa() {}
@@ -113,7 +113,7 @@ final class IndexTests: XCTestCase {
     }
 
     func checkRunningIndex(cleanUp: Bool, workspaceDirectory: URL) async throws -> URL? {
-      let ws = try await IndexedSingleSwiftFileWorkspace(
+      let ws = try await IndexedSingleSwiftFileTestProject(
         """
         func 1️⃣foo() {}
 

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -17,7 +17,7 @@ import XCTest
 final class IndexTests: XCTestCase {
   func testIndexSwiftModules() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
         public func 1️⃣aaa() {}
@@ -52,17 +52,17 @@ final class IndexTests: XCTestCase {
       build: true
     )
 
-    let (libAUri, libAPositions) = try ws.openDocument("LibA.swift")
-    let libBUri = try ws.uri(for: "LibB.swift")
-    let (libCUri, libCPositions) = try ws.openDocument("LibC.swift")
+    let (libAUri, libAPositions) = try project.openDocument("LibA.swift")
+    let libBUri = try project.uri(for: "LibB.swift")
+    let (libCUri, libCPositions) = try project.openDocument("LibC.swift")
 
     let definitionPos = libAPositions["1️⃣"]
-    let referencePos = try ws.position(of: "2️⃣", in: "LibB.swift")
+    let referencePos = try project.position(of: "2️⃣", in: "LibB.swift")
     let callPos = libCPositions["3️⃣"]
 
     // MARK: Jump to definition
 
-    let response = try await ws.testClient.send(
+    let response = try await project.testClient.send(
       DefinitionRequest(
         textDocument: TextDocumentIdentifier(libCUri),
         position: libCPositions["3️⃣"]
@@ -79,7 +79,7 @@ final class IndexTests: XCTestCase {
 
     // MARK: Find references
 
-    let refs = try await ws.testClient.send(
+    let refs = try await project.testClient.send(
       ReferencesRequest(
         textDocument: TextDocumentIdentifier(libAUri),
         position: definitionPos,
@@ -113,7 +113,7 @@ final class IndexTests: XCTestCase {
     }
 
     func checkRunningIndex(cleanUp: Bool, workspaceDirectory: URL) async throws -> URL? {
-      let ws = try await IndexedSingleSwiftFileTestProject(
+      let project = try await IndexedSingleSwiftFileTestProject(
         """
         func 1️⃣foo() {}
 
@@ -124,10 +124,10 @@ final class IndexTests: XCTestCase {
         cleanUp: cleanUp
       )
 
-      let response = try await ws.testClient.send(
+      let response = try await project.testClient.send(
         DefinitionRequest(
-          textDocument: TextDocumentIdentifier(ws.fileURI),
-          position: ws.positions["2️⃣"]
+          textDocument: TextDocumentIdentifier(project.fileURI),
+          position: project.positions["2️⃣"]
         )
       )
       guard case .locations(let jump) = response else {
@@ -135,10 +135,10 @@ final class IndexTests: XCTestCase {
         return nil
       }
       XCTAssertEqual(jump.count, 1)
-      XCTAssertEqual(jump.first?.uri, ws.fileURI)
-      XCTAssertEqual(jump.first?.range.lowerBound, ws.positions["1️⃣"])
+      XCTAssertEqual(jump.first?.uri, project.fileURI)
+      XCTAssertEqual(jump.first?.range.lowerBound, project.positions["1️⃣"])
 
-      let tmpContents = try listdir(ws.indexDBURL)
+      let tmpContents = try listdir(project.indexDBURL)
       guard let versionedPath = tmpContents.filter({ $0.lastPathComponent.starts(with: "v") }).spm_only else {
         XCTFail("expected one version path 'v[0-9]*', found \(tmpContents)")
         return nil
@@ -148,7 +148,7 @@ final class IndexTests: XCTestCase {
       XCTAssertEqual(versionContentsBefore.count, 1)
       XCTAssert(versionContentsBefore.first?.lastPathComponent.starts(with: "p") ?? false)
 
-      _ = try await ws.testClient.send(ShutdownRequest())
+      _ = try await project.testClient.send(ShutdownRequest())
       return versionedPath
     }
 

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -220,7 +220,7 @@ final class LocalClangTests: XCTestCase {
     // Note: tests generally should avoid including system headers
     // to keep them fast and portable. This test is specifically
     // ensuring clangd can find libc++ and builtin headers.
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "main.cpp": """
         #include <cstdint>
@@ -246,7 +246,7 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testClangModules() async throws {
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "ClangModuleA.h": """
         #ifndef ClangModuleA_h
@@ -304,7 +304,7 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testDocumentDependenciesUpdated() async throws {
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "Object.h": """
         struct Object {

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -220,7 +220,7 @@ final class LocalClangTests: XCTestCase {
     // Note: tests generally should avoid including system headers
     // to keep them fast and portable. This test is specifically
     // ensuring clangd can find libc++ and builtin headers.
-    let ws = try await MultiFileTestProject(
+    let project = try await MultiFileTestProject(
       files: [
         "main.cpp": """
         #include <cstdint>
@@ -234,9 +234,9 @@ final class LocalClangTests: XCTestCase {
       usePullDiagnostics: false
     )
 
-    let (_, positions) = try ws.openDocument("main.cpp")
+    let (_, positions) = try project.openDocument("main.cpp")
 
-    let diags = try await ws.testClient.nextDiagnosticsNotification()
+    let diags = try await project.testClient.nextDiagnosticsNotification()
     // Don't use exact equality because of differences in recent clang.
     XCTAssertEqual(diags.diagnostics.count, 1)
     let diag = try XCTUnwrap(diags.diagnostics.first)
@@ -246,7 +246,7 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testClangModules() async throws {
-    let ws = try await MultiFileTestProject(
+    let project = try await MultiFileTestProject(
       files: [
         "ClangModuleA.h": """
         #ifndef ClangModuleA_h
@@ -276,9 +276,9 @@ final class LocalClangTests: XCTestCase {
       ],
       usePullDiagnostics: false
     )
-    _ = try ws.openDocument("ClangModules_main.m")
+    _ = try project.openDocument("ClangModules_main.m")
 
-    let diags = try await ws.testClient.nextDiagnosticsNotification()
+    let diags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diags.diagnostics.count, 0)
   }
 
@@ -304,7 +304,7 @@ final class LocalClangTests: XCTestCase {
   }
 
   func testDocumentDependenciesUpdated() async throws {
-    let ws = try await MultiFileTestProject(
+    let project = try await MultiFileTestProject(
       files: [
         "Object.h": """
         struct Object {
@@ -325,11 +325,11 @@ final class LocalClangTests: XCTestCase {
       usePullDiagnostics: false
     )
 
-    let (mainUri, _) = try ws.openDocument("main.c")
-    let headerUri = try ws.uri(for: "Object.h")
+    let (mainUri, _) = try project.openDocument("main.c")
+    let headerUri = try project.uri(for: "Object.h")
 
     // Initially the workspace should build fine.
-    let initialDiags = try await ws.testClient.nextDiagnosticsNotification()
+    let initialDiags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssert(initialDiags.diagnostics.isEmpty)
 
     // We rename Object to MyObject in the header.
@@ -341,16 +341,16 @@ final class LocalClangTests: XCTestCase {
     struct MyObject * newObject();
     """.write(to: headerUri.fileURL!, atomically: false, encoding: .utf8)
 
-    let clangdServer = await ws.testClient.server._languageService(
+    let clangdServer = await project.testClient.server._languageService(
       for: mainUri,
       .c,
-      in: ws.testClient.server.workspaceForDocument(uri: mainUri)!
+      in: project.testClient.server.workspaceForDocument(uri: mainUri)!
     )!
 
     await clangdServer.documentDependenciesUpdated(mainUri)
 
     // Now we should get a diagnostic in main.c file because `Object` is no longer defined.
-    let editedDiags = try await ws.testClient.nextDiagnosticsNotification()
+    let editedDiags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertFalse(editedDiags.diagnostics.isEmpty)
   }
 }

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1371,10 +1371,10 @@ final class LocalSwiftTests: XCTestCase {
 
     let reusedNodeCallback = self.expectation(description: "reused node callback called")
     var reusedNodes: [Syntax] = []
-    let swiftLanguageServer =
+    let swiftLanguageService =
       await testClient.server._languageService(for: uri, .swift, in: testClient.server.workspaceForDocument(uri: uri)!)
-      as! SwiftLanguageServer
-    await swiftLanguageServer.setReusedNodeCallback {
+      as! SwiftLanguageService
+    await swiftLanguageService.setReusedNodeCallback {
       reusedNodes.append($0)
       reusedNodeCallback.fulfill()
     }

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1418,7 +1418,7 @@ final class LocalSwiftTests: XCTestCase {
   func testDebouncePublishDiagnosticsNotification() async throws {
     try SkipUnless.longTestsEnabled()
 
-    var serverOptions = SourceKitServer.Options.testDefault
+    var serverOptions = SourceKitLSPServer.Options.testDefault
     serverOptions.swiftPublishDiagnosticsDebounceDuration = 1 /* 1s */
 
     // Construct our own  `TestSourceKitLSPClient` instead of the one from set up because we want a higher debounce interval.

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 final class MainFilesProviderTests: XCTestCase {
   func testMainFileForHeaderInPackageTarget() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "MyLibrary/include/MyLibrary.h": """
         void bridging(void) {
@@ -60,7 +60,7 @@ final class MainFilesProviderTests: XCTestCase {
   }
 
   func testMainFileForHeaderOutsideOfTarget() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Sources/shared.h": """
         void bridging(void) {
@@ -98,7 +98,7 @@ final class MainFilesProviderTests: XCTestCase {
     let preBuildDiags = try await ws.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(preBuildDiags.diagnostics.count, 0)
 
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory)
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory)
 
     // After building we know that 'shared.h' is included from 'MyLibrary.c' and thus we use its build settings,
     // defining `VARIABLE_NAME` to `fromMyLibrary`.
@@ -109,7 +109,7 @@ final class MainFilesProviderTests: XCTestCase {
   }
 
   func testMainFileForSharedHeaderOutsideOfTarget() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Sources/shared.h": """
         void bridging(void) {
@@ -160,7 +160,7 @@ final class MainFilesProviderTests: XCTestCase {
   }
 
   func testMainFileChangesIfIncludeIsAdded() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Sources/shared.h": """
         void bridging(void) {
@@ -212,7 +212,7 @@ final class MainFilesProviderTests: XCTestCase {
     let fancyLibraryURL = try ws.uri(for: "MyFancyLibrary.c").fileURL!
     try newFancyLibraryContents.write(to: fancyLibraryURL, atomically: false, encoding: .utf8)
 
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory)
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory)
 
     // 'MyFancyLibrary.c' now also includes 'shared.h'. Since it lexicographically preceeds MyLibrary, we should use its
     // build settings.

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -110,7 +110,7 @@ final class PullDiagnosticsTests: XCTestCase {
   func testNotesFromIntegratedSwiftSyntaxDiagnostics() async throws {
     // Create a workspace that has compile_commands.json so that it has a build system but no compiler arguments
     // for test.swift so that we fall back to producing diagnostics from the built-in swift-syntax.
-    let ws = try await MultiFileTestWorkspace(files: [
+    let ws = try await MultiFileTestProject(files: [
       "test.swift": "func foo() 1️⃣{2️⃣",
       "compile_commands.json": "[]",
     ])

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -110,14 +110,16 @@ final class PullDiagnosticsTests: XCTestCase {
   func testNotesFromIntegratedSwiftSyntaxDiagnostics() async throws {
     // Create a workspace that has compile_commands.json so that it has a build system but no compiler arguments
     // for test.swift so that we fall back to producing diagnostics from the built-in swift-syntax.
-    let ws = try await MultiFileTestProject(files: [
+    let project = try await MultiFileTestProject(files: [
       "test.swift": "func foo() 1️⃣{2️⃣",
       "compile_commands.json": "[]",
     ])
 
-    let (uri, positions) = try ws.openDocument("test.swift")
+    let (uri, positions) = try project.openDocument("test.swift")
 
-    let report = try await ws.testClient.send(DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri)))
+    let report = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
     guard case .full(let fullReport) = report else {
       XCTFail("Expected full diagnostics report")
       return

--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -17,7 +17,7 @@ import XCTest
 /// Tests that test the overall state of the SourceKit-LSP server, that's not really specific to any language
 final class ReferencesTests: XCTestCase {
   func testReferencesInMacro() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       import Observation
 
@@ -29,18 +29,18 @@ final class ReferencesTests: XCTestCase {
       """
     )
 
-    let response = try await ws.testClient.send(
+    let response = try await project.testClient.send(
       ReferencesRequest(
-        textDocument: TextDocumentIdentifier(ws.fileURI),
-        position: ws.positions["2️⃣"],
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["2️⃣"],
         context: ReferencesContext(includeDeclaration: true)
       )
     )
     XCTAssertEqual(
       response,
       [
-        Location(uri: ws.fileURI, range: Range(ws.positions["1️⃣"])),
-        Location(uri: ws.fileURI, range: Range(ws.positions["2️⃣"])),
+        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
+        Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
       ]
     )
   }

--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -17,7 +17,7 @@ import XCTest
 /// Tests that test the overall state of the SourceKit-LSP server, that's not really specific to any language
 final class ReferencesTests: XCTestCase {
   func testReferencesInMacro() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       import Observation
 

--- a/Tests/SourceKitLSPTests/RenameAssertions.swift
+++ b/Tests/SourceKitLSPTests/RenameAssertions.swift
@@ -129,27 +129,27 @@ func assertMultiFileRename(
   line: UInt = #line
 ) async throws {
   try await SkipUnless.sourcekitdSupportsRename()
-  let ws = try await SwiftPMTestProject(
+  let project = try await SwiftPMTestProject(
     files: files,
     manifest: manifest,
     build: true,
     testName: testName
   )
-  try preRenameActions(ws)
+  try preRenameActions(project)
   for (fileLocation, markedSource) in files.sorted(by: { $0.key.fileName < $1.key.fileName }) {
     let markers = extractMarkers(markedSource).markers.keys.sorted().filter { $0 != "0️⃣" }
     if markers.isEmpty {
       continue
     }
-    let (uri, positions) = try ws.openDocument(
+    let (uri, positions) = try project.openDocument(
       fileLocation.fileName,
       language: fileLocation.fileName.hasSuffix(".h") ? headerFileLanguage : nil
     )
     defer {
-      ws.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
+      project.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
     }
     for marker in markers {
-      let prepareRenameResponse = try await ws.testClient.send(
+      let prepareRenameResponse = try await project.testClient.send(
         PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions[marker])
       )
       XCTAssertEqual(
@@ -160,7 +160,7 @@ func assertMultiFileRename(
         line: line
       )
 
-      let response = try await ws.testClient.send(
+      let response = try await project.testClient.send(
         RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions[marker], newName: newName)
       )
       let changes = try XCTUnwrap(response?.changes, "Did not receive any edits", file: file, line: line)
@@ -168,7 +168,7 @@ func assertMultiFileRename(
         originalFiles: files,
         changes: changes,
         expected: expected,
-        in: ws,
+        in: project,
         message: "while performing rename at \(marker)",
         file: file,
         line: line

--- a/Tests/SourceKitLSPTests/RenameAssertions.swift
+++ b/Tests/SourceKitLSPTests/RenameAssertions.swift
@@ -83,7 +83,7 @@ func assertRenamedSourceMatches(
   originalFiles: [RelativeFileLocation: String],
   changes: [DocumentURI: [TextEdit]],
   expected: [RelativeFileLocation: String],
-  in ws: MultiFileTestWorkspace,
+  in ws: MultiFileTestProject,
   message: String,
   testName: String = #function,
   file: StaticString = #file,
@@ -122,14 +122,14 @@ func assertMultiFileRename(
   newName: String,
   expectedPrepareRenamePlaceholder: String,
   expected: [RelativeFileLocation: String],
-  manifest: String = SwiftPMTestWorkspace.defaultPackageManifest,
-  preRenameActions: (SwiftPMTestWorkspace) throws -> Void = { _ in },
+  manifest: String = SwiftPMTestProject.defaultPackageManifest,
+  preRenameActions: (SwiftPMTestProject) throws -> Void = { _ in },
   testName: String = #function,
   file: StaticString = #file,
   line: UInt = #line
 ) async throws {
   try await SkipUnless.sourcekitdSupportsRename()
-  let ws = try await SwiftPMTestWorkspace(
+  let ws = try await SwiftPMTestProject(
     files: files,
     manifest: manifest,
     build: true,

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -829,7 +829,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCodeCompleteSwiftPackage() async throws {
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "a.swift": """
         struct A {
@@ -843,10 +843,10 @@ final class SwiftCompletionTests: XCTestCase {
         """,
       ]
     )
-    let (uri, positions) = try ws.openDocument("b.swift")
+    let (uri, positions) = try project.openDocument("b.swift")
 
     let testPosition = positions["1️⃣"]
-    let results = try await ws.testClient.send(
+    let results = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: testPosition)
     )
 

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -829,7 +829,7 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCodeCompleteSwiftPackage() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "a.swift": """
         struct A {

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -57,7 +57,7 @@ final class SwiftInterfaceTests: XCTestCase {
 
   func testOpenInterface() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "MyLibrary/MyLibrary.swift": """
         public struct Lib {
@@ -141,7 +141,7 @@ final class SwiftInterfaceTests: XCTestCase {
   }
 
   func testDefinitionInSystemModuleInterface() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       public func libFunc() async {
         let a: 1️⃣String = "test"
@@ -185,7 +185,7 @@ final class SwiftInterfaceTests: XCTestCase {
 
   func testSwiftInterfaceAcrossModules() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "MyLibrary/MyLibrary.swift": """
         public struct Lib {

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -18,7 +18,7 @@ import XCTest
 final class SwiftPMIntegrationTests: XCTestCase {
 
   func testSwiftPMIntegration() async throws {
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "Lib.swift": """
         struct Lib {
@@ -34,10 +34,10 @@ final class SwiftPMIntegrationTests: XCTestCase {
       build: true
     )
 
-    let (otherUri, otherPositions) = try ws.openDocument("Other.swift")
+    let (otherUri, otherPositions) = try project.openDocument("Other.swift")
     let callPosition = otherPositions["2️⃣"]
 
-    let refs = try await ws.testClient.send(
+    let refs = try await project.testClient.send(
       ReferencesRequest(
         textDocument: TextDocumentIdentifier(otherUri),
         position: callPosition,
@@ -49,11 +49,11 @@ final class SwiftPMIntegrationTests: XCTestCase {
       Set(refs),
       [
         Location(uri: otherUri, range: Range(callPosition)),
-        Location(uri: try ws.uri(for: "Lib.swift"), range: Range(try ws.position(of: "1️⃣", in: "Lib.swift"))),
+        Location(uri: try project.uri(for: "Lib.swift"), range: Range(try project.position(of: "1️⃣", in: "Lib.swift"))),
       ]
     )
 
-    let completions = try await ws.testClient.send(
+    let completions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(otherUri), position: callPosition)
     )
 
@@ -91,7 +91,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testAddFile() async throws {
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "Lib.swift": """
         struct Lib {
@@ -104,7 +104,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
       build: true
     )
 
-    let newFileUrl = ws.scratchDirectory
+    let newFileUrl = project.scratchDirectory
       .appendingPathComponent("Sources")
       .appendingPathComponent("MyLibrary")
       .appendingPathComponent("Other.swift")
@@ -119,25 +119,25 @@ final class SwiftPMIntegrationTests: XCTestCase {
 
     // Check that we don't get cross-file code completion before we send a `DidChangeWatchedFilesNotification` to make
     // sure we didn't include the file in the initial retrieval of build settings.
-    let (oldFileUri, oldFilePositions) = try ws.openDocument("Lib.swift")
-    let newFilePositions = ws.testClient.openDocument(newFileContents, uri: newFileUri)
+    let (oldFileUri, oldFilePositions) = try project.openDocument("Lib.swift")
+    let newFilePositions = project.testClient.openDocument(newFileContents, uri: newFileUri)
 
-    let completionsBeforeDidChangeNotification = try await ws.testClient.send(
+    let completionsBeforeDidChangeNotification = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(newFileUri), position: newFilePositions["2️⃣"])
     )
     XCTAssertEqual(completionsBeforeDidChangeNotification.items, [])
 
     // Send a `DidChangeWatchedFilesNotification` and verify that we now get cross-file code completion.
-    ws.testClient.send(
+    project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [
         FileEvent(uri: newFileUri, type: .created)
       ])
     )
 
     // Ensure that the DidChangeWatchedFilesNotification is handled before we continue.
-    _ = try await ws.testClient.send(BarrierRequest())
+    _ = try await project.testClient.send(BarrierRequest())
 
-    let completions = try await ws.testClient.send(
+    let completions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(newFileUri), position: newFilePositions["2️⃣"])
     )
 
@@ -176,7 +176,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     // Check that we get code completion for `baz` (defined in the new file) in the old file.
     // I.e. check that the existing file's build settings have been updated to include the new file.
 
-    let oldFileCompletions = try await ws.testClient.send(
+    let oldFileCompletions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(oldFileUri), position: oldFilePositions["1️⃣"])
     )
     XCTAssert(oldFileCompletions.items.contains(where: { $0.label == "baz(l: Lib)" }))

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -18,7 +18,7 @@ import XCTest
 final class SwiftPMIntegrationTests: XCTestCase {
 
   func testSwiftPMIntegration() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Lib.swift": """
         struct Lib {
@@ -91,7 +91,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testAddFile() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Lib.swift": """
         struct Lib {

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -183,7 +183,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testNestedPackage() async throws {
-    let ws = try await MultiFileTestWorkspace(files: [
+    let project = try await MultiFileTestProject(files: [
       "pkg/Sources/lib/lib.swift": "",
       "pkg/Package.swift": """
       // swift-tools-version:4.2
@@ -209,9 +209,9 @@ final class SwiftPMIntegrationTests: XCTestCase {
       """,
     ])
 
-    let (uri, positions) = try ws.openDocument("b.swift")
+    let (uri, positions) = try project.openDocument("b.swift")
 
-    let result = try await ws.testClient.send(
+    let result = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
 

--- a/Tests/SourceKitLSPTests/TestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/TestDiscoveryTests.swift
@@ -18,7 +18,7 @@ final class TestDiscoveryTests: XCTestCase {
   func testWorkspaceTests() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Tests/MyLibraryTests/MyTests.swift": """
         import XCTest
@@ -75,7 +75,7 @@ final class TestDiscoveryTests: XCTestCase {
   func testDocumentTests() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Tests/MyLibraryTests/MyTests.swift": """
         import XCTest

--- a/Tests/SourceKitLSPTests/TestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/TestDiscoveryTests.swift
@@ -18,7 +18,7 @@ final class TestDiscoveryTests: XCTestCase {
   func testWorkspaceTests() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "Tests/MyLibraryTests/MyTests.swift": """
         import XCTest
@@ -43,7 +43,7 @@ final class TestDiscoveryTests: XCTestCase {
       build: true
     )
 
-    let tests = try await ws.testClient.send(WorkspaceTestsRequest())
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
     XCTAssertEqual(
       tests,
       [
@@ -52,8 +52,8 @@ final class TestDiscoveryTests: XCTestCase {
             name: "MyTests",
             kind: .class,
             location: Location(
-              uri: try ws.uri(for: "MyTests.swift"),
-              range: Range(try ws.position(of: "1️⃣", in: "MyTests.swift"))
+              uri: try project.uri(for: "MyTests.swift"),
+              range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
             )
           )
         ),
@@ -62,8 +62,8 @@ final class TestDiscoveryTests: XCTestCase {
             name: "testMyLibrary()",
             kind: .method,
             location: Location(
-              uri: try ws.uri(for: "MyTests.swift"),
-              range: Range(try ws.position(of: "2️⃣", in: "MyTests.swift"))
+              uri: try project.uri(for: "MyTests.swift"),
+              range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
             ),
             containerName: "MyTests"
           )
@@ -75,7 +75,7 @@ final class TestDiscoveryTests: XCTestCase {
   func testDocumentTests() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let ws = try await SwiftPMTestProject(
+    let project = try await SwiftPMTestProject(
       files: [
         "Tests/MyLibraryTests/MyTests.swift": """
         import XCTest
@@ -107,8 +107,8 @@ final class TestDiscoveryTests: XCTestCase {
       build: true
     )
 
-    let (uri, positions) = try ws.openDocument("MyTests.swift")
-    let tests = try await ws.testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    let (uri, positions) = try project.openDocument("MyTests.swift")
+    let tests = try await project.testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
     XCTAssertEqual(
       tests,
       [
@@ -127,7 +127,7 @@ final class TestDiscoveryTests: XCTestCase {
             name: "testMyLibrary()",
             kind: .method,
             location: Location(
-              uri: try ws.uri(for: "MyTests.swift"),
+              uri: try project.uri(for: "MyTests.swift"),
               range: Range(positions["2️⃣"])
             ),
             containerName: "MyTests"

--- a/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 final class TypeHierarchyTests: XCTestCase {
   func testRootClassSupertypes() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       class 1️⃣MyClass {}
       """
@@ -30,7 +30,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testSupertypesOfClass() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       class 1️⃣MyClass {}
       protocol 2️⃣MyProtocol {}
@@ -50,7 +50,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testConformedProtocolsOfStruct() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       protocol 1️⃣MyProtocol {}
       protocol 2️⃣MyOtherProtocol {}
@@ -71,7 +71,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testSubtypesOfClass() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       class MySuperclass {}
       class 1️⃣MyClass: MySuperclass {}
@@ -92,7 +92,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testProtocolConformancesAsSubtypes() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       protocol 1️⃣MyProtocol {}
       class 2️⃣MyClass: MyProtocol {}
@@ -114,7 +114,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testExtensionsWithConformancesAsSubtypes() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       protocol MyProtocol {}
       enum 1️⃣MyEnum {}
@@ -143,7 +143,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testRetroactiveConformancesAsSubtypes() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       protocol 1️⃣MyProtocol {}
       struct MyStruct {}
@@ -168,7 +168,7 @@ final class TypeHierarchyTests: XCTestCase {
   }
 
   func testSupertypesFromCall() async throws {
-    let ws = try await IndexedSingleSwiftFileWorkspace(
+    let ws = try await IndexedSingleSwiftFileTestProject(
       """
       class 1️⃣MyClass {}
       class MySubclass: MyClass {}
@@ -224,7 +224,7 @@ fileprivate extension TypeHierarchyItem {
     kind: SymbolKind,
     detail: String = "test",
     location locationMarker: String,
-    in ws: IndexedSingleSwiftFileWorkspace
+    in ws: IndexedSingleSwiftFileTestProject
   ) {
     self.init(
       name: name,
@@ -238,7 +238,7 @@ fileprivate extension TypeHierarchyItem {
   }
 }
 
-fileprivate extension IndexedSingleSwiftFileWorkspace {
+fileprivate extension IndexedSingleSwiftFileTestProject {
   func prepareTypeHierarchy(at locationMarker: String, line: UInt = #line) async throws -> TypeHierarchyItem {
     let items = try await testClient.send(
       TypeHierarchyPrepareRequest(

--- a/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/TypeHierarchyTests.swift
@@ -18,19 +18,19 @@ import XCTest
 
 final class TypeHierarchyTests: XCTestCase {
   func testRootClassSupertypes() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       class 1️⃣MyClass {}
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "1️⃣")
-    let supertypes = try await ws.testClient.send(TypeHierarchySupertypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "1️⃣")
+    let supertypes = try await project.testClient.send(TypeHierarchySupertypesRequest(item: item))
     assertEqualIgnoringData(supertypes, [])
   }
 
   func testSupertypesOfClass() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       class 1️⃣MyClass {}
       protocol 2️⃣MyProtocol {}
@@ -38,19 +38,19 @@ final class TypeHierarchyTests: XCTestCase {
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "3️⃣")
-    let supertypes = try await ws.testClient.send(TypeHierarchySupertypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "3️⃣")
+    let supertypes = try await project.testClient.send(TypeHierarchySupertypesRequest(item: item))
     assertEqualIgnoringData(
       supertypes,
       [
-        TypeHierarchyItem(name: "MyClass", kind: .class, location: "1️⃣", in: ws),
-        TypeHierarchyItem(name: "MyProtocol", kind: .interface, location: "2️⃣", in: ws),
+        TypeHierarchyItem(name: "MyClass", kind: .class, location: "1️⃣", in: project),
+        TypeHierarchyItem(name: "MyProtocol", kind: .interface, location: "2️⃣", in: project),
       ]
     )
   }
 
   func testConformedProtocolsOfStruct() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       protocol 1️⃣MyProtocol {}
       protocol 2️⃣MyOtherProtocol {}
@@ -59,19 +59,19 @@ final class TypeHierarchyTests: XCTestCase {
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "3️⃣")
-    let supertypes = try await ws.testClient.send(TypeHierarchySupertypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "3️⃣")
+    let supertypes = try await project.testClient.send(TypeHierarchySupertypesRequest(item: item))
     assertEqualIgnoringData(
       supertypes,
       [
-        TypeHierarchyItem(name: "MyOtherProtocol", kind: .interface, location: "2️⃣", in: ws),
-        TypeHierarchyItem(name: "MyProtocol", kind: .interface, location: "1️⃣", in: ws),
+        TypeHierarchyItem(name: "MyOtherProtocol", kind: .interface, location: "2️⃣", in: project),
+        TypeHierarchyItem(name: "MyProtocol", kind: .interface, location: "1️⃣", in: project),
       ]
     )
   }
 
   func testSubtypesOfClass() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       class MySuperclass {}
       class 1️⃣MyClass: MySuperclass {}
@@ -80,19 +80,19 @@ final class TypeHierarchyTests: XCTestCase {
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "1️⃣")
-    let subtypes = try await ws.testClient.send(TypeHierarchySubtypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "1️⃣")
+    let subtypes = try await project.testClient.send(TypeHierarchySubtypesRequest(item: item))
     assertEqualIgnoringData(
       subtypes,
       [
-        TypeHierarchyItem(name: "SubclassA", kind: .class, location: "2️⃣", in: ws),
-        TypeHierarchyItem(name: "SubclassB", kind: .class, location: "3️⃣", in: ws),
+        TypeHierarchyItem(name: "SubclassA", kind: .class, location: "2️⃣", in: project),
+        TypeHierarchyItem(name: "SubclassB", kind: .class, location: "3️⃣", in: project),
       ]
     )
   }
 
   func testProtocolConformancesAsSubtypes() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       protocol 1️⃣MyProtocol {}
       class 2️⃣MyClass: MyProtocol {}
@@ -101,20 +101,20 @@ final class TypeHierarchyTests: XCTestCase {
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "1️⃣")
-    let subtypes = try await ws.testClient.send(TypeHierarchySubtypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "1️⃣")
+    let subtypes = try await project.testClient.send(TypeHierarchySubtypesRequest(item: item))
     assertEqualIgnoringData(
       subtypes,
       [
-        TypeHierarchyItem(name: "MyClass", kind: .class, location: "2️⃣", in: ws),
-        TypeHierarchyItem(name: "MyEnum", kind: .enum, location: "4️⃣", in: ws),
-        TypeHierarchyItem(name: "MyStruct", kind: .struct, location: "3️⃣", in: ws),
+        TypeHierarchyItem(name: "MyClass", kind: .class, location: "2️⃣", in: project),
+        TypeHierarchyItem(name: "MyEnum", kind: .enum, location: "4️⃣", in: project),
+        TypeHierarchyItem(name: "MyStruct", kind: .struct, location: "3️⃣", in: project),
       ]
     )
   }
 
   func testExtensionsWithConformancesAsSubtypes() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       protocol MyProtocol {}
       enum 1️⃣MyEnum {}
@@ -125,25 +125,25 @@ final class TypeHierarchyTests: XCTestCase {
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "1️⃣")
-    let subtypes = try await ws.testClient.send(TypeHierarchySubtypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "1️⃣")
+    let subtypes = try await project.testClient.send(TypeHierarchySubtypesRequest(item: item))
     assertEqualIgnoringData(
       subtypes,
       [
-        TypeHierarchyItem(name: "MyEnum", kind: .null, detail: "Extension at test.swift:3", location: "2️⃣", in: ws),
+        TypeHierarchyItem(name: "MyEnum", kind: .null, detail: "Extension at test.swift:3", location: "2️⃣", in: project),
         TypeHierarchyItem(
           name: "MyEnum: MyProtocol",
           kind: .null,
           detail: "Extension at test.swift:6",
           location: "3️⃣",
-          in: ws
+          in: project
         ),
       ]
     )
   }
 
   func testRetroactiveConformancesAsSubtypes() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       protocol 1️⃣MyProtocol {}
       struct MyStruct {}
@@ -151,8 +151,8 @@ final class TypeHierarchyTests: XCTestCase {
       """
     )
 
-    let item = try await ws.prepareTypeHierarchy(at: "1️⃣")
-    let subtypes = try await ws.testClient.send(TypeHierarchySubtypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "1️⃣")
+    let subtypes = try await project.testClient.send(TypeHierarchySubtypesRequest(item: item))
     assertEqualIgnoringData(
       subtypes,
       [
@@ -161,14 +161,14 @@ final class TypeHierarchyTests: XCTestCase {
           kind: .null,
           detail: "Extension at test.swift:3",
           location: "2️⃣",
-          in: ws
+          in: project
         )
       ]
     )
   }
 
   func testSupertypesFromCall() async throws {
-    let ws = try await IndexedSingleSwiftFileTestProject(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       class 1️⃣MyClass {}
       class MySubclass: MyClass {}
@@ -176,12 +176,12 @@ final class TypeHierarchyTests: XCTestCase {
       let x = 2️⃣MySubclass()
       """
     )
-    let item = try await ws.prepareTypeHierarchy(at: "2️⃣")
-    let supertypes = try await ws.testClient.send(TypeHierarchySupertypesRequest(item: item))
+    let item = try await project.prepareTypeHierarchy(at: "2️⃣")
+    let supertypes = try await project.testClient.send(TypeHierarchySupertypesRequest(item: item))
     assertEqualIgnoringData(
       supertypes,
       [
-        TypeHierarchyItem(name: "MyClass", kind: .class, location: "1️⃣", in: ws)
+        TypeHierarchyItem(name: "MyClass", kind: .class, location: "1️⃣", in: project)
       ]
     )
   }

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class WorkspaceSymbolsTests: XCTestCase {
   func testWorkspaceSymbolsAcrossPackages() async throws {
-    let ws = try await MultiFileTestProject(
+    let project = try await MultiFileTestProject(
       files: [
         "packageA/Sources/PackageALib/PackageALib.swift": """
         public func 1️⃣afuncFromA() {}
@@ -63,10 +63,10 @@ class WorkspaceSymbolsTests: XCTestCase {
       }
     )
 
-    try await SwiftPMTestProject.build(at: ws.scratchDirectory.appendingPathComponent("packageB"))
+    try await SwiftPMTestProject.build(at: project.scratchDirectory.appendingPathComponent("packageB"))
 
-    _ = try await ws.testClient.send(PollIndexRequest())
-    let response = try await ws.testClient.send(WorkspaceSymbolsRequest(query: "funcFrom"))
+    _ = try await project.testClient.send(PollIndexRequest())
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "funcFrom"))
 
     // Ideally, the item from the current package (PackageB) should be returned before the item from PackageA
     // https://github.com/apple/sourcekit-lsp/issues/1094
@@ -78,8 +78,8 @@ class WorkspaceSymbolsTests: XCTestCase {
             name: "afuncFromA()",
             kind: .function,
             location: Location(
-              uri: try ws.uri(for: "PackageALib.swift"),
-              range: Range(try ws.position(of: "1️⃣", in: "PackageALib.swift"))
+              uri: try project.uri(for: "PackageALib.swift"),
+              range: Range(try project.position(of: "1️⃣", in: "PackageALib.swift"))
             )
           )
         ),
@@ -88,8 +88,8 @@ class WorkspaceSymbolsTests: XCTestCase {
             name: "funcFromB()",
             kind: .function,
             location: Location(
-              uri: try ws.uri(for: "PackageBLib.swift"),
-              range: Range(try ws.position(of: "2️⃣", in: "PackageBLib.swift"))
+              uri: try project.uri(for: "PackageBLib.swift"),
+              range: Range(try project.position(of: "2️⃣", in: "PackageBLib.swift"))
             )
           )
         ),

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 class WorkspaceSymbolsTests: XCTestCase {
   func testWorkspaceSymbolsAcrossPackages() async throws {
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "packageA/Sources/PackageALib/PackageALib.swift": """
         public func 1️⃣afuncFromA() {}
@@ -63,7 +63,7 @@ class WorkspaceSymbolsTests: XCTestCase {
       }
     )
 
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory.appendingPathComponent("packageB"))
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory.appendingPathComponent("packageB"))
 
     _ = try await ws.testClient.send(PollIndexRequest())
     let response = try await ws.testClient.send(WorkspaceSymbolsRequest(query: "funcFrom"))

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -40,7 +40,7 @@ final class WorkspaceTests: XCTestCase {
       )
       """
 
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         // PackageA
         "PackageA/Sources/MyLibrary/libA.swift": """
@@ -79,8 +79,8 @@ final class WorkspaceTests: XCTestCase {
       }
     )
 
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory.appendingPathComponent("PackageA"))
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory.appendingPathComponent("PackageB"))
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory.appendingPathComponent("PackageA"))
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory.appendingPathComponent("PackageB"))
 
     let (bUri, bPositions) = try ws.openDocument("execB.swift")
 
@@ -178,7 +178,7 @@ final class WorkspaceTests: XCTestCase {
       )
       """
 
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         // PackageA
         "PackageA/Sources/MyLibrary/libA.swift": """
@@ -197,7 +197,7 @@ final class WorkspaceTests: XCTestCase {
         "PackageA/Package.swift": packageManifest,
       ]
     )
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory.appendingPathComponent("PackageA"))
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory.appendingPathComponent("PackageA"))
 
     let (uri, positions) = try ws.openDocument("execA.swift")
 
@@ -258,7 +258,7 @@ final class WorkspaceTests: XCTestCase {
       )
       """
 
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         // PackageA
         "PackageA/Sources/MyLibrary/libA.swift": """
@@ -291,8 +291,8 @@ final class WorkspaceTests: XCTestCase {
       ]
     )
 
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory.appendingPathComponent("PackageA"))
-    try await SwiftPMTestWorkspace.build(at: ws.scratchDirectory)
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory.appendingPathComponent("PackageA"))
+    try await SwiftPMTestProject.build(at: ws.scratchDirectory)
 
     let (bUri, bPositions) = try ws.openDocument("execB.swift")
 
@@ -374,7 +374,7 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testMultipleClangdWorkspaces() async throws {
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "WorkspaceA/main.cpp": """
         #if FOO
@@ -423,10 +423,10 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testRecomputeFileWorkspaceMembershipOnPackageSwiftChange() async throws {
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "PackageA/Sources/MyLibrary/libA.swift": "",
-        "PackageA/Package.swift": SwiftPMTestWorkspace.defaultPackageManifest,
+        "PackageA/Package.swift": SwiftPMTestProject.defaultPackageManifest,
 
         "PackageB/Sources/MyLibrary/libB.swift": """
         public struct Lib {
@@ -439,7 +439,7 @@ final class WorkspaceTests: XCTestCase {
 
         Lib().1️⃣
         """,
-        "PackageB/Package.swift": SwiftPMTestWorkspace.defaultPackageManifest,
+        "PackageB/Package.swift": SwiftPMTestProject.defaultPackageManifest,
       ],
       workspaces: { scratchDir in
         return [
@@ -513,7 +513,7 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testMixedPackage() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "clib/include/clib.h": """
         #ifndef CLIB_H
@@ -569,7 +569,7 @@ final class WorkspaceTests: XCTestCase {
   func testChangeWorkspaceFolders() async throws {
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
 
-    let ws = try await MultiFileTestWorkspace(
+    let ws = try await MultiFileTestProject(
       files: [
         "subdir/Sources/otherPackage/otherPackage.swift": """
         import package
@@ -701,7 +701,7 @@ final class WorkspaceTests: XCTestCase {
   }
 
   public func testWorkspaceSpecificBuildSettings() async throws {
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "test.swift": """
         #if MY_FLAG
@@ -744,7 +744,7 @@ final class WorkspaceTests: XCTestCase {
 
     try await SkipUnless.swiftpmStoresModulesInSubdirectory()
 
-    let ws = try await SwiftPMTestWorkspace(
+    let ws = try await SwiftPMTestProject(
       files: [
         "Sources/clib/include/clib.h": """
         #ifndef CLIB_H


### PR DESCRIPTION
- Rename `ws` in tests to `project`
  - Now that all the types that model test projects are suffixed `Project` instead of `Workspace`, the `ws` abbreviation doesn‘t make sense. It also never really fit with the new style of avoiding abbreviations. Rename all occurrences to `project`.
- Rename `SwiftPMWorkspace` to `SwiftPMBuildSystem`
  - All other types that conform to `BuildSystem` (which in sourcekit-lsp terms is something that can provide compiler arguments) had the `BuildSystem` suffix. `SwiftPMWorkspace` was an oddity here and was easily confused with the `Workspace` term in LSP, which essentially represents a single root folder that is being opened.
- Rename language specific language services
  - The naming was quite inconsistent here. Let’s rename these to `LanguageService` to highlight that they belong together.
    - ToolchainLanguageServer -> LanguageService
    - SwiftLanguageServer -> SwiftLanguageService
    - ClangLanguageServerShim -> ClangLanguageService
- Rename test projects for consistency
  - Rename all the classes that write files to disk to create a test project that we can open in sourcekit-lsp to end with `TestProject`. This is better than the old `Workspace` suffix because it avoids ambiguities with the `Workspace` type inside sourcekit-lsp.
    - IndexedSingleSwiftFileWorkspace -> IndexedSingleSwiftFileTestProject
    - MultiFileTestWorkspace -> MultiFileTestProject
    - SwiftPMTestWorkspace -> SwiftPMTestProject
- Rename `SourceKitServer` -> `SourceKitLSPServer`
  - This avoid ambiguities whether `SourceKitServer` handles sourcekitd or `sourcekit-lsp`.

rdar://124727401