### PR TITLE
Don’t rely on working directory during index preparation

### DIFF
--- a/Sources/SKSupport/Process+LaunchWithWorkingDirectoryIfPossible.swift
+++ b/Sources/SKSupport/Process+LaunchWithWorkingDirectoryIfPossible.swift
@@ -39,7 +39,7 @@ extension Process {
           loggingHandler: loggingHandler
         )
       } else {
-        self.init(
+        Process(
           arguments: arguments,
           environmentBlock: environmentBlock,
           startNewProcessGroup: startNewProcessGroup,

--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -447,15 +447,12 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
     }
     let arguments = [
       swift.pathString, "build",
+      "--package-path", workspacePath.pathString,
       "--scratch-path", self.workspace.location.scratchDirectory.pathString,
       "--disable-index-store",
       "--target", target.targetID,
     ]
-    let process = Process(
-      arguments: arguments,
-      workingDirectory: workspacePath
-    )
-    try process.launch()
+    let process = try Process.launch(arguments: arguments, workingDirectory: nil)
     let result = try await process.waitUntilExitSendingSigIntOnTaskCancellation()
     switch result.exitStatus.exhaustivelySwitchable {
     case .terminated(code: 0):


### PR DESCRIPTION
Amazon Linux and CentOS don’t support working directory. We can work around this by passing `--package-path` to `swift build`.

rdar://128037023