### PR TITLE
Instead of returning an empty array in `prepareTypeHierarchy`, sourcekit-lsp should return `nil`

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2291,6 +2291,13 @@ extension SourceKitLSPServer {
     }
     .sorted(by: { $0.name < $1.name })
 
+    if typeHierarchyItems.isEmpty {
+      // When returning an empty array, VS Code fails with the following two errors. Returning `nil` works around those
+      // VS Code-internal errors showing up
+      //  - MISSING provider
+      //  - Cannot read properties of null (reading 'kind')
+      return nil
+    }
     // Ideally, we should show multiple symbols. But VS Code fails to display type hierarchies with multiple root items,
     // failing with `Cannot read properties of undefined (reading 'map')`. Pick the first one.
     return Array(typeHierarchyItems.prefix(1))


### PR DESCRIPTION
Eg. when requesting type hierarchy of a class when the project hasn’t been built, sourcekit-lsp returns an empty array. That causes VS Code to fail with very ambiguous error messages
- MISSING provider
- Cannot read properties of null (reading 'kind')

To work around this, instead of returning an empty array, return `nil` instead.

rdar://126228814