### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # Owner of anything in SourceKit-LSP not owned by anyone else.
-# N: Ben Langmuir
-# E: blangmuir@apple.com
-# N: Alex Hoppen
-# E: ahoppen@apple.com
 * @benlangmuir @ahoppen

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Swift version
+      description: Which version of Swift are you using? If you are unsure, insert the output of `path/to/swift --version`
+      placeholder: Eg. swiftlang-5.10.0.13, swift-DEVELOPMENT-SNAPSHOT-2024-05-01-a
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: What operating system are you seeing the issue on?
+      placeholder: Eg. Ubuntu 22.04, Windows 11, macOS 14
+  - type: input
+    id: editor
+    attributes:
+      label: Editor
+      description: Which text editor are you using?
+      placeholder: Eg. Visual Studio Code with Swift plugin 1.9.0, neovim
+  - type: dropdown
+    id: reproduces-with-swift-6
+    attributes:
+      label: Does the issue reproduce with Swift 6?
+      description: |
+        Does the issue also reproduce using a [recent Swift 6 Development Snapshot](https://www.swift.org/download/#swift-60-development)?
+
+        We have made significant changes to SourceKit-LSP in Swift 6 and the issue might have already been fixed. If you didn’t try, that is fine.
+      options:
+        - "Yes"
+        - "No"
+        - I didn’t try
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A short description of the incorrect behavior.
+        If you think this issue has been recently introduced and did not occur in an earlier version, please note that. If possible, include the last version that the behavior was correct in addition to your current version.
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: If you have steps that reproduce the issue, please add them here. If you can share a project that reproduces the issue, please attach it.
+  - type: textarea
+    id: logging
+    attributes:
+      label: Logging
+      description: |
+        If you are using SourceKit-LSP from Swift 6, running `sourcekit-lsp diagnose` in terminal and attaching the generated bundle helps us diagnose the issue.
+        The generated bundle might contain portions of your source code, so please only attach it if you feel comfortable sharing it.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,13 @@
+name: Feature Request
+description: A suggestion for a new feature
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A description of your proposed feature.
+        Examples that show what's missing, or what new capabilities will be possible, are very helpful!
+        If this feature unlocks new use-cases please describe them.
+        Provide links to existing issues or external references/discussions, if appropriate.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# This source file is part of the Swift.org open source project
+ #
+ # Copyright (c) 2024 Apple Inc. and the Swift project authors
+ # Licensed under Apache License v2.0 with Runtime Library Exception
+ #
+ # See https://swift.org/LICENSE.txt for license information
+ # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+ contact_links:
+   - name: Discussion Forum
+     url: https://forums.swift.org/c/development/sourcekit-lsp
+     about: Ask and answer questions about SourceKit-LSP


### PR DESCRIPTION
Most importantly, the bug report template is now asking for the user’s OS, Swift version and logging.