### PR TITLE
Implement test discovery for swift-testing tests for the `textDocument/tests` request

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
@@ -39,6 +39,12 @@ public struct TestItem: ResponseType, Equatable {
   /// When `nil` the `label` is used.
   public let sortText: String?
 
+  /// Whether the test is disabled.
+  public let disabled: Bool
+
+  /// The type of test, eg. the testing framework that was used to declare the test.
+  public let style: String
+
   /// The location of the test item in the source code.
   public let location: Location
 
@@ -55,6 +61,8 @@ public struct TestItem: ResponseType, Equatable {
     label: String,
     description: String? = nil,
     sortText: String? = nil,
+    disabled: Bool,
+    style: String,
     location: Location,
     children: [TestItem],
     tags: [TestTag]
@@ -63,6 +71,8 @@ public struct TestItem: ResponseType, Equatable {
     self.label = label
     self.description = description
     self.sortText = sortText
+    self.disabled = disabled
+    self.style = style
     self.location = location
     self.children = children
     self.tags = tags

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(SourceKitLSP PRIVATE
   Swift/SourceKitD+ResponseError.swift
   Swift/SwiftCommand.swift
   Swift/SwiftLanguageService.swift
+  Swift/SwiftTestingScanner.swift
   Swift/SymbolInfo.swift
   Swift/SyntaxHighlightingToken.swift
   Swift/SyntaxHighlightingTokens.swift

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -1,0 +1,378 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPLogging
+import LanguageServerProtocol
+import SwiftSyntax
+
+// MARK: - Attribute parsing
+
+/// Get the traits applied to a testing attribute.
+///
+/// - Parameters:
+///   - testAttribute: The attribute to inspect.
+///
+/// - Returns: An array of `ExprSyntax` instances representing the traits
+///   applied to `testAttribute`. If the attribute has no traits, the empty
+///   array is returned.
+private func traits(ofTestAttribute testAttribute: AttributeSyntax) -> [ExprSyntax] {
+  guard let argument = testAttribute.arguments, case let .argumentList(argumentList) = argument else {
+    return []
+  }
+
+  // Skip the display name if present.
+  var traitArgumentsRange = argumentList.startIndex..<argumentList.endIndex
+  if let firstArgument = argumentList.first,
+    firstArgument.label == nil,
+    firstArgument.expression.is(StringLiteralExprSyntax.self)
+  {
+    traitArgumentsRange = argumentList.index(after: argumentList.startIndex)..<argumentList.endIndex
+  }
+
+  // Look for any traits in the remaining arguments and slice them off.
+  if let labelledArgumentIndex = argumentList[traitArgumentsRange].firstIndex(where: { $0.label != nil }) {
+    // There is an argument with a label, so splice there.
+    traitArgumentsRange = traitArgumentsRange.lowerBound..<labelledArgumentIndex
+  }
+
+  return argumentList[traitArgumentsRange].map(\.expression)
+}
+
+/// Contains information about a testing attribute such as `@Test` or `@Suite`.
+struct TestingAttributeData {
+  /// The display name in the attribute, if any.
+  let displayName: String?
+
+  /// The tags applied to the attribute.
+  let tags: [String]
+
+  /// Whether or not the attributed test is unconditionally disabled.
+  ///
+  /// Disabled tests can be presented differently in IDEs to indicate that they will never run, although they will still
+  /// be represented in the results.
+  let isDisabled: Bool
+
+  /// Whether or not the attributed test is hidden.
+  ///
+  /// Hidden tests are not reported by SourceKit-LSP and are not run automatically.
+  let isHidden: Bool
+
+  /// Extract the testing attribute data from the given attribute, which is assumed to be an `@Test` or `@Suite`
+  /// attribute.
+  init(attribute: AttributeSyntax) {
+    // If the first argument is an unlabelled string literal, it is the
+    // display name of the test. Otherwise, the test does not have a display
+    // name.
+    if case .argumentList(let argumentList) = attribute.arguments,
+      let firstArgument = argumentList.first,
+      firstArgument.label == nil,
+      let stringLiteral = firstArgument.expression.as(StringLiteralExprSyntax.self)
+    {
+      self.displayName = stringLiteral.representedLiteralValue
+    } else {
+      self.displayName = nil
+    }
+
+    let traitArguments = traits(ofTestAttribute: attribute)
+
+    // Map the arguments to tag's names.
+    self.tags = traitArguments.lazy
+      .compactMap { $0.as(FunctionCallExprSyntax.self) }
+      .filter { functionCall in
+        switch functionCall.calledExpression.as(MemberAccessExprSyntax.self)?.fullyQualifiedName {
+        case "tags", "Tag.List.tags", "Testing.Tag.List.tags":
+          return true
+        default:
+          return false
+        }
+      }.flatMap(\.arguments)
+      .compactMap { $0.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue }
+
+    self.isDisabled = traitArguments.lazy
+      .compactMap { $0.as(FunctionCallExprSyntax.self) }
+      .filter { functionCall in
+        switch functionCall.calledExpression.as(MemberAccessExprSyntax.self)?.fullyQualifiedName {
+        case "disabled", "ConditionTrait.disabled", "Testing.ConditionTrait.disabled":
+          return true
+        default:
+          return false
+        }
+      }
+      .contains { functionCall in
+        // Ignore disabled traits which have an `if:` parameter since
+        // they're conditional.
+        let hasConditionParam = functionCall.arguments.lazy
+          .compactMap(\.label?.text)
+          .contains("if")
+        if hasConditionParam {
+          return false
+        }
+
+        // Ignore disabled traits which have a trailing closure since
+        // they're conditional.
+        if functionCall.trailingClosure != nil {
+          return false
+        }
+
+        return true
+      }
+
+    self.isHidden = traitArguments.lazy
+      .compactMap { $0.as(MemberAccessExprSyntax.self) }
+      .contains { memberAccess in
+        switch memberAccess.fullyQualifiedName {
+        case "hidden", "HiddenTrait.hidden", "Testing.HiddenTrait.hidden":
+          true
+        default:
+          false
+        }
+      }
+  }
+}
+
+// MARK: - Test scanning
+
+final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
+  /// The `DocumentSnapshot` of the syntax tree that is being visited.
+  ///
+  /// Used to convert `AbsolutePosition` to line-column.
+  private let snapshot: DocumentSnapshot
+
+  /// Whether all tests discovered by the scanner should be marked as disabled.
+  ///
+  /// This is the case when the scanner is looking for tests inside a disabled suite.
+  private let allTestsDisabled: Bool
+
+  /// The names of the types that this scanner is scanning members for.
+  ///
+  /// For example, when scanning for tests inside `Bar` in the following, this is `["Foo", "Bar"]`
+  ///
+  /// ```swift
+  /// struct Foo {
+  ///   struct Bar {
+  ///     @Test func myTest() {}
+  ///   }
+  /// }
+  /// ```
+  private let parentTypeNames: [String]
+
+  /// The discovered test items.
+  private var result: [TestItem] = []
+
+  private init(snapshot: DocumentSnapshot, allTestsDisabled: Bool, parentTypeNames: [String]) {
+    self.snapshot = snapshot
+    self.allTestsDisabled = allTestsDisabled
+    self.parentTypeNames = parentTypeNames
+    super.init(viewMode: .fixedUp)
+  }
+
+  /// Public entry point. Scans the syntax tree of the given snapshot for swift-testing tests.
+  public static func findTestSymbols(
+    in snapshot: DocumentSnapshot,
+    syntaxTreeManager: SyntaxTreeManager
+  ) async -> [TestItem] {
+    let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    let visitor = SyntacticSwiftTestingTestScanner(snapshot: snapshot, allTestsDisabled: false, parentTypeNames: [])
+    visitor.walk(syntaxTree)
+    return visitor.result
+  }
+
+  /// Visit a class/struct/... or extension declaration.
+  ///
+  /// `typeNames` is the name of the class struct or, if this is an extension, an array containing the components of the
+  /// extended type. For example, `extension Foo.Bar {}` passes `["Foo", "Bar"]` as `typeNames`.
+  /// `typeNames` must not be empty.
+  private func visitTypeOrExtensionDecl(
+    _ node: DeclGroupSyntax,
+    typeNames: [String]
+  ) -> SyntaxVisitorContinueKind {
+    precondition(!typeNames.isEmpty)
+    let superclassName = node.inheritanceClause?.inheritedTypes.first?.type.as(IdentifierTypeSyntax.self)?.name.text
+    if superclassName == "XCTestCase" {
+      return .skipChildren
+    }
+
+    let suiteAttribute = node.attributes
+      .compactMap { $0.as(AttributeSyntax.self) }
+      .first { $0.isNamed("Suite", inModuleNamed: "Testing") }
+    let attributeData = suiteAttribute.map(TestingAttributeData.init(attribute:))
+
+    if attributeData?.isHidden ?? false {
+      return .skipChildren
+    }
+
+    let memberScanner = SyntacticSwiftTestingTestScanner(
+      snapshot: snapshot,
+      allTestsDisabled: attributeData?.isDisabled ?? false,
+      parentTypeNames: parentTypeNames + typeNames
+    )
+    memberScanner.walk(node.memberBlock)
+
+    guard !memberScanner.result.isEmpty || suiteAttribute != nil else {
+      // Only include this declaration if it has an `@Suite` attribute or contains nested tests.
+      return .skipChildren
+    }
+
+    let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
+    let testItem = TestItem(
+      id: (parentTypeNames + typeNames).joined(separator: "/"),
+      label: attributeData?.displayName ?? typeNames.last!,
+      disabled: (attributeData?.isDisabled ?? false) || allTestsDisabled,
+      style: TestStyle.swiftTesting,
+      location: Location(uri: snapshot.uri, range: range),
+      children: memberScanner.result,
+      tags: attributeData?.tags.map(TestTag.init(id:)) ?? []
+    )
+    result.append(testItem)
+    return .skipChildren
+  }
+
+  override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+  }
+
+  override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+  }
+
+  override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+  }
+
+  override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard let newContextComponents = node.extendedType.components else {
+      return .skipChildren
+    }
+
+    return visitTypeOrExtensionDecl(node, typeNames: newContextComponents)
+  }
+
+  override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+  }
+
+  override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    let testAttribute = node.attributes
+      .compactMap { $0.as(AttributeSyntax.self) }
+      .first { $0.isNamed("Test", inModuleNamed: "Testing") }
+
+    guard let testAttribute else {
+      return .skipChildren
+    }
+    let attributeData = TestingAttributeData(attribute: testAttribute)
+    if attributeData.isHidden {
+      return .skipChildren
+    }
+
+    let name =
+      node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName):" }.joined() + ")"
+
+    let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
+    let testItem = TestItem(
+      id: (parentTypeNames + [name]).joined(separator: "/"),
+      label: attributeData.displayName ?? name,
+      disabled: attributeData.isDisabled || allTestsDisabled,
+      style: TestStyle.swiftTesting,
+      location: Location(uri: snapshot.uri, range: range),
+      children: [],
+      tags: attributeData.tags.map(TestTag.init(id:))
+    )
+    result.append(testItem)
+    return .visitChildren
+  }
+}
+
+// MARK: - SwiftSyntax Utilities
+
+fileprivate extension AttributeSyntax {
+  /// Check whether or not this attribute is named with the specified name and
+  /// module.
+  ///
+  /// The attribute's name is accepted either without or with the specified
+  /// module name as a prefix to allow for either syntax. The name of this
+  /// attribute must not include generic type parameters.
+  ///
+  /// - Parameters:
+  ///   - name: The `"."`-separated type name to compare against.
+  ///   - moduleName: The module the specified type is declared in.
+  ///
+  /// - Returns: Whether or not this type has the given name.
+  func isNamed(_ name: String, inModuleNamed moduleName: String) -> Bool {
+    if let identifierType = attributeName.as(IdentifierTypeSyntax.self) {
+      return identifierType.name.text == name
+    } else if let memberType = attributeName.as(MemberTypeSyntax.self),
+      let baseIdentifierType = memberType.baseType.as(IdentifierTypeSyntax.self),
+      baseIdentifierType.genericArgumentClause == nil
+    {
+      return memberType.name.text == name && baseIdentifierType.name.text == moduleName
+    }
+
+    return false
+  }
+}
+
+fileprivate extension MemberAccessExprSyntax {
+  /// The base name of this instance, i.e. the string value of `base` joined
+  /// with any preceding base names.
+  ///
+  /// For example, if this instance represents the expression `x.y.z(123)`,
+  /// the value of this property is `"x.y"`. If the value of `base` is `nil`,
+  /// the value of this property is also `nil`.
+  var baseName: String? {
+    if let declReferenceExpr = base?.as(DeclReferenceExprSyntax.self) {
+      return declReferenceExpr.baseName.text
+    } else if let baseMemberAccessExpr = base?.as(MemberAccessExprSyntax.self) {
+      if let baseBaseName = baseMemberAccessExpr.baseName {
+        return "\(baseBaseName).\(baseMemberAccessExpr.declName.baseName.text)"
+      }
+      return baseMemberAccessExpr.declName.baseName.text
+    }
+
+    return nil
+  }
+
+  /// The fully-qualified name of this instance (subject to available
+  /// information.)
+  ///
+  /// The value of this property is this instance's `baseName` property joined
+  /// with its `name` property. For example, if this instance represents the
+  /// expression `x.y.z(123)`, the value of this property is `"x.y.z"`.
+  var fullyQualifiedName: String {
+    if let baseName {
+      return "\(baseName).\(declName.baseName.text)"
+    }
+    return declName.baseName.text
+  }
+}
+
+fileprivate extension TypeSyntax {
+  /// If this type is a simple chain of `MemberTypeSyntax` and `IdentifierTypeSyntax`, return the components that make
+  /// up the qualified type.
+  ///
+  /// ### Examples
+  ///  - `Foo.Bar` returns `["Foo", "Bar"]`
+  ///  - `Foo` returns `["Foo"]`
+  ///  - `[Int]` returns `nil`
+  var components: [String]? {
+    switch self.as(TypeSyntaxEnum.self) {
+    case .identifierType(let identifierType):
+      return [identifierType.name.text]
+    case .memberType(let memberType):
+      guard let baseComponents = memberType.baseType.components else {
+        return nil
+      }
+      return baseComponents + [memberType.name.text]
+    default:
+      return nil
+    }
+  }
+}

--- a/Tests/SourceKitLSPTests/TestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/TestDiscoveryTests.swift
@@ -12,6 +12,7 @@
 
 import LanguageServerProtocol
 import SKTestSupport
+import SourceKitLSP
 import XCTest
 
 final class TestDiscoveryTests: XCTestCase {
@@ -50,6 +51,8 @@ final class TestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
           location: Location(
             uri: try project.uri(for: "MyTests.swift"),
             range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
@@ -58,6 +61,8 @@ final class TestDiscoveryTests: XCTestCase {
             TestItem(
               id: "MyTests/testMyLibrary()",
               label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
               location: Location(
                 uri: try project.uri(for: "MyTests.swift"),
                 range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
@@ -115,11 +120,15 @@ final class TestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/testMyLibrary()",
               label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
               location: Location(uri: try project.uri(for: "MyTests.swift"), range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
               tags: []
@@ -141,6 +150,7 @@ final class TestDiscoveryTests: XCTestCase {
 
       1️⃣class MyTests: XCTestCase {
         2️⃣func testMyLibrary() {}3️⃣
+        func testWithAnArgument(x: Int) {}
         func unrelatedFunc() {}
         var testVariable: Int = 0
       }4️⃣
@@ -155,11 +165,15 @@ final class TestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/testMyLibrary()",
               label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
               tags: []
@@ -213,11 +227,15 @@ final class TestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/testMyLibrary()",
               label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
               tags: []
@@ -235,5 +253,652 @@ final class TestDiscoveryTests: XCTestCase {
       DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri))
     )
     XCTAssertEqual(indexBasedTests, [])
+  }
+
+  func testSwiftTestingDocumentTests() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣@Test
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingDocumentTestsInIndexedProject() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣@Test
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      allowBuildFailure: true
+    )
+
+    let tests = try await project.testClient.send(
+      DocumentTestsRequest(textDocument: TextDocumentIdentifier(project.fileURI))
+    )
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: project.fileURI, range: project.positions["1️⃣"]..<project.positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: project.fileURI, range: project.positions["2️⃣"]..<project.positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testNestedSwiftTestingSuites() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣struct Inner {
+          3️⃣@Test
+          func oneIsTwo() {
+            #expect(1 == 2)
+          }4️⃣
+        }5️⃣
+      }6️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/Inner",
+              label: "Inner",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["5️⃣"]),
+              children: [
+                TestItem(
+                  id: "MyTests/Inner/oneIsTwo()",
+                  label: "oneIsTwo()",
+                  disabled: false,
+                  style: TestStyle.swiftTesting,
+                  location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
+                  children: [],
+                  tags: []
+                )
+              ],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testParameterizedSwiftTestingTest() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣@Test(arguments: [0, 1, 2])
+        func numbersAreOne(x: Int) {
+          #expect(x == 1)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/numbersAreOne(x:)",
+              label: "numbersAreOne(x:)",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingSuiteWithNoTests() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Suite
+      struct MyTests {
+      }2️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingSuiteWithCustomName() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Suite("My tests")
+      struct MyTests {
+      }2️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "My tests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingTestWithCustomName() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Test("One is two")
+      func oneIsTwo() {
+        #expect(1 == 2)
+      }2️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "oneIsTwo()",
+          label: "One is two",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testDisabledSwiftTestingTest() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Test("One is two", .disabled())
+      func oneIsTwo() {
+        #expect(1 == 2)
+      }2️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "oneIsTwo()",
+          label: "One is two",
+          disabled: true,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingTestInDisabledSuite() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Suite(.disabled())
+      struct MyTests {
+        2️⃣@Test
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: true,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: true,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testHiddenSwiftTestingTest() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    testClient.openDocument(
+      """
+      import Testing
+
+      @Test("One is two", .hidden)
+      func oneIsTwo() {
+        #expect(1 == 2)
+      }
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      []
+    )
+  }
+
+  func testSwiftTestingTestWithTags() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Suite(.tags("Suites"))
+      struct MyTests {
+        2️⃣@Test(.tags("one", "two"))
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: [TestTag(id: "one"), TestTag(id: "two")]
+            )
+          ],
+          tags: [TestTag(id: "Suites")]
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingTestsWithExtension() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣@Test
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+
+      5️⃣extension MyTests {
+        6️⃣@Test
+        func twoIsThree() {
+          #expect(2 == 3)
+        }7️⃣
+      }8️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        ),
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["5️⃣"]..<positions["8️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/twoIsThree()",
+              label: "twoIsThree()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["6️⃣"]..<positions["7️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        ),
+      ]
+    )
+  }
+
+  func testSwiftTestingExtensionOfTypeInAnotherFile() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣extension MyTests {
+        2️⃣@Test
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingExtensionOfNestedType() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      struct MyTests {
+        struct Inner {}
+      }
+
+      1️⃣extension MyTests.Inner {
+        2️⃣@Test
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests/Inner",
+          label: "Inner",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/Inner/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testFullyQualifySwiftTestingTestAttribute() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Testing.Suite("My Tests")
+      struct MyTests {
+        2️⃣@Testing.Test("one is two")
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "My Tests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "one is two",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
   }
 }


### PR DESCRIPTION
This allows us to return swift-testing tests within a single document. It does not look for swift-testing tests workspace-wide (the `workspace/tests` request), which will be a follow-up PR.