### PR TITLE
Make all non-test modules except for SourceKitLSP build in Swift 6 mode

### DIFF
--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -16,7 +16,7 @@ import Foundation
 import LanguageServerProtocol
 import SKSupport
 
-@preconcurrency import enum PackageLoading.Platform
+import enum PackageLoading.Platform
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 

--- a/Sources/SKCore/Toolchain.swift
+++ b/Sources/SKCore/Toolchain.swift
@@ -14,7 +14,7 @@ import LSPLogging
 import LanguageServerProtocol
 import SKSupport
 
-@preconcurrency import enum PackageLoading.Platform
+import enum PackageLoading.Platform
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem

--- a/Sources/SKSupport/Process+LaunchWithWorkingDirectoryIfPossible.swift
+++ b/Sources/SKSupport/Process+LaunchWithWorkingDirectoryIfPossible.swift
@@ -26,7 +26,6 @@ extension Process {
     arguments: [String],
     environmentBlock: ProcessEnvironmentBlock = ProcessEnv.block,
     workingDirectory: AbsolutePath?,
-    outputRedirection: OutputRedirection = .collect,
     startNewProcessGroup: Bool = true,
     loggingHandler: LoggingHandler? = .none
   ) throws -> Process {
@@ -36,7 +35,6 @@ extension Process {
           arguments: arguments,
           environmentBlock: environmentBlock,
           workingDirectory: workingDirectory,
-          outputRedirection: outputRedirection,
           startNewProcessGroup: startNewProcessGroup,
           loggingHandler: loggingHandler
         )
@@ -44,7 +42,6 @@ extension Process {
         self.init(
           arguments: arguments,
           environmentBlock: environmentBlock,
-          outputRedirection: outputRedirection,
           startNewProcessGroup: startNewProcessGroup,
           loggingHandler: loggingHandler
         )
@@ -60,7 +57,6 @@ extension Process {
         arguments: arguments,
         environmentBlock: environmentBlock,
         workingDirectory: nil,
-        outputRedirection: outputRedirection,
         startNewProcessGroup: startNewProcessGroup,
         loggingHandler: loggingHandler
       )

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import IndexStoreDB
+@preconcurrency import IndexStoreDB
 import LSPLogging
 import LanguageServerProtocol
 
@@ -47,13 +47,17 @@ public enum IndexCheckLevel {
 /// `IndexCheckLevel`.
 ///
 /// - SeeAlso: Comment on `IndexOutOfDateChecker`
-public final class CheckedIndex: Sendable {
+public final class CheckedIndex {
   private var checker: IndexOutOfDateChecker
   private let index: IndexStoreDB
 
   fileprivate init(index: IndexStoreDB, checkLevel: IndexCheckLevel) {
     self.index = index
     self.checker = IndexOutOfDateChecker(checkLevel: checkLevel)
+  }
+
+  public var unchecked: UncheckedIndex {
+    return UncheckedIndex(index)
   }
 
   @discardableResult
@@ -146,13 +150,17 @@ public final class CheckedIndex: Sendable {
 /// access of the underlying `IndexStoreDB`. This makes sure that accesses to the raw `IndexStoreDB` are explicit (by
 /// calling `underlyingIndexStoreDB`) and we don't accidentally call into the `IndexStoreDB` when we wanted a
 /// `CheckedIndex`.
-public struct UncheckedIndex {
+public struct UncheckedIndex: Sendable {
   public let underlyingIndexStoreDB: IndexStoreDB
 
   public init?(_ index: IndexStoreDB?) {
     guard let index else {
       return nil
     }
+    self.underlyingIndexStoreDB = index
+  }
+
+  public init(_ index: IndexStoreDB) {
     self.underlyingIndexStoreDB = index
   }
 

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -153,7 +153,7 @@ public final actor SemanticIndexManager {
         UpdateIndexStoreTaskDescription(
           filesToIndex: Set(files),
           buildSystemManager: self.buildSystemManager,
-          index: self.index,
+          index: self.index.unchecked,
           didFinishCallback: { [weak self] taskDescription in
             self?.indexTaskDidFinish?(.updateIndexStore(taskDescription))
           }

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -22,7 +22,7 @@ import CRT
 #endif
 
 public final class SKDResponse: Sendable {
-  private nonisolated let response: sourcekitd_api_response_t
+  private nonisolated(unsafe) let response: sourcekitd_api_response_t
   let sourcekitd: SourceKitD
 
   /// Creates a new `SKDResponse` that exclusively manages the raw `sourcekitd_api_response_t`.

--- a/Tests/SKCoreTests/ToolchainRegistryTests.swift
+++ b/Tests/SKCoreTests/ToolchainRegistryTests.swift
@@ -36,36 +36,6 @@ final class ToolchainRegistryTests: XCTestCase {
     await assertTrue(tr.default === tr.toolchain(identifier: "a"))
   }
 
-  func testDefaultDarwin() async throws {
-    let prevPlatform = Platform.current
-    defer { Platform.current = prevPlatform }
-    Platform.current = .darwin
-
-    let tr = ToolchainRegistry(
-      toolchains: [
-        Toolchain(identifier: "a", displayName: "a", path: nil),
-        Toolchain(identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier, displayName: "a", path: nil),
-      ]
-    )
-    await assertEqual(tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
-  }
-
-  func testUnknownPlatform() throws {
-    let prevPlatform = Platform.current
-    defer { Platform.current = prevPlatform }
-    Platform.current = nil
-
-    let fs = InMemoryFileSystem()
-    let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    try makeToolchain(binPath: binPath, fs, sourcekitdInProc: true)
-
-    guard let t = Toolchain(binPath, fs) else {
-      XCTFail("could not find any tools")
-      return
-    }
-    XCTAssertNotNil(t.sourcekitd)
-  }
-
   func testFindXcodeDefaultToolchain() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
     let fs = InMemoryFileSystem()


### PR DESCRIPTION
Depends on https://github.com/apple/swift-package-manager/pull/7553

---

This would have caught a race condition in background indexing that was caused by accessing `CheckedIndex` from multiple threads despite it not being thread-safe.