### PR TITLE
Trim parameter names in SwiftTestingScanner

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -292,7 +292,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     }
 
     let name =
-      node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName):" }.joined() + ")"
+      node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.trimmed):" }.joined() + ")"
 
     let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
     let testItem = TestItem(

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -292,7 +292,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     }
 
     let name =
-      node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.trimmed):" }.joined() + ")"
+      node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.text):" }.joined() + ")"
 
     let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
     let testItem = TestItem(

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -386,6 +386,96 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     )
   }
 
+  func testParameterizedSwiftTestingTestWithAnonymousArgument() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣@Test(arguments: [0, 1, 2])
+        func numbersAreOne(_ x: Int) {
+          #expect(x == 1)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/numbersAreOne(_:)",
+              label: "numbersAreOne(_:)",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testParameterizedSwiftTestingTestWithCommentInSignature() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣struct MyTests {
+        2️⃣@Test(arguments: [0, 1, 2])
+        func numbersAreOne(x /* hello */: Int) {
+          #expect(x == 1)
+        }3️⃣
+      }4️⃣
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/numbersAreOne(x:)",
+              label: "numbersAreOne(x:)",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
   func testSwiftTestingSuiteWithNoTests() async throws {
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI.for(.swift)


### PR DESCRIPTION
Test specified with anonymous arguments would produce an id with extra whitespace, i.e: `funcWithArgument(_ x: Int)` would produce a TestItem id of `funcWithArgument(_ :)`

This patch trims this extra whitespace to produce IDs that are consistent with Swift's function ids, i.e: `funcWithArgument(_:)`