### PR TITLE
Don’t add the indentation of the current line to the insert text of subsequent lines when expanding trailing closures

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -294,16 +294,14 @@ class CodeCompletionSession {
       return nil
     }
 
-    let indentationOfLine = snapshot.lineTable[requestPosition.line].prefix(while: { $0.isWhitespace })
-
     let strippedPrefix: String
     let exprToExpand: String
     if insertText.starts(with: "?.") {
       strippedPrefix = "?."
-      exprToExpand = indentationOfLine + String(insertText.dropFirst(2))
+      exprToExpand = String(insertText.dropFirst(2))
     } else {
       strippedPrefix = ""
-      exprToExpand = indentationOfLine + insertText
+      exprToExpand = insertText
     }
 
     var parser = Parser(exprToExpand)
@@ -325,7 +323,7 @@ class CodeCompletionSession {
     // Add any part of the expression that didn't end up being part of the function call
     expandedBytes += bytesToExpand[0..<call.position.utf8Offset]
     // Add the expanded function call excluding the added `indentationOfLine`
-    expandedBytes += expandedCall.syntaxTextBytes[indentationOfLine.utf8.count...]
+    expandedBytes += expandedCall.syntaxTextBytes
     // Add any trailing text that didn't end up being part of the function call
     expandedBytes += bytesToExpand[call.endPosition.utf8Offset...]
     return String(bytes: expandedBytes, encoding: .utf8)

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -978,6 +978,7 @@ final class SwiftCompletionTests: XCTestCase {
       ]
     )
   }
+
   func testExpandClosurePlaceholder() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI.for(.swift)
@@ -1007,8 +1008,8 @@ final class SwiftCompletionTests: XCTestCase {
           filterText: "myMap(:)",
           insertText: """
             myMap { ${1:Int} in
-                    ${2:Bool}
-                }
+                ${2:Bool}
+            }
             """,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
@@ -1016,8 +1017,8 @@ final class SwiftCompletionTests: XCTestCase {
               range: Range(positions["1️⃣"]),
               newText: """
                 myMap { ${1:Int} in
-                        ${2:Bool}
-                    }
+                    ${2:Bool}
+                }
                 """
             )
           )
@@ -1055,8 +1056,8 @@ final class SwiftCompletionTests: XCTestCase {
           filterText: ".myMap(:)",
           insertText: """
             ?.myMap { ${1:Int} in
-                    ${2:Bool}
-                }
+                ${2:Bool}
+            }
             """,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
@@ -1064,8 +1065,8 @@ final class SwiftCompletionTests: XCTestCase {
               range: positions["1️⃣"]..<positions["2️⃣"],
               newText: """
                 ?.myMap { ${1:Int} in
-                        ${2:Bool}
-                    }
+                    ${2:Bool}
+                }
                 """
             )
           )
@@ -1103,10 +1104,10 @@ final class SwiftCompletionTests: XCTestCase {
           filterText: "myMap(::)",
           insertText: """
             myMap { ${1:Int} in
-                    ${2:Bool}
-                } _: { ${3:Int} in
-                    ${4:String}
-                }
+                ${2:Bool}
+            } _: { ${3:Int} in
+                ${4:String}
+            }
             """,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
@@ -1114,10 +1115,10 @@ final class SwiftCompletionTests: XCTestCase {
               range: Range(positions["1️⃣"]),
               newText: """
                 myMap { ${1:Int} in
-                        ${2:Bool}
-                    } _: { ${3:Int} in
-                        ${4:String}
-                    }
+                    ${2:Bool}
+                } _: { ${3:Int} in
+                    ${4:String}
+                }
                 """
             )
           )
@@ -1155,10 +1156,10 @@ final class SwiftCompletionTests: XCTestCase {
           filterText: "myMap(:second:)",
           insertText: """
             myMap { ${1:Int} in
-                    ${2:Bool}
-                } second: { ${3:Int} in
-                    ${4:String}
-                }
+                ${2:Bool}
+            } second: { ${3:Int} in
+                ${4:String}
+            }
             """,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
@@ -1166,10 +1167,10 @@ final class SwiftCompletionTests: XCTestCase {
               range: Range(positions["1️⃣"]),
               newText: """
                 myMap { ${1:Int} in
-                        ${2:Bool}
-                    } second: { ${3:Int} in
-                        ${4:String}
-                    }
+                    ${2:Bool}
+                } second: { ${3:Int} in
+                    ${4:String}
+                }
                 """
             )
           )
@@ -1209,8 +1210,8 @@ final class SwiftCompletionTests: XCTestCase {
           filterText: "myMap(:)",
           insertText: """
             myMap { ${1:Int} in
-                ${2:Bool}
-              }
+              ${2:Bool}
+            }
             """,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
@@ -1218,8 +1219,8 @@ final class SwiftCompletionTests: XCTestCase {
               range: Range(positions["1️⃣"]),
               newText: """
                 myMap { ${1:Int} in
-                    ${2:Bool}
-                  }
+                  ${2:Bool}
+                }
                 """
             )
           )


### PR DESCRIPTION
Visual Studio Code automatically inserts the indentation of the current line to any additional lines from code completion.

rdar://125071836