### PR TITLE
Fix issues when developing sourcekit-lsp using Xcode 15.3

### DIFF
--- a/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
+++ b/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
@@ -16,7 +16,11 @@ import SKSupport
 
 import struct TSCBasic.AbsolutePath
 
+#if compiler(<5.11)
+extension DLHandle: @unchecked Sendable {}
+#else
 extension DLHandle: @unchecked @retroactive Sendable {}
+#endif
 extension sourcekitd_api_keys: @unchecked Sendable {}
 extension sourcekitd_api_requests: @unchecked Sendable {}
 extension sourcekitd_api_values: @unchecked Sendable {}

--- a/Tests/LSPLoggingTests/LoggingTests.swift
+++ b/Tests/LSPLoggingTests/LoggingTests.swift
@@ -22,7 +22,8 @@ fileprivate func assertLogging(
   file: StaticString = #filePath,
   line: UInt = #line
 ) {
-  var messages: [String] = []
+  // nonisolated(unsafe) because calls of `assertLogging` do not log to `logHandler` concurrently.
+  nonisolated(unsafe) var messages: [String] = []
   let logger = NonDarwinLogger(
     subsystem: subsystem,
     category: "test",
@@ -71,7 +72,8 @@ fileprivate func assertLogging(
 final class LoggingTests: XCTestCase {
   func testLoggingFormat() async throws {
     let expectation = self.expectation(description: "message logged")
-    var message: String = ""
+    // nonisolated(unsafe) because we only have a single call to `logger.log` and that cannot race.
+    nonisolated(unsafe) var message: String = ""
     let logger = NonDarwinLogger(
       subsystem: subsystem,
       category: "test",

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -1083,6 +1083,7 @@ final class RenameTests: XCTestCase {
   }
 
   func testRenameAfterFileMove() async throws {
+    try await SkipUnless.sourcekitdSupportsRename()
     let project = try await SwiftPMTestProject(
       files: [
         "definition.swift": """


### PR DESCRIPTION
- Skip `testRenameAfterFileMove` if rename is not supported by sourcekitd
  - Otherwise this tests fail when running using Xcode 15.3 without an open source toolchain snapshot.
- Don’t use `@retroactive` when building with a Swift 5.10 compiler
  - This fixes a building using a Swift 5.10 compiler.
- Fix two concurrency warnings in LoggingTests.swift