### PR TITLE
Remove obsolete `availableLibraries` argument from `loadPackageGraph`

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -242,7 +242,6 @@ extension SwiftPMBuildSystem {
     let modulesGraph = try self.workspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [AbsolutePath(projectRoot)]),
       forceResolvedVersions: true,
-      availableLibraries: self.buildParameters.toolchain.providedLibraries,
       observabilityScope: observabilitySystem.topScope
     )
 


### PR DESCRIPTION
[SwiftPM PR](https://github.com/apple/swift-package-manager/pull/7496) consolidates use of provided libraries around Workspace and PubGrub dependency resolver.