### PR TITLE
Don’t report no-op rename edits

### DIFF
--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -1236,4 +1236,26 @@ final class RenameTests: XCTestCase {
         """
     )
   }
+
+  func testRenameDoesNotReportEditsIfNoActualChangeIsMade() async throws {
+    try await SkipUnless.sourcekitdSupportsRename()
+    let project = try await SwiftPMTestProject(
+      files: [
+        "FileA.swift": """
+        func 1️⃣foo(x: Int) {}
+        """,
+        "FileB.swift": """
+        func test() {
+          foo(x: 1)
+        }
+        """,
+      ],
+      build: true
+    )
+    let (uri, positions) = try project.openDocument("FileA.swift")
+    let result = try await project.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"], newName: "foo(x:)")
+    )
+    XCTAssertEqual(result?.changes, [:])
+  }
 }


### PR DESCRIPTION
When renaming `func test(foo: Int) {}` to `test2(foo:)`, rename used to report an edit from `foo` to `foo`, which clutters the refactor preview view. We shouldn’t report edits if no text is actually changed.

rdar://127291815