### PR TITLE
Address my own review comments to #1179

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(SourceKitLSP STATIC
   SourceKitLSPServer+Options.swift
   SymbolLocation+DocumentURI.swift
   TestDiscovery.swift
+  TextEdit+IsNoop.swift
   WorkDoneProgressManager.swift
   Workspace.swift
 )

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -1490,13 +1490,3 @@ fileprivate extension RelatedIdentifiersResponse {
     }
   }
 }
-
-fileprivate extension TextEdit {
-  /// Returns `true` the replaced text is the same as the new text
-  func isNoOp(in snapshot: DocumentSnapshot) -> Bool {
-    if snapshot.text[snapshot.indexRange(of: range)] == newText {
-      return true
-    }
-    return false
-  }
-}

--- a/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
@@ -37,16 +37,20 @@ import SwiftSyntax
 public struct AddDocumentation: EditRefactoringProvider {
   @_spi(Testing)
   public static func textRefactor(syntax: DeclSyntax, in context: Void) -> [SourceEdit] {
-    let hasDocumentation = syntax.leadingTrivia.contains(where: { trivia in
+    let hasDocumentation = syntax.leadingTrivia.contains { trivia in
       switch trivia {
-      case .blockComment(_), .docBlockComment(_), .lineComment(_), .docLineComment(_):
+      case .blockComment, .docBlockComment, .lineComment, .docLineComment:
         return true
       default:
         return false
       }
-    })
+    }
 
-    guard !hasDocumentation else {
+    // We consider nodes at the start of the source file at being on a new line
+    let isOnNewLine =
+      syntax.leadingTrivia.contains(where: \.isNewline) || syntax.previousToken(viewMode: .sourceAccurate) == nil
+
+    guard !hasDocumentation && isOnNewLine else {
       return []
     }
 

--- a/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
@@ -52,7 +52,6 @@ public struct AddDocumentation: EditRefactoringProvider {
 
     let newlineAndIndentation = [.newlines(1)] + (syntax.firstToken(viewMode: .sourceAccurate)?.indentationOfLine ?? [])
     var content: [TriviaPiece] = []
-    content += newlineAndIndentation
     content.append(.docLineComment("/// A description"))
 
     if let parameters = syntax.parameters?.parameters {
@@ -82,8 +81,9 @@ public struct AddDocumentation: EditRefactoringProvider {
       content += newlineAndIndentation
       content.append(.docLineComment("/// - Returns:"))
     }
+    content += newlineAndIndentation
 
-    let insertPos = syntax.position
+    let insertPos = syntax.positionAfterSkippingLeadingTrivia
     return [
       SourceEdit(
         range: insertPos..<insertPos,

--- a/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
@@ -94,6 +94,13 @@ public struct AddDocumentation: EditRefactoringProvider {
 }
 
 extension AddDocumentation: SyntaxRefactoringCodeActionProvider {
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: DeclSyntax.self,
+      stoppingIf: { $0.is(CodeBlockItemSyntax.self) || $0.is(MemberBlockItemSyntax.self) || $0.is(ExprSyntax.self) }
+    )
+  }
+
   static var title: String { "Add documentation" }
 }
 

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
@@ -14,9 +14,6 @@ import LanguageServerProtocol
 import SwiftRefactor
 import SwiftSyntax
 
-// TODO: Make the type IntegerLiteralExprSyntax.Radix conform to CaseEnumerable
-// in swift-syntax.
-
 extension IntegerLiteralExprSyntax.Radix {
   static var allCases: [Self] = [.binary, .octal, .decimal, .hex]
 }
@@ -26,7 +23,7 @@ extension IntegerLiteralExprSyntax.Radix {
 struct ConvertIntegerLiteral: SyntaxCodeActionProvider {
   static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
     guard
-      let token = scope.firstToken,
+      let token = scope.innermostNodeContainingRange,
       let integerExpr = token.parent?.as(IntegerLiteralExprSyntax.self),
       let integerValue = Int(
         integerExpr.split().value.filter { $0 != "_" },

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
@@ -192,6 +192,17 @@ public struct ConvertJSONToCodableStruct: EditRefactoringProvider {
 }
 
 extension ConvertJSONToCodableStruct: SyntaxRefactoringCodeActionProvider {
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Syntax? {
+    var node: Syntax? = scope.innermostNodeContainingRange
+    while let unwrappedNode = node, ![.codeBlockItem, .memberBlockItem].contains(unwrappedNode.kind) {
+      if preflightRefactoring(unwrappedNode) != nil {
+        return unwrappedNode
+      }
+      node = unwrappedNode.parent
+    }
+    return nil
+  }
+
   static var title = "Create Codable structs from JSON"
 }
 

--- a/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
@@ -20,9 +20,7 @@ import SwiftSyntax
 /// edit a package manifest.
 struct PackageManifestEdits: SyntaxCodeActionProvider {
   static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
-    guard let token = scope.firstToken,
-      let call = token.findEnclosingCall()
-    else {
+    guard let call = scope.innermostNodeContainingRange?.findEnclosingCall() else {
       return []
     }
 

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
@@ -18,29 +18,35 @@ import SwiftSyntax
 /// swift-syntax) into a SyntaxCodeActionProvider.
 protocol SyntaxRefactoringCodeActionProvider: SyntaxCodeActionProvider, EditRefactoringProvider {
   static var title: String { get }
+
+  /// Returns the node that the syntax refactoring should be performed on, if code actions are requested for the given
+  /// scope.
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input?
 }
 
 /// SyntaxCodeActionProviders with a \c Void context can automatically be
 /// adapted provide a code action based on their refactoring operation.
 extension SyntaxRefactoringCodeActionProvider where Self.Context == Void {
   static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
-    guard
-      let token = scope.firstToken,
-      let node = token.parent?.as(Input.self)
-    else {
+    guard let node = nodeToRefactor(in: scope) else {
       return []
     }
 
     let sourceEdits = Self.textRefactor(syntax: node)
-    if sourceEdits.isEmpty {
-      return []
-    }
 
-    let textEdits = sourceEdits.map { edit in
-      TextEdit(
+    let textEdits = sourceEdits.compactMap { (edit) -> TextEdit? in
+      let edit = TextEdit(
         range: scope.snapshot.range(of: edit.range),
         newText: edit.replacement
       )
+      if edit.isNoOp(in: scope.snapshot) {
+        return nil
+      }
+      return edit
+    }
+
+    if textEdits.isEmpty {
+      return []
     }
 
     return [
@@ -57,22 +63,77 @@ extension SyntaxRefactoringCodeActionProvider where Self.Context == Void {
 
 extension AddSeparatorsToIntegerLiteral: SyntaxRefactoringCodeActionProvider {
   public static var title: String { "Add digit separators" }
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: IntegerLiteralExprSyntax.self,
+      stoppingIf: { $0.is(CodeBlockSyntax.self) || $0.is(MemberBlockSyntax.self) }
+    )
+  }
 }
 
 extension FormatRawStringLiteral: SyntaxRefactoringCodeActionProvider {
   public static var title: String {
     "Convert string literal to minimal number of '#'s"
   }
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: StringLiteralExprSyntax.self,
+      stoppingIf: {
+        $0.is(CodeBlockSyntax.self) || $0.is(MemberBlockSyntax.self)
+          || $0.keyPathInParent == \ExpressionSegmentSyntax.expressions
+      }
+    )
+  }
 }
 
 extension MigrateToNewIfLetSyntax: SyntaxRefactoringCodeActionProvider {
   public static var title: String { "Migrate to shorthand 'if let' syntax" }
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: IfExprSyntax.self,
+      stoppingIf: { $0.is(CodeBlockSyntax.self) || $0.is(MemberBlockSyntax.self) }
+    )
+  }
 }
 
 extension OpaqueParameterToGeneric: SyntaxRefactoringCodeActionProvider {
   public static var title: String { "Expand 'some' parameters to generic parameters" }
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: DeclSyntax.self,
+      stoppingIf: { $0.is(CodeBlockSyntax.self) || $0.is(MemberBlockSyntax.self) }
+    )
+  }
 }
 
 extension RemoveSeparatorsFromIntegerLiteral: SyntaxRefactoringCodeActionProvider {
   public static var title: String { "Remove digit separators" }
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> Input? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: IntegerLiteralExprSyntax.self,
+      stoppingIf: { $0.is(CodeBlockSyntax.self) || $0.is(MemberBlockSyntax.self) }
+    )
+  }
+}
+
+extension Syntax {
+  /// Finds the innermost parent of the given type while not walking outside of nodes that satisfy `stoppingIf`.
+  func findParentOfSelf<ParentType: SyntaxProtocol>(
+    ofType: ParentType.Type,
+    stoppingIf: (Syntax) -> Bool
+  ) -> ParentType? {
+    var node: Syntax? = self
+    while let unwrappedNode = node, !stoppingIf(unwrappedNode) {
+      if let expectedType = unwrappedNode.as(ParentType.self) {
+        return expectedType
+      }
+      node = unwrappedNode.parent
+    }
+    return nil
+  }
 }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -755,9 +755,10 @@ extension SwiftLanguageService {
     return response
   }
 
-  func retrieveCodeActions(_ req: CodeActionRequest, providers: [CodeActionProvider]) async throws
-    -> [CodeAction]
-  {
+  func retrieveCodeActions(
+    _ req: CodeActionRequest,
+    providers: [CodeActionProvider]
+  ) async throws -> [CodeAction] {
     guard providers.isEmpty == false else {
       return []
     }
@@ -776,7 +777,9 @@ extension SwiftLanguageService {
     let snapshot = try documentManager.latestSnapshot(uri)
 
     let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
-    let scope = try SyntaxCodeActionScope(snapshot: snapshot, syntaxTree: syntaxTree, request: request)
+    guard let scope = SyntaxCodeActionScope(snapshot: snapshot, syntaxTree: syntaxTree, request: request) else {
+      return []
+    }
     return await allSyntaxCodeActions.concurrentMap { provider in
       return provider.codeActions(in: scope)
     }.flatMap { $0 }
@@ -1152,8 +1155,8 @@ extension DocumentSnapshot {
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line
   ) -> Range<Position> {
-    let lowerBound = self.position(of: node.position)
-    let upperBound = self.position(of: node.endPosition)
+    let lowerBound = self.position(of: node.position, callerFile: callerFile, callerLine: callerLine)
+    let upperBound = self.position(of: node.endPosition, callerFile: callerFile, callerLine: callerLine)
     return lowerBound..<upperBound
   }
 

--- a/Sources/SourceKitLSP/TextEdit+IsNoop.swift
+++ b/Sources/SourceKitLSP/TextEdit+IsNoop.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+extension TextEdit {
+  /// Returns `true` the replaced text is the same as the new text
+  func isNoOp(in snapshot: DocumentSnapshot) -> Bool {
+    if snapshot.text[snapshot.indexRange(of: range)] == newText {
+      return true
+    }
+    return false
+  }
+}

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -16,23 +16,22 @@ import SKTestSupport
 import SourceKitLSP
 import XCTest
 
+private typealias CodeActionCapabilities = TextDocumentClientCapabilities.CodeAction
+private typealias CodeActionLiteralSupport = CodeActionCapabilities.CodeActionLiteralSupport
+private typealias CodeActionKindCapabilities = CodeActionLiteralSupport.CodeActionKind
+
+private var clientCapabilitiesWithCodeActionSupport: ClientCapabilities = {
+  var documentCapabilities = TextDocumentClientCapabilities()
+  var codeActionCapabilities = CodeActionCapabilities()
+  let codeActionKinds = CodeActionKindCapabilities(valueSet: [.refactor, .quickFix])
+  let codeActionLiteralSupport = CodeActionLiteralSupport(codeActionKind: codeActionKinds)
+  codeActionCapabilities.codeActionLiteralSupport = codeActionLiteralSupport
+  documentCapabilities.codeAction = codeActionCapabilities
+  documentCapabilities.completion = .init(completionItem: .init(snippetSupport: true))
+  return ClientCapabilities(workspace: nil, textDocument: documentCapabilities)
+}()
+
 final class CodeActionTests: XCTestCase {
-
-  typealias CodeActionCapabilities = TextDocumentClientCapabilities.CodeAction
-  typealias CodeActionLiteralSupport = CodeActionCapabilities.CodeActionLiteralSupport
-  typealias CodeActionKindCapabilities = CodeActionLiteralSupport.CodeActionKind
-
-  private func clientCapabilitiesWithCodeActionSupport() -> ClientCapabilities {
-    var documentCapabilities = TextDocumentClientCapabilities()
-    var codeActionCapabilities = CodeActionCapabilities()
-    let codeActionKinds = CodeActionKindCapabilities(valueSet: [.refactor, .quickFix])
-    let codeActionLiteralSupport = CodeActionLiteralSupport(codeActionKind: codeActionKinds)
-    codeActionCapabilities.codeActionLiteralSupport = codeActionLiteralSupport
-    documentCapabilities.codeAction = codeActionCapabilities
-    documentCapabilities.completion = .init(completionItem: .init(snippetSupport: true))
-    return ClientCapabilities(workspace: nil, textDocument: documentCapabilities)
-  }
-
   func testCodeActionResponseLegacySupport() throws {
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
     let codeAction = CodeAction(title: "1")
@@ -191,7 +190,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testEmptyCodeActionResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -214,7 +213,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testSemanticRefactorLocalRenameResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -227,16 +226,20 @@ final class CodeActionTests: XCTestCase {
     )
 
     let request = CodeActionRequest(
-      range: positions["1️⃣"]..<positions["1️⃣"],
+      range: Range(positions["1️⃣"]),
       context: .init(),
       textDocument: TextDocumentIdentifier(uri)
     )
     let result = try await testClient.send(request)
-    XCTAssertEqual(result, .codeActions([]))
+    guard case .codeActions(let codeActions) = result else {
+      XCTFail("Expected code actions")
+      return
+    }
+    XCTAssertEqual(codeActions.map(\.title), ["Add documentation"])
   }
 
   func testSemanticRefactorLocationCodeActionResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -290,17 +293,10 @@ final class CodeActionTests: XCTestCase {
     }
 
     XCTAssertTrue(codeActions.contains(expectedCodeAction))
-
-    // Make sure we get one of the swift-syntax refactoring actions.
-    XCTAssertTrue(
-      codeActions.contains { action in
-        return action.title == "Convert string literal to minimal number of \'#\'s"
-      }
-    )
   }
 
   func testJSONCodableCodeActionResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -342,7 +338,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testSemanticRefactorRangeCodeActionResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -411,7 +407,7 @@ final class CodeActionTests: XCTestCase {
 
   func testCodeActionsRemovePlaceholders() async throws {
     let testClient = try await TestSourceKitLSPClient(
-      capabilities: clientCapabilitiesWithCodeActionSupport(),
+      capabilities: clientCapabilitiesWithCodeActionSupport,
       usePullDiagnostics: false
     )
     let uri = DocumentURI.for(.swift)
@@ -500,7 +496,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testAddDocumentationCodeActionResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -579,7 +575,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testPackageManifestEditingCodeActionResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -647,7 +643,7 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testPackageManifestEditingCodeActionNoTestResult() async throws {
-    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport())
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI.for(.swift)
     let positions = testClient.openDocument(
       """
@@ -687,5 +683,269 @@ final class CodeActionTests: XCTestCase {
         return action.title == "Add product to export this target"
       }
     )
+  }
+
+  func testConvertIntegerLiteral() async throws {
+    try await assertCodeActions(
+      """
+      let x = 1️⃣12️⃣63️⃣
+      """
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Convert 16 to 0b10000",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: "0b10000")]]
+          ),
+          command: nil
+        ),
+        CodeAction(
+          title: "Convert 16 to 0o20",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: "0o20")]]
+          ),
+          command: nil
+        ),
+        CodeAction(
+          title: "Convert 16 to 0x10",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: "0x10")]]
+          ),
+          command: nil
+        ),
+      ]
+    }
+  }
+
+  func testFormatRawStringLiteral() async throws {
+    try await assertCodeActions(
+      """
+      let x = 1️⃣#"Hello 2️⃣world"#3️⃣
+      """,
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Convert string literal to minimal number of \'#\'s",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: #""Hello world""#)]]
+          ),
+          command: nil
+        )
+      ]
+    }
+  }
+
+  func testFormatRawStringLiteralFromInterpolation() async throws {
+    try await assertCodeActions(
+      ##"""
+      let x = 1️⃣#"Hello 2️⃣\#(name)"#3️⃣
+      """##,
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Convert string literal to minimal number of \'#\'s",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["3️⃣"],
+                  newText: ##"""
+                    ##"Hello \#(name)"##
+                    """##
+                )
+              ]
+            ]
+          ),
+          command: nil
+        )
+      ]
+    }
+  }
+
+  func testFormatRawStringLiteralDoesNotShowUpWhenInvokedFromInsideInterpolationSegment() async throws {
+    try await assertCodeActions(
+      ##"""
+      let x = #"Hello \#(n1️⃣ame)"#
+      """##
+    ) { uri, positions in
+      []
+    }
+  }
+
+  func testMigrateIfLetSyntax() async throws {
+    try await assertCodeActions(
+      ##"""
+      1️⃣if 2️⃣let 3️⃣foo = 4️⃣foo {}9️⃣
+      """##,
+      markers: ["1️⃣", "2️⃣", "3️⃣", "4️⃣"]
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Migrate to shorthand 'if let' syntax",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["9️⃣"],
+                  newText: "if let foo {}"
+                )
+              ]
+            ]
+          ),
+          command: nil
+        )
+      ]
+    }
+  }
+
+  func testMigrateIfLetSyntaxDoesNotShowUpWhenInvokedFromInsideTheBody() async throws {
+    try await assertCodeActions(
+      ##"""
+      if let foo = foo 1️⃣{
+        2️⃣print(foo)
+      3️⃣}4️⃣
+      """##
+    ) { uri, positions in
+      []
+    }
+  }
+
+  func testOpaqueParameterToGeneric() async throws {
+    try await assertCodeActions(
+      ##"""
+      1️⃣func 2️⃣someFunction(_ 3️⃣input: some4️⃣ Value) {}9️⃣
+      """##,
+      markers: ["1️⃣", "2️⃣", "3️⃣", "4️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Expand 'some' parameters to generic parameters",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["9️⃣"],
+                  newText: "func someFunction<T1: Value>(_ input: T1) {}"
+                )
+              ]
+            ]
+          ),
+          command: nil
+        )
+      ]
+    }
+  }
+
+  func testOpaqueParameterToGenericIsNotShownFromTheBody() async throws {
+    try await assertCodeActions(
+      ##"""
+      func someFunction(_ input: some Value) 1️⃣{
+        2️⃣print("x")
+      }3️⃣
+      """##,
+      exhaustive: false
+    ) { uri, positions in
+      []
+    }
+  }
+
+  func testConvertJSONToCodable() async throws {
+    try await assertCodeActions(
+      ##"""
+      1️⃣{
+        2️⃣"id": 3️⃣1,
+        "values": 4️⃣["foo", "bar"]
+      }5️⃣
+
+      """##,
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Create Codable structs from JSON",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["5️⃣"],
+                  newText: """
+                    struct JSONValue: Codable {
+                      var id: Double
+                      var values: [String]
+                    }
+                    """
+                )
+              ]
+            ]
+          ),
+          command: nil
+        )
+      ]
+    }
+  }
+
+  private func assertCodeActions(
+    _ markedText: String,
+    markers: [String]? = nil,
+    exhaustive: Bool = true,
+    expected: (_ uri: DocumentURI, _ positions: DocumentPositions) -> [CodeAction],
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
+    let uri = DocumentURI.for(.swift)
+    let positions = testClient.openDocument(markedText, uri: uri)
+
+    for marker in markers ?? extractMarkers(markedText).markers.map(\.key) {
+      let result = try await testClient.send(
+        CodeActionRequest(
+          range: Range(positions[marker]),
+          context: .init(),
+          textDocument: TextDocumentIdentifier(uri)
+        )
+      )
+      guard case .codeActions(let codeActions) = result else {
+        XCTFail("Expected code actions at marker \(marker)", file: file, line: line)
+        return
+      }
+      if exhaustive {
+        XCTAssertEqual(
+          codeActions,
+          expected(uri, positions),
+          "Found unexpected code actions at \(marker)",
+          file: file,
+          line: line
+        )
+      } else {
+        XCTAssert(
+          codeActions.contains(expected(uri, positions)),
+          """
+          Code actions did not contain expected at \(marker):
+          \(codeActions)
+          """,
+          file: file,
+          line: line
+        )
+      }
+    }
   }
 }

--- a/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
+++ b/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
@@ -27,15 +27,15 @@ final class SyntaxRefactorTests: XCTestCase {
       provider: AddDocumentation.self,
       expected: [
         SourceEdit(
-          range: AbsolutePosition(utf8Offset: 0)..<AbsolutePosition(utf8Offset: 0),
+          range: AbsolutePosition(utf8Offset: 2)..<AbsolutePosition(utf8Offset: 2),
           replacement: """
-
-              /// A description
+            /// A description
               /// - Parameters:
               ///   - syntax:
               ///   - context:
               ///
               /// - Returns:
+              \("")
             """
         )
       ]
@@ -51,11 +51,11 @@ final class SyntaxRefactorTests: XCTestCase {
       provider: AddDocumentation.self,
       expected: [
         SourceEdit(
-          range: AbsolutePosition(utf8Offset: 0)..<AbsolutePosition(utf8Offset: 0),
+          range: AbsolutePosition(utf8Offset: 2)..<AbsolutePosition(utf8Offset: 2),
           replacement: """
-
-              /// A description
+            /// A description
               /// - Parameter syntax:
+              \("")
             """
         )
       ]

--- a/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
+++ b/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
@@ -42,6 +42,26 @@ final class SyntaxRefactorTests: XCTestCase {
     )
   }
 
+  func testAddDocumentationRefactorSingleParameter() throws {
+    try assertRefactor(
+      """
+        1️⃣func 2️⃣refactor(syntax: DeclSyntax) { }
+      """,
+      context: (),
+      provider: AddDocumentation.self,
+      expected: [
+        SourceEdit(
+          range: AbsolutePosition(utf8Offset: 0)..<AbsolutePosition(utf8Offset: 0),
+          replacement: """
+
+              /// A description
+              /// - Parameter syntax:
+            """
+        )
+      ]
+    )
+  }
+
   func testConvertJSONToCodableStructClosure() throws {
     try assertRefactor(
       """


### PR DESCRIPTION
Addresses a few minor comments and the following major ones:
- Add test cases for the syntax refactorings
- Don’t report code actions for refactorings that don’t actually modify the source
- Instead of just looking at the parent of the token of the selected range, walk up the syntax tree to find the syntax node to refactor. This makes the refactorings available in a lot more locations.