### PR TITLE
Skip a few hover tests if sourcekitd doesn’t return raw documentation in cursor info

### DIFF
--- a/Tests/SourceKitLSPTests/HoverTests.swift
+++ b/Tests/SourceKitLSPTests/HoverTests.swift
@@ -87,6 +87,7 @@ final class HoverTests: XCTestCase {
   }
 
   func testMultiCursorInfoResultsHoverWithDocumentation() async throws {
+    try await SkipUnless.sourcekitdReturnsRawDocumentationResponse()
     try await assertHover(
       """
       /// A struct
@@ -118,6 +119,7 @@ final class HoverTests: XCTestCase {
   }
 
   func testHoverNameEscapingOnFunction() async throws {
+    try await SkipUnless.sourcekitdReturnsRawDocumentationResponse()
     try await assertHover(
       """
       /// this is **bold** documentation
@@ -134,6 +136,7 @@ final class HoverTests: XCTestCase {
   }
 
   func testHoverNameEscapingOnOperator() async throws {
+    try await SkipUnless.sourcekitdReturnsRawDocumentationResponse()
     try await assertHover(
       """
       /// this is *italic* documentation


### PR DESCRIPTION
The formatting of these hover responses contains a newline if we don’t have a raw documentation response. Skip these tests if sourcekitd doesn’t return the raw documentation in cursor info, like we do with other tests in this file.

This ensures that all tests are passing in Xcode 15.4 again.