### PR TITLE
Add refactoring actions for adding a test targets and products to a package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -309,6 +309,7 @@ let package = Package(
         .product(name: "SwiftRefactor", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+        .product(name: "SwiftPM-auto", package: "swift-package-manager"),
       ],
       exclude: ["CMakeLists.txt"]
     ),

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
@@ -52,31 +52,4 @@ public struct TextDocumentEdit: Hashable, Codable, Sendable {
     self.textDocument = textDocument
     self.edits = edits
   }
-
-  public enum CodingKeys: String, CodingKey {
-    case kind
-    case textDocument
-    case edits
-  }
-
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode("textDocumentEdit", forKey: .kind)
-    try container.encode(self.textDocument, forKey: .textDocument)
-    try container.encode(self.edits, forKey: .edits)
-  }
-
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    let kind = try container.decode(String.self, forKey: .kind)
-    guard kind == "textDocumentEdit" else {
-      throw DecodingError.dataCorruptedError(
-        forKey: .kind,
-        in: container,
-        debugDescription: "Kind of TextDocumentEdit is not 'textDocumentEdit'"
-      )
-    }
-    self.textDocument = try container.decode(OptionalVersionedTextDocumentIdentifier.self, forKey: .textDocument)
-    self.edits = try container.decode([Edit].self, forKey: .edits)
-  }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TextDocumentEdit.swift
@@ -52,4 +52,31 @@ public struct TextDocumentEdit: Hashable, Codable, Sendable {
     self.textDocument = textDocument
     self.edits = edits
   }
+
+  public enum CodingKeys: String, CodingKey {
+    case kind
+    case textDocument
+    case edits
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode("textDocumentEdit", forKey: .kind)
+    try container.encode(self.textDocument, forKey: .textDocument)
+    try container.encode(self.edits, forKey: .edits)
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let kind = try container.decode(String.self, forKey: .kind)
+    guard kind == "textDocumentEdit" else {
+      throw DecodingError.dataCorruptedError(
+        forKey: .kind,
+        in: container,
+        debugDescription: "Kind of TextDocumentEdit is not 'textDocumentEdit'"
+      )
+    }
+    self.textDocument = try container.decode(OptionalVersionedTextDocumentIdentifier.self, forKey: .textDocument)
+    self.edits = try container.decode([Edit].self, forKey: .edits)
+  }
 }

--- a/Sources/LanguageServerProtocol/SupportTypes/VersionedTextDocumentIdentifier.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/VersionedTextDocumentIdentifier.swift
@@ -53,4 +53,18 @@ public struct OptionalVersionedTextDocumentIdentifier: Hashable, Codable, Sendab
     self.uri = uri
     self.version = version
   }
+
+  enum CodingKeys: CodingKey {
+    case uri
+    case version
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.uri, forKey: .uri)
+
+    // Note: we use encode(_:forKey:) here instead of encodeIf(_:forKey:)
+    // because VSCode will drop requests without the explicit 'null'.
+    try container.encode(self.version, forKey: .version)
+  }
 }

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(SourceKitLSP PRIVATE
 target_sources(SourceKitLSP PRIVATE
   Swift/AdjustPositionToStartOfIdentifier.swift
   Swift/CodeActions/ConvertIntegerLiteral.swift
+  Swift/CodeActions/PackageManifestEdits.swift
   Swift/CodeActions/SyntaxCodeActionProvider.swift
   Swift/CodeActions/SyntaxCodeActions.swift
   Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -75,5 +75,6 @@ target_link_libraries(SourceKitLSP PUBLIC
   SwiftSyntax::SwiftRefactor
   SwiftSyntax::SwiftSyntax)
 target_link_libraries(SourceKitLSP PRIVATE
+  PackageModelSyntax
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 

--- a/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import PackageModel
+import PackageModelSyntax
+import SwiftRefactor
+import SwiftSyntax
+
+/// Syntactic code action provider to provide refactoring actions that
+/// edit a package manifest.
+struct PackageManifestEdits: SyntaxCodeActionProvider {
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard
+      let token = scope.firstToken,
+      let call = token.findEnclosingCall()
+    else {
+      return []
+    }
+
+    var actions = [CodeAction]()
+
+    // If there's a target name, offer to create a test target derived from it.
+    if let targetName = call.findStringArgument(label: "name") {
+        do {
+            let target = try TargetDescription(
+                name: "\(targetName)Tests",
+                dependencies: [ .byName(name: targetName, condition: nil) ],
+                type: .test
+            )
+
+            let edits = try AddTarget.addTarget(target, to: scope.file)
+            actions.append(
+              CodeAction(
+                title: "Add test target for this target",
+                kind: .refactor,
+                edit: edits.asWorkspaceEdit(snapshot: scope.snapshot)
+              )
+            )
+        } catch {
+            // nothing to do
+        }
+    }
+
+    return actions
+  }
+}
+
+fileprivate extension PackageEditResult {
+    /// Translate package manifest edits into a workspace edit. This can
+    /// involve both modifications to the manifest file as well as the creation
+    /// of new files.
+    func asWorkspaceEdit(snapshot: DocumentSnapshot) -> WorkspaceEdit {
+        // The edits to perform on the manifest itself.
+        let manifestTextEdits = manifestEdits.map { edit in
+            TextEdit(
+                range: snapshot.range(of: edit.range),
+                newText: edit.replacement
+            )
+        }
+
+        // If we couldn't figure out the manifest directory, or there are no
+        // files to add, the only changes are the manifest edits. We're done
+        // here.
+        let manifestDirectoryURI = snapshot.uri.fileURL?
+            .deletingLastPathComponent()
+        guard let manifestDirectoryURI, !auxiliaryFiles.isEmpty else {
+            return WorkspaceEdit(
+                changes: [snapshot.uri: manifestTextEdits]
+            )
+        }
+
+        // Use the more full-featured documentChanges, which takes precedence
+        // over the individual changes to documents.
+        var documentChanges: [WorkspaceEditDocumentChange] = []
+
+        // Put the manifest changes into the array.
+        documentChanges.append(
+            .textDocumentEdit(
+                .init(
+                    textDocument: .init(snapshot.uri, version: nil),
+                    edits: manifestTextEdits.map { .textEdit($0) }
+                )
+            )
+        )
+
+        // Create an populate all of the auxiliary files.
+        for (relativePath, contents) in auxiliaryFiles {
+            guard let uri = URL(
+                string: relativePath.pathString,
+                relativeTo: manifestDirectoryURI
+            ) else {
+                continue
+            }
+
+            let documentURI = DocumentURI(uri)
+            let createFile = CreateFile(
+                uri: documentURI
+            )
+
+            let zeroPosition = Position(line: 0, utf16index: 0)
+            let edit = TextEdit(
+                range: zeroPosition..<zeroPosition,
+                newText: contents.description
+            )
+
+            documentChanges.append(.createFile(createFile))
+            documentChanges.append(
+                .textDocumentEdit(
+                    .init(
+                        textDocument: .init(documentURI, version: nil),
+                        edits: [ .textEdit(edit) ]
+                    )
+                )
+            )
+        }
+
+        return WorkspaceEdit(
+            changes: [ snapshot.uri: manifestTextEdits ],
+            documentChanges: documentChanges
+        )
+    }
+}
+
+fileprivate extension SyntaxProtocol {
+    // Find an enclosing call syntax expression.
+    func findEnclosingCall() -> FunctionCallExprSyntax? {
+        var current = Syntax(self)
+        while true {
+            if let call = current.as(FunctionCallExprSyntax.self) {
+                return call
+            }
+
+            if let parent = current.parent {
+                current = parent
+                continue
+            }
+
+          return nil
+      }
+  }
+}
+
+fileprivate extension FunctionCallExprSyntax {
+    /// Find an argument with the given label that has a string literal as
+    /// its argument.
+    func findStringArgument(label: String) -> String? {
+        for arg in arguments {
+            if arg.label?.text == label {
+                return arg.expression.as(StringLiteralExprSyntax.self)?
+                    .representedLiteralValue
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
@@ -19,232 +19,236 @@ import SwiftSyntax
 /// Syntactic code action provider to provide refactoring actions that
 /// edit a package manifest.
 struct PackageManifestEdits: SyntaxCodeActionProvider {
-    static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
-        guard let token = scope.firstToken,
-              let call = token.findEnclosingCall()
-        else {
-            return []
-        }
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard let token = scope.firstToken,
+      let call = token.findEnclosingCall()
+    else {
+      return []
+    }
 
-        var actions = [CodeAction]()
+    var actions = [CodeAction]()
 
-        // Add test target(s)
-        actions.append(
-            contentsOf: maybeAddTestTargetActions(call: call, in: scope)
+    // Add test target(s)
+    actions.append(
+      contentsOf: maybeAddTestTargetActions(call: call, in: scope)
+    )
+
+    // Add product(s).
+    actions.append(
+      contentsOf: maybeAddProductActions(call: call, in: scope)
+    )
+
+    return actions
+  }
+
+  /// Produce code actions to add test target(s) if we are currently on
+  /// a target for which we know how to create a test.
+  static func maybeAddTestTargetActions(
+    call: FunctionCallExprSyntax,
+    in scope: SyntaxCodeActionScope
+  ) -> [CodeAction] {
+    guard let calledMember = call.findMemberAccessCallee(),
+      targetsThatAllowTests.contains(calledMember),
+      let targetName = call.findStringArgument(label: "name")
+    else {
+      return []
+    }
+
+    do {
+      // Describe the target we are going to create.
+      let target = try TargetDescription(
+        name: "\(targetName)Tests",
+        dependencies: [.byName(name: targetName, condition: nil)],
+        type: .test
+      )
+
+      let edits = try AddTarget.addTarget(target, to: scope.file)
+      return [
+        CodeAction(
+          title: "Add test target",
+          kind: .refactor,
+          edit: edits.asWorkspaceEdit(snapshot: scope.snapshot)
         )
+      ]
+    } catch {
+      return []
+    }
+  }
 
-        // Add product(s).
-        actions.append(
-            contentsOf: maybeAddProductActions(call: call, in: scope)
+  /// A list of target kinds that allow the creation of tests.
+  static let targetsThatAllowTests: Set<String> = [
+    "executableTarget",
+    "macro",
+    "target",
+  ]
+
+  /// Produce code actions to add a product if we are currently on
+  /// a target for which we can create a product.
+  static func maybeAddProductActions(
+    call: FunctionCallExprSyntax,
+    in scope: SyntaxCodeActionScope
+  ) -> [CodeAction] {
+    guard let calledMember = call.findMemberAccessCallee(),
+      targetsThatAllowProducts.contains(calledMember),
+      let targetName = call.findStringArgument(label: "name")
+    else {
+      return []
+    }
+
+    do {
+      let type: ProductType =
+        calledMember == "executableTarget"
+        ? .executable
+        : .library(.automatic)
+
+      // Describe the target we are going to create.
+      let product = try ProductDescription(
+        name: "\(targetName)",
+        type: type,
+        targets: [targetName]
+      )
+
+      let edits = try AddProduct.addProduct(product, to: scope.file)
+      return [
+        CodeAction(
+          title: "Add product to export this target",
+          kind: .refactor,
+          edit: edits.asWorkspaceEdit(snapshot: scope.snapshot)
         )
-
-        return actions
+      ]
+    } catch {
+      return []
     }
+  }
 
-    /// Produce code actions to add test target(s) if we are currently on
-    /// a target for which we know how to create a test.
-    static func maybeAddTestTargetActions(
-        call: FunctionCallExprSyntax,
-        in scope: SyntaxCodeActionScope
-    ) -> [CodeAction] {
-        guard let calledMember = call.findMemberAccessCallee(),
-              targetsThatAllowTests.contains(calledMember),
-              let targetName = call.findStringArgument(label: "name")
-        else {
-            return []
-        }
-
-        do {
-            // Describe the target we are going to create.
-            let target = try TargetDescription(
-                name: "\(targetName)Tests",
-                dependencies: [ .byName(name: targetName, condition: nil) ],
-                type: .test
-            )
-
-            let edits = try AddTarget.addTarget(target, to: scope.file)
-            return [
-                CodeAction(
-                    title: "Add test target",
-                    kind: .refactor,
-                    edit: edits.asWorkspaceEdit(snapshot: scope.snapshot)
-                )
-            ]
-        } catch {
-            return []
-        }
-    }
-
-    /// A list of target kinds that allow the creation of tests.
-    static let targetsThatAllowTests: Set<String> = [
-        "executableTarget",
-        "macro",
-        "target",
-    ]
-
-    /// Produce code actions to add a product if we are currently on
-    /// a target for which we can create a product.
-    static func maybeAddProductActions(
-        call: FunctionCallExprSyntax,
-        in scope: SyntaxCodeActionScope
-    ) -> [CodeAction] {
-        guard let calledMember = call.findMemberAccessCallee(),
-              targetsThatAllowProducts.contains(calledMember),
-              let targetName = call.findStringArgument(label: "name")
-        else {
-            return []
-        }
-
-        do {
-            let type: ProductType = calledMember == "executableTarget"
-                ? .executable
-                : .library(.automatic)
-
-            // Describe the target we are going to create.
-            let product = try ProductDescription(
-                name: "\(targetName)",
-                type: type,
-                targets: [ targetName ]
-            )
-
-            let edits = try AddProduct.addProduct(product, to: scope.file)
-            return [
-                CodeAction(
-                    title: "Add product to export this target",
-                    kind: .refactor,
-                    edit: edits.asWorkspaceEdit(snapshot: scope.snapshot)
-                )
-            ]
-        } catch {
-            return []
-        }
-    }
-
-    /// A list of target kinds that allow the creation of tests.
-    static let targetsThatAllowProducts: Set<String> = [
-        "executableTarget",
-        "target",
-    ]
+  /// A list of target kinds that allow the creation of tests.
+  static let targetsThatAllowProducts: Set<String> = [
+    "executableTarget",
+    "target",
+  ]
 }
 
 fileprivate extension PackageEditResult {
-    /// Translate package manifest edits into a workspace edit. This can
-    /// involve both modifications to the manifest file as well as the creation
-    /// of new files.
-    func asWorkspaceEdit(snapshot: DocumentSnapshot) -> WorkspaceEdit {
-        // The edits to perform on the manifest itself.
-        let manifestTextEdits = manifestEdits.map { edit in
-            TextEdit(
-                range: snapshot.range(of: edit.range),
-                newText: edit.replacement
-            )
-        }
-
-        // If we couldn't figure out the manifest directory, or there are no
-        // files to add, the only changes are the manifest edits. We're done
-        // here.
-        let manifestDirectoryURI = snapshot.uri.fileURL?
-            .deletingLastPathComponent()
-        guard let manifestDirectoryURI, !auxiliaryFiles.isEmpty else {
-            return WorkspaceEdit(
-                changes: [snapshot.uri: manifestTextEdits]
-            )
-        }
-
-        // Use the more full-featured documentChanges, which takes precedence
-        // over the individual changes to documents.
-        var documentChanges: [WorkspaceEditDocumentChange] = []
-
-        // Put the manifest changes into the array.
-        documentChanges.append(
-            .textDocumentEdit(
-                .init(
-                    textDocument: .init(snapshot.uri, version: nil),
-                    edits: manifestTextEdits.map { .textEdit($0) }
-                )
-            )
-        )
-
-        // Create an populate all of the auxiliary files.
-        for (relativePath, contents) in auxiliaryFiles {
-            guard let uri = URL(
-                string: relativePath.pathString,
-                relativeTo: manifestDirectoryURI
-            ) else {
-                continue
-            }
-
-            let documentURI = DocumentURI(uri)
-            let createFile = CreateFile(
-                uri: documentURI
-            )
-
-            let zeroPosition = Position(line: 0, utf16index: 0)
-            let edit = TextEdit(
-                range: zeroPosition..<zeroPosition,
-                newText: contents.description
-            )
-
-            documentChanges.append(.createFile(createFile))
-            documentChanges.append(
-                .textDocumentEdit(
-                    .init(
-                        textDocument: .init(documentURI, version: nil),
-                        edits: [ .textEdit(edit) ]
-                    )
-                )
-            )
-        }
-
-        return WorkspaceEdit(
-            changes: [ snapshot.uri: manifestTextEdits ],
-            documentChanges: documentChanges
-        )
+  /// Translate package manifest edits into a workspace edit. This can
+  /// involve both modifications to the manifest file as well as the creation
+  /// of new files.
+  func asWorkspaceEdit(snapshot: DocumentSnapshot) -> WorkspaceEdit {
+    // The edits to perform on the manifest itself.
+    let manifestTextEdits = manifestEdits.map { edit in
+      TextEdit(
+        range: snapshot.range(of: edit.range),
+        newText: edit.replacement
+      )
     }
+
+    // If we couldn't figure out the manifest directory, or there are no
+    // files to add, the only changes are the manifest edits. We're done
+    // here.
+    let manifestDirectoryURI = snapshot.uri.fileURL?
+      .deletingLastPathComponent()
+    guard let manifestDirectoryURI, !auxiliaryFiles.isEmpty else {
+      return WorkspaceEdit(
+        changes: [snapshot.uri: manifestTextEdits]
+      )
+    }
+
+    // Use the more full-featured documentChanges, which takes precedence
+    // over the individual changes to documents.
+    var documentChanges: [WorkspaceEditDocumentChange] = []
+
+    // Put the manifest changes into the array.
+    documentChanges.append(
+      .textDocumentEdit(
+        .init(
+          textDocument: .init(snapshot.uri, version: nil),
+          edits: manifestTextEdits.map { .textEdit($0) }
+        )
+      )
+    )
+
+    // Create an populate all of the auxiliary files.
+    for (relativePath, contents) in auxiliaryFiles {
+      guard
+        let uri = URL(
+          string: relativePath.pathString,
+          relativeTo: manifestDirectoryURI
+        )
+      else {
+        continue
+      }
+
+      let documentURI = DocumentURI(uri)
+      let createFile = CreateFile(
+        uri: documentURI
+      )
+
+      let zeroPosition = Position(line: 0, utf16index: 0)
+      let edit = TextEdit(
+        range: zeroPosition..<zeroPosition,
+        newText: contents.description
+      )
+
+      documentChanges.append(.createFile(createFile))
+      documentChanges.append(
+        .textDocumentEdit(
+          .init(
+            textDocument: .init(documentURI, version: nil),
+            edits: [.textEdit(edit)]
+          )
+        )
+      )
+    }
+
+    return WorkspaceEdit(
+      changes: [snapshot.uri: manifestTextEdits],
+      documentChanges: documentChanges
+    )
+  }
 }
 
 fileprivate extension SyntaxProtocol {
-    // Find an enclosing call syntax expression.
-    func findEnclosingCall() -> FunctionCallExprSyntax? {
-        var current = Syntax(self)
-        while true {
-            if let call = current.as(FunctionCallExprSyntax.self) {
-                return call
-            }
-
-            if let parent = current.parent {
-                current = parent
-                continue
-            }
-
-          return nil
+  // Find an enclosing call syntax expression.
+  func findEnclosingCall() -> FunctionCallExprSyntax? {
+    var current = Syntax(self)
+    while true {
+      if let call = current.as(FunctionCallExprSyntax.self) {
+        return call
       }
+
+      if let parent = current.parent {
+        current = parent
+        continue
+      }
+
+      return nil
+    }
   }
 }
 
 fileprivate extension FunctionCallExprSyntax {
-    /// Find an argument with the given label that has a string literal as
-    /// its argument.
-    func findStringArgument(label: String) -> String? {
-        for arg in arguments {
-            if arg.label?.text == label {
-                return arg.expression.as(StringLiteralExprSyntax.self)?
-                    .representedLiteralValue
-            }
-        }
-
-        return nil
+  /// Find an argument with the given label that has a string literal as
+  /// its argument.
+  func findStringArgument(label: String) -> String? {
+    for arg in arguments {
+      if arg.label?.text == label {
+        return arg.expression.as(StringLiteralExprSyntax.self)?
+          .representedLiteralValue
+      }
     }
 
-    /// Find the callee when it is a member access expression referencing
-    /// a declaration when a specific name.
-    func findMemberAccessCallee() -> String? {
-        guard let memberAccess = self.calledExpression
-            .as(MemberAccessExprSyntax.self)
-        else {
-            return nil
-        }
+    return nil
+  }
 
-        return memberAccess.declName.baseName.text
+  /// Find the callee when it is a member access expression referencing
+  /// a declaration when a specific name.
+  func findMemberAccessCallee() -> String? {
+    guard
+      let memberAccess = self.calledExpression
+        .as(MemberAccessExprSyntax.self)
+    else {
+      return nil
     }
+
+    return memberAccess.declName.baseName.text
+  }
 }

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
@@ -20,5 +20,6 @@ let allSyntaxCodeActions: [SyntaxCodeActionProvider.Type] = [
   FormatRawStringLiteral.self,
   MigrateToNewIfLetSyntax.self,
   OpaqueParameterToGeneric.self,
+  PackageManifestEdits.self,
   RemoveSeparatorsFromIntegerLiteral.self,
 ]

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -74,7 +74,8 @@ final class CodingTests: XCTestCase {
       OptionalVersionedTextDocumentIdentifier(uri, version: nil),
       json: """
         {
-          "uri" : "\(urljson)"
+          "uri" : "\(urljson)",
+          "version" : null
         }
         """
     )


### PR DESCRIPTION
Leverage the newly-introduced package manifest editing tools in SwiftPM
to create a package editing refactoring operation. This operation can
be triggered from the a target in the manifest itself, e.g.,

    .target(name: "MyLib")

and will add a test target to the package manifest that depends on
this target, i.e.,

    .testTarget(
      name: "MyLibTests",
      dependencies: [ "MyLib" ]
    )

It will also create a new source file `Tests/MyLibTests/MyLibTests.swift`
that that imports both MyLib and XCTest, and contains an XCTestCase subclass
with one test to get you started.