### PR TITLE
Never return `nil` for position conversions

### DIFF
--- a/Sources/Diagnose/SourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/SourcekitdRequestCommand.swift
@@ -56,10 +56,9 @@ public struct SourceKitdRequestCommand: AsyncParsableCommand {
       let requestInfo = try RequestInfo(request: requestString)
 
       let lineTable = LineTable(requestInfo.fileContents)
-      if let offset = lineTable.utf8OffsetOf(line: line - 1, utf8Column: column - 1) {
-        print("Adjusting request offset to \(offset)")
-        requestString.replace(#/key.offset: [0-9]+/#, with: "key.offset: \(offset)")
-      }
+      let offset = lineTable.utf8OffsetOf(line: line - 1, utf8Column: column - 1)
+      print("Adjusting request offset to \(offset)")
+      requestString.replace(#/key.offset: [0-9]+/#, with: "key.offset: \(offset)")
     }
 
     let request = try requestString.cString(using: .utf8)!.withUnsafeBufferPointer { buffer in

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -125,15 +125,50 @@ extension LineTable {
   }
 }
 
-// MARK: - Position translation
+// MARK: - Position conversion
 
 extension LineTable {
   // MARK: line:column <-> String.Index
 
+  /// Result of `lineSlice(at:)`
+  @usableFromInline
+  enum LineSliceResult {
+    /// The line index passed to `lineSlice(at:)` was negative.
+    case beforeFirstLine
+    /// The contents of the line at the index passed to `lineSlice(at:)`.
+    case line(Substring)
+    /// The line index passed to `lineSlice(at:)` was after the last line of the file
+    case afterLastLine
+  }
+
+  /// Extracts the contents of the line at the given index.
+  ///
+  /// If `line` is out-of-bounds, logs a fault and returns either `beforeFirstLine` or `afterLastLine`.
+  @usableFromInline
+  func lineSlice(at line: Int, callerFile: StaticString, callerLine: UInt) -> LineSliceResult {
+    guard line >= 0 else {
+      logger.fault(
+        """
+        Line \(line) is negative (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return .beforeFirstLine
+    }
+    guard line < count else {
+      logger.fault(
+        """
+        Line \(line) is out-of range (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return .afterLastLine
+    }
+    return .line(self[line])
+  }
+
   /// Converts the given UTF-16-based `line:column`` position to a `String.Index`.
   ///
-  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the source file, returns the closest valid position and
+  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf16Column: UTF-16 column offset (zero-based).
@@ -143,34 +178,42 @@ extension LineTable {
     utf16Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> String.Index? {
-    guard line < count else {
+  ) -> String.Index {
+    let lineSlice: Substring
+    switch self.lineSlice(at: line, callerFile: callerFile, callerLine: callerLine) {
+    case .beforeFirstLine:
+      return self.content.startIndex
+    case .afterLastLine:
+      return self.content.endIndex
+    case .line(let line):
+      lineSlice = line
+    }
+    guard utf16Column >= 0 else {
       logger.fault(
         """
-        Unable to get string index for \(line):\(utf16Column) (UTF-16) because line is out of range \
+        Column is negative while converting \(line):\(utf16Column) (UTF-16) to String.Index \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return lineSlice.startIndex
     }
-    let lineSlice = self[line]
     guard let index = content.utf16.index(lineSlice.startIndex, offsetBy: utf16Column, limitedBy: lineSlice.endIndex)
     else {
       logger.fault(
         """
-        Unable to get string index for \(line):\(utf16Column) (UTF-16) because column is out of range \
+        Column is past line end while converting \(line):\(utf16Column) (UTF-16) to String.Index \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return lineSlice.endIndex
     }
     return index
   }
 
   /// Converts the given UTF-8-based `line:column`` position to a `String.Index`.
   ///
-  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the source file, returns the closest valid position and
+  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
@@ -180,35 +223,46 @@ extension LineTable {
     utf8Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> String.Index? {
-    guard 0 <= line, line < count else {
+  ) -> String.Index {
+    let lineSlice: Substring
+    switch self.lineSlice(at: line, callerFile: callerFile, callerLine: callerLine) {
+    case .beforeFirstLine:
+      return self.content.startIndex
+    case .afterLastLine:
+      return self.content.endIndex
+    case .line(let line):
+      lineSlice = line
+    }
+
+    guard utf8Column >= 0 else {
       logger.fault(
         """
-        Unable to get string index for \(line):\(utf8Column) (UTF-8) because line is out of range \
+        Column is negative while converting \(line):\(utf8Column) (UTF-8) to String.Index. \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return lineSlice.startIndex
     }
-    guard 0 <= utf8Column else {
+    guard let index = content.utf8.index(lineSlice.startIndex, offsetBy: utf8Column, limitedBy: lineSlice.endIndex)
+    else {
       logger.fault(
         """
-        Unable to get string index for \(line):\(utf8Column) (UTF-8) because column is out of range \
+        Column is after end of line while converting \(line):\(utf8Column) (UTF-8) to String.Index. \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return lineSlice.endIndex
     }
-    let lineSlice = self[line]
-    return content.utf8.index(lineSlice.startIndex, offsetBy: utf8Column, limitedBy: lineSlice.endIndex)
+
+    return index
   }
 
   // MARK: line:column <-> UTF-8 offset
 
   /// Converts the given UTF-16-based `line:column`` position to a UTF-8 offset within the source file.
   ///
-  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the source file, returns the closest valid offset and
+  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf16Column: UTF-16 column offset (zero-based).
@@ -218,24 +272,20 @@ extension LineTable {
     utf16Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Int? {
-    guard
-      let stringIndex = stringIndexOf(
-        line: line,
-        utf16Column: utf16Column,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
+  ) -> Int {
+    let stringIndex = stringIndexOf(
+      line: line,
+      utf16Column: utf16Column,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
     return content.utf8.distance(from: content.startIndex, to: stringIndex)
   }
 
-  /// Converts the given UTF-8-based `line:column`` position to a UTF-8 offset within the source file.
+  /// Converts the given UTF-8-based `line:column` position to a UTF-8 offset within the source file.
   ///
-  /// If the position does not refer to a valid position with in the source file, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the source file, returns the closest valid offset and
+  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
@@ -245,24 +295,20 @@ extension LineTable {
     utf8Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Int? {
-    guard
-      let stringIndex = stringIndexOf(
-        line: line,
-        utf8Column: utf8Column,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
+  ) -> Int {
+    let stringIndex = stringIndexOf(
+      line: line,
+      utf8Column: utf8Column,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
     return content.utf8.distance(from: content.startIndex, to: stringIndex)
   }
 
-  /// Converts the given UTF-16-based line:column position to the UTF-8 offset of that position within the source file.
+  /// Converts the given UTF-8 offset to a zero-based UTF-16 line:column pair.
   ///
-  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the snapshot, returns the closest valid line:column
+  /// pair and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter utf8Offset: UTF-8 buffer offset (zero-based).
   @inlinable
@@ -270,47 +316,48 @@ extension LineTable {
     utf8Offset: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> (line: Int, utf16Column: Int)? {
-    guard utf8Offset <= content.utf8.count else {
+  ) -> (line: Int, utf16Column: Int) {
+    guard utf8Offset >= 0 else {
       logger.fault(
         """
-        Unable to get line and UTF-16 column for UTF-8 offset \(utf8Offset) because offset is out of range \
+        UTF-8 offset \(utf8Offset) is negative while converting it to UTF-16 line:column \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return (line: 0, utf16Column: 0)
+    }
+    guard utf8Offset <= content.utf8.count else {
+      logger.fault(
+        """
+        UTF-8 offset \(utf8Offset) is past the end of the file while converting it to UTF-16 line:column \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return lineAndUTF16ColumnOf(content.endIndex)
     }
     return lineAndUTF16ColumnOf(content.utf8.index(content.startIndex, offsetBy: utf8Offset))
   }
 
   /// Converts the given UTF-8-based line:column position to the UTF-8 offset of that position within the source file.
   ///
-  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the snapshot, returns the closest valid line:colum pair
+  /// and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   @inlinable func lineAndUTF8ColumnOf(
     utf8Offset: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> (line: Int, utf8Column: Int)? {
-    guard
-      let (line, utf16Column) = lineAndUTF16ColumnOf(
-        utf8Offset: utf8Offset,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
-    guard
-      let utf8Column = utf8ColumnAt(
-        line: line,
-        utf16Column: utf16Column,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
+  ) -> (line: Int, utf8Column: Int) {
+    let (line, utf16Column) = lineAndUTF16ColumnOf(
+      utf8Offset: utf8Offset,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
+    let utf8Column = utf8ColumnAt(
+      line: line,
+      utf16Column: utf16Column,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
     return (line, utf8Column)
   }
 
@@ -318,8 +365,8 @@ extension LineTable {
 
   /// Returns UTF-16 column offset at UTF-8 based `line:column` position.
   ///
-  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the snapshot, performs a best-effort recovery and logs
+  /// a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf8Column: UTF-8 column offset (zero-based).
@@ -329,21 +376,34 @@ extension LineTable {
     utf8Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Int? {
-    return convertColumn(
-      line: line,
-      column: utf8Column,
-      indexFunction: content.utf8.index(_:offsetBy:limitedBy:),
-      distanceFunction: content.utf16.distance(from:to:),
-      callerFile: callerFile,
-      callerLine: callerLine
-    )
+  ) -> Int {
+    let lineSlice: Substring
+    switch self.lineSlice(at: line, callerFile: callerFile, callerLine: callerLine) {
+    case .beforeFirstLine, .afterLastLine:
+      // This line is out-of-bounds. `lineSlice(at:)` already logged a fault.
+      // Recovery by assuming that UTF-8 and UTF-16 columns are similar.
+      return utf8Column
+    case .line(let line):
+      lineSlice = line
+    }
+    guard
+      let stringIndex = lineSlice.utf8.index(lineSlice.startIndex, offsetBy: utf8Column, limitedBy: lineSlice.endIndex)
+    else {
+      logger.fault(
+        """
+        UTF-8 column is past the end of the line while getting UTF-16 column of \(line):\(utf8Column) \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return lineSlice.utf16.count
+    }
+    return lineSlice.utf16.distance(from: lineSlice.startIndex, to: stringIndex)
   }
 
   /// Returns UTF-8 column offset at UTF-16 based `line:column` position.
   ///
-  /// If the position does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the position does not refer to a valid position with in the snapshot, performs a bets-effort recovery and logs
+  /// a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   ///
   /// - parameter line: Line number (zero-based).
   /// - parameter utf16Column: UTF-16 column offset (zero-based).
@@ -353,45 +413,31 @@ extension LineTable {
     utf16Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Int? {
-    return convertColumn(
-      line: line,
-      column: utf16Column,
-      indexFunction: content.utf16.index(_:offsetBy:limitedBy:),
-      distanceFunction: content.utf8.distance(from:to:),
-      callerFile: callerFile,
-      callerLine: callerLine
-    )
-  }
-
-  @inlinable
-  func convertColumn(
-    line: Int,
-    column: Int,
-    indexFunction: (Substring.Index, Int, Substring.Index) -> Substring.Index?,
-    distanceFunction: (Substring.Index, Substring.Index) -> Int,
-    callerFile: StaticString = #fileID,
-    callerLine: UInt = #line
-  ) -> Int? {
-    guard line < count else {
+  ) -> Int {
+    let lineSlice: Substring
+    switch self.lineSlice(at: line, callerFile: callerFile, callerLine: callerLine) {
+    case .beforeFirstLine, .afterLastLine:
+      // This line is out-of-bounds. `lineSlice` already logged a fault.
+      // Recovery by assuming that UTF-8 and UTF-16 columns are similar.
+      return utf16Column
+    case .line(let line):
+      lineSlice = line
+    }
+    guard
+      let stringIndex = lineSlice.utf16.index(
+        lineSlice.startIndex,
+        offsetBy: utf16Column,
+        limitedBy: lineSlice.endIndex
+      )
+    else {
       logger.fault(
         """
-        Unable to convert column of \(line):\(column) because line is out of range \
+        UTF-16 column is past the end of the line while getting UTF-8 column of \(line):\(utf16Column) \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return lineSlice.utf8.count
     }
-    let lineSlice = self[line]
-    guard let targetIndex = indexFunction(lineSlice.startIndex, column, lineSlice.endIndex) else {
-      logger.fault(
-        """
-        Unable to convert column of \(line):\(column) because column is out of range \
-        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
-        """
-      )
-      return nil
-    }
-    return distanceFunction(lineSlice.startIndex, targetIndex)
+    return lineSlice.utf8.distance(from: lineSlice.startIndex, to: stringIndex)
   }
 }

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -357,9 +357,7 @@ public struct DocumentPositions {
 
     let lineTable = LineTable(textWithoutMarkers)
     positions = markers.mapValues { offset in
-      guard let (line, column) = lineTable.lineAndUTF16ColumnOf(utf8Offset: offset) else {
-        preconditionFailure("UTF-8 offset not within source file: \(offset)")
-      }
+      let (line, column) = lineTable.lineAndUTF16ColumnOf(utf8Offset: offset)
       return Position(line: line, utf16index: column)
     }
   }

--- a/Sources/SourceKitLSP/Swift/AdjustPositionToStartOfIdentifier.swift
+++ b/Sources/SourceKitLSP/Swift/AdjustPositionToStartOfIdentifier.swift
@@ -53,10 +53,7 @@ extension SwiftLanguageService {
     in snapshot: DocumentSnapshot
   ) async -> Position {
     let tree = await self.syntaxTreeManager.syntaxTree(for: snapshot)
-    guard let swiftSyntaxPosition = snapshot.absolutePosition(of: position) else {
-      return position
-    }
-    let visitor = StartOfIdentifierFinder(position: swiftSyntaxPosition)
+    let visitor = StartOfIdentifierFinder(position: snapshot.absolutePosition(of: position))
     visitor.walk(tree)
     if let resolvedPosition = visitor.resolvedPosition {
       return snapshot.position(of: resolvedPosition) ?? position

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -21,20 +21,10 @@ extension SwiftLanguageService {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
 
     let completionPos = await adjustPositionToStartOfIdentifier(req.position, in: snapshot)
-
-    guard let offset = snapshot.utf8Offset(of: completionPos) else {
-      return CompletionList(isIncomplete: true, items: [])
-    }
+    let offset = snapshot.utf8Offset(of: completionPos)
+    let filterText = String(snapshot.text[snapshot.indexOf(utf8Offset: offset)..<snapshot.index(of: req.position)])
 
     let options = req.sourcekitlspOptions ?? serverOptions.completionOptions
-
-    guard let start = snapshot.indexOf(utf8Offset: offset),
-      let end = snapshot.index(of: req.position)
-    else {
-      return CompletionList(isIncomplete: true, items: [])
-    }
-
-    let filterText = String(snapshot.text[start..<end])
 
     let clientSupportsSnippets =
       capabilityRegistry.clientCapabilities.textDocument?.completion?.completionItem?.snippetSupport ?? false

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -365,17 +365,13 @@ class CodeCompletionSession {
 
       let textEdit: TextEdit?
       if let text = text {
-        guard
-          let edit = self.computeCompletionTextEdit(
-            completionPos: completionPos,
-            requestPosition: requestPosition,
-            utf8CodeUnitsToErase: utf8CodeUnitsToErase,
-            newText: text,
-            snapshot: snapshot
-          )
-        else {
-          return true  // continue
-        }
+        let edit = self.computeCompletionTextEdit(
+          completionPos: completionPos,
+          requestPosition: requestPosition,
+          utf8CodeUnitsToErase: utf8CodeUnitsToErase,
+          newText: text,
+          snapshot: snapshot
+        )
         textEdit = edit
 
         if utf8CodeUnitsToErase != 0, filterName != nil, let textEdit = textEdit {
@@ -383,19 +379,7 @@ class CodeCompletionSession {
           // we need to prepend the deleted text to filterText.
           // This also works around a behaviour in VS Code that causes completions to not show up
           // if a '.' is being replaced for Optional completion.
-          guard
-            let startIndex = snapshot.lineTable.stringIndexOf(
-              line: textEdit.range.lowerBound.line,
-              utf16Column: textEdit.range.lowerBound.utf16index
-            ),
-            let endIndex = snapshot.lineTable.stringIndexOf(
-              line: completionPos.line,
-              utf16Column: completionPos.utf16index
-            )
-          else {
-            return true  // continue
-          }
-          let filterPrefix = snapshot.text[startIndex..<endIndex]
+          let filterPrefix = snapshot.text[snapshot.indexRange(of: textEdit.range.lowerBound..<completionPos)]
           filterName = filterPrefix + filterName!
         }
       } else {
@@ -433,7 +417,7 @@ class CodeCompletionSession {
     utf8CodeUnitsToErase: Int,
     newText: String,
     snapshot: DocumentSnapshot
-  ) -> TextEdit? {
+  ) -> TextEdit {
     let textEditRangeStart: Position
 
     // Compute the TextEdit
@@ -456,15 +440,7 @@ class CodeCompletionSession {
       assert(completionPos.line == requestPosition.line)
       // Construct a string index for the edit range start by subtracting the UTF-8 code units to erase from the completion position.
       let line = snapshot.lineTable[completionPos.line]
-      guard
-        let completionPosStringIndex = snapshot.lineTable.stringIndexOf(
-          line: completionPos.line,
-          utf16Column: completionPos.utf16index
-        )
-      else {
-        return nil
-      }
-      let deletionStartStringIndex = line.utf8.index(completionPosStringIndex, offsetBy: -utf8CodeUnitsToErase)
+      let deletionStartStringIndex = line.utf8.index(snapshot.index(of: completionPos), offsetBy: -utf8CodeUnitsToErase)
 
       // Compute the UTF-16 offset of the deletion start range. If the start lies in a previous line, this will be negative
       let deletionStartUtf16Offset = line.utf16.distance(from: line.startIndex, to: deletionStartStringIndex)

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -132,9 +132,7 @@ extension SwiftLanguageService {
   ) async throws -> (cursorInfo: [CursorInfo], refactorActions: [SemanticRefactorCommand]) {
     let snapshot = try documentManager.latestSnapshot(uri)
 
-    guard let offsetRange = snapshot.utf8OffsetRange(of: range) else {
-      throw CursorInfoError.invalidRange(range)
-    }
+    let offsetRange = snapshot.utf8OffsetRange(of: range)
 
     let keys = self.keys
 

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -116,12 +116,8 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
   // Map the offset-based edits to line-column based edits to be consumed by LSP
 
   return concurrentEdits.edits.compactMap { (edit) -> TextEdit? in
-    guard let (startLine, startColumn) = original.lineTable.lineAndUTF16ColumnOf(utf8Offset: edit.offset) else {
-      return nil
-    }
-    guard let (endLine, endColumn) = original.lineTable.lineAndUTF16ColumnOf(utf8Offset: edit.endOffset) else {
-      return nil
-    }
+    let (startLine, startColumn) = original.lineTable.lineAndUTF16ColumnOf(utf8Offset: edit.offset)
+    let (endLine, endColumn) = original.lineTable.lineAndUTF16ColumnOf(utf8Offset: edit.endOffset)
     guard let newText = String(bytes: edit.replacement, encoding: .utf8) else {
       logger.fault("Failed to get String from UTF-8 bytes \(edit.replacement)")
       return nil

--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -74,13 +74,8 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
     if !self.range.overlaps(range) {
       return .skipChildren
     }
-    guard let rangeLowerBound = snapshot.position(of: range.lowerBound),
-      let rangeUpperBound = snapshot.position(of: range.upperBound),
-      let selectionLowerBound = snapshot.position(of: selection.lowerBound),
-      let selectionUpperBound = snapshot.position(of: selection.upperBound)
-    else {
-      return .skipChildren
-    }
+    let positionRange = snapshot.range(of: range)
+    let selectionPositionRange = snapshot.range(of: selection)
 
     // Record MARK comments on the node's leading and trailing trivia in `result` not as a child of `node`.
     visit(node.leadingTrivia, position: node.position)
@@ -94,8 +89,8 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
       DocumentSymbol(
         name: name,
         kind: symbolKind,
-        range: rangeLowerBound..<rangeUpperBound,
-        selectionRange: selectionLowerBound..<selectionUpperBound,
+        range: positionRange,
+        selectionRange: selectionPositionRange,
         children: children
       )
     )
@@ -146,17 +141,13 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
         let trimmedComment = commentText.trimmingCharacters(in: CharacterSet(["/", "*"]).union(.whitespaces))
         if trimmedComment.starts(with: markPrefix) {
           let markText = trimmedComment.dropFirst(markPrefix.count)
-          guard let rangeLowerBound = snapshot.position(of: position),
-            let rangeUpperBound = snapshot.position(of: position.advanced(by: piece.sourceLength.utf8Length))
-          else {
-            break
-          }
+          let range = snapshot.range(of: position..<position.advanced(by: piece.sourceLength.utf8Length))
           result.append(
             DocumentSymbol(
               name: String(markText),
               kind: .namespace,
-              range: rangeLowerBound..<rangeUpperBound,
-              selectionRange: rangeLowerBound..<rangeUpperBound,
+              range: range,
+              selectionRange: range,
               children: nil
             )
           )

--- a/Sources/SourceKitLSP/Swift/FoldingRange.swift
+++ b/Sources/SourceKitLSP/Swift/FoldingRange.swift
@@ -195,11 +195,8 @@ fileprivate final class FoldingRangeFinder: SyntaxAnyVisitor {
       return .visitChildren
     }
 
-    guard let start: Position = snapshot.positionOf(utf8Offset: start.utf8Offset),
-      let end: Position = snapshot.positionOf(utf8Offset: end.utf8Offset)
-    else {
-      return .visitChildren
-    }
+    let start = snapshot.positionOf(utf8Offset: start.utf8Offset)
+    let end = snapshot.positionOf(utf8Offset: end.utf8Offset)
     let range: FoldingRange
     if lineFoldingOnly {
       // Since the client cannot fold less than a single line, if the

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -101,10 +101,8 @@ extension SwiftLanguageService {
       ])
 
       let dict = try await self.sourcekitd.send(skreq, fileContents: snapshot.text)
-      if let offset: Int = dict[keys.offset],
-        let position = snapshot.positionOf(utf8Offset: offset)
-      {
-        return InterfaceDetails(uri: uri, position: position)
+      if let offset: Int = dict[keys.offset] {
+        return InterfaceDetails(uri: uri, position: snapshot.positionOf(utf8Offset: offset))
       } else {
         return InterfaceDetails(uri: uri, position: nil)
       }

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -48,26 +48,26 @@ struct SemanticRefactoring {
       }
       edits.forEach { _, value in
         // The LSP is zero based, but semantic_refactoring is one based.
-        if let startLine: Int = value[keys.line],
+        guard let startLine: Int = value[keys.line],
           let startColumn: Int = value[keys.column],
-          let startPosition = snapshot.positionOf(
-            zeroBasedLine: startLine - 1,
-            utf8Column: startColumn - 1
-          ),
           let endLine: Int = value[keys.endLine],
           let endColumn: Int = value[keys.endColumn],
-          let endPosition = snapshot.positionOf(
-            zeroBasedLine: endLine - 1,
-            utf8Column: endColumn - 1
-          ),
           let text: String = value[keys.text]
-        {
-          // Snippets are only supported in code completion.
-          // Remove SourceKit placeholders in refactoring actions because they can't be represented in the editor properly.
-          let textWithSnippets = rewriteSourceKitPlaceholders(in: text, clientSupportsSnippets: false)
-          let edit = TextEdit(range: startPosition..<endPosition, newText: textWithSnippets)
-          textEdits.append(edit)
+        else {
+          return true  // continue
         }
+        let startPosition = snapshot.positionOf(
+          zeroBasedLine: startLine - 1,
+          utf8Column: startColumn - 1
+        )
+        let endPosition = snapshot.positionOf(
+          zeroBasedLine: endLine - 1,
+          utf8Column: endColumn - 1
+        )
+        // Snippets are only supported in code completion.
+        // Remove SourceKit placeholders in refactoring actions because they can't be represented in the editor properly.
+        let textWithSnippets = rewriteSourceKitPlaceholders(in: text, clientSupportsSnippets: false)
+        textEdits.append(TextEdit(range: startPosition..<endPosition, newText: textWithSnippets))
         return true
       }
       return true
@@ -84,12 +84,6 @@ struct SemanticRefactoring {
 
 /// An error from a semantic refactoring request.
 enum SemanticRefactoringError: Error {
-  /// The given position range is invalid.
-  case invalidRange(Range<Position>)
-
-  /// The given position failed to convert to UTF-8.
-  case failedToRetrieveOffset(Range<Position>)
-
   /// The underlying sourcekitd request failed with the given error.
   case responseError(ResponseError)
 
@@ -100,10 +94,6 @@ enum SemanticRefactoringError: Error {
 extension SemanticRefactoringError: CustomStringConvertible {
   var description: String {
     switch self {
-    case .invalidRange(let range):
-      return "failed to refactor due to invalid range: \(range)"
-    case .failedToRetrieveOffset(let range):
-      return "Failed to convert range to UTF-8 offset: \(range)"
     case .responseError(let error):
       return "\(error)"
     case .noEditsNeeded(let url):
@@ -128,14 +118,9 @@ extension SwiftLanguageService {
 
     let uri = refactorCommand.textDocument.uri
     let snapshot = try self.documentManager.latestSnapshot(uri)
-    guard let offsetRange = snapshot.utf8OffsetRange(of: refactorCommand.positionRange) else {
-      throw SemanticRefactoringError.failedToRetrieveOffset(refactorCommand.positionRange)
-    }
     let line = refactorCommand.positionRange.lowerBound.line
     let utf16Column = refactorCommand.positionRange.lowerBound.utf16index
-    guard let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column) else {
-      throw SemanticRefactoringError.invalidRange(refactorCommand.positionRange)
-    }
+    let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column)
 
     let skreq = sourcekitd.dictionary([
       keys.request: self.requests.semanticRefactoring,
@@ -146,7 +131,7 @@ extension SwiftLanguageService {
       // LSP is zero based, but this request is 1 based.
       keys.line: line + 1,
       keys.column: utf8Column + 1,
-      keys.length: offsetRange.count,
+      keys.length: snapshot.utf8OffsetRange(of: refactorCommand.positionRange).count,
       keys.actionUID: self.sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!,
       keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
     ])

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -107,14 +107,7 @@ extension SyntaxClassifiedRange {
       return SyntaxHighlightingTokens(tokens: [])
     }
 
-    guard
-      let start: Position = snapshot.positionOf(utf8Offset: self.offset),
-      let end: Position = snapshot.positionOf(utf8Offset: self.endOffset)
-    else {
-      return SyntaxHighlightingTokens(tokens: [])
-    }
-
-    let multiLineRange = start..<end
+    let multiLineRange = snapshot.positionOf(utf8Offset: self.offset)..<snapshot.positionOf(utf8Offset: self.endOffset)
     let ranges = multiLineRange.splitToSingleLineRanges(in: snapshot)
 
     let tokens = ranges.map {

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -654,15 +654,9 @@ extension SwiftLanguageService {
           return .skipChildren
         }
 
-        guard let startPosition = snapshot.position(of: node.position),
-          let endPosition = snapshot.position(of: node.endPosition)
-        else {
-          return .skipChildren
-        }
-
         result.append(
           ColorInformation(
-            range: startPosition..<endPosition,
+            range: snapshot.range(of: node.position..<node.endPosition),
             color: Color(red: red, green: green, blue: blue, alpha: alpha)
           )
         )
@@ -940,28 +934,37 @@ extension DocumentSnapshot {
 
   /// Converts the given UTF-8 offset to `String.Index`.
   ///
-  /// If the offset is after the end of the snapshot, returns `nil` and logs a fault containing the file and line of
-  /// the caller (from `callerFile` and `callerLine`).
-  func indexOf(utf8Offset: Int, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> String.Index? {
-    guard let index = text.utf8.index(text.startIndex, offsetBy: utf8Offset, limitedBy: text.endIndex) else {
+  /// If the offset is out-of-bounds of the snapshot, returns the closest valid index and logs a fault containing the
+  /// file and line of the caller (from `callerFile` and `callerLine`).
+  func indexOf(utf8Offset: Int, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> String.Index {
+    guard utf8Offset >= 0 else {
       logger.fault(
         """
-        Unable to get String index for UTF-8 offset \(utf8Offset) because offset is out of range \
+        UTF-8 offset \(utf8Offset) is negative while converting it to String.Index \
         (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
         """
       )
-      return nil
+      return text.startIndex
+    }
+    guard let index = text.utf8.index(text.startIndex, offsetBy: utf8Offset, limitedBy: text.endIndex) else {
+      logger.fault(
+        """
+        UTF-8 offset \(utf8Offset) is past end of file while converting it to String.Index \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return text.endIndex
     }
     return index
   }
 
-  // MARK: Position <-> Raw UTF-8
+  // MARK: Position <-> Raw UTF-8 offset
 
   /// Converts the given UTF-16-based line:column position to the UTF-8 offset of that position within the source file.
   ///
-  /// If `position` does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
-  func utf8Offset(of position: Position, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> Int? {
+  /// If `position` does not refer to a valid position with in the snapshot, returns the offset of the closest valid
+  /// position and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  func utf8Offset(of position: Position, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> Int {
     return lineTable.utf8OffsetOf(
       line: position.line,
       utf16Column: position.utf16index,
@@ -970,13 +973,41 @@ extension DocumentSnapshot {
     )
   }
 
+  /// Converts the given UTF-8 offset to a UTF-16-based line:column position.
+  ///
+  /// If the offset is after the end of the snapshot, returns `nil` and logs a fault containing the file and line of
+  /// the caller (from `callerFile` and `callerLine`).
+  func positionOf(utf8Offset: Int, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> Position {
+    let (line, utf16Column) = lineTable.lineAndUTF16ColumnOf(
+      utf8Offset: utf8Offset,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
+    return Position(line: line, utf16index: utf16Column)
+  }
+
+  /// Converts the given UTF-16 based line:column range to a UTF-8 based offset range.
+  ///
+  /// If the bounds of the range do not refer to a valid positions with in the snapshot, this function adjusts them to
+  /// the closest valid positions and logs a fault containing the file and line of the caller (from `callerFile` and
+  /// `callerLine`).
+  func utf8OffsetRange(
+    of range: Range<Position>,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> Range<Int> {
+    let startOffset = utf8Offset(of: range.lowerBound, callerFile: callerFile, callerLine: callerLine)
+    let endOffset = utf8Offset(of: range.upperBound, callerFile: callerFile, callerLine: callerLine)
+    return startOffset..<endOffset
+  }
+
   // MARK: Position <-> String.Index
 
-  /// Converts the given UTF-16-based `line:column`` position to a `String.Index`.
+  /// Converts the given UTF-16-based `line:column` position to a `String.Index`.
   ///
-  /// If `position` does not refer to a valid position with in the snapshot, returns `nil` and logs a fault
-  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
-  func index(of position: Position, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> String.Index? {
+  /// If `position` does not refer to a valid position with in the snapshot, returns the index of the closest valid
+  /// position and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  func index(of position: Position, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> String.Index {
     return lineTable.stringIndexOf(
       line: position.line,
       utf16Column: position.utf16index,
@@ -985,60 +1016,35 @@ extension DocumentSnapshot {
     )
   }
 
-  /// Converts the given UTF-16 based line:column range to a UTF-8 based offset range.
+  /// Converts the given UTF-16-based `line:column` range to a `String.Index` range.
   ///
-  /// If either the lower or upper bound of `range` do not refer to valid positions with in the snapshot, returns
-  /// `nil` and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
-  func utf8OffsetRange(
+  /// If the bounds of the range do not refer to a valid positions with in the snapshot, this function adjusts them to
+  /// the closest valid positions and logs a fault containing the file and line of the caller (from `callerFile` and
+  /// `callerLine`).
+  func indexRange(
     of range: Range<Position>,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Range<Int>? {
-    guard let startOffset = utf8Offset(of: range.lowerBound, callerFile: callerFile, callerLine: callerLine),
-      let endOffset = utf8Offset(of: range.upperBound, callerFile: callerFile, callerLine: callerLine)
-    else {
-      return nil
-    }
-    return startOffset..<endOffset
-  }
-
-  /// Converts the given UTF-8 offset to a UTF-16-based line:column position.
-  ///
-  /// If the offset is after the end of the snapshot, returns `nil` and logs a fault containing the file and line of
-  /// the caller (from `callerFile` and `callerLine`).
-  func positionOf(utf8Offset: Int, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> Position? {
-    guard
-      let (line, utf16Column) = lineTable.lineAndUTF16ColumnOf(
-        utf8Offset: utf8Offset,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
-    return Position(line: line, utf16index: utf16Column)
+  ) -> Range<String.Index> {
+    return self.index(of: range.lowerBound)..<self.index(of: range.upperBound)
   }
 
   /// Converts the given UTF-8 based line:column position to a UTF-16 based line-column position.
   ///
-  /// If the UTF-8 based line:column pair does not refer to a valid position within the snapshot, returns `nil` and logs
-  /// a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the UTF-8 based line:column pair does not refer to a valid position within the snapshot, returns the closest
+  /// valid position and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   func positionOf(
     zeroBasedLine: Int,
     utf8Column: Int,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Position? {
-    guard
-      let utf16Column = lineTable.utf16ColumnAt(
-        line: zeroBasedLine,
-        utf8Column: utf8Column,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
+  ) -> Position {
+    let utf16Column = lineTable.utf16ColumnAt(
+      line: zeroBasedLine,
+      utf8Column: utf8Column,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
     return Position(line: zeroBasedLine, utf16index: utf16Column)
   }
 
@@ -1046,61 +1052,56 @@ extension DocumentSnapshot {
 
   /// Converts the given UTF-8-offset-based `AbsolutePosition` to a UTF-16-based line:column.
   ///
-  /// If the `AbsolutePosition` out of bounds of the source file, returns `nil` and logs a fault containing the file and
-  /// line of the caller (from `callerFile` and `callerLine`).
+  /// If the `AbsolutePosition` out of bounds of the source file, returns the closest valid position and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   func position(
     of position: AbsolutePosition,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Position? {
+  ) -> Position {
     return positionOf(utf8Offset: position.utf8Offset, callerFile: callerFile, callerLine: callerLine)
   }
 
   /// Converts the given UTF-16-based line:column `Position` to a UTF-8-offset-based `AbsolutePosition`.
   ///
-  /// If the UTF-16 based line:column pair does not refer to a valid position within the snapshot, returns `nil` and
-  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the UTF-16 based line:column pair does not refer to a valid position within the snapshot, returns the closest
+  /// valid position and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   func absolutePosition(
     of position: Position,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> AbsolutePosition? {
-    guard let offset = utf8Offset(of: position, callerFile: callerFile, callerLine: callerLine) else {
-      return nil
-    }
+  ) -> AbsolutePosition {
+    let offset = utf8Offset(of: position, callerFile: callerFile, callerLine: callerLine)
     return AbsolutePosition(utf8Offset: offset)
   }
 
   /// Converts the lower and upper bound of the given UTF-8-offset-based `AbsolutePosition` range to a UTF-16-based
   /// line:column range for use in LSP.
   ///
-  /// If either the lower or the upper bound of the range is out of bounds of the source file, returns `nil` and logs
-  /// a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the bounds of the range do not refer to a valid positions with in the snapshot, this function adjusts them to
+  /// the closest valid positions and logs a fault containing the file and line of the caller (from `callerFile` and
+  /// `callerLine`).
   func range(
     of range: Range<AbsolutePosition>,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Range<Position>? {
-    guard let lowerBound = self.position(of: range.lowerBound, callerFile: callerFile, callerLine: callerLine),
-      let upperBound = self.position(of: range.upperBound, callerFile: callerFile, callerLine: callerLine)
-    else {
-      return nil
-    }
+  ) -> Range<Position> {
+    let lowerBound = self.position(of: range.lowerBound, callerFile: callerFile, callerLine: callerLine)
+    let upperBound = self.position(of: range.upperBound, callerFile: callerFile, callerLine: callerLine)
     return lowerBound..<upperBound
   }
 
   /// Converts the given UTF-16-based line:column range to a UTF-8-offset-based `ByteSourceRange`.
   ///
-  /// If either the lower or upper bound of the range does not refer to a valid position within the snapshot, returns
-  /// `nil` and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the bounds of the range do not refer to a valid positions with in the snapshot, this function adjusts them to
+  /// the closest valid positions and logs a fault containing the file and line of the caller (from `callerFile` and
+  /// `callerLine`).
   func byteSourceRange(
     of range: Range<Position>,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> ByteSourceRange? {
-    guard let utf8OffsetRange = utf8OffsetRange(of: range, callerFile: callerFile, callerLine: callerLine) else {
-      return nil
-    }
+  ) -> ByteSourceRange {
+    let utf8OffsetRange = utf8OffsetRange(of: range, callerFile: callerFile, callerLine: callerLine)
     return ByteSourceRange(offset: utf8OffsetRange.startIndex, length: utf8OffsetRange.count)
   }
 
@@ -1108,13 +1109,13 @@ extension DocumentSnapshot {
 
   /// Converts the given UTF-8-based line:column `RenamedLocation` to a UTF-16-based line:column `Position`.
   ///
-  /// If the UTF-8 based line:column pair does not refer to a valid position within the snapshot, returns `nil` and
-  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the UTF-8 based line:column pair does not refer to a valid position within the snapshot, returns the closest
+  /// valid position and logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
   func position(
     of renameLocation: RenameLocation,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Position? {
+  ) -> Position {
     return positionOf(
       zeroBasedLine: renameLocation.line - 1,
       utf8Column: renameLocation.utf8Column - 1,
@@ -1127,13 +1128,13 @@ extension DocumentSnapshot {
 
   /// Converts the given UTF-8-offset-based `SymbolLocation` to a UTF-16-based line:column `Position`.
   ///
-  /// If the UTF-8 offset is out-of-bounds of the snapshot, returns `nil` and  logs a fault containing the file and line
-  /// of the caller (from `callerFile` and `callerLine`).
+  /// If the UTF-8 offset is out-of-bounds of the snapshot, returns the closest valid position and logs a fault
+  /// containing the file and line of the caller (from `callerFile` and `callerLine`).
   func position(
     of symbolLocation: SymbolLocation,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> Position? {
+  ) -> Position {
     return positionOf(
       zeroBasedLine: symbolLocation.line - 1,
       utf8Column: symbolLocation.utf8Column - 1,
@@ -1146,23 +1147,20 @@ extension DocumentSnapshot {
 
   /// Converts the given UTF-8-based line:column `RenamedLocation` to a UTF-8-offset-based `AbsolutePosition`.
   ///
-  /// If the UTF-8 based line:column pair does not refer to a valid position within the snapshot, returns `nil` and
-  /// logs a fault containing the file and line of the caller (from `callerFile` and `callerLine`).
+  /// If the UTF-8 based line:column pair does not refer to a valid position within the snapshot, returns the offset of
+  /// the closest valid position and logs a fault containing the file and line of the caller (from `callerFile` and
+  /// `callerLine`).
   func absolutePosition(
     of renameLocation: RenameLocation,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
-  ) -> AbsolutePosition? {
-    guard
-      let utf8Offset = lineTable.utf8OffsetOf(
-        line: renameLocation.line - 1,
-        utf8Column: renameLocation.utf8Column - 1,
-        callerFile: callerFile,
-        callerLine: callerLine
-      )
-    else {
-      return nil
-    }
+  ) -> AbsolutePosition {
+    let utf8Offset = lineTable.utf8OffsetOf(
+      line: renameLocation.line - 1,
+      utf8Column: renameLocation.utf8Column - 1,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
     return AbsolutePosition(utf8Offset: utf8Offset)
   }
 }

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokenParser.swift
@@ -31,7 +31,6 @@ struct SyntaxHighlightingTokenParser {
 
     if let offset: Int = response[keys.offset],
       var length: Int = response[keys.length],
-      let start: Position = snapshot.positionOf(utf8Offset: offset),
       let skKind: sourcekitd_api_uid_t = response[keys.kind],
       case (let kind, var modifiers)? = parseKindAndModifiers(skKind)
     {
@@ -39,7 +38,7 @@ struct SyntaxHighlightingTokenParser {
       // If the name is escaped in backticks, we need to add two characters to the
       // length for the backticks.
       if modifiers.contains(.declaration),
-        let index = snapshot.indexOf(utf8Offset: offset), snapshot.text[index] == "`"
+        snapshot.text[snapshot.indexOf(utf8Offset: offset)] == "`"
       {
         length += 2
       }
@@ -48,17 +47,15 @@ struct SyntaxHighlightingTokenParser {
         modifiers.insert(.defaultLibrary)
       }
 
-      if let end: Position = snapshot.positionOf(utf8Offset: offset + length) {
-        let multiLineRange = start..<end
-        let ranges = multiLineRange.splitToSingleLineRanges(in: snapshot)
+      let multiLineRange = snapshot.positionOf(utf8Offset: offset)..<snapshot.positionOf(utf8Offset: offset + length)
+      let ranges = multiLineRange.splitToSingleLineRanges(in: snapshot)
 
-        tokens.tokens += ranges.map {
-          SyntaxHighlightingToken(
-            range: $0,
-            kind: kind,
-            modifiers: modifiers
-          )
-        }
+      tokens.tokens += ranges.map {
+        SyntaxHighlightingToken(
+          range: $0,
+          kind: kind,
+          modifiers: modifiers
+        )
       }
     }
 
@@ -217,14 +214,7 @@ extension Range<Position> {
       return [self]
     }
 
-    guard let startIndex = snapshot.index(of: lowerBound),
-      let endIndex = snapshot.index(of: upperBound)
-    else {
-      logger.fault("Range \(self) reaches outside of the document")
-      return [self]
-    }
-
-    let text = snapshot.text[startIndex..<endIndex]
+    let text = snapshot.text[snapshot.indexRange(of: self)]
     let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
 
     return

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -60,8 +60,6 @@ struct VariableTypeInfo {
 
     guard let offset: Int = dict[keys.variableOffset],
       let length: Int = dict[keys.variableLength],
-      let startIndex = snapshot.positionOf(utf8Offset: offset),
-      let endIndex = snapshot.positionOf(utf8Offset: offset + length),
       let printedType: String = dict[keys.variableType],
       let hasExplicitType: Bool = dict[keys.variableTypeExplicit]
     else {
@@ -69,7 +67,7 @@ struct VariableTypeInfo {
     }
     let tokenAtOffset = syntaxTree.token(at: AbsolutePosition(utf8Offset: offset))
 
-    self.range = startIndex..<endIndex
+    self.range = snapshot.positionOf(utf8Offset: offset)..<snapshot.positionOf(utf8Offset: offset + length)
     self.printedType = printedType
     self.hasExplicitType = hasExplicitType
     self.canBeFollowedByTypeAnnotation = tokenAtOffset?.canBeFollowedByTypeAnnotation ?? true
@@ -93,10 +91,9 @@ extension SwiftLanguageService {
       keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
     ])
 
-    if let range = range,
-      let start = snapshot.utf8Offset(of: range.lowerBound),
+    if let range = range {
+      let start = snapshot.utf8Offset(of: range.lowerBound)
       let end = snapshot.utf8Offset(of: range.upperBound)
-    {
       skreq.set(keys.offset, to: start)
       skreq.set(keys.length, to: end - start)
     }

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -105,10 +105,8 @@ extension SourceKitLSPServer {
       let symbolPosition: Position
       if let snapshot = try? documentManager.latestSnapshot(
         DocumentURI(URL(fileURLWithPath: testSymbolOccurrence.location.path))
-      ),
-        let position = snapshot.position(of: testSymbolOccurrence.location)
-      {
-        symbolPosition = position
+      ) {
+        symbolPosition = snapshot.position(of: testSymbolOccurrence.location)
       } else {
         // Technically, we always need to convert UTF-8 columns to UTF-16 columns, which requires reading the file.
         // In practice, they are almost always the same.
@@ -256,13 +254,10 @@ private final class SyntacticSwiftXCTestScanner: SyntaxVisitor {
         // declarations are probably less common than helper functions that start with `test` and have a return type.
         return nil
       }
-      guard
-        let range = snapshot.range(
-          of: function.positionAfterSkippingLeadingTrivia..<function.endPositionBeforeTrailingTrivia
-        )
-      else {
-        return nil
-      }
+      let range = snapshot.range(
+        of: function.positionAfterSkippingLeadingTrivia..<function.endPositionBeforeTrailingTrivia
+      )
+
       return TestItem(
         id: "\(containerName)/\(function.name.text)()",
         label: "\(function.name.text)()",
@@ -292,10 +287,7 @@ private final class SyntacticSwiftXCTestScanner: SyntaxVisitor {
       // Don't report a test class if it doesn't contain any test methods.
       return .visitChildren
     }
-    guard let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
-    else {
-      return .visitChildren
-    }
+    let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
     let testItem = TestItem(
       id: node.name.text,
       label: node.name.text,


### PR DESCRIPTION
Instead of returning `nil` to indicate that the position conversion failed, log a fault and perform a best-effort recovery.

I think this allows us to perform better recovery and also makes code calling these position conversions a lot simpler because it doesn’t need to make decisions about what to do if position conversions fail.