### PR TITLE
Skip new tests that use Swift modules if the host’s SwiftPM doesn’t store `.swiftmodule` files in a subdirectory

### DIFF
--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -440,6 +440,7 @@ class DefinitionTests: XCTestCase {
 
   func testDependentModuleGotBuilt() async throws {
     try SkipUnless.longTestsEnabled()
+    try await SkipUnless.swiftpmStoresModulesInSubdirectory()
     let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -154,6 +154,7 @@ final class PublishDiagnosticsTests: XCTestCase {
 
   func testDiagnosticUpdatedAfterDependentModuleIsBuilt() async throws {
     try SkipUnless.longTestsEnabled()
+    try await SkipUnless.swiftpmStoresModulesInSubdirectory()
 
     let project = try await SwiftPMTestProject(
       files: [

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -182,6 +182,7 @@ final class PullDiagnosticsTests: XCTestCase {
 
   func testDiagnosticUpdatedAfterDependentModuleIsBuilt() async throws {
     try SkipUnless.longTestsEnabled()
+    try await SkipUnless.swiftpmStoresModulesInSubdirectory()
 
     let project = try await SwiftPMTestProject(
       files: [


### PR DESCRIPTION
This fixes a test failure when running tests using Xcode 15.3.