### PR TITLE
Fall back to launching subprocesses without a working directory

### DIFF
--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(SKSupport STATIC
   DocumentURI+CustomLogStringConvertible.swift
   FileSystem.swift
   LineTable.swift
+  Process+LaunchWithWorkingDirectoryIfPossible.swift
   Process+WaitUntilExitWithCancellation.swift
   Random.swift
   Result.swift

--- a/Sources/SKSupport/Process+LaunchWithWorkingDirectoryIfPossible.swift
+++ b/Sources/SKSupport/Process+LaunchWithWorkingDirectoryIfPossible.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPLogging
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import enum TSCBasic.ProcessEnv
+import struct TSCBasic.ProcessEnvironmentBlock
+
+extension Process {
+  /// Launches a new process with the given parameters.
+  ///
+  /// - Important: If `workingDirectory` is not supported on this platform, this logs an error and falls back to launching the
+  ///   process without the working directory set.
+  public static func launch(
+    arguments: [String],
+    environmentBlock: ProcessEnvironmentBlock = ProcessEnv.block,
+    workingDirectory: AbsolutePath?,
+    outputRedirection: OutputRedirection = .collect,
+    startNewProcessGroup: Bool = true,
+    loggingHandler: LoggingHandler? = .none
+  ) throws -> Process {
+    let process =
+      if let workingDirectory {
+        Process(
+          arguments: arguments,
+          environmentBlock: environmentBlock,
+          workingDirectory: workingDirectory,
+          outputRedirection: outputRedirection,
+          startNewProcessGroup: startNewProcessGroup,
+          loggingHandler: loggingHandler
+        )
+      } else {
+        self.init(
+          arguments: arguments,
+          environmentBlock: environmentBlock,
+          outputRedirection: outputRedirection,
+          startNewProcessGroup: startNewProcessGroup,
+          loggingHandler: loggingHandler
+        )
+      }
+    do {
+      try process.launch()
+    } catch Process.Error.workingDirectoryNotSupported where workingDirectory != nil {
+      // TODO (indexing): We need to figure out how to set the working directory on all platforms.
+      logger.error(
+        "Working directory not supported on the platform. Launching process without working directory \(workingDirectory!.pathString)"
+      )
+      return try Process.launch(
+        arguments: arguments,
+        environmentBlock: environmentBlock,
+        workingDirectory: nil,
+        outputRedirection: outputRedirection,
+        startNewProcessGroup: startNewProcessGroup,
+        loggingHandler: loggingHandler
+      )
+    }
+    return process
+  }
+}

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -188,16 +188,10 @@ public struct UpdateIndexStoreTaskDescription: TaskDescriptionProtocol {
       return
     }
 
-    let process =
-      if let workingDirectory = buildSettings.workingDirectory {
-        Process(
-          arguments: [swiftc.pathString] + indexingArguments,
-          workingDirectory: try AbsolutePath(validating: workingDirectory)
-        )
-      } else {
-        Process(arguments: [swiftc.pathString] + indexingArguments)
-      }
-    try process.launch()
+    let process = try Process.launch(
+      arguments: [swiftc.pathString] + indexingArguments,
+      workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
+    )
     let result = try await process.waitUntilExitSendingSigIntOnTaskCancellation()
     switch result.exitStatus.exhaustivelySwitchable {
     case .terminated(code: 0):


### PR DESCRIPTION
Details from https://github.com/apple/sourcekit-lsp/issues/1271

> Amazon Linux 2 and CentOS 7 have a glibc that doesn’t support `posix_spawn_file_actions_addchdir_np` and thus `TSCBasic.Process` can’t launch a process on these platforms with the working directory set. We currently fall back to launching the index tasks without a working directory on these platforms, which I think is fine because SwiftPM gives us compiler arguments with absolute paths. But we should figure something out.
>
> Using `Foundation.Process` is not an option because it runs `chdir` on the current process for Posix platforms, which is racy if there are multiple subprocesses being spawned simultaneously. On Windows `TSCBasic.Processs` uses `Foundation.Process` and `Foundation.Process` properly set the working directory of the subprocesses on Windows, so Windows is not a problem.

rdar://127797048