### PR TITLE
Implement a syntactic workspace-wide test index

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -316,6 +316,17 @@ extension BuildServerBuildSystem: BuildSystem {
 
     return .unhandled
   }
+
+  public func testFiles() async -> [DocumentURI] {
+    // BuildServerBuildSystem does not support syntactic test discovery
+    // (https://github.com/apple/sourcekit-lsp/issues/1173).
+    return []
+  }
+
+  public func addTestFilesDidChangeCallback(_ callback: @escaping () async -> Void) {
+    // BuildServerBuildSystem does not support syntactic test discovery
+    // (https://github.com/apple/sourcekit-lsp/issues/1173).
+  }
 }
 
 private func loadBuildServerConfig(path: AbsolutePath, fileSystem: FileSystem) throws -> BuildServerConfig {

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -87,6 +87,18 @@ public protocol BuildSystem: AnyObject, Sendable {
   func filesDidChange(_ events: [FileEvent]) async
 
   func fileHandlingCapability(for uri: DocumentURI) async -> FileHandlingCapability
+
+  /// Returns the list of files that might contain test cases.
+  ///
+  /// The returned file list is an over-approximation. It might contain tests from non-test targets or files that don't
+  /// actually contain any tests. Keeping this list as minimal as possible helps reduce the amount of work that the
+  /// syntactic test indexer needs to perform.
+  func testFiles() async -> [DocumentURI]
+
+  /// Adds a callback that should be called when the value returned by `testFiles()` changes.
+  ///
+  /// The callback might also be called without an actual change to `testFiles`.
+  func addTestFilesDidChangeCallback(_ callback: @Sendable @escaping () async -> Void) async
 }
 
 public let buildTargetsNotSupported =

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -176,6 +176,10 @@ extension BuildSystemManager {
       fallbackBuildSystem != nil ? .fallback : .unhandled
     )
   }
+
+  public func testFiles() async -> [DocumentURI] {
+    return await buildSystem?.testFiles() ?? []
+  }
 }
 
 extension BuildSystemManager: BuildSystemDelegate {

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -68,6 +68,25 @@ public struct IndexedSingleSwiftFileTestProject {
 
     if let sdk = TibsBuilder.defaultSDKPath {
       compilerArguments += ["-sdk", sdk]
+
+      // The following are needed so we can import XCTest
+      let sdkUrl = URL(fileURLWithPath: sdk)
+      let usrLibDir =
+        sdkUrl
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("usr")
+        .appendingPathComponent("lib")
+      let frameworksDir =
+        sdkUrl
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Library")
+        .appendingPathComponent("Frameworks")
+      compilerArguments += [
+        "-I", usrLibDir.path,
+        "-F", frameworksDir.path,
+      ]
     }
 
     let compilationDatabase = JSONCompilationDatabase(

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -142,4 +142,13 @@ public class MultiFileTestProject {
     }
     return DocumentPositions(markedText: fileData.markedText)[marker]
   }
+
+  public func range(from fromMarker: String, to toMarker: String, in fileName: String) throws -> Range<Position> {
+    return try position(of: fromMarker, in: fileName)..<position(of: toMarker, in: fileName)
+  }
+
+  public func location(from fromMarker: String, to toMarker: String, in fileName: String) throws -> Location {
+    let range = try self.range(from: fromMarker, to: toMarker, in: fileName)
+    return Location(uri: try self.uri(for: fileName), range: range)
+  }
 }

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -40,6 +40,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
     manifest: String = SwiftPMTestProject.defaultPackageManifest,
     workspaces: (URL) -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
     build: Bool = false,
+    allowBuildFailure: Bool = false,
     usePullDiagnostics: Bool = true,
     testName: String = #function
   ) async throws {
@@ -66,7 +67,11 @@ public class SwiftPMTestProject: MultiFileTestProject {
     )
 
     if build {
-      try await Self.build(at: self.scratchDirectory)
+      if allowBuildFailure {
+        try? await Self.build(at: self.scratchDirectory)
+      } else {
+        try await Self.build(at: self.scratchDirectory)
+      }
     }
     // Wait for the indexstore-db to finish indexing
     _ = try await testClient.send(PollIndexRequest())

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -362,7 +362,7 @@ public struct DocumentPositions {
     }
   }
 
-  init(markedText: String) {
+  public init(markedText: String) {
     let (markers, textWithoutMarker) = extractMarkers(markedText)
     self.init(markers: markers, textWithoutMarkers: textWithoutMarker)
   }

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(SourceKitLSP STATIC
   CapabilityRegistry.swift
   DocumentManager.swift
+  DocumentSnapshot+FromFileContents.swift
   IndexOutOfDateChecker.swift
   IndexStoreDB+MainFilesProvider.swift
   LanguageService.swift
@@ -12,6 +13,7 @@ add_library(SourceKitLSP STATIC
   SourceKitLSPCommandMetadata.swift
   SourceKitLSPServer.swift
   SourceKitLSPServer+Options.swift
+  SymbolLocation+DocumentURI.swift
   TestDiscovery.swift
   WorkDoneProgressManager.swift
   Workspace.swift
@@ -44,9 +46,10 @@ target_sources(SourceKitLSP PRIVATE
   Swift/SwiftLanguageService.swift
   Swift/SwiftTestingScanner.swift
   Swift/SymbolInfo.swift
+  Swift/SyntacticTestIndex.swift
   Swift/SyntaxHighlightingToken.swift
-  Swift/SyntaxHighlightingTokens.swift
   Swift/SyntaxHighlightingTokenParser.swift
+  Swift/SyntaxHighlightingTokens.swift
   Swift/SyntaxTreeManager.swift
   Swift/VariableTypeInfo.swift
 )

--- a/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SKSupport
+
+public extension DocumentSnapshot {
+  /// Creates a `DocumentSnapshot` with the file contents from disk.
+  ///
+  /// Throws an error if the file could not be read.
+  /// Returns `nil` if the `uri` is not a file URL.
+  init?(withContentsFromDisk uri: DocumentURI, language: Language) throws {
+    guard let url = uri.fileURL else {
+      return nil
+    }
+    try self.init(withContentsFromDisk: url, language: language)
+  }
+
+  /// Creates a `DocumentSnapshot` with the file contents from disk.
+  ///
+  /// Throws an error if the file could not be read.
+  init(withContentsFromDisk url: URL, language: Language) throws {
+    let contents = try String(contentsOf: url)
+    self.init(uri: DocumentURI(url), language: language, version: 0, lineTable: LineTable(contents))
+  }
+}

--- a/Sources/SourceKitLSP/IndexOutOfDateChecker.swift
+++ b/Sources/SourceKitLSP/IndexOutOfDateChecker.swift
@@ -55,7 +55,7 @@ struct IndexOutOfDateChecker {
 
   private func modificationDateUncached(of url: URL) throws -> ModificationTime {
     do {
-      let attributes = try FileManager.default.attributesOfItem(atPath: url.path())
+      let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
       guard let modificationDate = attributes[FileAttributeKey.modificationDate] as? Date else {
         throw Error.fileAttributesDontHaveModificationDate
       }
@@ -124,7 +124,7 @@ struct IndexOutOfDateChecker {
     if fileHasInMemoryModifications(filePath) {
       return false
     }
-    guard let lastUnitDate = index.dateOfLatestUnitFor(filePath: filePath.path()) else {
+    guard let lastUnitDate = index.dateOfLatestUnitFor(filePath: filePath.path) else {
       return false
     }
     do {

--- a/Sources/SourceKitLSP/IndexOutOfDateChecker.swift
+++ b/Sources/SourceKitLSP/IndexOutOfDateChecker.swift
@@ -13,13 +13,19 @@
 import Foundation
 import IndexStoreDB
 import LSPLogging
+import LanguageServerProtocol
 
 /// Helper class to check if symbols from the index are up-to-date or if the source file has been modified after it was
-/// indexed.
+/// indexed. Modifications include both changes to the file on disk as well as modifications to the file that have not
+/// been saved to disk (ie. changes that only live in `DocumentManager`).
 ///
 /// The checker caches mod dates of source files. It should thus not be long lived. Its intended lifespan is the
 /// evaluation of a single request.
 struct IndexOutOfDateChecker {
+  /// The `DocumentManager` that holds the in-memory file contents. We consider the index out-of-date for all files that
+  /// have in-memory changes.
+  private let documentManager: DocumentManager
+
   /// The last modification time of a file. Can also represent the fact that the file does not exist.
   private enum ModificationTime {
     case fileDoesNotExist
@@ -37,12 +43,19 @@ struct IndexOutOfDateChecker {
     }
   }
 
-  /// File paths to modification times that have already been computed.
-  private var modTimeCache: [String: ModificationTime] = [:]
+  /// File URLs to modification times that have already been computed.
+  private var modTimeCache: [URL: ModificationTime] = [:]
 
-  private func modificationDateUncached(of path: String) throws -> ModificationTime {
+  /// Caches whether a file URL has modifications in `documentManager` that haven't been saved to disk yet.
+  private var hasFileInMemoryModificationsCache: [URL: Bool] = [:]
+
+  init(documentManager: DocumentManager) {
+    self.documentManager = documentManager
+  }
+
+  private func modificationDateUncached(of url: URL) throws -> ModificationTime {
     do {
-      let attributes = try FileManager.default.attributesOfItem(atPath: path)
+      let attributes = try FileManager.default.attributesOfItem(atPath: url.path())
       guard let modificationDate = attributes[FileAttributeKey.modificationDate] as? Date else {
         throw Error.fileAttributesDontHaveModificationDate
       }
@@ -52,20 +65,46 @@ struct IndexOutOfDateChecker {
     }
   }
 
-  private mutating func modificationDate(of path: String) throws -> ModificationTime {
-    if let cached = modTimeCache[path] {
+  private mutating func modificationDate(of url: URL) throws -> ModificationTime {
+    if let cached = modTimeCache[url] {
       return cached
     }
-    let modTime = try modificationDateUncached(of: path)
-    modTimeCache[path] = modTime
+    let modTime = try modificationDateUncached(of: url)
+    modTimeCache[url] = modTime
     return modTime
+  }
+
+  private func hasFileInMemoryModificationsUncached(at url: URL) -> Bool {
+    guard let document = try? documentManager.latestSnapshot(DocumentURI(url)) else {
+      return false
+    }
+
+    guard let onDiskFileContents = try? String(contentsOf: url, encoding: .utf8) else {
+      // If we can't read the file on disk, it's an in-memory document
+      return true
+    }
+    return onDiskFileContents != document.lineTable.content
+  }
+
+  /// Returns `true` if the file has modified in-memory state, ie. if the version stored in the `DocumentManager` is
+  /// different than the version on disk.
+  public mutating func fileHasInMemoryModifications(_ url: URL) -> Bool {
+    if let cached = hasFileInMemoryModificationsCache[url] {
+      return cached
+    }
+    let hasInMemoryModifications = hasFileInMemoryModificationsUncached(at: url)
+    hasFileInMemoryModificationsCache[url] = hasInMemoryModifications
+    return hasInMemoryModifications
   }
 
   /// Returns `true` if the source file for the given symbol location exists and has not been modified after it has been
   /// indexed.
   mutating func isUpToDate(_ symbolLocation: SymbolLocation) -> Bool {
+    if fileHasInMemoryModifications(URL(fileURLWithPath: symbolLocation.path)) {
+      return false
+    }
     do {
-      let sourceFileModificationDate = try modificationDate(of: symbolLocation.path)
+      let sourceFileModificationDate = try modificationDate(of: URL(fileURLWithPath: symbolLocation.path))
       switch sourceFileModificationDate {
       case .fileDoesNotExist:
         return false
@@ -81,8 +120,11 @@ struct IndexOutOfDateChecker {
   /// Return `true` if a unit file has been indexed for the given file path after its last modification date.
   ///
   /// This means that at least a single build configuration of this file has been indexed since its last modification.
-  mutating func indexHasUpToDateUnit(for filePath: String, index: IndexStoreDB) -> Bool {
-    guard let lastUnitDate = index.dateOfLatestUnitFor(filePath: filePath) else {
+  mutating func indexHasUpToDateUnit(for filePath: URL, index: IndexStoreDB) -> Bool {
+    if fileHasInMemoryModifications(filePath) {
+      return false
+    }
+    guard let lastUnitDate = index.dateOfLatestUnitFor(filePath: filePath.path()) else {
       return false
     }
     do {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -198,6 +198,14 @@ fileprivate enum TaskMetadata: DependencyTracker {
   /// might be relying on this task to take effect.
   case globalConfigurationChange
 
+  /// A request that depends on the state of all documents.
+  ///
+  /// These requests wait for `documentUpdate` tasks for all documents to finish before being executed.
+  ///
+  /// Requests that only read the semantic index and are not affected by changes to the in-memory file contents should
+  /// `freestanding` requests.
+  case workspaceRequest
+
   /// Changes the contents of the document with the given URI.
   ///
   /// Any other updates or requests to this document must wait for the
@@ -218,16 +226,30 @@ fileprivate enum TaskMetadata: DependencyTracker {
   /// Whether this request needs to finish before `other` can start executing.
   func isDependency(of other: TaskMetadata) -> Bool {
     switch (self, other) {
+    // globalConfigurationChange
     case (.globalConfigurationChange, _): return true
     case (_, .globalConfigurationChange): return true
+
+    // globalDocumentState
+    case (.workspaceRequest, .workspaceRequest): return false
+    case (.documentUpdate, .workspaceRequest): return true
+    case (.workspaceRequest, .documentUpdate): return true
+    case (.workspaceRequest, .documentRequest): return false
+    case (.documentRequest, .workspaceRequest): return false
+
+    // documentUpdate
     case (.documentUpdate(let selfUri), .documentUpdate(let otherUri)):
       return selfUri == otherUri
     case (.documentUpdate(let selfUri), .documentRequest(let otherUri)):
       return selfUri == otherUri
     case (.documentRequest(let selfUri), .documentUpdate(let otherUri)):
       return selfUri == otherUri
+
+    // documentRequest
     case (.documentRequest, .documentRequest):
       return false
+
+    // freestanding
     case (.freestanding, _):
       return false
     case (_, .freestanding):
@@ -248,7 +270,7 @@ fileprivate enum TaskMetadata: DependencyTracker {
     case let notification as DidChangeTextDocumentNotification:
       self = .documentUpdate(notification.textDocument.uri)
     case is DidChangeWatchedFilesNotification:
-      self = .freestanding
+      self = .globalConfigurationChange
     case is DidChangeWorkspaceFoldersNotification:
       self = .globalConfigurationChange
     case let notification as DidCloseNotebookDocumentNotification:
@@ -372,7 +394,7 @@ fileprivate enum TaskMetadata: DependencyTracker {
     case is WorkspaceSymbolsRequest:
       self = .freestanding
     case is WorkspaceTestsRequest:
-      self = .freestanding
+      self = .workspaceRequest
     default:
       logger.error(
         """
@@ -1624,7 +1646,7 @@ extension SourceKitLSPServer {
     // (e.g. Package.swift doesn't have build settings but affects build
     // settings). Inform the build system about all file changes.
     for workspace in workspaces {
-      await workspace.buildSystemManager.filesDidChange(notification.changes)
+      await workspace.filesDidChange(notification.changes)
     }
   }
 
@@ -1826,7 +1848,7 @@ extension SourceKitLSPServer {
   private func indexToLSPLocation(_ location: SymbolLocation) -> Location? {
     guard !location.path.isEmpty else { return nil }
     return Location(
-      uri: DocumentURI(URL(fileURLWithPath: location.path)),
+      uri: location.documentUri,
       range: Range(
         Position(
           // 1-based -> 0-based
@@ -2584,7 +2606,7 @@ extension WorkspaceSymbolItem {
     )
 
     let symbolLocation = Location(
-      uri: DocumentURI(URL(fileURLWithPath: symbolOccurrence.location.path)),
+      uri: symbolOccurrence.location.documentUri,
       range: Range(symbolPosition)
     )
 

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -180,6 +180,13 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     in snapshot: DocumentSnapshot,
     syntaxTreeManager: SyntaxTreeManager
   ) async -> [TestItem] {
+    guard snapshot.text.contains("Suite") || snapshot.text.contains("Test") else {
+      // If the file contains swift-testing tests, it must contain a `@Suite` or `@Test` attribute.
+      // Only check for the attribute name because the attribute may be module qualified and contain an arbitrary amount
+      // of whitespace.
+      // This is intended to filter out files that obviously do not contain tests.
+      return []
+    }
     let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
     let visitor = SyntacticSwiftTestingTestScanner(snapshot: snapshot, allTestsDisabled: false, parentTypeNames: [])
     visitor.walk(syntaxTree)

--- a/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LSPLogging
+import LanguageServerProtocol
+import SKSupport
+
+/// Task metadata for `SyntacticTestIndexer.indexingQueue`
+fileprivate enum TaskMetadata: DependencyTracker, Equatable {
+  case read
+  case index(DocumentURI)
+
+  /// Reads can be concurrent and files can be indexed concurrently. But we need to wait for all files to finish
+  /// indexing before reading the index.
+  func isDependency(of other: TaskMetadata) -> Bool {
+    switch (self, other) {
+    case (.read, .read):
+      // We allow concurrent reads
+      return false
+    case (.read, .index(_)):
+      // We allow index tasks scheduled after a read task to be be executed before the read.
+      // This effectively means that a `read` requires the index to be updated *at least* up to the state at which the
+      // read was scheduled. If more changes come in in the meantime, it is OK for the read to pick them up. This also
+      // ensures that reads aren't parallelization barriers.
+      return false
+    case (.index(_), .read):
+      // We require all index tasks scheduled before the read to be finished.
+      // This ensures that the index has been updated at least to the state of file at which the read was scheduled.
+      // Adding the dependency also elevates the index task's priorities.
+      return true
+    case (.index(let lhsUri), .index(let rhsUri)):
+      // Technically, we should be able to allow simultaneous indexing of the same file. But conceptually the code
+      // becomes simpler if we don't need to think racing indexing tasks for the same file and it shouldn't make a
+      // performance impact because if the same file state is indexed twice, the second one will realize that the mtime
+      // hasn't changed and thus be a no-op.
+      return lhsUri == rhsUri
+    }
+  }
+}
+
+/// Data from a syntactic scan of a source file for tests.
+fileprivate struct IndexedTests {
+  /// The tests within the source file.
+  let tests: [TestItem]
+
+  /// The modification date of the source file when it was scanned. A file won't get re-scanned if its modification date
+  /// is older or the same as this date.
+  let sourceFileModificationDate: Date
+}
+
+/// Syntactically scans the file at the given URL for tests declared within it.
+///
+/// Does not write the results to the index.
+///
+/// The order of the returned tests is not defined. The results should be sorted before being returned to the editor.
+fileprivate func testItems(in url: URL) async -> [TestItem] {
+  guard url.pathExtension == "swift" else {
+    return []
+  }
+  let syntaxTreeManager = SyntaxTreeManager()
+  let snapshot = orLog("Getting document snapshot for swift-testing scanning") {
+    try DocumentSnapshot(withContentsFromDisk: url, language: .swift)
+  }
+  guard let snapshot else {
+    return []
+  }
+  async let swiftTestingTests = SyntacticSwiftTestingTestScanner.findTestSymbols(
+    in: snapshot,
+    syntaxTreeManager: syntaxTreeManager
+  )
+  async let xcTests = SyntacticSwiftXCTestScanner.findTestSymbols(in: snapshot, syntaxTreeManager: syntaxTreeManager)
+  return await swiftTestingTests + xcTests
+}
+
+actor SyntacticTestIndex {
+  /// The tests discovered by the index.
+  private var indexedTests: [DocumentURI: IndexedTests] = [:]
+
+  /// The queue on which the index is being updated and queried.
+  ///
+  /// Tracking dependencies between tasks within this queue allows us to start indexing tasks in parallel with low
+  /// priority and elevate their priority once a read task comes in, which has higher priority and depends on the
+  /// indexing tasks to finish.
+  private let indexingQueue = AsyncQueue<TaskMetadata>()
+
+  init() {}
+
+  private func removeFilesFromIndex(_ removedFiles: Set<DocumentURI>) {
+    // Cancel any tasks for the removed files to ensure any pending indexing tasks don't re-add index data for the
+    // removed files.
+    self.indexingQueue.cancelTasks(where: { taskMetadata in
+      guard case .index(let uri) = taskMetadata else {
+        return false
+      }
+      return removedFiles.contains(uri)
+    })
+    for removedFile in removedFiles {
+      self.indexedTests[removedFile] = nil
+    }
+  }
+
+  /// Called when the list of files that may contain tests is updated.
+  ///
+  /// All files that are not in the new list of test files will be removed from the index.
+  func listOfTestFilesDidChange(_ testFiles: Set<DocumentURI>) {
+    let testFiles = Set(testFiles)
+    let removedFiles = Set(self.indexedTests.keys.filter { !testFiles.contains($0) })
+    removeFilesFromIndex(removedFiles)
+
+    for testFile in testFiles {
+      rescanFile(testFile)
+    }
+  }
+
+  func filesDidChange(_ events: [FileEvent]) {
+    for fileEvent in events {
+      switch fileEvent.type {
+      case .created:
+        // We don't know if this is a potential test file. It would need to be added to the index via
+        // `listOfTestFilesDidChange`
+        break
+      case .changed:
+        rescanFile(fileEvent.uri)
+      case .deleted:
+        removeFilesFromIndex([fileEvent.uri])
+      default:
+        logger.error("Ignoring unknown FileEvent type \(fileEvent.type.rawValue) in SyntacticTestIndex")
+      }
+    }
+  }
+
+  /// Called when a single file was updated. Just re-scans that file.
+  private func rescanFile(_ uri: DocumentURI) {
+    self.indexingQueue.async(priority: .low, metadata: .index(uri)) {
+      guard let url = uri.fileURL else {
+        logger.log("Not indexing \(uri.forLogging) for swift-testing tests because it is not a file URL")
+        return
+      }
+      if Task.isCancelled {
+        return
+      }
+      guard
+        let fileModificationDate = try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]
+          as? Date
+      else {
+        logger.fault("Not indexing \(uri.forLogging) for tests because the modification date could not be determined")
+        return
+      }
+      if let indexModificationDate = self.indexedTests[uri]?.sourceFileModificationDate,
+        indexModificationDate >= fileModificationDate
+      {
+        // Index already up to date.
+        return
+      }
+      if Task.isCancelled {
+        return
+      }
+      let testItems = await testItems(in: url)
+
+      if Task.isCancelled {
+        // This `isCancelled` check is essential for correctness. When `testFilesDidChange` is called, it cancels all
+        // indexing tasks for files that have been removed. If we didn't have this check, an index task that was already
+        // started might add the file back into `indexedTests`.
+        return
+      }
+      self.indexedTests[uri] = IndexedTests(tests: testItems, sourceFileModificationDate: fileModificationDate)
+    }
+  }
+
+  /// Gets all the tests in the syntactic index.
+  ///
+  /// This waits for any pending document updates to be indexed before returning a result.
+  nonisolated func tests() async -> [TestItem] {
+    let readTask = indexingQueue.async(metadata: .read) {
+      return await self.indexedTests.values.flatMap { $0.tests }
+    }
+    return await readTask.value
+  }
+}

--- a/Sources/SourceKitLSP/SymbolLocation+DocumentURI.swift
+++ b/Sources/SourceKitLSP/SymbolLocation+DocumentURI.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import IndexStoreDB
+import LanguageServerProtocol
+
+extension SymbolLocation {
+  var documentUri: DocumentURI {
+    return DocumentURI(URL(fileURLWithPath: self.path))
+  }
+}

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -458,6 +458,12 @@ class ManualBuildSystem: BuildSystem {
       return .unhandled
     }
   }
+
+  func testFiles() async -> [DocumentURI] {
+    return []
+  }
+
+  func addTestFilesDidChangeCallback(_ callback: @escaping () async -> Void) {}
 }
 
 /// A `BuildSystemDelegate` setup for testing.

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -60,6 +60,12 @@ final class TestBuildSystem: BuildSystem {
       return .unhandled
     }
   }
+
+  func testFiles() async -> [DocumentURI] {
+    return []
+  }
+
+  func addTestFilesDidChangeCallback(_ callback: @escaping () async -> Void) async {}
 }
 
 final class BuildSystemTests: XCTestCase {

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -46,7 +46,7 @@ class DefinitionTests: XCTestCase {
         func 1️⃣doThing()
       }
 
-      struct TestImpl: TestProtocol { 
+      struct TestImpl: TestProtocol {
         func 2️⃣doThing() { }
       }
 
@@ -297,13 +297,7 @@ class DefinitionTests: XCTestCase {
 
     XCTAssertEqual(locations.count, 1)
     let location = try XCTUnwrap(locations.first)
-    XCTAssertEqual(
-      location,
-      Location(
-        uri: try project.uri(for: "LibA.h"),
-        range: try project.position(of: "1️⃣", in: "LibA.h")..<project.position(of: "2️⃣", in: "LibA.h")
-      )
-    )
+    XCTAssertEqual(location, try project.location(from: "1️⃣", to: "2️⃣", in: "LibA.h"))
   }
 
   func testDefinitionOfMethodBetweenModulesObjC() async throws {
@@ -354,13 +348,7 @@ class DefinitionTests: XCTestCase {
 
     XCTAssertEqual(locations.count, 1)
     let location = try XCTUnwrap(locations.first)
-    XCTAssertEqual(
-      location,
-      Location(
-        uri: try project.uri(for: "LibA.h"),
-        range: try project.position(of: "1️⃣", in: "LibA.h")..<project.position(of: "2️⃣", in: "LibA.h")
-      )
-    )
+    XCTAssertEqual(location, try project.location(from: "1️⃣", to: "2️⃣", in: "LibA.h"))
   }
 
   func testDefinitionOfImplicitInitializer() async throws {

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -15,68 +15,7 @@ import SKTestSupport
 import SourceKitLSP
 import XCTest
 
-final class TestDiscoveryTests: XCTestCase {
-  func testWorkspaceTests() async throws {
-    try SkipUnless.longTestsEnabled()
-
-    let project = try await SwiftPMTestProject(
-      files: [
-        "Tests/MyLibraryTests/MyTests.swift": """
-        import XCTest
-
-        class 1️⃣MyTests: XCTestCase {
-          func 2️⃣testMyLibrary() {}
-          func unrelatedFunc() {}
-          var testVariable: Int = 0
-        }
-        """
-      ],
-      manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
-        let package = Package(
-          name: "MyLibrary",
-          targets: [.testTarget(name: "MyLibraryTests")]
-        )
-        """,
-      build: true
-    )
-
-    let tests = try await project.testClient.send(WorkspaceTestsRequest())
-    XCTAssertEqual(
-      tests,
-      [
-        TestItem(
-          id: "MyTests",
-          label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
-          location: Location(
-            uri: try project.uri(for: "MyTests.swift"),
-            range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
-          ),
-          children: [
-            TestItem(
-              id: "MyTests/testMyLibrary()",
-              label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(
-                uri: try project.uri(for: "MyTests.swift"),
-                range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
-              ),
-              children: [],
-              tags: []
-            )
-          ],
-          tags: []
-        )
-      ]
-    )
-  }
-
+final class DocumentTestDiscoveryTests: XCTestCase {
   func testIndexBasedDocumentTests() async throws {
     try SkipUnless.longTestsEnabled()
 

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -1,0 +1,751 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LSPTestSupport
+import LanguageServerProtocol
+@_spi(Testing) import SKCore
+import SKTestSupport
+@_spi(Testing) import SourceKitLSP
+import XCTest
+
+private let packageManifestWithTestTarget = """
+  // swift-tools-version: 5.7
+
+  import PackageDescription
+
+  let package = Package(
+    name: "MyLibrary",
+    targets: [.testTarget(name: "MyLibraryTests")]
+  )
+  """
+
+final class WorkspaceTestDiscoveryTests: XCTestCase {
+  func testIndexBasedWorkspaceXCTests() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class 1️⃣MyTests: XCTestCase {
+          func 2️⃣testMyLibrary() {}
+          func unrelatedFunc() {}
+          var testVariable: Int = 0
+        }
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      build: true
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(
+            uri: try project.uri(for: "MyTests.swift"),
+            range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
+          ),
+          children: [
+            TestItem(
+              id: "MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(
+                uri: try project.uri(for: "MyTests.swift"),
+                range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
+              ),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSyntacticWorkspaceXCTests() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        1️⃣class MyTests: XCTestCase {
+          2️⃣func testMyLibrary() {}3️⃣
+          func unrelatedFunc() {}
+          var testVariable: Int = 0
+        }4️⃣
+        """
+      ],
+      manifest: packageManifestWithTestTarget
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSyntacticOrIndexBasedXCTestsBasedOnWhetherFileIsIndexed() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class 1️⃣MyTests: XCTestCase {
+          func 2️⃣testMyLibrary() {}
+          func unrelatedFunc() {}
+          var testVariable: Int = 0
+        }
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      build: true
+    )
+
+    let myTestsUri = try project.uri(for: "MyTests.swift")
+
+    // First get the tests from the original file contents, which are computed by the semantic index.
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(
+            uri: myTestsUri,
+            range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
+          ),
+          children: [
+            TestItem(
+              id: "MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(
+                uri: myTestsUri,
+                range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
+              ),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+
+    // Now update the file on disk and recompute tests. This should give use tests using the syntactic index, which will
+    // include the tests in here even though `NotQuiteTests` doesn't inherit from XCTest
+
+    let newMarkedFileContents = """
+      import XCTest
+
+      class ClassThatMayInheritFromXCTest {}
+
+      3️⃣class NotQuiteTests: ClassThatMayInheritFromXCTest {
+        4️⃣func testSomething() {}5️⃣
+      }6️⃣
+      """
+    let newFileContents = extractMarkers(newMarkedFileContents).textWithoutMarkers
+    let newFilePositions = DocumentPositions(markedText: newMarkedFileContents)
+    try newFileContents.write(to: try XCTUnwrap(myTestsUri.fileURL), atomically: true, encoding: .utf8)
+    project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: myTestsUri, type: .changed)]))
+
+    let testsAfterDocumentChanged = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      testsAfterDocumentChanged,
+      [
+        TestItem(
+          id: "NotQuiteTests",
+          label: "NotQuiteTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(
+            uri: myTestsUri,
+            range: newFilePositions["3️⃣"]..<newFilePositions["6️⃣"]
+          ),
+          children: [
+            TestItem(
+              id: "NotQuiteTests/testSomething()",
+              label: "testSomething()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(
+                uri: myTestsUri,
+                range: newFilePositions["4️⃣"]..<newFilePositions["5️⃣"]
+              ),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+
+    // After building again, we should have updated the updated the semantic index and realize that `NotQuiteTests` does
+    // not inherit from XCTest and thus doesn't have any test methods.
+
+    try await SwiftPMTestProject.build(at: project.scratchDirectory)
+
+    let testsAfterRebuild = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(testsAfterRebuild, [])
+  }
+
+  func testWorkspaceSwiftTestingTests() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import Testing
+
+        1️⃣struct MyTests {
+          2️⃣@Test
+          func oneIsTwo() {
+            #expect(1 == 2)
+          }3️⃣
+        }4️⃣
+        """
+      ],
+      manifest: packageManifestWithTestTarget
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingAndXCTestInTheSameFile() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import Testing
+        import XCTest
+
+        1️⃣struct MyTests {
+          2️⃣@Test
+          func oneIsTwo() {
+            #expect(1 == 2)
+          }3️⃣
+        }4️⃣
+
+        class 5️⃣MyOldTests: XCTestCase {
+          func 6️⃣testOld() {}
+        }
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      build: true,
+      allowBuildFailure: true
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        ),
+        TestItem(
+          id: "MyOldTests",
+          label: "MyOldTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: try project.location(from: "5️⃣", to: "5️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyOldTests/testOld()",
+              label: "testOld()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: try project.location(from: "6️⃣", to: "6️⃣", in: "MyTests.swift"),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        ),
+      ]
+    )
+  }
+
+  func testWorkspaceTestsForInMemoryEditedFile() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class MayInheritFromXCTestCase {}
+
+        1️⃣class MyTests: MayInheritFromXCTestCase {
+          2️⃣func testMyLibrary0️⃣() {
+          }3️⃣
+          func unrelatedFunc() {}
+          var testVariable: Int = 0
+        }4️⃣
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      build: true
+    )
+
+    let (uri, positions) = try project.openDocument("MyTests.swift")
+
+    // If the document has been opened but not modified in-memory, we can still use the semantic index and detect that
+    // `MyTests` does not inherit from `XCTestCase`.
+    let testsAfterDocumentOpen = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(testsAfterDocumentOpen, [])
+
+    // After we have an in-memory change to the file, we can't use the semantic index to discover the tests anymore.
+    // Use the syntactic index instead.
+    project.testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(uri, version: 2),
+        contentChanges: [
+          TextDocumentContentChangeEvent(range: Range(positions["0️⃣"]), text: "Updated")
+        ]
+      )
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/testMyLibraryUpdated()",
+              label: "testMyLibraryUpdated()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testWorkspaceTestsAfterOneFileHasBeenEdited() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyFirstTests.swift": """
+        import XCTest
+
+        1️⃣class MyFirstTests: XCTestCase {
+          2️⃣func testOne0️⃣() {
+          }3️⃣
+        }4️⃣
+        """,
+        "Tests/MyLibraryTests/MySecondTests.swift": """
+        import XCTest
+
+        class 5️⃣MySecondTests: XCTestCase {
+          func 6️⃣testTwo() {}
+        }
+        """,
+      ],
+      manifest: packageManifestWithTestTarget,
+      build: true
+    )
+
+    let (uri, positions) = try project.openDocument("MyFirstTests.swift")
+    project.testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(uri, version: 2),
+        contentChanges: [TextDocumentContentChangeEvent(range: Range(positions["0️⃣"]), text: "Updated")]
+      )
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyFirstTests",
+          label: "MyFirstTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyFirstTests/testOneUpdated()",
+              label: "testOneUpdated()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        ),
+        TestItem(
+          id: "MySecondTests",
+          label: "MySecondTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: try project.location(from: "5️⃣", to: "5️⃣", in: "MySecondTests.swift"),
+          children: [
+            TestItem(
+              id: "MySecondTests/testTwo()",
+              label: "testTwo()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: try project.location(from: "6️⃣", to: "6️⃣", in: "MySecondTests.swift"),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        ),
+      ]
+    )
+  }
+
+  func testRemoveFileWithSemanticIndex() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class 1️⃣MyTests: XCTestCase {
+          func 2️⃣testSomething() {
+          }
+        }
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      build: true
+    )
+
+    let uri = try project.uri(for: "MyTests.swift")
+    try FileManager.default.removeItem(at: XCTUnwrap(uri.fileURL))
+    project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: .deleted)]))
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(tests, [])
+  }
+
+  func testRemoveFileWithSyntacticIndex() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class 1️⃣MyTests: XCTestCase {
+          func 2️⃣testSomething() {
+          }
+        }
+        """
+      ],
+      manifest: packageManifestWithTestTarget
+    )
+
+    let uri = try project.uri(for: "MyTests.swift")
+    try FileManager.default.removeItem(at: XCTUnwrap(uri.fileURL))
+    project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: .deleted)]))
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(tests, [])
+  }
+
+  func testAddFileToSyntacticIndex() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": ""
+      ],
+      manifest: packageManifestWithTestTarget
+    )
+
+    let markedFileContents = """
+      import XCTest
+
+      1️⃣class 2️⃣MyTests: XCTestCase {
+        3️⃣func 4️⃣testSomething() {}5️⃣
+      }6️⃣
+      """
+
+    let url = try XCTUnwrap(project.uri(for: "MyTests.swift").fileURL)
+      .deletingLastPathComponent()
+      .appendingPathComponent("MyNewTests.swift")
+    let uri = DocumentURI(url)
+    try extractMarkers(markedFileContents).textWithoutMarkers.write(to: url, atomically: true, encoding: .utf8)
+    project.testClient.send(
+      DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: .created)])
+    )
+
+    let positions = DocumentPositions(markedText: markedFileContents)
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/testSomething()",
+              label: "testSomething()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testInMemoryFileWithFallbackBuildSystem() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import XCTest
+
+      1️⃣class 2️⃣MyTests: XCTestCase {
+        3️⃣func 4️⃣testSomething() {}5️⃣
+      }6️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/testSomething()",
+              label: "testSomething()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testIndexedFileWithCompilationDbBuildSystem() async throws {
+    try SkipUnless.longTestsEnabled()
+
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      import XCTest
+
+      class 1️⃣MyTests: XCTestCase {
+        func 2️⃣testSomething() {}
+      }
+      """
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
+          children: [
+            TestItem(
+              id: "MyTests/testSomething()",
+              label: "testSomething()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testOnDiskFileWithCompilationDbBuildSystem() async throws {
+    let project = try await MultiFileTestProject(files: [
+      "MyTests.swift": """
+      import XCTest
+
+      1️⃣class MyTests: XCTestCase {
+        2️⃣func testSomething() {}3️⃣
+      }4️⃣
+      """,
+      "compile_commands.json": "[]",
+    ])
+
+    // When MyTests.swift is not part of the compilation database, the build system doesn't know about the file and thus
+    // doesn't return any tests for it.
+    let testsWithEmptyCompilationDatabase = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(testsWithEmptyCompilationDatabase, [])
+
+    let swiftc = try await unwrap(ToolchainRegistry.forTesting.default?.swiftc?.asURL)
+    let uri = try project.uri(for: "MyTests.swift")
+
+    let compilationDatabase = JSONCompilationDatabase([
+      JSONCompilationDatabase.Command(
+        directory: project.scratchDirectory.path,
+        filename: uri.pseudoPath,
+        commandLine: [swiftc.path, uri.pseudoPath]
+      )
+    ])
+
+    try JSONEncoder()
+      .encode(compilationDatabase).write(to: XCTUnwrap(project.uri(for: "compile_commands.json").fileURL))
+
+    project.testClient.send(
+      DidChangeWatchedFilesNotification(changes: [
+        FileEvent(uri: try project.uri(for: "compile_commands.json"), type: .changed)
+      ])
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyTests/testSomething()",
+              label: "testSomething()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+}


### PR DESCRIPTION
This workspace-wide syntactic test index is used for two purposes:
- It is used for XCTests instead of the semantic index for files that have on-disk or in-memory modifications to files
- It is uses for swift-testing tests, which are only discovered syntactically

rdar://119191037