### PR TITLE
Remove --sync option

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -111,11 +111,6 @@ struct SourceKitLSP: AsyncParsableCommand {
     ]
   )
 
-  /// Whether to wait for a response before handling the next request.
-  /// Used for testing.
-  @Flag(name: .customLong("sync"))
-  var syncRequests = false
-
   @Option(
     name: [.customLong("configuration")],
     help: "Build with configuration [debug|release]"
@@ -243,8 +238,7 @@ struct SourceKitLSP: AsyncParsableCommand {
       name: "client",
       protocol: MessageRegistry.lspProtocol,
       inFD: FileHandle.standardInput,
-      outFD: realStdoutHandle,
-      syncRequests: syncRequests
+      outFD: realStdoutHandle
     )
 
     let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)


### PR DESCRIPTION
With the `test-sourcekit-lsp.py` integration test rewritten to not use `--sync`, there are no more users of this option. Remove it since we don’t really test it anyway.