### PR TITLE
Don’t include files from package dependencies in the syntactic test index

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -263,7 +263,7 @@ extension SwiftPMBuildSystem {
     self.fileToTarget = [AbsolutePath: SwiftBuildTarget](
       modulesGraph.allTargets.flatMap { target in
         return target.sources.paths.compactMap {
-          guard let buildTarget = buildDescription.getBuildTarget(for: target) else {
+          guard let buildTarget = buildDescription.getBuildTarget(for: target, in: modulesGraph) else {
             return nil
           }
           return (key: $0, value: buildTarget)
@@ -277,7 +277,7 @@ extension SwiftPMBuildSystem {
 
     self.sourceDirToTarget = [AbsolutePath: SwiftBuildTarget](
       modulesGraph.allTargets.compactMap { (target) -> (AbsolutePath, SwiftBuildTarget)? in
-        guard let buildTarget = buildDescription.getBuildTarget(for: target) else {
+        guard let buildTarget = buildDescription.getBuildTarget(for: target, in: modulesGraph) else {
           return nil
         }
         return (key: target.sources.root, value: buildTarget)
@@ -439,8 +439,13 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
   }
 
   public func testFiles() -> [DocumentURI] {
-    // We should only include source files from test targets (https://github.com/apple/sourcekit-lsp/issues/1174).
-    return fileToTarget.map { DocumentURI($0.key.asURL) }
+    return fileToTarget.compactMap { (path, target) -> DocumentURI? in
+      guard target.isPartOfRootPackage else {
+        // Don't consider files from package dependencies as possible test files.
+        return nil
+      }
+      return DocumentURI(path.asURL)
+    }
   }
 
   public func addTestFilesDidChangeCallback(_ callback: @Sendable @escaping () async -> Void) async {

--- a/Sources/SKTestSupport/SwiftPMDependencyProject.swift
+++ b/Sources/SKTestSupport/SwiftPMDependencyProject.swift
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import ISDBTibs
+import XCTest
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import enum TSCBasic.ProcessEnv
+import struct TSCBasic.ProcessResult
+
+/// A SwiftPM package that gets written to disk and for which a Git repository is initialized with a commit tagged
+/// `1.0.0`. This repository can then be used as a dependency for another package, usually a `SwiftPMTestProject`.
+public class SwiftPMDependencyProject {
+  /// The directory in which the repository lives.
+  public let packageDirectory: URL
+
+  private func runCommand(_ toolName: String, _ arguments: [String], workingDirectory: URL) async throws {
+    enum Error: Swift.Error {
+      case cannotFindTool(toolName: String)
+      case processedTerminatedWithNonZeroExitCode(ProcessResult)
+    }
+    guard let toolUrl = findTool(name: toolName) else {
+      if ProcessEnv.block["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+        // Never skip the test in CI, similar to what SkipUnless does.
+        throw XCTSkip("\(toolName) cannot be found")
+      }
+      throw Error.cannotFindTool(toolName: toolName)
+    }
+    print([toolUrl.path] + arguments)
+    let process = TSCBasic.Process(
+      arguments: [toolUrl.path] + arguments,
+      workingDirectory: try AbsolutePath(validating: workingDirectory.path)
+    )
+    try process.launch()
+    let processResult = try await process.waitUntilExit()
+    guard processResult.exitStatus == .terminated(code: 0) else {
+      throw Error.processedTerminatedWithNonZeroExitCode(processResult)
+    }
+  }
+
+  public static let defaultPackageManifest: String = """
+    // swift-tools-version: 5.7
+
+    import PackageDescription
+
+    let package = Package(
+      name: "MyDependency",
+      products: [.library(name: "MyDependency", targets: ["MyDependency"])],
+      targets: [.target(name: "MyDependency")]
+    )
+    """
+
+  public init(
+    files: [RelativeFileLocation: String],
+    manifest: String = defaultPackageManifest,
+    testName: String = #function
+  ) async throws {
+    packageDirectory = try testScratchDir(testName: testName).appendingPathComponent("MyDependency")
+
+    var files = files
+    files["Package.swift"] = manifest
+
+    for (fileLocation, contents) in files {
+      let fileURL = fileLocation.url(relativeTo: packageDirectory)
+      try FileManager.default.createDirectory(
+        at: fileURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
+
+    try await runCommand("git", ["init"], workingDirectory: packageDirectory)
+    try await runCommand(
+      "git",
+      ["add"] + files.keys.map { $0.url(relativeTo: packageDirectory).path },
+      workingDirectory: packageDirectory
+    )
+    try await runCommand(
+      "git",
+      ["-c", "user.name=Dummy", "-c", "user.email=noreply@swift.org", "commit", "-m", "Initial commit"],
+      workingDirectory: packageDirectory
+    )
+    try await runCommand("git", ["tag", "1.0.0"], workingDirectory: packageDirectory)
+  }
+
+  deinit {
+    if cleanScratchDirectories {
+      try? FileManager.default.removeItem(at: packageDirectory)
+    }
+  }
+
+  /// Function that makes sure the project stays alive until this is called. Otherwise, the `SwiftPMDependencyProject`
+  /// might get deinitialized, which deletes the package on disk.
+  public func keepAlive() {
+    withExtendedLifetime(self) { _ in }
+  }
+}


### PR DESCRIPTION
`SwiftPMBuildSystem.testFiles()` returned all source files in the package, including files of package dependencies. This caused us to index those files for tests in the syntactic test index, which we should not.

Make `SwiftPMBuildSystem.testFiles` only return files from the root package.

Also add test infrastructure to be able to test cross-package functionality.

rdar://126965614