### PR TITLE
Filter backticks in TestItem IDs

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
@@ -68,7 +68,7 @@ public struct TestItem: ResponseType, Equatable {
     tags: [TestTag]
   ) {
     self.id = id
-    self.label = label
+    self.label = id == label ? self.id : label
     self.description = description
     self.sortText = sortText
     self.disabled = disabled

--- a/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/TestItem.swift
@@ -68,7 +68,7 @@ public struct TestItem: ResponseType, Equatable {
     tags: [TestTag]
   ) {
     self.id = id
-    self.label = id == label ? self.id : label
+    self.label = label
     self.description = description
     self.sortText = sortText
     self.disabled = disabled

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -317,8 +317,10 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
       return .skipChildren
     }
 
-    let name =
-      identifier.name + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.identifier?.name ?? $0.firstName.text):" }.joined() + ")"
+    let parameters = node.signature.parameterClause.parameters.map {
+      "\($0.firstName.identifier?.name ?? $0.firstName.text):"
+    }.joined()
+    let name = "\(identifier.name)(\(parameters))"
 
     let range = snapshot.absolutePositionRange(
       of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -269,15 +269,24 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
   }
 
   override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+    guard let identifier = node.name.identifier else {
+      return .skipChildren
+    }
+    return visitTypeOrExtensionDecl(node, typeNames: [identifier.name])
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+    guard let identifier = node.name.identifier else {
+      return .skipChildren
+    }
+    return visitTypeOrExtensionDecl(node, typeNames: [identifier.name])
   }
 
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+    guard let identifier = node.name.identifier else {
+      return .skipChildren
+    }
+    return visitTypeOrExtensionDecl(node, typeNames: [identifier.name])
   }
 
   override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -289,7 +298,10 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
   }
 
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    return visitTypeOrExtensionDecl(node, typeNames: [node.name.text])
+    guard let identifier = node.name.identifier else {
+      return .skipChildren
+    }
+    return visitTypeOrExtensionDecl(node, typeNames: [identifier.name])
   }
 
   override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -297,7 +309,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
       .compactMap { $0.as(AttributeSyntax.self) }
       .first { $0.isNamed("Test", inModuleNamed: "Testing") }
 
-    guard let testAttribute else {
+    guard let testAttribute, let identifier = node.name.identifier else {
       return .skipChildren
     }
     let attributeData = TestingAttributeData(attribute: testAttribute)
@@ -306,7 +318,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     }
 
     let name =
-      node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.text):" }.joined() + ")"
+      identifier.name + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.identifier?.name ?? $0.firstName.text):" }.joined() + ")"
 
     let range = snapshot.absolutePositionRange(
       of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia
@@ -398,12 +410,12 @@ fileprivate extension TypeSyntax {
   var components: [String]? {
     switch self.as(TypeSyntaxEnum.self) {
     case .identifierType(let identifierType):
-      return [identifierType.name.text]
+      return [identifierType.name.identifier?.name ?? identifierType.name.text]
     case .memberType(let memberType):
       guard let baseComponents = memberType.baseType.components else {
         return nil
       }
-      return baseComponents + [memberType.name.text]
+      return baseComponents + [memberType.name.identifier?.name ?? memberType.name.text]
     default:
       return nil
     }


### PR DESCRIPTION
Test functions with backticks in their identifier should have them filtered out.

This is a stopgap until apple/swift-syntax#2576 is ready.