### PR TITLE
[6.0] Adopt SwiftPM ModulesGraph initializer API adjustment

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -211,6 +211,7 @@ public actor SwiftPMBuildSystem {
 
     self.modulesGraph = try ModulesGraph(
       rootPackages: [],
+      packages: IdentifiableSet(),
       dependencies: [],
       binaryArtifacts: [:]
     )


### PR DESCRIPTION
- Explanation:

  Cherry-pick of https://github.com/apple/sourcekit-lsp/pull/1233 paired with https://github.com/apple/swift-package-manager/pull/7541

  `ModulesGraph.init` was changed by https://github.com/apple/swift-package-manager/pull/7530 to accept `packages` as a way to avoid having to recompute the full list of packages by walking roots.

- Scope: NFC change

- Main Branch PRs: https://github.com/apple/sourcekit-lsp/pull/1233

- Risk: Very Low

- Reviewed By: @ahoppen     

- Testing: No new tests are necessary

(cherry picked from commit 2270631a32eeb83b9a63bca8d643c9240be91151)