### PR TITLE
Fix test discovery for Objective-C XCTests

### DIFF
--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -198,7 +198,9 @@ public protocol LanguageService: AnyObject {
   /// Perform a syntactic scan of the file at the given URI for test cases and test classes.
   ///
   /// This is used as a fallback to show the test cases in a file if the index for a given file is not up-to-date.
-  func syntacticDocumentTests(for uri: DocumentURI, in workspace: Workspace) async throws -> [TestItem]
+  ///
+  /// A return value of `nil` indicates that this language service does not support syntactic test discovery.
+  func syntacticDocumentTests(for uri: DocumentURI, in workspace: Workspace) async throws -> [TestItem]?
 
   /// Crash the language server. Should be used for crash recovery testing only.
   func _crash() async

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -1065,4 +1065,138 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     XCTAssertFalse(testsAfterEdit.contains { $0.label == "NotQuiteTest" })
     XCTAssertTrue(testsAfterEdit.contains { $0.label == "OtherNotQuiteTest" })
   }
+
+  func testObjectiveCTestFromSemanticIndex() async throws {
+    try SkipUnless.platformIsDarwin("Non-Darwin platforms don't support Objective-C")
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/Test.m": """
+        #import <XCTest/XCTest.h>
+
+        @interface MyTests : XCTestCase
+        @end
+
+        1️⃣@implementation MyTests
+        2️⃣- (void)testSomething {
+        }3️⃣
+        @4️⃣end
+        """
+      ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [.testTarget(name: "MyLibraryTests")]
+        )
+        """,
+      build: true
+    )
+
+    let (uri, positions) = try project.openDocument("Test.m")
+
+    let tests = try await project.testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/testSomething",
+              label: "testSomething",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testObjectiveCTestsAfterInMemoryEdit() async throws {
+    try SkipUnless.platformIsDarwin("Non-Darwin platforms don't support Objective-C")
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/Test.m": """
+        #import <XCTest/XCTest.h>
+
+        @interface MyTests : XCTestCase
+        @end
+
+        1️⃣@implementation MyTests
+        2️⃣- (void)testSomething {}3️⃣
+        0️⃣
+        @4️⃣end
+        """
+      ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [.testTarget(name: "MyLibraryTests")]
+        )
+        """,
+      build: true
+    )
+
+    let (uri, positions) = try project.openDocument("Test.m")
+
+    project.testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(uri, version: 2),
+        contentChanges: [
+          TextDocumentContentChangeEvent(
+            range: Range(positions["0️⃣"]),
+            text: """
+              - (void)testSomethingElse {}
+              """
+          )
+        ]
+      )
+    )
+
+    let tests = try await project.testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    // Since we don't have syntactic test discovery for clang-languages, we don't discover `testSomethingElse` as a
+    // test method until we perform a build
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/testSomething",
+              label: "testSomething",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
 }


### PR DESCRIPTION
There were two issues with Objective-C XCTest discovery:
1. We were relying on syntactic test discovery after a document is edited. But since we don't have syntactic test discovery for Objective-C tests, this meant that all tests would disappear as a document got edited. Until we get syntactic test discovery for Objective-C, use the semantic index to discover tests, even if they are out-of-date.
2. We were assuming that the `DocumentSymbols` request returned `[DocumentSymbol]` to find the ranges of tests. But clangd returns the alternative `[SymbolInformation]`, which meant that we were only returning the position of a test function’s name instead of the test function’s range.

rdar://126810202