### PR TITLE
Log request ID of received requests

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -935,7 +935,7 @@ extension SourceKitLSPServer: MessageHandler {
       }
     }
 
-    logger.log("Received request: \(params.forLogging)")
+    logger.log("Received request \(id): \(params.forLogging)")
 
     switch request {
     case let request as RequestAndReply<InitializeRequest>:


### PR DESCRIPTION
Useful for correlating request IDs with cancellation notifications.