### PR TITLE
Set time zone to the user's local time zone when using date formatters

### DIFF
--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -134,6 +134,7 @@ public struct DiagnoseCommand: AsyncParsableCommand {
 
     for crashInfo in crashInfos {
       let dateFormatter = DateFormatter()
+      dateFormatter.timeZone = NSTimeZone.local
       dateFormatter.dateStyle = .none
       dateFormatter.timeStyle = .medium
       let progressMessagePrefix = "Reducing Swift compiler crash at \(dateFormatter.string(from: crashInfo.date))"
@@ -304,7 +305,9 @@ public struct DiagnoseCommand: AsyncParsableCommand {
 
     progressBar = PercentProgressAnimation(stream: stderrStream, header: "Diagnosing sourcekit-lsp issues")
 
-    let date = ISO8601DateFormatter().string(from: Date()).replacingOccurrences(of: ":", with: "-")
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.timeZone = NSTimeZone.local
+    let date = dateFormatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
     let bundlePath = FileManager.default.temporaryDirectory
       .appendingPathComponent("sourcekitd-reproducer-\(date)")
     try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
@@ -330,9 +333,9 @@ public struct DiagnoseCommand: AsyncParsableCommand {
     print(
       """
 
-      Bundle created. 
-      When filing an issue at https://github.com/apple/sourcekit-lsp/issues/new, 
-      please attach the bundle located at 
+      Bundle created.
+      When filing an issue at https://github.com/apple/sourcekit-lsp/issues/new,
+      please attach the bundle located at
       \(bundlePath.path)
       """
     )

--- a/Sources/Diagnose/SwiftFrontendCrashScraper.swift
+++ b/Sources/Diagnose/SwiftFrontendCrashScraper.swift
@@ -70,6 +70,7 @@ struct SwiftFrontendCrashScraper {
       }
       let interestingString = fileContents[firstNewline...]
       let dateFormatter = DateFormatter()
+      dateFormatter.timeZone = NSTimeZone.local
       dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
       let decoder = JSONDecoder()
       decoder.dateDecodingStrategy = .formatted(dateFormatter)

--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -245,7 +245,8 @@ public struct NonDarwinLogMessage: ExpressibleByStringInterpolation, Expressible
 /// a new `DateFormatter` is rather expensive and its the same for all loggers.
 private let dateFormatter = {
   let dateFormatter = DateFormatter()
-  dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+  dateFormatter.timeZone = NSTimeZone.local
+  dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSS Z"
   return dateFormatter
 }()
 


### PR DESCRIPTION
Otherwise, the date formatters always output the time in UTC, which has confused me multiple times. Setting the user’s local time zone will emit the date in the user’s local time zone and include the time zone offset to GMT in the date as well.