### PR TITLE
Make sure the range returned by `PrepareRenameRequest` always contains the position from which the rename was initiated

### DIFF
--- a/Tests/SourceKitLSPTests/RenameAssertions.swift
+++ b/Tests/SourceKitLSPTests/RenameAssertions.swift
@@ -54,13 +54,23 @@ func assertSingleFileRename(
     let prepareRenameResponse = try await testClient.send(
       PrepareRenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions[marker])
     )
-    XCTAssertEqual(
-      prepareRenameResponse?.placeholder,
-      expectedPrepareRenamePlaceholder,
-      "Prepare rename placeholder does not match while performing rename at \(marker)",
-      file: file,
-      line: line
-    )
+    if let prepareRenameResponse {
+      XCTAssertEqual(
+        prepareRenameResponse.placeholder,
+        expectedPrepareRenamePlaceholder,
+        "Prepare rename placeholder does not match while performing rename at \(marker)",
+        file: file,
+        line: line
+      )
+      XCTAssert(
+        prepareRenameResponse.range.contains(positions[marker]),
+        "Prepare rename range \(prepareRenameResponse.range) does not contain rename position \(positions[marker])",
+        file: file,
+        line: line
+      )
+    } else {
+      XCTFail("Expected non-nil prepareRename response", file: file, line: line)
+    }
 
     let response = try await testClient.send(
       RenameRequest(

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -66,12 +66,12 @@ final class RenameTests: XCTestCase {
     )
   }
 
-  func testFoo() async throws {
+  func testRenameFromFunctionParameter() async throws {
     try await assertSingleFileRename(
       """
-      func foo(5️⃣x: Int) {}
-      foo(x: 1)
-      _ = foo(x:)
+      func foo(1️⃣x: Int) {}
+      foo(2️⃣x: 1)
+      _ = foo(3️⃣x:)
       _ = foo
       """,
       newName: "bar(y:)",
@@ -81,6 +81,25 @@ final class RenameTests: XCTestCase {
         bar(y: 1)
         _ = bar(y:)
         _ = bar
+        """
+    )
+  }
+
+  func testRenameFromFunctionParameterOnSeparateLine() async throws {
+    try await assertSingleFileRename(
+      """
+      func foo(
+        1️⃣x: Int
+      ) {}
+      foo(x: 1)
+      """,
+      newName: "bar(y:)",
+      expectedPrepareRenamePlaceholder: "foo(x:)",
+      expected: """
+        func bar(
+          y: Int
+        ) {}
+        bar(y: 1)
         """
     )
   }


### PR DESCRIPTION
VS Code rejects the placeholder name returned by the `PrepareRenameRequest`. When initiating rename on `x` in the following, this means that VS Code picks its own internal symbol name as the placeholder text, opening the rename textbox with `x`.

```swift
func foo(
  x: Int
) {}
```

Users then enter `y` in the expectation to rename only the parameter but sourcekit-lsp expects a function name and thus renames `foo` to `y(x:)`, which is unexpected.

rdar://125551489