### PR TITLE
Introduce new refactoring code actions based on the Swift syntax tree.

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -20,6 +20,10 @@ target_sources(SourceKitLSP PRIVATE
   Clang/ClangLanguageService.swift)
 target_sources(SourceKitLSP PRIVATE
   Swift/AdjustPositionToStartOfIdentifier.swift
+  Swift/CodeActions/ConvertIntegerLiteral.swift
+  Swift/CodeActions/SyntaxCodeActionProvider.swift
+  Swift/CodeActions/SyntaxCodeActions.swift
+  Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
   Swift/CodeCompletion.swift
   Swift/CodeCompletionSession.swift
   Swift/CommentXML.swift

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SwiftRefactor
+import SwiftSyntax
+
+// TODO: Make the type IntegerLiteralExprSyntax.Radix conform to CaseEnumerable
+// in swift-syntax.
+
+extension IntegerLiteralExprSyntax.Radix {
+  static var allCases: [Self] = [.binary, .octal, .decimal, .hex]
+}
+
+/// Syntactic code action provider to convert integer literals between
+/// different bases.
+struct ConvertIntegerLiteral: SyntaxCodeActionProvider {
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard
+      let token = scope.firstToken,
+      let integerExpr = token.parent?.as(IntegerLiteralExprSyntax.self),
+      let integerValue = Int(
+        integerExpr.split().value.filter { $0 != "_" },
+        radix: integerExpr.radix.size
+      )
+    else {
+      return []
+    }
+
+    var actions = [CodeAction]()
+    let currentRadix = integerExpr.radix
+    for radix in IntegerLiteralExprSyntax.Radix.allCases {
+      guard radix != currentRadix else {
+        continue
+      }
+
+      //TODO: Add this to swift-syntax?
+      let prefix: String
+      switch radix {
+      case .binary:
+        prefix = "0b"
+      case .octal:
+        prefix = "0o"
+      case .hex:
+        prefix = "0x"
+      case .decimal:
+        prefix = ""
+      }
+
+      let convertedValue: ExprSyntax =
+        "\(raw: prefix)\(raw: String(integerValue, radix: radix.size))"
+      let edit = TextEdit(
+        range: scope.snapshot.range(of: integerExpr),
+        newText: convertedValue.description
+      )
+      actions.append(
+        CodeAction(
+          title: "Convert \(integerExpr) to \(convertedValue)",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(changes: [scope.snapshot.uri: [edit]])
+        )
+      )
+    }
+
+    return actions
+  }
+}

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActionProvider.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActionProvider.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPLogging
+import LanguageServerProtocol
+import SwiftRefactor
+import SwiftSyntax
+
+/// Describes types that provide one or more code actions based on purely
+/// syntactic information.
+protocol SyntaxCodeActionProvider {
+  /// Produce code actions within the given scope. Each code action
+  /// corresponds to one syntactic transformation that can be performed, such
+  /// as adding or removing separators from an integer literal.
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction]
+}
+
+/// Defines the scope in which a syntactic code action occurs.
+struct SyntaxCodeActionScope {
+  /// The snapshot of the document on which the code actions will be evaluated.
+  var snapshot: DocumentSnapshot
+
+  /// The actual code action request, which can specify additional parameters
+  /// to guide the code actions.
+  var request: CodeActionRequest
+
+  /// The source file in which the syntactic code action will operate.
+  var file: SourceFileSyntax
+
+  /// The UTF-8 byte range in the source file in which code actions should be
+  /// considered, i.e., where the cursor or selection is.
+  var range: Range<AbsolutePosition>
+
+  init(
+    snapshot: DocumentSnapshot,
+    syntaxTree tree: SourceFileSyntax,
+    request: CodeActionRequest
+  ) throws {
+    self.snapshot = snapshot
+    self.request = request
+    self.file = tree
+
+    let start = snapshot.absolutePosition(of: request.range.lowerBound)
+    let end = snapshot.absolutePosition(of: request.range.upperBound)
+    let left = file.token(at: start)
+    let right = file.token(at: end)
+    let leftOff = left?.position ?? AbsolutePosition(utf8Offset: 0)
+    let rightOff = right?.endPosition ?? leftOff
+    self.range = leftOff..<rightOff
+  }
+
+  /// The first token in the
+  var firstToken: TokenSyntax? {
+    file.token(at: range.lowerBound)
+  }
+}

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftRefactor
+
+/// List of all of the syntactic code action providers, which can be used
+/// to produce code actions using only the swift-syntax tree of a file.
+let allSyntaxCodeActions: [SyntaxCodeActionProvider.Type] = [
+  AddSeparatorsToIntegerLiteral.self,
+  ConvertIntegerLiteral.self,
+  FormatRawStringLiteral.self,
+  MigrateToNewIfLetSyntax.self,
+  OpaqueParameterToGeneric.self,
+  RemoveSeparatorsFromIntegerLiteral.self,
+]

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SwiftRefactor
+import SwiftSyntax
+
+/// Protocol that adapts a SyntaxRefactoringProvider (that comes from
+/// swift-syntax) into a SyntaxCodeActionProvider.
+protocol SyntaxRefactoringCodeActionProvider: SyntaxCodeActionProvider, SyntaxRefactoringProvider {
+  static var title: String { get }
+}
+
+/// SyntaxCodeActionProviders with a \c Void context can automatically be
+/// adapted provide a code action based on their refactoring operation.
+extension SyntaxRefactoringCodeActionProvider where Self.Context == Void {
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard
+      let token = scope.firstToken,
+      let node = token.parent?.as(Input.self)
+    else {
+      return []
+    }
+
+    guard let refactored = Self.refactor(syntax: node) else {
+      return []
+    }
+
+    let edit = TextEdit(
+      range: scope.snapshot.range(of: node),
+      newText: refactored.description
+    )
+
+    return [
+      CodeAction(
+        title: Self.title,
+        kind: .refactorInline,
+        edit: WorkspaceEdit(changes: [scope.snapshot.uri: [edit]])
+      )
+    ]
+  }
+}
+
+// Adapters for specific refactoring provides in swift-syntax.
+
+extension AddSeparatorsToIntegerLiteral: SyntaxRefactoringCodeActionProvider {
+  public static var title: String { "Add digit separators" }
+}
+
+extension FormatRawStringLiteral: SyntaxRefactoringCodeActionProvider {
+  public static var title: String {
+    "Convert string literal to minimal number of '#'s"
+  }
+}
+
+extension MigrateToNewIfLetSyntax: SyntaxRefactoringCodeActionProvider {
+  public static var title: String { "Migrate to shorthand 'if let' syntax" }
+}
+
+extension OpaqueParameterToGeneric: SyntaxRefactoringCodeActionProvider {
+  public static var title: String { "Expand 'some' parameters to generic parameters" }
+}
+
+extension RemoveSeparatorsFromIntegerLiteral: SyntaxRefactoringCodeActionProvider {
+  public static var title: String { "Remove digit separators" }
+}

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -284,7 +284,12 @@ final class CodeActionTests: XCTestCase {
       command: expectedCommand
     )
 
-    XCTAssertEqual(result, .codeActions([expectedCodeAction]))
+    guard case .codeActions(let codeActions) = result else {
+      XCTFail("Expected code actions")
+      return
+    }
+
+    XCTAssertTrue(codeActions.contains(expectedCodeAction))
   }
 
   func testSemanticRefactorRangeCodeActionResult() async throws {


### PR DESCRIPTION
This change includes a number of new refactoring code actions that build on the syntax refactorings for the SwiftRefactor module of swift-syntax:

  * Add digit separators to an integer literal, e.g., `1000000` -> `1_000_000`.
  * Remove digit separators from an integer literal, e.g., 1_000_000 -> 1000000.
  * Format a raw string literal, e.g., `"Hello \#(world)"` -> `##"Hello\#(world)"##`
  * Migrate to new if let syntax, e.g., `if let x = x { ... }` -> `if let x { ... }`
  * Replace opaque parameters with generic parameters, e.g., `func f(p: some P)` --> `func f<T1: P>(p: T1)`.

This is generally easy to do, requiring one conformance to provide a name for the refactoring:

    extension AddSeparatorsToIntegerLiteral: SyntaxRefactoringCodeActionProvider {
      public static var title: String { "Add digit separators" }
    }