### PR TITLE
Minor improvements to the diagnose subcommand

### DIFF
--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -27,11 +27,11 @@ private var progressBar: PercentProgressAnimation? = nil
 
 /// A component of the diagnostic bundle that's collected in independent stages.
 fileprivate enum BundleComponent: String, CaseIterable, ExpressibleByArgument {
-  case crashReports
-  case logs
-  case swiftVersions
-  case sourcekitdCrashes
-  case swiftFrontendCrashes
+  case crashReports = "crash-reports"
+  case logs = "logs"
+  case swiftVersions = "swift-versions"
+  case sourcekitdCrashes = "sourcekitd-crashes"
+  case swiftFrontendCrashes = "swift-frontend-crashes"
 }
 
 public struct DiagnoseCommand: AsyncParsableCommand {

--- a/Sources/Diagnose/ReproducerBundle.swift
+++ b/Sources/Diagnose/ReproducerBundle.swift
@@ -41,7 +41,7 @@ func makeReproducerBundle(for requestInfo: RequestInfo, toolchain: Toolchain, bu
   } else {
     let request = try requestInfo.request(for: URL(fileURLWithPath: "/input.swift"))
     try request.write(
-      to: bundlePath.appendingPathComponent("request.json"),
+      to: bundlePath.appendingPathComponent("request.yml"),
       atomically: true,
       encoding: .utf8
     )


### PR DESCRIPTION
- Change name of request in reproducer bundle from `request.json` to `request.yml` because it’s a YAML file, not a JSON file
- Change names of diagnose components to use dashes instead of camel case