### PR TITLE
Add separate "add test" manifest actions for XCTest and Swift Testing

### DIFF
--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -609,12 +609,12 @@ final class CodeActionTests: XCTestCase {
 
     // Make sure we get the expected package manifest editing actions.
     let addTestAction = codeActions.first { action in
-      return action.title == "Add test target"
+      return action.title == "Add test target (Swift Testing)"
     }
     XCTAssertNotNil(addTestAction)
 
     guard let addTestChanges = addTestAction?.edit?.documentChanges else {
-      XCTFail("Didn't have changes in the 'Add test target' action")
+      XCTFail("Didn't have changes in the 'Add test target (Swift Testing)' action")
       return
     }
 


### PR DESCRIPTION
Builds on https://github.com/apple/sourcekit-lsp/pull/1193 and https://github.com/apple/swift-package-manager/pull/7481