### PR TITLE
Truncate log message in `NonDarwinLogger` at 10.000 characters

### DIFF
--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -299,11 +299,20 @@ public struct NonDarwinLogger: Sendable {
     guard level >= self.logLevel else { return }
     let date = Date()
     loggingQueue.async {
+      // Truncate log message after 10.000 characters to avoid flooding the log with huge log messages (eg. from a
+      // sourcekitd response). 10.000 characters was chosen because it seems to fit the result of most sourcekitd
+      // responses that are not generated interface or global completion results (which are a lot bigger).
+      var message = message().value.string(for: self.privacyLevel)
+      if message.utf8.count > 10_000 {
+        // Check for UTF-8 byte length first because that's faster since it doesn't need to count UTF-8 characters.
+        // Truncate using `.prefix` to avoid cutting of in the middle of a UTF-8 multi-byte character.
+        message = message.prefix(10_000) + "..."
+      }
       // Start each log message with `[org.swift.sourcekit-lsp` so that it’s easy to split the log to the different messages
       logHandler(
         """
         [\(subsystem):\(category)] \(level) \(dateFormatter.string(from: date))
-        \(message().value.string(for: self.privacyLevel))
+        \(message)
         ---
         """
       )


### PR DESCRIPTION
Truncate log message after 10.000 characters to avoid flooding the log with huge log messages (eg. from a sourcekitd response). 10.000 characters wasn't chosen because it seems to fit the result of most sourcekitd responses that are not generated interface or global completion results (which are a lot bigger).