### PR TITLE
Fix jump-to-definition to methods in swift interfaces that are in synthesized extensions

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
@@ -23,27 +23,24 @@ public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
   public var moduleName: String
 
   /// The module group name.
-  public var groupNames: [String]
+  public var groupName: String?
 
   /// The symbol USR to search for in the generated module interface.
   public var symbolUSR: String?
 
-  public init(textDocument: TextDocumentIdentifier, name: String, symbolUSR: String?) {
+  public init(textDocument: TextDocumentIdentifier, name: String, groupName: String?, symbolUSR: String?) {
     self.textDocument = textDocument
     self.symbolUSR = symbolUSR
-    // Stdlib Swift modules are all in the "Swift" module, but their symbols return a module name `Swift.***`.
-    let splitName = name.split(separator: ".")
-    self.moduleName = String(splitName[0])
-    self.groupNames = [String.SubSequence](splitName.dropFirst()).map(String.init)
+    self.moduleName = name
+    self.groupName = groupName
   }
 
   /// Name of interface module name with group names appended
   public var name: String {
-    if groupNames.count > 0 {
-      return "\(self.moduleName).\(self.groupNames.joined(separator: "."))"
-    } else {
-      return self.moduleName
+    if let groupName {
+      return "\(self.moduleName).\(groupName.replacing("/", with: "."))"
     }
+    return self.moduleName
   }
 }
 

--- a/Sources/LanguageServerProtocol/Requests/SymbolInfoRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SymbolInfoRequest.swift
@@ -48,6 +48,18 @@ public struct SymbolInfoRequest: TextDocumentRequest, Hashable {
 /// Detailed information about a symbol, such as the response to a `SymbolInfoRequest`
 /// **(LSP Extension)**.
 public struct SymbolDetails: ResponseType, Hashable {
+  public struct ModuleInfo: Codable, Hashable, Sendable {
+    /// The name of the module in which the symbol is defined.
+    public let moduleName: String
+
+    /// If the symbol is defined within a subgroup of a module, the name of the group. Otherwise `nil`.
+    public let groupName: String?
+
+    public init(moduleName: String, groupName: String? = nil) {
+      self.moduleName = moduleName
+      self.groupName = groupName
+    }
+  }
 
   /// The name of the symbol, if any.
   public var name: String?
@@ -87,6 +99,11 @@ public struct SymbolDetails: ResponseType, Hashable {
   /// Optional because `clangd` does not return whether a symbol is dynamic.
   public var isDynamic: Bool?
 
+  /// Whether this symbol is defined in the SDK or standard library.
+  ///
+  /// This property only applies to Swift symbols.
+  public var isSystem: Bool?
+
   /// If the symbol is dynamic, the USRs of the types that might be called.
   ///
   /// This is relevant in the following cases
@@ -112,6 +129,12 @@ public struct SymbolDetails: ResponseType, Hashable {
   /// `B` may be called dynamically.
   public var receiverUsrs: [String]?
 
+  /// If the symbol is defined in a module that doesn't have source information associated with it, the name and group
+  /// and group name that defines this symbol.
+  ///
+  /// This property only applies to Swift symbols.
+  public var systemModule: ModuleInfo?
+
   public init(
     name: String?,
     containerName: String?,
@@ -119,7 +142,9 @@ public struct SymbolDetails: ResponseType, Hashable {
     bestLocalDeclaration: Location?,
     kind: SymbolKind?,
     isDynamic: Bool?,
-    receiverUsrs: [String]?
+    isSystem: Bool?,
+    receiverUsrs: [String]?,
+    systemModule: ModuleInfo?
   ) {
     self.name = name
     self.containerName = containerName
@@ -127,6 +152,8 @@ public struct SymbolDetails: ResponseType, Hashable {
     self.bestLocalDeclaration = bestLocalDeclaration
     self.kind = kind
     self.isDynamic = isDynamic
+    self.isSystem = isSystem
     self.receiverUsrs = receiverUsrs
+    self.systemModule = systemModule
   }
 }

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -65,7 +65,7 @@ struct CursorInfo {
       return nil
     }
 
-    var location: Location? = nil
+    let location: Location?
     if let filepath: String = dict[keys.filePath],
       let line: Int = dict[keys.line],
       let column: Int = dict[keys.column]
@@ -76,6 +76,16 @@ struct CursorInfo {
         utf16index: column - 1
       )
       location = Location(uri: DocumentURI(URL(fileURLWithPath: filepath)), range: Range(position))
+    } else {
+      location = nil
+    }
+
+    let module: SymbolDetails.ModuleInfo?
+    if let moduleName: String = dict[keys.moduleName] {
+      let groupName: String? = dict[keys.groupName]
+      module = SymbolDetails.ModuleInfo(moduleName: moduleName, groupName: groupName)
+    } else {
+      module = nil
     }
 
     self.init(
@@ -86,7 +96,9 @@ struct CursorInfo {
         bestLocalDeclaration: location,
         kind: kind.asSymbolKind(sourcekitd.values),
         isDynamic: dict[keys.isDynamic] ?? false,
-        receiverUsrs: dict[keys.receivers]?.compactMap { $0[keys.usr] as String? } ?? []
+        isSystem: dict[keys.isSystem] ?? false,
+        receiverUsrs: dict[keys.receivers]?.compactMap { $0[keys.usr] as String? } ?? [],
+        systemModule: module
       ),
       annotatedDeclaration: dict[keys.annotatedDecl],
       documentationXML: dict[keys.docFullAsXML],

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -73,7 +73,7 @@ extension SwiftLanguageService {
     let skreq = sourcekitd.dictionary([
       keys.request: requests.editorOpenInterface,
       keys.moduleName: name,
-      keys.groupName: request.groupNames.isEmpty ? nil : request.groupNames as [SKDRequestValue],
+      keys.groupName: request.groupName,
       keys.name: interfaceURI.pseudoPath,
       keys.synthesizedExtension: 1,
       keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,


### PR DESCRIPTION
For example when trying to go-to-definition to `filter` on `Array`, we get a USR `s:s14_ArrayProtocolPsE6filterySay7ElementQzGSbAEKXEKF::SYNTHESIZED::s:Sa`. We were trying to look it up in the index, which failed because synthesized extension methods are not indexed.

Instead, consult the `module` and `groupName` that `sourcekitd` returns in the cursor info request to decide which module to jump to.

rdar://126240558