### PR TITLE
Elevate the log level for messages that record which toolchain was used for a document

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -821,7 +821,7 @@ public actor SourceKitLSPServer {
       return nil
     }
 
-    logger.info("Using toolchain \(toolchain.displayName) (\(toolchain.identifier)) for \(uri.forLogging)")
+    logger.log("Using toolchain \(toolchain.displayName) (\(toolchain.identifier)) for \(uri.forLogging)")
 
     if let concurrentlySetService = workspace.documentService[uri] {
       // Since we await the construction of `service`, another call to this


### PR DESCRIPTION
This is some fairly essential information for troubleshooting and should be logged at the same level as the build settings for a file.