### PR TITLE
Enhance syntactic test discovery with information from the semantic index

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
@@ -12,7 +12,7 @@
 
 public struct TestTag: Codable, Equatable, Sendable {
   /// ID of the test tag. `TestTag` instances with the same ID are considered to be identical.
-  public let id: String
+  public var id: String
 
   public init(id: String) {
     self.id = id
@@ -26,35 +26,35 @@ public struct TestItem: ResponseType, Equatable {
   /// Identifier for the `TestItem`.
   ///
   /// This identifier uniquely identifies the test case or test suite. It can be used to run an individual test (suite).
-  public let id: String
+  public var id: String
 
   /// Display name describing the test.
-  public let label: String
+  public var label: String
 
   /// Optional description that appears next to the label.
-  public let description: String?
+  public var description: String?
 
   /// A string that should be used when comparing this item with other items.
   ///
   /// When `nil` the `label` is used.
-  public let sortText: String?
+  public var sortText: String?
 
   /// Whether the test is disabled.
-  public let disabled: Bool
+  public var disabled: Bool
 
   /// The type of test, eg. the testing framework that was used to declare the test.
-  public let style: String
+  public var style: String
 
   /// The location of the test item in the source code.
-  public let location: Location
+  public var location: Location
 
   /// The children of this test item.
   ///
   /// For a test suite, this may contain the individual test cases or nested suites.
-  public let children: [TestItem]
+  public var children: [TestItem]
 
   /// Tags associated with this test item.
-  public let tags: [TestTag]
+  public var tags: [TestTag]
 
   public init(
     id: String,

--- a/Sources/SourceKitLSP/CheckedIndex.swift
+++ b/Sources/SourceKitLSP/CheckedIndex.swift
@@ -95,6 +95,13 @@ public class CheckedIndex {
     return index.symbolProvider(for: sourceFilePath)
   }
 
+  public func symbols(inFilePath path: String) -> [Symbol] {
+    guard self.hasUpToDateUnit(for: URL(fileURLWithPath: path, isDirectory: false)) else {
+      return []
+    }
+    return index.symbols(inFilePath: path)
+  }
+
   /// Returns all unit test symbol in unit files that reference one of the main files in `mainFilePaths`.
   public func unitTests(referencedByMainFiles mainFilePaths: [String]) -> [SymbolOccurrence] {
     return index.unitTests(referencedByMainFiles: mainFilePaths).filter { checker.isUpToDate($0.location) }

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -198,7 +198,7 @@ public protocol LanguageService: AnyObject {
   /// Perform a syntactic scan of the file at the given URI for test cases and test classes.
   ///
   /// This is used as a fallback to show the test cases in a file if the index for a given file is not up-to-date.
-  func syntacticDocumentTests(for uri: DocumentURI) async throws -> [TestItem]
+  func syntacticDocumentTests(for uri: DocumentURI, in workspace: Workspace) async throws -> [TestItem]
 
   /// Crash the language server. Should be used for crash recovery testing only.
   func _crash() async

--- a/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
@@ -142,6 +142,8 @@ actor SyntacticTestIndex {
 
   /// Called when a list of files was updated. Re-scans those files
   private func rescanFiles(_ uris: [DocumentURI]) {
+    logger.info("Syntactically scanning files for tests: \(uris)")
+
     // If we scan a file again, it might have been added after being removed before. Remove it from the list of removed
     // files.
     removedFiles.subtract(uris)


### PR DESCRIPTION
When the semantic index is out-of-date, we currently purely rely on the syntactic index to discover tests and completely ignore data from the semantic index. This may lead to confusing behavior. For example if you have

```
class MightInheritFromXCTestCaseOrNot {}

class MyClass: MightInheritFromXCTestCaseOrNot {
  func testStuff() {}
}
```

Then we don’t return any tests when the semantic index is up-to-date. But once the file is modified (either on disk or in-memory), we purely rely on the syntactic index, which reports `testStuff` as a test method. After a build / background indexing finishes, the test method disappears again.

We can mitigate this problem as follows: If we have stale semantic index data for the test file, for every test method found by the syntactic index, check if we have an entry for this method in the semantic index. If we do, but that entry is not marked as a test class/method, we know that the semantic index knows about this method but decided that it’s not a test method for some reason. So we should ignore it.

rdar://126492948