### PR TITLE
Don’t send `WorkDoneProgressRequest` to the client if it doesn’t support work done progress

### DIFF
--- a/Sources/SourceKitLSP/SourceKitServer.swift
+++ b/Sources/SourceKitLSP/SourceKitServer.swift
@@ -132,8 +132,15 @@ final actor WorkDoneProgressState {
   /// Start a new task, creating a new `WorkDoneProgress` if none is running right now.
   ///
   /// - Parameter server: The server that is used to create the `WorkDoneProgress` on the client
-  func startProgress(server: SourceKitServer) {
+  func startProgress(server: SourceKitServer) async {
     activeTasks += 1
+    guard await server.capabilityRegistry?.clientCapabilities.window?.workDoneProgress ?? false else {
+      // If the client doesn't support workDoneProgress, keep track of the active task count but don't update the state.
+      // That way, if we call `startProgress` before initialization finishes, we won't send the
+      // `CreateWorkDoneProgressRequest` but if we call `startProgress` again after initialization finished (and thus
+      // the capability is set), we will create the work done progress.
+      return
+    }
     if state == .noProgress {
       state = .creating
       // Discard the handle. We don't support cancellation of the creation of a work done progress.
@@ -161,9 +168,12 @@ final actor WorkDoneProgressState {
   /// If this drops the active task count to 0, the work done progress is ended on the client.
   ///
   /// - Parameter server: The server that is used to send and update of the `WorkDoneProgress` to the client
-  func endProgress(server: SourceKitServer) {
+  func endProgress(server: SourceKitServer) async {
     assert(activeTasks > 0, "Unbalanced startProgress/endProgress calls")
     activeTasks -= 1
+    guard await server.capabilityRegistry?.clientCapabilities.window?.workDoneProgress ?? false else {
+      return
+    }
     if state == .created && activeTasks == 0 {
       server.client.send(WorkDoneProgress(token: token, value: .end(WorkDoneProgressEnd())))
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageServer.swift
@@ -147,6 +147,7 @@ public actor SwiftLanguageServer: ToolchainLanguageServer {
         if sourcekitdCrashedWorkDoneProgress == nil {
           sourcekitdCrashedWorkDoneProgress = WorkDoneProgressManager(
             server: sourceKitServer,
+            capabilityRegistry: capabilityRegistry,
             title: "SourceKit-LSP: Restoring functionality",
             message: "Please run 'sourcekit-lsp diagnose' to file an issue"
           )

--- a/Sources/SourceKitLSP/WorkDoneProgressManager.swift
+++ b/Sources/SourceKitLSP/WorkDoneProgressManager.swift
@@ -23,7 +23,10 @@ final class WorkDoneProgressManager {
   private let queue = AsyncQueue<Serial>()
   private let server: SourceKitServer
 
-  init(server: SourceKitServer, title: String, message: String? = nil) {
+  init?(server: SourceKitServer, capabilityRegistry: CapabilityRegistry, title: String, message: String? = nil) {
+    guard capabilityRegistry.clientCapabilities.window?.workDoneProgress ?? false else {
+      return nil
+    }
     self.token = .string("WorkDoneProgress-\(UUID())")
     self.server = server
     queue.async { [server, token] in

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -48,7 +48,10 @@ final class CrashRecoveryTests: XCTestCase {
     try SkipUnless.platformIsDarwin("Linux and Windows use in-process sourcekitd")
     try SkipUnless.longTestsEnabled()
 
-    let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(window: WindowClientCapabilities(workDoneProgress: true)),
+      usePullDiagnostics: false
+    )
     let uri = DocumentURI.for(.swift)
 
     let positions = testClient.openDocument(


### PR DESCRIPTION
The way this happens in VS Code is that we sometimes tried to send a `WorkDoneProgressRequest` before initialization was complete. At that stage VS Code isn’t ready to receive work done progress yet.