### PR TITLE
Make hover popover prettier

### DIFF
--- a/Sources/SourceKitLSP/Swift/CommentXML.swift
+++ b/Sources/SourceKitLSP/Swift/CommentXML.swift
@@ -77,7 +77,7 @@ private struct XMLToMarkdown {
       newlineIfNeeded(count: 2)
       out += "```swift\n"
       toMarkdown(node.children)
-      out += "\n```\n\n---\n"
+      out += "\n```\n"
 
     case "Name", "USR", "Direction":
       break

--- a/Tests/SourceKitLSPTests/HoverTests.swift
+++ b/Tests/SourceKitLSPTests/HoverTests.swift
@@ -26,12 +26,10 @@ final class HoverTests: XCTestCase {
       struct 1️⃣S {}
       """,
       expectedContent: """
-        S
         ```swift
         struct S
         ```
 
-        ---
         This is a doc comment for S.
 
         Details.
@@ -70,21 +68,51 @@ final class HoverTests: XCTestCase {
       _ = 1️⃣Foo()
       """,
       expectedContent: """
-        Foo
+        ## Multiple results
+
         ```swift
         struct Foo
         ```
 
+
         ---
 
-        # Alternative result
-        init()
         ```swift
+
         init()
         ```
 
+        """
+    )
+  }
+
+  func testMultiCursorInfoResultsHoverWithDocumentation() async throws {
+    try await assertHover(
+      """
+      /// A struct
+      struct Foo {
+        /// The initializer
+        init() {}
+      }
+      _ = 1️⃣Foo()
+      """,
+      expectedContent: """
+        ## Multiple results
+
+        ```swift
+        struct Foo
+        ```
+
+        A struct
+
         ---
 
+        ```swift
+
+        init()
+        ```
+
+        The initializer
         """
     )
   }
@@ -96,12 +124,10 @@ final class HoverTests: XCTestCase {
       func 1️⃣test(_ a: Int, _ b: Int) { }
       """,
       expectedContent: ##"""
-        test(\_:\_:)
         ```swift
         func test(_ a: Int, _ b: Int)
         ```
 
-        ---
         this is **bold** documentation
         """##
     )
@@ -114,12 +140,10 @@ final class HoverTests: XCTestCase {
       func 1️⃣*%*(lhs: String, rhs: String) { }
       """,
       expectedContent: ##"""
-        \*%\*(\_:\_:)
         ```swift
         func *%* (lhs: String, rhs: String)
         ```
 
-        ---
         this is *italic* documentation
         """##
     )
@@ -135,12 +159,10 @@ final class HoverTests: XCTestCase {
       func 1️⃣eatApple() {}
       """,
       expectedContent: """
-        eatApple()
         ```swift
         func eatApple()
         ```
 
-        ---
         Eat an apple
 
         - Precondition: Must have an apple

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -755,8 +755,6 @@ final class LocalSwiftTests: XCTestCase {
       func foo(_ bar: Baz)
       ```
 
-      ---
-
       """
     )
     XCTAssertEqual(
@@ -769,8 +767,6 @@ final class LocalSwiftTests: XCTestCase {
       ```swift
       func foo() -> Bar
       ```
-
-      ---
 
       """
     )
@@ -805,8 +801,6 @@ final class LocalSwiftTests: XCTestCase {
       func replacingOccurrences<Target, Replacement>(of target: Target, with replacement: Replacement, options: String.CompareOptions = default, range searchRange: Range<String.Index>? = default) -> String where Target : StringProtocol, Replacement : StringProtocol
       ```
 
-      ---
-
       """
     )
   }
@@ -823,8 +817,6 @@ final class LocalSwiftTests: XCTestCase {
       var foo
       ```
 
-      ---
-
       """
     )
 
@@ -839,8 +831,6 @@ final class LocalSwiftTests: XCTestCase {
       var foo
       ```
 
-      ---
-
       """
     )
     XCTAssertEqual(
@@ -853,8 +843,6 @@ final class LocalSwiftTests: XCTestCase {
       ```swift
       var foo
       ```
-
-      ---
 
       """
     )
@@ -881,8 +869,6 @@ final class LocalSwiftTests: XCTestCase {
       ```swift
       var foo
       ```
-
-      ---
 
       """
     )
@@ -1064,8 +1050,6 @@ final class LocalSwiftTests: XCTestCase {
       ```swift
       struct String
       ```
-
-      ---
       A Unicode s
 
       ### Discussion
@@ -1147,8 +1131,6 @@ final class LocalSwiftTests: XCTestCase {
       ```swift
       struct S
       ```
-
-      ---
       ### Discussion
 
       ```swift


### PR DESCRIPTION
Essentially two changes:
1. Remove the symbol name from the hover. This name is already included in the documentation
2. Make the `Alternative Result` heading smaller.

Changes it from looking like this
<img width="482" alt="Screenshot 2024-04-17 at 21 41 27" src="https://github.com/apple/sourcekit-lsp/assets/4062178/641d7617-219f-4586-a689-d85f11128152">
to
<img width="473" alt="Screenshot 2024-04-17 at 21 40 42" src="https://github.com/apple/sourcekit-lsp/assets/4062178/7b6538a6-3f85-471a-84c7-565cb4b9972e">



rdar://126488098