### PR TITLE
Unify logging of errors during position conversions

### DIFF
--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPLogging
+
 public struct LineTable: Hashable {
   @usableFromInline
   var impl: [String.Index]
@@ -123,113 +125,242 @@ extension LineTable {
   }
 }
 
+// MARK: - Position translation
+
 extension LineTable {
+  // MARK: line:column <-> String.Index
 
-  // MARK: - Position translation
-
-  /// Returns `String.Index` of given logical position.
+  /// Converts the given UTF-16-based `line:column`` position to a `String.Index`.
+  ///
+  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf16Column: UTF-16 column offset (zero-based).
   @inlinable
-  public func stringIndexOf(line: Int, utf16Column: Int) -> String.Index? {
+  public func stringIndexOf(
+    line: Int,
+    utf16Column: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> String.Index? {
     guard line < count else {
-      // Line out of range.
+      logger.fault(
+        """
+        Unable to get string index for \(line):\(utf16Column) (UTF-16) because line is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
       return nil
     }
     let lineSlice = self[line]
-    return content.utf16.index(lineSlice.startIndex, offsetBy: utf16Column, limitedBy: lineSlice.endIndex)
+    guard let index = content.utf16.index(lineSlice.startIndex, offsetBy: utf16Column, limitedBy: lineSlice.endIndex)
+    else {
+      logger.fault(
+        """
+        Unable to get string index for \(line):\(utf16Column) (UTF-16) because column is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return nil
+    }
+    return index
   }
 
-  /// Returns `String.Index` of given logical position.
+  /// Converts the given UTF-8-based `line:column`` position to a `String.Index`.
+  ///
+  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
   @inlinable
-  public func stringIndexOf(line: Int, utf8Column: Int) -> String.Index? {
+  public func stringIndexOf(
+    line: Int,
+    utf8Column: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> String.Index? {
     guard 0 <= line, line < count else {
-      // Line out of range.
+      logger.fault(
+        """
+        Unable to get string index for \(line):\(utf8Column) (UTF-8) because line is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
       return nil
     }
     guard 0 <= utf8Column else {
-      // Column out of range.
+      logger.fault(
+        """
+        Unable to get string index for \(line):\(utf8Column) (UTF-8) because column is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
       return nil
     }
     let lineSlice = self[line]
     return content.utf8.index(lineSlice.startIndex, offsetBy: utf8Column, limitedBy: lineSlice.endIndex)
   }
 
-  /// Returns UTF8 buffer offset of given logical position.
+  // MARK: line:column <-> UTF-8 offset
+
+  /// Converts the given UTF-16-based `line:column`` position to a UTF-8 offset within the source file.
+  ///
+  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf16Column: UTF-16 column offset (zero-based).
   @inlinable
-  public func utf8OffsetOf(line: Int, utf16Column: Int) -> Int? {
-    guard let stringIndex = stringIndexOf(line: line, utf16Column: utf16Column) else {
+  public func utf8OffsetOf(
+    line: Int,
+    utf16Column: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> Int? {
+    guard
+      let stringIndex = stringIndexOf(
+        line: line,
+        utf16Column: utf16Column,
+        callerFile: callerFile,
+        callerLine: callerLine
+      )
+    else {
       return nil
     }
     return content.utf8.distance(from: content.startIndex, to: stringIndex)
   }
 
-  /// Returns UTF8 buffer offset of given logical position.
+  /// Converts the given UTF-8-based `line:column`` position to a UTF-8 offset within the source file.
+  ///
+  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
   @inlinable
-  public func utf8OffsetOf(line: Int, utf8Column: Int) -> Int? {
-    guard let stringIndex = stringIndexOf(line: line, utf8Column: utf8Column) else {
+  public func utf8OffsetOf(
+    line: Int,
+    utf8Column: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> Int? {
+    guard
+      let stringIndex = stringIndexOf(
+        line: line,
+        utf8Column: utf8Column,
+        callerFile: callerFile,
+        callerLine: callerLine
+      )
+    else {
       return nil
     }
     return content.utf8.distance(from: content.startIndex, to: stringIndex)
   }
 
-  /// Returns logical position of given source offset.
+  /// Converts the given UTF-16-based line:column position to the UTF-8 offset of that position within the source file.
+  ///
+  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter utf8Offset: UTF-8 buffer offset (zero-based).
   @inlinable
-  public func lineAndUTF16ColumnOf(utf8Offset: Int) -> (line: Int, utf16Column: Int)? {
+  public func lineAndUTF16ColumnOf(
+    utf8Offset: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> (line: Int, utf16Column: Int)? {
     guard utf8Offset <= content.utf8.count else {
-      // Offset ouf of range.
+      logger.fault(
+        """
+        Unable to get line and UTF-16 column for UTF-8 offset \(utf8Offset) because offset is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
       return nil
     }
     return lineAndUTF16ColumnOf(content.utf8.index(content.startIndex, offsetBy: utf8Offset))
   }
 
-  @inlinable func lineAndUTF8ColumnOf(utf8Offset: Int) -> (line: Int, utf8Column: Int)? {
-    guard let (line, utf16Column) = lineAndUTF16ColumnOf(utf8Offset: utf8Offset) else {
+  /// Converts the given UTF-8-based line:column position to the UTF-8 offset of that position within the source file.
+  ///
+  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  @inlinable func lineAndUTF8ColumnOf(
+    utf8Offset: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> (line: Int, utf8Column: Int)? {
+    guard
+      let (line, utf16Column) = lineAndUTF16ColumnOf(
+        utf8Offset: utf8Offset,
+        callerFile: callerFile,
+        callerLine: callerLine
+      )
+    else {
       return nil
     }
-    guard let utf8Column = utf8ColumnAt(line: line, utf16Column: utf16Column) else {
+    guard
+      let utf8Column = utf8ColumnAt(
+        line: line,
+        utf16Column: utf16Column,
+        callerFile: callerFile,
+        callerLine: callerLine
+      )
+    else {
       return nil
     }
     return (line, utf8Column)
   }
 
-  /// Returns UTF16 column offset at UTF8 version of logical position.
+  // MARK: UTF-8 line:column <-> UTF-16 line:column
+
+  /// Returns UTF-16 column offset at UTF-8 based `line:column` position.
+  ///
+  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
   @inlinable
-  public func utf16ColumnAt(line: Int, utf8Column: Int) -> Int? {
+  public func utf16ColumnAt(
+    line: Int,
+    utf8Column: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> Int? {
     return convertColumn(
       line: line,
       column: utf8Column,
       indexFunction: content.utf8.index(_:offsetBy:limitedBy:),
-      distanceFunction: content.utf16.distance(from:to:)
+      distanceFunction: content.utf16.distance(from:to:),
+      callerFile: callerFile,
+      callerLine: callerLine
     )
   }
 
-  /// Returns UTF8 column offset at UTF16 version of logical position.
+  /// Returns UTF-8 column offset at UTF-16 based `line:column` position.
+  ///
+  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf16Column: UTF-16 column offset (zero-based).
   @inlinable
-  public func utf8ColumnAt(line: Int, utf16Column: Int) -> Int? {
+  public func utf8ColumnAt(
+    line: Int,
+    utf16Column: Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> Int? {
     return convertColumn(
       line: line,
       column: utf16Column,
       indexFunction: content.utf16.index(_:offsetBy:limitedBy:),
-      distanceFunction: content.utf8.distance(from:to:)
+      distanceFunction: content.utf8.distance(from:to:),
+      callerFile: callerFile,
+      callerLine: callerLine
     )
   }
 
@@ -238,15 +369,27 @@ extension LineTable {
     line: Int,
     column: Int,
     indexFunction: (Substring.Index, Int, Substring.Index) -> Substring.Index?,
-    distanceFunction: (Substring.Index, Substring.Index) -> Int
+    distanceFunction: (Substring.Index, Substring.Index) -> Int,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
   ) -> Int? {
     guard line < count else {
-      // Line out of range.
+      logger.fault(
+        """
+        Unable to convert column of \(line):\(column) because line is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
       return nil
     }
     let lineSlice = self[line]
     guard let targetIndex = indexFunction(lineSlice.startIndex, column, lineSlice.endIndex) else {
-      // Column out of range
+      logger.fault(
+        """
+        Unable to convert column of \(line):\(column) because column is out of range \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
       return nil
     }
     return distanceFunction(lineSlice.startIndex, targetIndex)

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -57,10 +57,6 @@ public struct DocumentSnapshot: Identifiable {
     self.language = language
     self.lineTable = lineTable
   }
-
-  func index(of pos: Position) -> String.Index? {
-    return lineTable.stringIndexOf(line: pos.line, utf16Column: pos.utf16index)
-  }
 }
 
 public final class Document {

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -266,9 +266,24 @@ fileprivate struct SyntacticRenameName {
 }
 
 private extension LineTable {
-  subscript(range: Range<Position>) -> Substring? {
-    guard let start = self.stringIndexOf(line: range.lowerBound.line, utf16Column: range.lowerBound.utf16index),
-      let end = self.stringIndexOf(line: range.upperBound.line, utf16Column: range.upperBound.utf16index)
+  /// Returns the string in the source file that's with the given position range.
+  ///
+  /// If either the lower or upper bound of `range` do not refer to valid positions with in the snapshot, returns
+  /// `nil` and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  subscript(range: Range<Position>, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> Substring? {
+    guard
+      let start = self.stringIndexOf(
+        line: range.lowerBound.line,
+        utf16Column: range.lowerBound.utf16index,
+        callerFile: callerFile,
+        callerLine: callerLine
+      ),
+      let end = self.stringIndexOf(
+        line: range.upperBound.line,
+        utf16Column: range.upperBound.utf16index,
+        callerFile: callerFile,
+        callerLine: callerLine
+      )
     else {
       return nil
     }
@@ -1092,7 +1107,6 @@ extension SwiftLanguageService {
     newName: CrossLanguageName
   ) async -> [TextEdit] {
     guard let position = snapshot.absolutePosition(of: renameLocation) else {
-      logger.fault("Failed to convert \(renameLocation.line):\(renameLocation.utf8Column) to AbsolutePosition")
       return []
     }
     let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
@@ -1155,7 +1169,6 @@ extension SwiftLanguageService {
       )
 
       guard let parameterPosition = snapshot.position(of: parameter.positionAfterSkippingLeadingTrivia) else {
-        logger.fault("Failed to convert position of \(parameter.firstName.text) to line-column")
         continue
       }
 
@@ -1447,7 +1460,6 @@ fileprivate extension RelatedIdentifiersResponse {
       let position = relatedIdentifier.range.lowerBound
       guard let utf8Column = snapshot.lineTable.utf8ColumnAt(line: position.line, utf16Column: position.utf16index)
       else {
-        logger.fault("Unable to find UTF-8 column for \(position.description, privacy: .public)")
         return nil
       }
       return RenameLocation(line: position.line + 1, utf8Column: utf8Column + 1, usage: relatedIdentifier.usage)

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -23,9 +23,6 @@ extension SwiftLanguageService {
     let completionPos = await adjustPositionToStartOfIdentifier(req.position, in: snapshot)
 
     guard let offset = snapshot.utf8Offset(of: completionPos) else {
-      logger.error(
-        "invalid completion position \(req.position, privacy: .public) (adjusted: \(completionPos, privacy: .public)"
-      )
       return CompletionList(isIncomplete: true, items: [])
     }
 
@@ -34,7 +31,6 @@ extension SwiftLanguageService {
     guard let start = snapshot.indexOf(utf8Offset: offset),
       let end = snapshot.index(of: req.position)
     else {
-      logger.error("invalid completion position \(req.position, privacy: .public)")
       return CompletionList(isIncomplete: true, items: [])
     }
 

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -367,27 +367,36 @@ class CodeCompletionSession {
 
       let textEdit: TextEdit?
       if let text = text {
-        textEdit = self.computeCompletionTextEdit(
-          completionPos: completionPos,
-          requestPosition: requestPosition,
-          utf8CodeUnitsToErase: utf8CodeUnitsToErase,
-          newText: text,
-          snapshot: snapshot
-        )
+        guard
+          let edit = self.computeCompletionTextEdit(
+            completionPos: completionPos,
+            requestPosition: requestPosition,
+            utf8CodeUnitsToErase: utf8CodeUnitsToErase,
+            newText: text,
+            snapshot: snapshot
+          )
+        else {
+          return true  // continue
+        }
+        textEdit = edit
 
         if utf8CodeUnitsToErase != 0, filterName != nil, let textEdit = textEdit {
           // To support the case where the client is doing prefix matching on the TextEdit range,
           // we need to prepend the deleted text to filterText.
           // This also works around a behaviour in VS Code that causes completions to not show up
           // if a '.' is being replaced for Optional completion.
-          let startIndex = snapshot.lineTable.stringIndexOf(
-            line: textEdit.range.lowerBound.line,
-            utf16Column: textEdit.range.lowerBound.utf16index
-          )!
-          let endIndex = snapshot.lineTable.stringIndexOf(
-            line: completionPos.line,
-            utf16Column: completionPos.utf16index
-          )!
+          guard
+            let startIndex = snapshot.lineTable.stringIndexOf(
+              line: textEdit.range.lowerBound.line,
+              utf16Column: textEdit.range.lowerBound.utf16index
+            ),
+            let endIndex = snapshot.lineTable.stringIndexOf(
+              line: completionPos.line,
+              utf16Column: completionPos.utf16index
+            )
+          else {
+            return true  // continue
+          }
           let filterPrefix = snapshot.text[startIndex..<endIndex]
           filterName = filterPrefix + filterName!
         }
@@ -426,7 +435,7 @@ class CodeCompletionSession {
     utf8CodeUnitsToErase: Int,
     newText: String,
     snapshot: DocumentSnapshot
-  ) -> TextEdit {
+  ) -> TextEdit? {
     let textEditRangeStart: Position
 
     // Compute the TextEdit
@@ -449,10 +458,14 @@ class CodeCompletionSession {
       assert(completionPos.line == requestPosition.line)
       // Construct a string index for the edit range start by subtracting the UTF-8 code units to erase from the completion position.
       let line = snapshot.lineTable[completionPos.line]
-      let completionPosStringIndex = snapshot.lineTable.stringIndexOf(
-        line: completionPos.line,
-        utf16Column: completionPos.utf16index
-      )!
+      guard
+        let completionPosStringIndex = snapshot.lineTable.stringIndexOf(
+          line: completionPos.line,
+          utf16Column: completionPos.utf16index
+        )
+      else {
+        return nil
+      }
       let deletionStartStringIndex = line.utf8.index(completionPosStringIndex, offsetBy: -utf8CodeUnitsToErase)
 
       // Compute the UTF-16 offset of the deletion start range. If the start lies in a previous line, this will be negative

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -87,7 +87,6 @@ extension CodeAction {
       snapshot.text.indices.contains(startIndex),
       endIndex <= snapshot.text.endIndex
     else {
-      logger.fault("position mapped, but indices failed for edit range \(String(reflecting: edits[0]))")
       return nil
     }
     let oldText = String(snapshot.text[startIndex..<endIndex])
@@ -279,12 +278,6 @@ extension Diagnostic {
     in snapshot: DocumentSnapshot
   ) {
     guard let position = snapshot.position(of: diag.position) else {
-      logger.error(
-        """
-        Cannot construct Diagnostic from SwiftSyntax diagnostic because its UTF-8 offset \(diag.position.utf8Offset) \
-        is out of range of the source file \(snapshot.uri.forLogging)
-        """
-      )
       return nil
     }
     // Start with a zero-length range based on the position.

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -117,11 +117,9 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
 
   return concurrentEdits.edits.compactMap { (edit) -> TextEdit? in
     guard let (startLine, startColumn) = original.lineTable.lineAndUTF16ColumnOf(utf8Offset: edit.offset) else {
-      logger.fault("Failed to convert offset \(edit.offset) into line:column")
       return nil
     }
     guard let (endLine, endColumn) = original.lineTable.lineAndUTF16ColumnOf(utf8Offset: edit.endOffset) else {
-      logger.fault("Failed to convert offset \(edit.endOffset) into line:column")
       return nil
     }
     guard let newText = String(bytes: edit.replacement, encoding: .utf8) else {

--- a/Sources/SourceKitLSP/Swift/FoldingRange.swift
+++ b/Sources/SourceKitLSP/Swift/FoldingRange.swift
@@ -198,9 +198,6 @@ fileprivate final class FoldingRangeFinder: SyntaxAnyVisitor {
     guard let start: Position = snapshot.positionOf(utf8Offset: start.utf8Offset),
       let end: Position = snapshot.positionOf(utf8Offset: end.utf8Offset)
     else {
-      logger.error(
-        "folding range failed to retrieve position of \(self.snapshot.uri.forLogging): \(start.utf8Offset)-\(end.utf8Offset)"
-      )
       return .visitChildren
     }
     let range: FoldingRange

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -62,7 +62,7 @@ struct SemanticRefactoring {
           ),
           let text: String = value[keys.text]
         {
-          // Snippets are only suppored in code completion.
+          // Snippets are only supported in code completion.
           // Remove SourceKit placeholders in refactoring actions because they can't be represented in the editor properly.
           let textWithSnippets = rewriteSourceKitPlaceholders(in: text, clientSupportsSnippets: false)
           let edit = TextEdit(range: startPosition..<endPosition, newText: textWithSnippets)

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -55,7 +55,7 @@ extension SwiftLanguageService {
     let semanticTokens = await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
 
     let range =
-      if let range = range.flatMap({ $0.byteSourceRange(in: snapshot) }) {
+      if let range = range.flatMap({ snapshot.byteSourceRange(of: $0) }) {
         range
       } else {
         ByteSourceRange(offset: 0, length: await tree.totalLength.utf8Length)
@@ -98,12 +98,6 @@ extension SwiftLanguageService {
     let encodedTokens = tokens.lspEncoded
 
     return DocumentSemanticTokensResponse(data: encodedTokens)
-  }
-}
-
-extension Range where Bound == Position {
-  fileprivate func byteSourceRange(in snapshot: DocumentSnapshot) -> ByteSourceRange? {
-    return snapshot.utf8OffsetRange(of: self).map({ ByteSourceRange(offset: $0.startIndex, length: $0.count) })
   }
 }
 

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -123,9 +123,6 @@ private final class SyntacticSwiftXCTestScanner: SyntaxVisitor {
         return nil
       }
       guard let position = snapshot.position(of: function.name.positionAfterSkippingLeadingTrivia) else {
-        logger.fault(
-          "Failed to convert offset \(function.name.positionAfterSkippingLeadingTrivia.utf8Offset) to UTF-16-based position"
-        )
         return nil
       }
       let symbolInformation = SymbolInformation(
@@ -158,9 +155,6 @@ private final class SyntacticSwiftXCTestScanner: SyntaxVisitor {
       return .visitChildren
     }
     guard let position = snapshot.position(of: node.name.positionAfterSkippingLeadingTrivia) else {
-      logger.fault(
-        "Failed to convert offset \(node.name.positionAfterSkippingLeadingTrivia.utf8Offset) to UTF-16-based position"
-      )
       return .visitChildren
     }
     let testClassSymbolInformation = SymbolInformation(


### PR DESCRIPTION
Instead of logging errors in position translation ad-hoc at the caller’s side (and ofter forgetting to do so), log these errors in `LineTable`. To be able to debug where the position conversion error is coming from, also log the file name and line number of the caller.