### PR TITLE
Remove unused `import Dispatch` from `Message.swift`

### DIFF
--- a/Sources/LanguageServerProtocol/Message.swift
+++ b/Sources/LanguageServerProtocol/Message.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
-
 public protocol MessageType: Codable, Sendable {}
 
 /// `RequestType` with no associated type or same-type requirements. Most users should prefer


### PR DESCRIPTION
This import is unused and is redundant in that file.