### PR TITLE
Support member access in tags

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -96,16 +96,16 @@ struct TestingAttributeData {
         }
       }.flatMap(\.arguments)
       .compactMap {
-          if let memberAccess = $0.expression.as(MemberAccessExprSyntax.self) {
-            var components = memberAccess.components[...]
-            if components.starts(with: ["Testing", "Tag"]) {
-              components = components.dropFirst(2)
-            } else if components.starts(with: ["Tag"]) {
-              components = components.dropFirst(1)
-            }
-            return components.joined(separator: ".")
+        if let memberAccess = $0.expression.as(MemberAccessExprSyntax.self) {
+          var components = memberAccess.components[...]
+          if components.starts(with: ["Testing", "Tag"]) {
+            components = components.dropFirst(2)
+          } else if components.starts(with: ["Tag"]) {
+            components = components.dropFirst(1)
           }
-          return nil
+          return components.joined(separator: ".")
+        }
+        return nil
       }
 
     self.isDisabled = traitArguments.lazy

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -95,7 +95,10 @@ struct TestingAttributeData {
           return false
         }
       }.flatMap(\.arguments)
-      .compactMap { $0.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue }
+      .compactMap {
+          $0.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue ??
+          $0.expression.as(MemberAccessExprSyntax.self)?.declName.baseName.text
+      }
 
     self.isDisabled = traitArguments.lazy
       .compactMap { $0.as(FunctionCallExprSyntax.self) }

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -364,8 +364,7 @@ fileprivate extension MemberAccessExprSyntax {
     if let declReferenceExpr = base?.as(DeclReferenceExprSyntax.self) {
       return [declReferenceExpr.baseName.text, declName.baseName.text]
     } else if let baseMemberAccessExpr = base?.as(MemberAccessExprSyntax.self) {
-      let baseBaseNames = baseMemberAccessExpr.components.dropLast()
-      return baseBaseNames + [baseMemberAccessExpr.declName.baseName.text, declName.baseName.text]
+      return baseMemberAccessExpr.components + [declName.baseName.text]
     }
 
     return [declName.baseName.text]

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -96,8 +96,13 @@ struct TestingAttributeData {
         }
       }.flatMap(\.arguments)
       .compactMap {
-          $0.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue ??
-          $0.expression.as(MemberAccessExprSyntax.self)?.declName.baseName.text
+          if let stringLiteral = $0.expression.as(StringLiteralExprSyntax.self) {
+              return stringLiteral.representedLiteralValue
+          } else if let memberAccess = $0.expression.as(MemberAccessExprSyntax.self) {
+              let baseName = (memberAccess.baseName.map { "\($0)." } ?? "").replacing(#/Tag\./#, with: "")
+              return "\(baseName)\(memberAccess.declName.baseName.text)"
+          }
+          return nil
       }
 
     self.isDisabled = traitArguments.lazy

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -364,6 +364,7 @@ fileprivate extension MemberAccessExprSyntax {
     } else if let baseMemberAccessExpr = base?.as(MemberAccessExprSyntax.self) {
       return baseMemberAccessExpr.components + [declName.baseName.text]
     }
+    return [declName.baseName.text]
   }
 }
 

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -96,16 +96,17 @@ struct TestingAttributeData {
         }
       }.flatMap(\.arguments)
       .compactMap {
-          if let stringLiteral = $0.expression.as(StringLiteralExprSyntax.self) {
-            return stringLiteral.representedLiteralValue
-          } else if let memberAccess = $0.expression.as(MemberAccessExprSyntax.self) {
+          if let memberAccess = $0.expression.as(MemberAccessExprSyntax.self) {
             var components = memberAccess.components[...]
             if components.starts(with: ["Testing", "Tag"]) {
               components = components.dropFirst(2)
             } else if components.starts(with: ["Tag"]) {
               components = components.dropFirst(1)
             }
-            return components.joined(separator: ".")
+
+            // Tags.foo resolves to ".foo", Tags.Nested.foo resolves to "Nested.foo"
+            let prefix = components.count == 1 ? "." : ""
+            return "\(prefix)\(components.joined(separator: "."))"
           }
           return nil
       }

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -103,9 +103,7 @@ struct TestingAttributeData {
             } else if components.starts(with: ["Tag"]) {
               components = components.dropFirst(1)
             }
-
-            // Tags.foo resolves to ".foo", Tags.Nested.foo resolves to ".Nested.foo"
-            return ".\(components.joined(separator: "."))"
+            return components.joined(separator: ".")
           }
           return nil
       }

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -104,9 +104,8 @@ struct TestingAttributeData {
               components = components.dropFirst(1)
             }
 
-            // Tags.foo resolves to ".foo", Tags.Nested.foo resolves to "Nested.foo"
-            let prefix = components.count == 1 ? "." : ""
-            return "\(prefix)\(components.joined(separator: "."))"
+            // Tags.foo resolves to ".foo", Tags.Nested.foo resolves to ".Nested.foo"
+            return ".\(components.joined(separator: "."))"
           }
           return nil
       }

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -364,8 +364,6 @@ fileprivate extension MemberAccessExprSyntax {
     } else if let baseMemberAccessExpr = base?.as(MemberAccessExprSyntax.self) {
       return baseMemberAccessExpr.components + [declName.baseName.text]
     }
-
-    return [declName.baseName.text]
   }
 }
 

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -642,6 +642,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       extension Tag {
         @Tag static var foo: Self
         @Tag static var bar: Self
+        @Tag static var baz: Self
 
         struct Nested {
           @Tag static var foo: Tag
@@ -650,7 +651,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
       1️⃣@Suite(.tags("Suites"))
       struct MyTests {
-        2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar))
+        2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar, Tag.baz))
         func oneIsTwo() {
           #expect(1 == 2)
         }3️⃣
@@ -677,7 +678,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
-              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar")]
+              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar"), TestTag(id: "baz")]
             )
           ],
           tags: [TestTag(id: "Suites")]

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -595,7 +595,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
       1️⃣@Suite(.tags("Suites"))
       struct MyTests {
-        2️⃣@Test(.tags("one", "two"))
+        2️⃣@Test(.tags("one", "two", .red, .blue))
         func oneIsTwo() {
           #expect(1 == 2)
         }3️⃣
@@ -622,7 +622,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
-              tags: [TestTag(id: "one"), TestTag(id: "two")]
+              tags: [TestTag(id: "one"), TestTag(id: "two"), TestTag(id: "red"), TestTag(id: "blue")]
             )
           ],
           tags: [TestTag(id: "Suites")]

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -585,7 +585,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     )
   }
 
-  func testSwiftTestingTestWithStringTags() async throws {
+  func testSwiftTestingTestWithTags() async throws {
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 
@@ -688,62 +688,6 @@ final class DocumentTestDiscoveryTests: XCTestCase {
             )
           ],
           tags: [TestTag(id: "suite")]
-        )
-      ]
-    )
-  }
-
-  func testSwiftTestingTestWithCustomTags() async throws {
-    let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
-
-    let positions = testClient.openDocument(
-      """
-      import Testing
-
-      extension Tag {
-        @Tag static var foo: Self
-        @Tag static var bar: Self
-        @Tag static var baz: Self
-
-        struct Nested {
-          @Tag static var foo: Tag
-        }
-      }
-
-      1️⃣@Suite(.tags("Suites"))
-      struct MyTests {
-        2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar, Tag.baz))
-        func oneIsTwo() {
-          #expect(1 == 2)
-        }3️⃣
-      }4️⃣
-      """,
-      uri: uri
-    )
-
-    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
-    XCTAssertEqual(
-      tests,
-      [
-        TestItem(
-          id: "MyTests",
-          label: "MyTests",
-          disabled: false,
-          style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
-          children: [
-            TestItem(
-              id: "MyTests/oneIsTwo()",
-              label: "oneIsTwo()",
-              disabled: false,
-              style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar"), TestTag(id: "baz")]
-            )
-          ],
-          tags: [TestTag(id: "Suites")]
         )
       ]
     )

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -585,7 +585,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     )
   }
 
-  func testSwiftTestingTestWithStringTags() async throws {
+  func testSwiftTestingTestWithTags() async throws {
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 
@@ -593,54 +593,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       """
       import Testing
 
-      1️⃣@Suite(.tags("Suites"))
-      struct MyTests {
-        2️⃣@Test(.tags("one", "two"))
-        func oneIsTwo() {
-          #expect(1 == 2)
-        }3️⃣
-      }4️⃣
-      """,
-      uri: uri
-    )
-
-    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
-    XCTAssertEqual(
-      tests,
-      [
-        TestItem(
-          id: "MyTests",
-          label: "MyTests",
-          disabled: false,
-          style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
-          children: [
-            TestItem(
-              id: "MyTests/oneIsTwo()",
-              label: "oneIsTwo()",
-              disabled: false,
-              style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: [TestTag(id: "one"), TestTag(id: "two")]
-            )
-          ],
-          tags: [TestTag(id: "Suites")]
-        )
-      ]
-    )
-  }
-
-
-  func testSwiftTestingTestWithMemberTags() async throws {
-    let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
-
-    let positions = testClient.openDocument(
-      """
-      import Testing
-
-      1️⃣@Suite(.tags("Suites"))
+      1️⃣@Suite(.tags(.green))
       struct MyTests {
         2️⃣@Test(.tags(.red, .blue))
         func oneIsTwo() {
@@ -669,10 +622,10 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
-              tags: [TestTag(id: "red"), TestTag(id: "blue")]
+              tags: [TestTag(id: ".red"), TestTag(id: ".blue")]
             )
           ],
-          tags: [TestTag(id: "Suites")]
+          tags: [TestTag(id: ".green")]
         )
       ]
     )
@@ -687,6 +640,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       import Testing
 
       extension Tag {
+        @Tag static var suite: Self
         @Tag static var foo: Self
         @Tag static var bar: Self
         @Tag static var baz: Self
@@ -696,7 +650,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         }
       }
 
-      1️⃣@Suite(.tags("Suites"))
+      1️⃣@Suite(.tags(.suite))
       struct MyTests {
         2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar, Tag.baz))
         func oneIsTwo() {
@@ -725,10 +679,15 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
-              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar"), TestTag(id: "baz")]
+              tags: [
+                TestTag(id: ".foo"),
+                TestTag(id: "Nested.foo"),
+                TestTag(id: ".bar"),
+                TestTag(id: ".baz")
+              ]
             )
           ],
-          tags: [TestTag(id: "Suites")]
+          tags: [TestTag(id: ".suite")]
         )
       ]
     )

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -631,6 +631,61 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     )
   }
 
+  func testSwiftTestingTestWithCustomTags() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      extension Tag {
+        @Tag static var foo: Self
+        @Tag static var bar: Self
+
+        struct Nested {
+          @Tag static var foo: Tag
+        }
+      }
+
+      1️⃣@Suite(.tags("Suites"))
+      struct MyTests {
+        2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar))
+        func oneIsTwo() {
+          #expect(1 == 2)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar")]
+            )
+          ],
+          tags: [TestTag(id: "Suites")]
+        )
+      ]
+    )
+  }
+
   func testSwiftTestingTestsWithExtension() async throws {
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -622,10 +622,10 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
-              tags: [TestTag(id: ".red"), TestTag(id: ".blue")]
+              tags: [TestTag(id: "red"), TestTag(id: "blue")]
             )
           ],
-          tags: [TestTag(id: ".green")]
+          tags: [TestTag(id: "green")]
         )
       ]
     )
@@ -680,14 +680,14 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
               tags: [
-                TestTag(id: ".foo"),
-                TestTag(id: ".Nested.foo"),
-                TestTag(id: ".bar"),
-                TestTag(id: ".baz")
+                TestTag(id: "foo"),
+                TestTag(id: "Nested.foo"),
+                TestTag(id: "bar"),
+                TestTag(id: "baz")
               ]
             )
           ],
-          tags: [TestTag(id: ".suite")]
+          tags: [TestTag(id: "suite")]
         )
       ]
     )

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -683,7 +683,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
                 TestTag(id: "foo"),
                 TestTag(id: "Nested.foo"),
                 TestTag(id: "bar"),
-                TestTag(id: "baz")
+                TestTag(id: "baz"),
               ]
             )
           ],

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -585,7 +585,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     )
   }
 
-  func testSwiftTestingTestWithTags() async throws {
+  func testSwiftTestingTestWithStringTags() async throws {
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)
 

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -704,6 +704,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       extension Tag {
         @Tag static var foo: Self
         @Tag static var bar: Self
+        @Tag static var baz: Self
 
         struct Nested {
           @Tag static var foo: Tag
@@ -712,7 +713,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
       1️⃣@Suite(.tags("Suites"))
       struct MyTests {
-        2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar))
+        2️⃣@Test(.tags(.foo, Nested.foo, Testing.Tag.bar, Tag.baz))
         func oneIsTwo() {
           #expect(1 == 2)
         }3️⃣
@@ -739,7 +740,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
-              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar")]
+              tags: [TestTag(id: "foo"), TestTag(id: "Nested.foo"), TestTag(id: "bar"), TestTag(id: "baz")]
             )
           ],
           tags: [TestTag(id: "Suites")]

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -681,7 +681,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               children: [],
               tags: [
                 TestTag(id: ".foo"),
-                TestTag(id: "Nested.foo"),
+                TestTag(id: ".Nested.foo"),
                 TestTag(id: ".bar"),
                 TestTag(id: ".baz")
               ]


### PR DESCRIPTION
Currently tags are only recognized when the tag is specified by string literal, i.e: `@Tag("foo")`.

Support Tags added via the staticMember Tag.Kind, i.e: `@Tag(.blue)`.