### PR TITLE
Inherit actor isolation of closure passed to `orLog`

### DIFF
--- a/Sources/LSPLogging/OrLog.swift
+++ b/Sources/LSPLogging/OrLog.swift
@@ -14,7 +14,7 @@
 import os
 #endif
 
-public func logError(prefix: String, error: Error, level: LogLevel = .error) {
+private func logError(prefix: String, error: Error, level: LogLevel = .error) {
   logger.log(
     level: level,
     "\(prefix, privacy: .public)\(prefix.isEmpty ? "" : ": ", privacy: .public)\(error.forLogging)"
@@ -41,7 +41,7 @@ public func orLog<R>(
 public func orLog<R>(
   _ prefix: String,
   level: LogLevel = .error,
-  _ block: () async throws -> R?
+  @_inheritActorContext _ block: @Sendable () async throws -> R?
 ) async -> R? {
   do {
     return try await block()

--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -363,11 +363,9 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
   public func filesDidChange(_ events: [FileEvent]) async {
     if events.contains(where: { self.fileEventShouldTriggerPackageReload(event: $0) }) {
       logger.log("Reloading package because of file change")
-      do {
+      await orLog("Reloading package") {
         // TODO: It should not be necessary to reload the entire package just to get build settings for one file.
         try await self.reloadPackage()
-      } catch {
-        logError(prefix: "Reloading package", error: error)
       }
     }
   }


### PR DESCRIPTION
This allows us to express that `body` will run on the same actor isolation domain as the caller of `orLog`, which effectively makes `orLog` usable from actors again.