### PR TITLE
Adjustment for the removal of `IncrementalEdit(offset:length:replacement:)` 🤝 swift-syntax#2588

### DIFF
--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -105,9 +105,11 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
   let sequentialEdits = difference.map { change in
     switch change {
     case .insert(offset: let offset, element: let element, associatedWith: _):
-      IncrementalEdit(offset: offset, length: 0, replacement: [element])
+      let absolutePosition = AbsolutePosition(utf8Offset: offset)
+      return IncrementalEdit(range: absolutePosition..<absolutePosition, replacement: [element])
     case .remove(offset: let offset, element: _, associatedWith: _):
-      IncrementalEdit(offset: offset, length: 1, replacement: [])
+      let absolutePosition = AbsolutePosition(utf8Offset: offset)
+      return IncrementalEdit(range: absolutePosition..<absolutePosition.advanced(by: 1), replacement: [])
     }
   }
 


### PR DESCRIPTION
This initializer was only introduced very recently since `IncrementalEdit` stores the replacement bytes instead of just the replacement length. We are now changing `IncrementalEdit` store the range it’s replacing as `Range<AbsolutePosition>` instead of `ByteSourceRange`.

Companion of https://github.com/apple/swift-syntax/pull/2588