### PR TITLE
Add "Add documentation" code action to stub out documentation for a function

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(SourceKitLSP PRIVATE
   Clang/ClangLanguageService.swift)
 target_sources(SourceKitLSP PRIVATE
   Swift/AdjustPositionToStartOfIdentifier.swift
+  Swift/CodeActions/AddDocumentation.swift
   Swift/CodeActions/ConvertIntegerLiteral.swift
   Swift/CodeActions/PackageManifestEdits.swift
   Swift/CodeActions/SyntaxCodeActionProvider.swift

--- a/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftParser
+import SwiftRefactor
+import SwiftSyntax
+
+/// Insert a documentation template associated with a function or macro.
+///
+/// ## Before
+///
+/// ```swift
+/// static func refactor(syntax: DeclSyntax, in context: Void) -> DeclSyntax? {}
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// ///
+/// /// - Parameters:
+/// ///   - syntax:
+/// ///   - context:
+/// /// - Returns:
+/// static func refactor(syntax: DeclSyntax, in context: Void) -> DeclSyntax? {}
+/// ```
+@_spi(Testing)
+public struct AddDocumentation: EditRefactoringProvider {
+  @_spi(Testing)
+  public static func textRefactor(syntax: DeclSyntax, in context: Void) -> [SourceEdit] {
+    let hasDocumentation = syntax.leadingTrivia.contains(where: { trivia in
+      switch trivia {
+      case .blockComment(_), .docBlockComment(_), .lineComment(_), .docLineComment(_):
+        return true
+      default:
+        return false
+      }
+    })
+
+    guard !hasDocumentation else {
+      return []
+    }
+
+    let indentation = [.newlines(1)] + syntax.leadingTrivia.lastLineIndentation()
+    var content: [TriviaPiece] = []
+    content.append(contentsOf: indentation)
+    content.append(.docLineComment("/// A description"))
+
+    if let parameters = syntax.parameters?.parameters {
+      if let onlyParam = parameters.only {
+        let paramToken = onlyParam.secondName?.text ?? onlyParam.firstName.text
+        content.append(contentsOf: indentation)
+        content.append(.docLineComment("/// - Parameter \(paramToken):"))
+      } else {
+        content.append(contentsOf: indentation)
+        content.append(.docLineComment("/// - Parameters:"))
+        content.append(
+          contentsOf: parameters.flatMap({ param in
+            indentation + [
+              .docLineComment("///   - \(param.secondName?.text ?? param.firstName.text):")
+            ]
+          })
+        )
+        content.append(contentsOf: indentation)
+        content.append(.docLineComment("///"))
+      }
+    }
+
+    if syntax.throwsKeyword != nil {
+      content.append(contentsOf: indentation)
+      content.append(.docLineComment("/// - Throws:"))
+    }
+
+    if syntax.returnType != nil {
+      content.append(contentsOf: indentation)
+      content.append(.docLineComment("/// - Returns:"))
+    }
+
+    let insertPos = syntax.position
+    return [
+      SourceEdit(
+        range: insertPos..<insertPos,
+        replacement: Trivia(pieces: content).description
+      )
+    ]
+  }
+}
+
+extension AddDocumentation: SyntaxRefactoringCodeActionProvider {
+  static var title: String { "Add documentation" }
+}
+
+extension DeclSyntax {
+  fileprivate var parameters: FunctionParameterClauseSyntax? {
+    switch self.syntaxNodeType {
+    case is FunctionDeclSyntax.Type:
+      return self.as(FunctionDeclSyntax.self)!.signature.parameterClause
+    case is SubscriptDeclSyntax.Type:
+      return self.as(SubscriptDeclSyntax.self)!.parameterClause
+    case is InitializerDeclSyntax.Type:
+      return self.as(InitializerDeclSyntax.self)!.signature.parameterClause
+    case is MacroDeclSyntax.Type:
+      return self.as(MacroDeclSyntax.self)!.signature.parameterClause
+    default:
+      return nil
+    }
+  }
+
+  fileprivate var throwsKeyword: TokenSyntax? {
+    switch self.syntaxNodeType {
+    case is FunctionDeclSyntax.Type:
+      return self.as(FunctionDeclSyntax.self)!.signature.effectSpecifiers?
+        .throwsClause?.throwsSpecifier
+    case is InitializerDeclSyntax.Type:
+      return self.as(InitializerDeclSyntax.self)!.signature.effectSpecifiers?
+        .throwsClause?.throwsSpecifier
+    default:
+      return nil
+    }
+  }
+
+  fileprivate var returnType: TypeSyntax? {
+    switch self.syntaxNodeType {
+    case is FunctionDeclSyntax.Type:
+      return self.as(FunctionDeclSyntax.self)!.signature.returnClause?.type
+    case is SubscriptDeclSyntax.Type:
+      return self.as(SubscriptDeclSyntax.self)!.returnClause.type
+    case is InitializerDeclSyntax.Type:
+      return self.as(InitializerDeclSyntax.self)!.signature.returnClause?.type
+    case is MacroDeclSyntax.Type:
+      return self.as(MacroDeclSyntax.self)!.signature.returnClause?.type
+    default:
+      return nil
+    }
+  }
+}
+
+extension Trivia {
+  /// Produce trivia from the last newline to the end, dropping anything
+  /// prior to that.
+  fileprivate func lastLineIndentation() -> Trivia {
+    guard let lastNewline = pieces.lastIndex(where: { $0.isNewline }) else {
+      return self
+    }
+
+    return Trivia(pieces: pieces[(lastNewline + 1)...])
+  }
+}

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
@@ -15,6 +15,7 @@ import SwiftRefactor
 /// List of all of the syntactic code action providers, which can be used
 /// to produce code actions using only the swift-syntax tree of a file.
 let allSyntaxCodeActions: [SyntaxCodeActionProvider.Type] = [
+  AddDocumentation.self,
   AddSeparatorsToIntegerLiteral.self,
   ConvertIntegerLiteral.self,
   FormatRawStringLiteral.self,

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -93,17 +93,18 @@ final class PullDiagnosticsTests: XCTestCase {
       return
     }
 
-    XCTAssertEqual(actions.count, 1)
-    let action = try XCTUnwrap(actions.first)
-    // Allow the action message to be the one before or after
-    // https://github.com/apple/swift/pull/67909, ensuring this test passes with
-    // a sourcekitd that contains the change from that PR as well as older
-    // toolchains that don't contain the change yet.
+    XCTAssertEqual(actions.count, 2)
     XCTAssert(
-      [
-        "Add stubs for conformance",
-        "Do you want to add protocol stubs?",
-      ].contains(action.title)
+      actions.contains { action in
+        // Allow the action message to be the one before or after
+        // https://github.com/apple/swift/pull/67909, ensuring this test passes with
+        // a sourcekitd that contains the change from that PR as well as older
+        // toolchains that don't contain the change yet.
+        [
+          "Add stubs for conformance",
+          "Do you want to add protocol stubs?",
+        ].contains(action.title)
+      }
     )
   }
 

--- a/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
+++ b/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
@@ -1,0 +1,265 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) import SourceKitLSP
+import SwiftParser
+import SwiftRefactor
+import SwiftSyntax
+import XCTest
+
+final class SyntaxRefactorTests: XCTestCase {
+  func testAddDocumentationRefactor() throws {
+    try assertRefactor(
+      """
+        func refactor(syntax: DeclSyntax, in context: Void) -> DeclSyntax? { }
+      """,
+      context: (),
+      provider: AddDocumentation.self,
+      expected: [
+        SourceEdit(
+          range: AbsolutePosition(utf8Offset: 0)..<AbsolutePosition(utf8Offset: 0),
+          replacement: """
+
+              /// A description
+              /// - Parameters:
+              ///   - syntax:
+              ///   - context:
+              ///
+              /// - Returns:
+            """
+        )
+      ]
+    )
+  }
+}
+
+func assertRefactor<R: EditRefactoringProvider>(
+  malformedInput input: String,
+  context: R.Context,
+  provider: R.Type,
+  expected: [SourceEdit],
+  file: StaticString = #filePath,
+  line: UInt = #line
+) throws where R.Input == Syntax {
+  var parser = Parser(input)
+  let syntax = ExprSyntax.parse(from: &parser)
+  try assertRefactor(
+    Syntax(syntax),
+    context: context,
+    provider: provider,
+    expected: expected,
+    file: file,
+    line: line
+  )
+}
+
+// Borrowed from the swift-syntax library's SwiftRefactor tests.
+
+func assertRefactor<R: EditRefactoringProvider>(
+  _ input: R.Input,
+  context: R.Context,
+  provider: R.Type,
+  expected: [SourceEdit],
+  file: StaticString = #filePath,
+  line: UInt = #line
+) throws {
+  let edits = R.textRefactor(syntax: input, in: context)
+  guard !edits.isEmpty else {
+    if !expected.isEmpty {
+      XCTFail(
+        """
+        Refactoring produced empty result, expected:
+        \(expected)
+        """,
+        file: file,
+        line: line
+      )
+    }
+    return
+  }
+
+  if edits.count != expected.count {
+    XCTFail(
+      """
+      Refactoring produced incorrect number of edits, expected \(expected.count) not \(edits.count).
+
+      Actual:
+      \(edits.map({ $0.debugDescription }).joined(separator: "\n"))
+
+      Expected:
+      \(expected.map({ $0.debugDescription }).joined(separator: "\n"))
+
+      """,
+      file: file,
+      line: line
+    )
+    return
+  }
+
+  for (actualEdit, expectedEdit) in zip(edits, expected) {
+    XCTAssertEqual(
+      actualEdit,
+      expectedEdit,
+      "Incorrect edit, expected \(expectedEdit.debugDescription) but actual was \(actualEdit.debugDescription)",
+      file: file,
+      line: line
+    )
+    assertStringsEqualWithDiff(
+      actualEdit.replacement,
+      expectedEdit.replacement,
+      file: file,
+      line: line
+    )
+  }
+}
+
+/// Asserts that the two strings are equal, providing Unix `diff`-style output if they are not.
+///
+/// - Parameters:
+///   - actual: The actual string.
+///   - expected: The expected string.
+///   - message: An optional description of the failure.
+///   - additionalInfo: Additional information about the failed test case that will be printed after the diff
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///     which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this
+///     function was called.
+public func assertStringsEqualWithDiff(
+  _ actual: String,
+  _ expected: String,
+  _ message: String = "",
+  additionalInfo: @autoclosure () -> String? = nil,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  if actual == expected {
+    return
+  }
+  failStringsEqualWithDiff(
+    actual,
+    expected,
+    message,
+    additionalInfo: additionalInfo(),
+    file: file,
+    line: line
+  )
+}
+
+/// Asserts that the two data are equal, providing Unix `diff`-style output if they are not.
+///
+/// - Parameters:
+///   - actual: The actual string.
+///   - expected: The expected string.
+///   - message: An optional description of the failure.
+///   - additionalInfo: Additional information about the failed test case that will be printed after the diff
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///     which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this
+///     function was called.
+public func assertDataEqualWithDiff(
+  _ actual: Data,
+  _ expected: Data,
+  _ message: String = "",
+  additionalInfo: @autoclosure () -> String? = nil,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  if actual == expected {
+    return
+  }
+
+  // NOTE: Converting to `Stirng` here looses invalid UTF8 sequence difference,
+  // but at least we can see something is different.
+  failStringsEqualWithDiff(
+    String(decoding: actual, as: UTF8.self),
+    String(decoding: expected, as: UTF8.self),
+    message,
+    additionalInfo: additionalInfo(),
+    file: file,
+    line: line
+  )
+}
+
+/// `XCTFail` with `diff`-style output.
+public func failStringsEqualWithDiff(
+  _ actual: String,
+  _ expected: String,
+  _ message: String = "",
+  additionalInfo: @autoclosure () -> String? = nil,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  let stringComparison: String
+
+  // Use `CollectionDifference` on supported platforms to get `diff`-like line-based output. On
+  // older platforms, fall back to simple string comparison.
+  if #available(macOS 10.15, *) {
+    let actualLines = actual.components(separatedBy: .newlines)
+    let expectedLines = expected.components(separatedBy: .newlines)
+
+    let difference = actualLines.difference(from: expectedLines)
+
+    var result = ""
+
+    var insertions = [Int: String]()
+    var removals = [Int: String]()
+
+    for change in difference {
+      switch change {
+      case .insert(let offset, let element, _):
+        insertions[offset] = element
+      case .remove(let offset, let element, _):
+        removals[offset] = element
+      }
+    }
+
+    var expectedLine = 0
+    var actualLine = 0
+
+    while expectedLine < expectedLines.count || actualLine < actualLines.count {
+      if let removal = removals[expectedLine] {
+        result += "–\(removal)\n"
+        expectedLine += 1
+      } else if let insertion = insertions[actualLine] {
+        result += "+\(insertion)\n"
+        actualLine += 1
+      } else {
+        result += " \(expectedLines[expectedLine])\n"
+        expectedLine += 1
+        actualLine += 1
+      }
+    }
+
+    stringComparison = result
+  } else {
+    // Fall back to simple message on platforms that don't support CollectionDifference.
+    stringComparison = """
+      Expected:
+      \(expected)
+
+      Actual:
+      \(actual)
+      """
+  }
+
+  var fullMessage = """
+    \(message.isEmpty ? "Actual output does not match the expected" : message)
+    \(stringComparison)
+    """
+  if let additional = additionalInfo() {
+    fullMessage = """
+      \(fullMessage)
+      \(additional)
+      """
+  }
+  XCTFail(fullMessage, file: file, line: line)
+}


### PR DESCRIPTION
This code action takes an undocumented function declaration like

    func refactor(syntax: DeclSyntax, in context: Void) -> DeclSyntax?

and adds stub documentation for the parameters / result / etc., like this:

    /// A description
    /// - Parameters:
    ///   - syntax:
    ///   - context:
    ///
    /// - Returns:
