### PR TITLE
Add code actions for adding library/executable/macro targets to a package manifest

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
@@ -26,7 +26,47 @@ struct PackageManifestEdits: SyntaxCodeActionProvider {
       return []
     }
 
-    return addTestTargetActions(call: call, in: scope) + addProductActions(call: call, in: scope)
+    return addTargetActions(call: call, in: scope) + addTestTargetActions(call: call, in: scope)
+      + addProductActions(call: call, in: scope)
+  }
+
+  /// Produce code actions to add new targets of various kinds.
+  static func addTargetActions(
+    call: FunctionCallExprSyntax,
+    in scope: SyntaxCodeActionScope
+  ) -> [CodeAction] {
+    do {
+      var actions: [CodeAction] = []
+      let variants: [(TargetDescription.TargetType, String)] = [
+        (.regular, "library"),
+        (.executable, "executable"),
+        (.macro, "macro"),
+      ]
+
+      for (type, name) in variants {
+        let target = try TargetDescription(
+          name: "NewTarget",
+          type: type
+        )
+
+        let edits = try AddTarget.addTarget(
+          target,
+          to: scope.file
+        )
+
+        actions.append(
+          CodeAction(
+            title: "Add \(name) target",
+            kind: .refactor,
+            edit: edits.asWorkspaceEdit(snapshot: scope.snapshot)
+          )
+        )
+      }
+
+      return actions
+    } catch {
+      return []
+    }
   }
 
   /// Produce code actions to add test target(s) if we are currently on
@@ -79,7 +119,7 @@ struct PackageManifestEdits: SyntaxCodeActionProvider {
   }
 
   /// A list of target kinds that allow the creation of tests.
-  static let targetsThatAllowTests: Set<String> = [
+  static let targetsThatAllowTests: [String] = [
     "executableTarget",
     "macro",
     "target",
@@ -125,7 +165,7 @@ struct PackageManifestEdits: SyntaxCodeActionProvider {
   }
 
   /// A list of target kinds that allow the creation of tests.
-  static let targetsThatAllowProducts: Set<String> = [
+  static let targetsThatAllowProducts: [String] = [
     "executableTarget",
     "target",
   ]

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -613,6 +613,12 @@ final class CodeActionTests: XCTestCase {
     }
     XCTAssertNotNil(addTestAction)
 
+    XCTAssertTrue(
+      codeActions.contains { action in
+        action.title == "Add library target"
+      }
+    )
+
     guard let addTestChanges = addTestAction?.edit?.documentChanges else {
       XCTFail("Didn't have changes in the 'Add test target (Swift Testing)' action")
       return

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -609,12 +609,12 @@ final class CodeActionTests: XCTestCase {
 
     // Make sure we get the expected package manifest editing actions.
     let addTestAction = codeActions.first { action in
-      return action.title == "Add test target"
+      return action.title == "Add test target (Swift Testing)"
     }
     XCTAssertNotNil(addTestAction)
 
     guard let addTestChanges = addTestAction?.edit?.documentChanges else {
-      XCTFail("Didn't have changes in the 'Add test target' action")
+      XCTFail("Didn't have changes in the 'Add test target (Swift Testing)' action")
       return
     }
 


### PR DESCRIPTION
Add code actions for introducing new library, executable, or macro targets to a package manifest. I'm a little unhappy with these because we have to pick a name for the target (we choose "NewTarget") and it's a little annoying to change it after the fact. On the other hand, this at least puts the right structural pieces in place.