### PR TITLE
Don’t fail OSLogScraper if a single crashed request could not be parsed

### DIFF
--- a/Sources/Diagnose/OSLogScraper.swift
+++ b/Sources/Diagnose/OSLogScraper.swift
@@ -82,7 +82,12 @@ struct OSLogScraper {
   /// Name is a human readable name that identifies the crash.
   func getCrashedRequests() throws -> [(name: String, info: RequestInfo)] {
     let crashedRequests = try crashedSourceKitLSPRequests().reversed()
-    return try crashedRequests.map { ($0.name, try requestInfo(for: $0.logCategory)) }
+    return crashedRequests.compactMap { (name: String, logCategory: String) -> (name: String, info: RequestInfo)? in
+      guard let requestInfo = try? requestInfo(for: logCategory) else {
+        return nil
+      }
+      return (name, requestInfo)
+    }
   }
 }
 #endif


### PR DESCRIPTION
If we fail to extract the failed request from one crashed sourcekitd request, we should not fail sourcekitd request reduction altogether. Instead, we should just continue searching for the next crashed requested and see if we can reduce that one.