### PR TITLE
Replace usages of `fatalError` that are recoverable by non-fatal error propagation constructs

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -12,6 +12,14 @@
 
 import Foundation
 
+struct FailedToConstructDocumentURIFromStringError: Error, CustomStringConvertible {
+  let string: String
+
+  var description: String {
+    return "Failed to construct DocumentURI from '\(string)'"
+  }
+}
+
 public struct DocumentURI: Codable, Hashable, Sendable {
   /// The URL that store the URIs value
   private let storage: URL
@@ -55,9 +63,9 @@ public struct DocumentURI: Codable, Hashable, Sendable {
 
   /// Construct a DocumentURI from the given URI string, automatically parsing
   ///  it either as a URL or an opaque URI.
-  public init(string: String) {
+  public init(string: String) throws {
     guard let url = URL(string: string) else {
-      fatalError("Failed to construct DocumentURI from '\(string)'")
+      throw FailedToConstructDocumentURIFromStringError(string: string)
     }
     self.init(url)
   }
@@ -68,7 +76,7 @@ public struct DocumentURI: Codable, Hashable, Sendable {
   }
 
   public init(from decoder: Decoder) throws {
-    self.init(string: try decoder.singleValueContainer().decode(String.self))
+    try self.init(string: decoder.singleValueContainer().decode(String.self))
   }
 
   /// Equality check to handle escape sequences in file URLs.

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentIdentifier.swift
@@ -26,7 +26,10 @@ extension TextDocumentIdentifier: LSPAnyCodable {
     guard case .string(let uriString)? = dictionary[CodingKeys.uri.stringValue] else {
       return nil
     }
-    self.uri = DocumentURI(string: uriString)
+    guard let uri = try? DocumentURI(string: uriString) else {
+      return nil
+    }
+    self.uri = uri
   }
 
   public func encodeToLSPAny() -> LSPAny {

--- a/Sources/LanguageServerProtocol/SupportTypes/WorkspaceEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/WorkspaceEdit.swift
@@ -49,7 +49,7 @@ extension WorkspaceEdit: Codable {
     if let changesDict = try container.decodeIfPresent([String: [TextEdit]].self, forKey: .changes) {
       var changes = [DocumentURI: [TextEdit]]()
       for change in changesDict {
-        let uri = DocumentURI(string: change.key)
+        let uri = try DocumentURI(string: change.key)
         changes[uri] = change.value
       }
       self.changes = changes
@@ -311,8 +311,10 @@ extension WorkspaceEdit: LSPAnyCodable {
     }
     var dictionary = [DocumentURI: [TextEdit]]()
     for (key, value) in lspDict {
-      let uri = DocumentURI(string: key)
-      guard let edits = [TextEdit](fromLSPArray: value) else {
+      guard
+        let uri = try? DocumentURI(string: key),
+        let edits = [TextEdit](fromLSPArray: value)
+      else {
         return nil
       }
       dictionary[uri] = edits

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2104,14 +2104,12 @@ extension SourceKitLSPServer {
   private nonisolated func extractCallHierarchyItemData(_ rawData: LSPAny?) -> (uri: DocumentURI, usr: String)? {
     guard case let .dictionary(data) = rawData,
       case let .string(uriString) = data["uri"],
-      case let .string(usr) = data["usr"]
+      case let .string(usr) = data["usr"],
+      let uri = orLog("DocumentURI for call hierarchy item", { try DocumentURI(string: uriString) })
     else {
       return nil
     }
-    return (
-      uri: DocumentURI(string: uriString),
-      usr: usr
-    )
+    return (uri: uri, usr: usr)
   }
 
   func incomingCalls(_ req: CallHierarchyIncomingCallsRequest) async throws -> [CallHierarchyIncomingCall]? {
@@ -2289,14 +2287,12 @@ extension SourceKitLSPServer {
   private nonisolated func extractTypeHierarchyItemData(_ rawData: LSPAny?) -> (uri: DocumentURI, usr: String)? {
     guard case let .dictionary(data) = rawData,
       case let .string(uriString) = data["uri"],
-      case let .string(usr) = data["usr"]
+      case let .string(usr) = data["usr"],
+      let uri = orLog("DocumentURI for type hierarchy item", { try DocumentURI(string: uriString) })
     else {
       return nil
     }
-    return (
-      uri: DocumentURI(string: uriString),
-      usr: usr
-    )
+    return (uri: uri, usr: usr)
   }
 
   func supertypes(_ req: TypeHierarchySupertypesRequest) async throws -> [TypeHierarchyItem]? {

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -110,7 +110,8 @@ extension CodeAction {
     case (true, false):
       return "Insert '\(newText)'"
     case (true, true):
-      preconditionFailure("FixIt makes no changes")
+      logger.fault("Both oldText and newText of FixIt are empty")
+      return "Fix"
     }
   }
 }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -518,7 +518,12 @@ extension SwiftLanguageService {
       do {
         _ = try await self.sourcekitd.send(req, fileContents: nil)
       } catch {
-        fatalError("failed to apply edit")
+        logger.fault(
+          """
+          failed to replace \(edit.range.lowerBound.utf8Offset):\(edit.range.upperBound.utf8Offset) by \
+          '\(edit.replacement)' in sourcekitd
+          """
+        )
       }
     }
 

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
@@ -206,7 +206,7 @@ struct SyntaxHighlightingTokenParser {
   }
 }
 
-extension Range where Bound == Position {
+extension Range<Position> {
   /// Splits a potentially multi-line range to multiple single-line ranges.
   func splitToSingleLineRanges(in snapshot: DocumentSnapshot) -> [Self] {
     if isEmpty {
@@ -220,7 +220,8 @@ extension Range where Bound == Position {
     guard let startIndex = snapshot.index(of: lowerBound),
       let endIndex = snapshot.index(of: upperBound)
     else {
-      fatalError("Range \(self) reaches outside of the document")
+      logger.fault("Range \(self) reaches outside of the document")
+      return [self]
     }
 
     let text = snapshot.text[startIndex..<endIndex]

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 final class CodingTests: XCTestCase {
 
-  func testValueCoding() {
+  func testValueCoding() throws {
     let url = URL(fileURLWithPath: "/foo.swift")
     let uri = DocumentURI(url)
     // The \\/\\/\\/ is escaping file:// + /foo.swift, which is silly but allowed by json.
@@ -252,7 +252,7 @@ final class CodingTests: XCTestCase {
     checkCoding(DiagnosticCode.string("hi"), json: "\"hi\"")
 
     checkCoding(
-      CodeDescription(href: DocumentURI(string: "file:///some/path")),
+      CodeDescription(href: try DocumentURI(string: "file:///some/path")),
       json: """
         {
           "href" : "file:\\/\\/\\/some\\/path"
@@ -816,7 +816,7 @@ final class CodingTests: XCTestCase {
     checkCoding(ProgressToken.string("foobar"), json: #""foobar""#)
   }
 
-  func testDocumentDiagnosticReport() {
+  func testDocumentDiagnosticReport() throws {
     checkCoding(
       DocumentDiagnosticReport.full(RelatedFullDocumentDiagnosticReport(items: [])),
       json: """
@@ -848,7 +848,7 @@ final class CodingTests: XCTestCase {
           resultId: "myResults",
           items: [],
           relatedDocuments: [
-            DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(
+            try DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(
               RelatedUnchangedDocumentDiagnosticReport(resultId: "myOtherResults")
             )
           ]
@@ -887,7 +887,7 @@ final class CodingTests: XCTestCase {
         RelatedUnchangedDocumentDiagnosticReport(
           resultId: "myResults",
           relatedDocuments: [
-            DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(
+            try DocumentURI(string: "file:///some/path"): DocumentDiagnosticReport.unchanged(
               RelatedUnchangedDocumentDiagnosticReport(resultId: "myOtherResults")
             )
           ]
@@ -1033,10 +1033,10 @@ final class CodingTests: XCTestCase {
     )
   }
 
-  func testWorkspaceDocumentDiagnosticReport() {
+  func testWorkspaceDocumentDiagnosticReport() throws {
     checkCoding(
       WorkspaceDocumentDiagnosticReport.full(
-        WorkspaceFullDocumentDiagnosticReport(items: [], uri: DocumentURI(string: "file:///some/path"))
+        WorkspaceFullDocumentDiagnosticReport(items: [], uri: try DocumentURI(string: "file:///some/path"))
       ),
       json: #"""
         {
@@ -1051,7 +1051,10 @@ final class CodingTests: XCTestCase {
 
     checkCoding(
       WorkspaceDocumentDiagnosticReport.unchanged(
-        WorkspaceUnchangedDocumentDiagnosticReport(resultId: "myResults", uri: DocumentURI(string: "file:///some/path"))
+        WorkspaceUnchangedDocumentDiagnosticReport(
+          resultId: "myResults",
+          uri: try DocumentURI(string: "file:///some/path")
+        )
       ),
       json: #"""
         {
@@ -1063,14 +1066,14 @@ final class CodingTests: XCTestCase {
     )
   }
 
-  func testWorkspaceSymbolItem() {
+  func testWorkspaceSymbolItem() throws {
     checkCoding(
       WorkspaceSymbolItem.symbolInformation(
         SymbolInformation(
           name: "mySym",
           kind: .constant,
           location: Location(
-            uri: DocumentURI(string: "file:///some/path"),
+            uri: try DocumentURI(string: "file:///some/path"),
             range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)
           )
         )
@@ -1101,7 +1104,9 @@ final class CodingTests: XCTestCase {
         WorkspaceSymbol(
           name: "mySym",
           kind: .boolean,
-          location: WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: DocumentURI(string: "file:///some/path")))
+          location: WorkspaceSymbol.WorkspaceSymbolLocation.uri(
+            .init(uri: try DocumentURI(string: "file:///some/path"))
+          )
         )
       ),
       json: #"""
@@ -1116,9 +1121,9 @@ final class CodingTests: XCTestCase {
     )
   }
 
-  func testWorkspapceSymbolLocation() {
+  func testWorkspapceSymbolLocation() throws {
     checkCoding(
-      WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: DocumentURI(string: "file:///some/path"))),
+      WorkspaceSymbol.WorkspaceSymbolLocation.uri(.init(uri: try DocumentURI(string: "file:///some/path"))),
       json: #"""
         {
           "uri" : "file:\/\/\/some\/path"
@@ -1129,7 +1134,7 @@ final class CodingTests: XCTestCase {
     checkCoding(
       WorkspaceSymbol.WorkspaceSymbolLocation.location(
         Location(
-          uri: DocumentURI(string: "file:///some/path"),
+          uri: try DocumentURI(string: "file:///some/path"),
           range: Position(line: 3, utf16index: 14)..<Position(line: 4, utf16index: 3)
         )
       ),

--- a/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
+++ b/Tests/LanguageServerProtocolTests/LanguageServerProtocolTests.swift
@@ -36,9 +36,9 @@ final class LanguageServerProtocolTests: XCTestCase {
     XCTAssertEqual(Language.objective_cpp.xflagHeader, "objective-c++-header")
   }
 
-  func testURLEscaping() {
+  func testURLEscaping() throws {
     let fileURI = DocumentURI(URL(fileURLWithPath: "/folder/image@3x.png", isDirectory: false))
-    let encodedURI = DocumentURI(string: "file:///folder/image%403x.png")
+    let encodedURI = try DocumentURI(string: "file:///folder/image%403x.png")
     XCTAssertEqual(encodedURI, fileURI)
     XCTAssertEqual(encodedURI.hashValue, fileURI.hashValue)
   }

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -87,7 +87,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "target changed")
-    let targetIdentifier = BuildTargetIdentifier(uri: DocumentURI(string: "build://target/a"))
+    let targetIdentifier = BuildTargetIdentifier(uri: try DocumentURI(string: "build://target/a"))
     let buildSystemDelegate = TestDelegate(targetExpectations: [
       BuildTargetEvent(
         target: targetIdentifier,

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -19,11 +19,11 @@ import XCTest
 
 final class BuildSystemManagerTests: XCTestCase {
 
-  func testMainFiles() async {
-    let a = DocumentURI(string: "bsm:a")
-    let b = DocumentURI(string: "bsm:b")
-    let c = DocumentURI(string: "bsm:c")
-    let d = DocumentURI(string: "bsm:d")
+  func testMainFiles() async throws {
+    let a = try DocumentURI(string: "bsm:a")
+    let b = try DocumentURI(string: "bsm:b")
+    let c = try DocumentURI(string: "bsm:c")
+    let d = try DocumentURI(string: "bsm:d")
 
     let mainFiles = ManualMainFilesProvider(
       [
@@ -88,7 +88,7 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsMainFile() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
+    let a = try try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
@@ -111,7 +111,7 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsMainFileInitialNil() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
+    let a = try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
@@ -132,7 +132,7 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsMainFileWithFallback() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
+    let a = try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bs = ManualBuildSystem()
     let fallback = FallbackBuildSystem(buildSetup: .default)
@@ -161,8 +161,8 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsMainFileInitialIntersect() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
-    let b = DocumentURI(string: "bsm:b.swift")
+    let a = try DocumentURI(string: "bsm:a.swift")
+    let b = try DocumentURI(string: "bsm:b.swift")
     let mainFiles = ManualMainFilesProvider([a: [a], b: [b]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
@@ -201,8 +201,8 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsMainFileUnchanged() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
-    let b = DocumentURI(string: "bsm:b.swift")
+    let a = try DocumentURI(string: "bsm:a.swift")
+    let b = try DocumentURI(string: "bsm:b.swift")
     let mainFiles = ManualMainFilesProvider([a: [a], b: [b]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
@@ -231,9 +231,9 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsHeaderChangeMainFile() async throws {
-    let h = DocumentURI(string: "bsm:header.h")
-    let cpp1 = DocumentURI(string: "bsm:main.cpp")
-    let cpp2 = DocumentURI(string: "bsm:other.cpp")
+    let h = try DocumentURI(string: "bsm:header.h")
+    let cpp1 = try DocumentURI(string: "bsm:main.cpp")
+    let cpp2 = try DocumentURI(string: "bsm:other.cpp")
     let mainFiles = ManualMainFilesProvider(
       [
         h: [cpp1],
@@ -286,9 +286,9 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsOneMainTwoHeader() async throws {
-    let h1 = DocumentURI(string: "bsm:header1.h")
-    let h2 = DocumentURI(string: "bsm:header2.h")
-    let cpp = DocumentURI(string: "bsm:main.cpp")
+    let h1 = try DocumentURI(string: "bsm:header1.h")
+    let h2 = try DocumentURI(string: "bsm:header2.h")
+    let cpp = try DocumentURI(string: "bsm:main.cpp")
     let mainFiles = ManualMainFilesProvider(
       [
         h1: [cpp],
@@ -333,9 +333,9 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testSettingsChangedAfterUnregister() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
-    let b = DocumentURI(string: "bsm:b.swift")
-    let c = DocumentURI(string: "bsm:c.swift")
+    let a = try DocumentURI(string: "bsm:a.swift")
+    let b = try DocumentURI(string: "bsm:b.swift")
+    let c = try DocumentURI(string: "bsm:c.swift")
     let mainFiles = ManualMainFilesProvider([a: [a], b: [b], c: [c]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
@@ -376,7 +376,7 @@ final class BuildSystemManagerTests: XCTestCase {
   }
 
   func testDependenciesUpdated() async throws {
-    let a = DocumentURI(string: "bsm:a.swift")
+    let a = try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
 
     let bs = ManualBuildSystem()

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -158,7 +158,7 @@ final class LocalSwiftTests: XCTestCase {
 
   func testEditingNonURL() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI(string: "urn:uuid:A1B08909-E791-469E-BF0F-F5790977E051")
+    let uri = try DocumentURI(string: "urn:uuid:A1B08909-E791-469E-BF0F-F5790977E051")
 
     let documentManager = await testClient.server._documentManager
 
@@ -285,7 +285,7 @@ final class LocalSwiftTests: XCTestCase {
     let includedURL = URL(fileURLWithPath: "/a.swift")
     let includedURI = DocumentURI(includedURL)
 
-    let excludedURI = DocumentURI(string: "git:/a.swift")
+    let excludedURI = try DocumentURI(string: "git:/a.swift")
 
     // Open the excluded URI first so our later notification handlers can confirm
     // that no diagnostics were emitted for this excluded URI.


### PR DESCRIPTION
Best reviews commit-by-commit.