### PR TITLE
Rename diagnose bundle created on disk from `sourcekitd-reproducer` to `sourcekit-lsp-diagnose`

### DIFF
--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -309,7 +309,7 @@ public struct DiagnoseCommand: AsyncParsableCommand {
     dateFormatter.timeZone = NSTimeZone.local
     let date = dateFormatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
     let bundlePath = FileManager.default.temporaryDirectory
-      .appendingPathComponent("sourcekitd-reproducer-\(date)")
+      .appendingPathComponent("sourcekit-lsp-diagnose-\(date)")
     try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
 
     if components.isEmpty || components.contains(.crashReports) {


### PR DESCRIPTION
The name still dated back to when `sourcekit-lsp diagnose` would only reduce sourcekitd crashes. Now it does quite a bit more.