### PR TITLE
Don’t fail rename if there are multiple index entries for the same USR

### DIFF
--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -554,24 +554,50 @@ extension SourceKitServer {
     index: IndexStoreDB
   ) async throws -> CrossLanguageName? {
     let definitions = index.occurrences(ofUSR: usr, roles: [.definition])
+    if definitions.isEmpty {
+      logger.error("no definitions for \(usr) found")
+      return nil
+    }
     if definitions.count > 1 {
       logger.log("Multiple definitions for \(usr) found")
     }
     // There might be multiple definitions of the same symbol eg. in different `#if` branches. In this case pick any of
     // them because with very high likelihood they all translate to the same clang and Swift name. Sort the entries to
     // ensure that we deterministically pick the same entry every time.
-    guard let definitionSymbol = definitions.sorted().first else {
-      logger.error("no definitions for \(usr) found")
-      return nil
+    for definitionOccurrence in definitions.sorted() {
+      do {
+        return try await getCrossLanguageName(
+          forDefinitionOccurrence: definitionOccurrence,
+          overrideName: overrideName,
+          workspace: workspace,
+          index: index
+        )
+      } catch {
+        // If getting the cross-language name fails for this occurrence, try the next definition, if there are multiple.
+        logger.log(
+          "Getting cross-language name for occurrence at \(definitionOccurrence.location) failed. \(error.forLogging)"
+        )
+      }
     }
+    return nil
+  }
+
+  private func getCrossLanguageName(
+    forDefinitionOccurrence definitionOccurrence: SymbolOccurrence,
+    overrideName: String? = nil,
+    workspace: Workspace,
+    index: IndexStoreDB
+  ) async throws -> CrossLanguageName {
+    let definitionSymbol = definitionOccurrence.symbol
+    let usr = definitionSymbol.usr
     let definitionLanguage: Language =
-      switch definitionSymbol.symbol.language {
+      switch definitionSymbol.language {
       case .c: .c
       case .cxx: .cpp
       case .objc: .objective_c
       case .swift: .swift
       }
-    let definitionDocumentUri = DocumentURI(URL(fileURLWithPath: definitionSymbol.location.path))
+    let definitionDocumentUri = DocumentURI(URL(fileURLWithPath: definitionOccurrence.location.path))
 
     guard
       let definitionLanguageService = await self.languageService(
@@ -580,17 +606,16 @@ extension SourceKitServer {
         in: workspace
       )
     else {
-      logger.fault("Failed to get language service for the document defining \(usr)")
-      return nil
+      throw ResponseError.unknown("Failed to get language service for the document defining \(usr)")
     }
 
-    let definitionName = overrideName ?? definitionSymbol.symbol.name
+    let definitionName = overrideName ?? definitionSymbol.name
 
     switch definitionLanguageService {
     case is ClangLanguageServerShim:
       let swiftName: String?
       if let swiftReference = await getReferenceFromSwift(usr: usr, index: index, workspace: workspace) {
-        let isObjectiveCSelector = definitionLanguage == .objective_c && definitionSymbol.symbol.kind.isMethod
+        let isObjectiveCSelector = definitionLanguage == .objective_c && definitionSymbol.kind.isMethod
         swiftName = try await swiftReference.languageServer.translateClangNameToSwift(
           at: swiftReference.location,
           in: swiftReference.snapshot,
@@ -598,7 +623,7 @@ extension SourceKitServer {
           name: definitionName
         )
       } else {
-        logger.debug("Not translating \(usr) to Swift because it is not referenced from Swift")
+        logger.debug("Not translating \(definitionSymbol) to Swift because it is not referenced from Swift")
         swiftName = nil
       }
       return CrossLanguageName(clangName: definitionName, swiftName: swiftName, definitionLanguage: definitionLanguage)
@@ -612,7 +637,7 @@ extension SourceKitServer {
       let clangName: String?
       if hasReferenceFromClang {
         clangName = try await swiftLanguageServer.translateSwiftNameToClang(
-          at: definitionSymbol.location,
+          at: definitionOccurrence.location,
           in: definitionDocumentUri,
           name: CompoundDeclName(definitionName)
         )


### PR DESCRIPTION
The test case that I’m adding right now is that we have a lingering index entry from a file that has been moved on disk. While the proper fix here would be to ignore such an entry from the index, we should also be more resilient and not fail rename altogether just because there are multiple entries for a USR – the chances are very high that they all translate to the same Swift and Objective-C name.

rdar://123937371