### PR TITLE
Make the `SourceKitLSP` module build in Swift 6 mode

### DIFF
--- a/Sources/LSPLogging/Logging.swift
+++ b/Sources/LSPLogging/Logging.swift
@@ -28,6 +28,16 @@ public typealias LogLevel = os.OSLogType
 public typealias Logger = os.Logger
 public typealias Signposter = OSSignposter
 
+#if compiler(<5.11)
+extension OSSignposter: @unchecked Sendable {}
+extension OSSignpostID: @unchecked Sendable {}
+extension OSSignpostIntervalState: @unchecked Sendable {}
+#else
+extension OSSignposter: @retroactive @unchecked Sendable {}
+extension OSSignpostID: @retroactive @unchecked Sendable {}
+extension OSSignpostIntervalState: @retroactive @unchecked Sendable {}
+#endif
+
 extension os.Logger {
   public func makeSignposter() -> Signposter {
     return OSSignposter(logger: self)

--- a/Sources/LSPLogging/LoggingScope.swift
+++ b/Sources/LSPLogging/LoggingScope.swift
@@ -80,7 +80,7 @@ public func withLoggingScope<Result>(
 /// - SeeAlso: ``withLoggingScope(_:_:)-6qtga``
 public func withLoggingScope<Result>(
   _ scope: String,
-  _ operation: () async throws -> Result
+  @_inheritActorContext _ operation: @Sendable () async throws -> Result
 ) async rethrows -> Result {
   return try await LoggingScope.$_scope.withValue(
     scope,

--- a/Sources/LSPLogging/NonDarwinLogging.swift
+++ b/Sources/LSPLogging/NonDarwinLogging.swift
@@ -361,14 +361,14 @@ public struct NonDarwinLogger: Sendable {
 
 // MARK: - Signposter
 
-public struct NonDarwinSignpostID {}
+public struct NonDarwinSignpostID: Sendable {}
 
-public struct NonDarwinSignpostIntervalState {}
+public struct NonDarwinSignpostIntervalState: Sendable {}
 
 /// A type that is API-compatible to `OSLogMessage` for all uses within sourcekit-lsp.
 ///
 /// Since non-Darwin platforms don't have signposts, the type just has no-op operations.
-public struct NonDarwinSignposter {
+public struct NonDarwinSignposter: Sendable {
   public func makeSignpostID() -> NonDarwinSignpostID {
     return NonDarwinSignpostID()
   }

--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -44,7 +44,7 @@ public protocol MessageHandler: AnyObject, Sendable {
   func handle<Request: RequestType>(
     _ request: Request,
     id: RequestID,
-    reply: @escaping (LSPResult<Request.Response>) -> Void
+    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
   )
 }
 
@@ -110,7 +110,7 @@ public final class LocalConnection: Connection, @unchecked Sendable {
 
   public func send<Request: RequestType>(
     _ request: Request,
-    reply: @escaping (LSPResult<Request.Response>) -> Void
+    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
   ) -> RequestID {
     let id = nextRequestID()
 

--- a/Sources/LanguageServerProtocol/Message.swift
+++ b/Sources/LanguageServerProtocol/Message.swift
@@ -24,7 +24,7 @@ public protocol _RequestType: MessageType {
   func _handle(
     _ handler: MessageHandler,
     id: RequestID,
-    reply: @escaping (LSPResult<ResponseType>, RequestID) -> Void
+    reply: @Sendable @escaping (LSPResult<ResponseType>, RequestID) -> Void
   )
 }
 
@@ -49,7 +49,7 @@ extension RequestType {
   public func _handle(
     _ handler: MessageHandler,
     id: RequestID,
-    reply: @escaping (LSPResult<ResponseType>, RequestID) -> Void
+    reply: @Sendable @escaping (LSPResult<ResponseType>, RequestID) -> Void
   ) {
     handler.handle(self, id: id) { response in
       reply(response.map({ $0 as ResponseType }), id)

--- a/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/CodeActionRequest.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public typealias CodeActionProvider = (CodeActionRequest) async throws -> [CodeAction]
+public typealias CodeActionProvider = @Sendable (CodeActionRequest) async throws -> [CodeAction]
 
 /// Request for returning all possible code actions for a given text document and range.
 ///

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -587,7 +587,7 @@ public struct DocumentRangeFormattingOptions: WorkDoneProgressOptions, Codable, 
   }
 }
 
-public struct FoldingRangeOptions: Codable, Hashable {
+public struct FoldingRangeOptions: Codable, Hashable, Sendable {
   /// Currently empty in the spec.
   public init() {}
 }

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -17,6 +17,10 @@ import LanguageServerProtocol
 
 import struct TSCBasic.AbsolutePath
 
+#if canImport(os)
+import os
+#endif
+
 /// `BuildSystem` that integrates client-side information such as main-file lookup as well as providing
 ///  common functionality such as caching.
 ///
@@ -169,7 +173,7 @@ extension BuildSystemManager {
       logger.error("Getting build settings failed: \(error.forLogging)")
     }
 
-    guard var settings = fallbackBuildSystem?.buildSettings(for: document, language: language) else {
+    guard var settings = await fallbackBuildSystem?.buildSettings(for: document, language: language) else {
       return nil
     }
     if buildSystem == nil {

--- a/Sources/SKCore/FallbackBuildSystem.swift
+++ b/Sources/SKCore/FallbackBuildSystem.swift
@@ -21,7 +21,7 @@ import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 
 /// A simple BuildSystem suitable as a fallback when accurate settings are unknown.
-public final class FallbackBuildSystem {
+public actor FallbackBuildSystem {
 
   let buildSetup: BuildSetup
 
@@ -37,6 +37,10 @@ public final class FallbackBuildSystem {
         .trimmingCharacters(in: .whitespacesAndNewlines)
     )
   }()
+
+  @_spi(Testing) public func setSdkPath(_ newValue: AbsolutePath?) {
+    self.sdkpath = newValue
+  }
 
   /// Delegate to handle any build system events.
   public weak var delegate: BuildSystemDelegate? = nil

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -11,8 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 import LSPLogging
+#if canImport(os)
+import os
+#endif
 
-public struct LineTable: Hashable {
+public struct LineTable: Hashable, Sendable {
   @usableFromInline
   var impl: [String.Index]
 

--- a/Sources/SKSupport/ThreadSafeBox.swift
+++ b/Sources/SKSupport/ThreadSafeBox.swift
@@ -47,6 +47,12 @@ public class ThreadSafeBox<T>: @unchecked Sendable {
     _value = initialValue
   }
 
+  public func withLock<Result>(_ body: (inout T) -> Result) -> Result {
+    return lock.withLock {
+      return body(&_value)
+    }
+  }
+
   /// If the value in the box is an optional, return it and reset it to `nil`
   /// in an atomic operation.
   public func takeValue<U>() -> T where U? == T {

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -24,7 +24,7 @@ public enum LanguageServerState {
   case semanticFunctionalityDisabled
 }
 
-public struct RenameLocation {
+public struct RenameLocation: Sendable {
   /// How the identifier at a given location is being used.
   ///
   /// This is primarily used to influence how argument labels should be renamed in Swift and if a location should be
@@ -64,7 +64,7 @@ public struct RenameLocation {
 ///
 /// For example, we may have a language service that provides semantic functionality for c-family using a clangd server,
 /// launched from a specific toolchain or from sourcekitd.
-public protocol LanguageService: AnyObject {
+public protocol LanguageService: AnyObject, Sendable {
 
   // MARK: - Creation
 
@@ -90,7 +90,7 @@ public protocol LanguageService: AnyObject {
 
   /// Add a handler that is called whenever the state of the language server changes.
   func addStateChangeHandler(
-    handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void
+    handler: @Sendable @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void
   ) async
 
   // MARK: - Text synchronization

--- a/Sources/SourceKitLSP/Sequence+AsyncMap.swift
+++ b/Sources/SourceKitLSP/Sequence+AsyncMap.swift
@@ -13,7 +13,7 @@
 extension Sequence {
   /// Just like `Sequence.map` but allows an `async` transform function.
   func asyncMap<T>(
-    _ transform: (Element) async throws -> T
+    @_inheritActorContext _ transform: @Sendable (Element) async throws -> T
   ) async rethrows -> [T] {
     var result: [T] = []
     result.reserveCapacity(self.underestimatedCount)
@@ -27,7 +27,7 @@ extension Sequence {
 
   /// Just like `Sequence.compactMap` but allows an `async` transform function.
   func asyncCompactMap<T>(
-    _ transform: (Element) async throws -> T?
+    @_inheritActorContext _ transform: @Sendable (Element) async throws -> T?
   ) async rethrows -> [T] {
     var result: [T] = []
 

--- a/Sources/SourceKitLSP/SourceKitIndexDelegate.swift
+++ b/Sources/SourceKitLSP/SourceKitIndexDelegate.swift
@@ -24,7 +24,7 @@ public actor SourceKitIndexDelegate: IndexDelegate {
   let queue = AsyncQueue<Serial>()
 
   /// Registered `MainFilesDelegate`s to notify when main files change.
-  var mainFilesChangedCallbacks: [() async -> Void] = []
+  var mainFilesChangedCallbacks: [@Sendable () async -> Void] = []
 
   /// The count of pending unit events. Whenever this transitions to 0, it represents a time where
   /// the index finished processing known events. Of course, that may have already changed by the
@@ -72,7 +72,7 @@ public actor SourceKitIndexDelegate: IndexDelegate {
   }
 
   /// Register a delegate to receive notifications when main files change.
-  public func addMainFileChangedCallback(_ callback: @escaping () async -> Void) {
+  public func addMainFileChangedCallback(_ callback: @escaping @Sendable () async -> Void) {
     mainFilesChangedCallbacks.append(callback)
   }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
@@ -21,7 +21,7 @@ import struct TSCBasic.RelativePath
 extension SourceKitLSPServer {
 
   /// Configuration options for the SourceKitServer.
-  public struct Options {
+  public struct Options: Sendable {
 
     /// Additional compiler flags (e.g. `-Xswiftc` for SwiftPM projects) and other build-related
     /// configuration.

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
@@ -15,7 +15,7 @@ import SwiftRefactor
 import SwiftSyntax
 
 extension IntegerLiteralExprSyntax.Radix {
-  static var allCases: [Self] = [.binary, .octal, .decimal, .hex]
+  static let allCases: [Self] = [.binary, .octal, .decimal, .hex]
 }
 
 /// Syntactic code action provider to convert integer literals between

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
@@ -203,7 +203,7 @@ extension ConvertJSONToCodableStruct: SyntaxRefactoringCodeActionProvider {
     return nil
   }
 
-  static var title = "Create Codable structs from JSON"
+  static let title = "Create Codable structs from JSON"
 }
 
 /// A JSON object, which is has a set of fields, each of which has the given

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -68,7 +68,7 @@ fileprivate func diagnosticsEnabled(for document: DocumentURI) -> Bool {
 }
 
 /// A swift compiler command derived from a `FileBuildSettingsChange`.
-public struct SwiftCompileCommand: Equatable {
+public struct SwiftCompileCommand: Sendable, Equatable {
 
   /// The compiler arguments, including working directory. This is required since sourcekitd only
   /// accepts the working directory via the compiler arguments.
@@ -90,7 +90,7 @@ public struct SwiftCompileCommand: Equatable {
   }
 }
 
-public actor SwiftLanguageService: LanguageService {
+public actor SwiftLanguageService: LanguageService, Sendable {
   /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageService`.
   weak var sourceKitLSPServer: SourceKitLSPServer?
 
@@ -218,7 +218,7 @@ public actor SwiftLanguageService: LanguageService {
   }
 
   /// - Important: For testing only
-  public func setReusedNodeCallback(_ callback: ReusedNodeCallback?) async {
+  public func setReusedNodeCallback(_ callback: (@Sendable (_ node: Syntax) -> ())?) async {
     await self.syntaxTreeManager.setReusedNodeCallback(callback)
   }
 
@@ -246,7 +246,7 @@ public actor SwiftLanguageService: LanguageService {
   }
 
   public func addStateChangeHandler(
-    handler: @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void
+    handler: @Sendable @escaping (_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void
   ) {
     self.stateChangeHandlers.append(handler)
   }

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
@@ -15,7 +15,7 @@ import LanguageServerProtocol
 import SourceKitD
 
 /// A ranged token in the document used for syntax highlighting.
-public struct SyntaxHighlightingToken: Hashable {
+public struct SyntaxHighlightingToken: Hashable, Sendable {
   /// The range of the token in the document. Must be on a single line.
   public var range: Range<Position> {
     didSet {

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingTokens.swift
@@ -15,7 +15,7 @@ import LanguageServerProtocol
 import SourceKitD
 
 /// A wrapper around an array of syntax highlighting tokens.
-public struct SyntaxHighlightingTokens {
+public struct SyntaxHighlightingTokens: Sendable {
   public var tokens: [SyntaxHighlightingToken]
 
   public init(tokens: [SyntaxHighlightingToken]) {

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -22,11 +22,11 @@ fileprivate extension TokenSyntax {
     var node = Syntax(self)
     LOOP: while let parent = node.parent {
       switch parent.kind {
-      case .caseItem, .closureParam:
+      case .switchCaseItem, .closureShorthandParameter:
         // case items (inside a switch) and closure parameters can’t have type
         // annotations.
         return false
-      case .codeBlockItem, .memberDeclListItem:
+      case .codeBlockItem, .memberBlockItem:
         // Performance optimization. If we walked the parents up to code block item,
         // we can’t enter a case item or closure param anymore. No need walking
         // the tree any further.

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -21,7 +21,7 @@ public enum TestStyle {
   public static let swiftTesting = "swift-testing"
 }
 
-public struct AnnotatedTestItem {
+public struct AnnotatedTestItem: Sendable {
   /// The test item to be annotated
   public var testItem: TestItem
 
@@ -180,6 +180,7 @@ extension SourceKitLSPServer {
       )
     }
 
+    let documentManager = self.documentManager
     return occurrencesByParent[nil, default: []]
       .sorted()
       .map { testItem(for: $0, documentManager: documentManager, context: []) }
@@ -212,7 +213,7 @@ extension SourceKitLSPServer {
     }
 
     let testsFromFilesWithInMemoryState = await filesWithInMemoryState.concurrentMap { (uri) -> [AnnotatedTestItem] in
-      guard let languageService = workspace.documentService[uri] else {
+      guard let languageService = workspace.documentService.value[uri] else {
         return []
       }
       return await orLog("Getting document tests for \(uri)") {

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -147,7 +147,7 @@ final class BuildSystemManagerTests: XCTestCase {
     )
     defer { withExtendedLifetime(bsm) {} }  // Keep BSM alive for callbacks.
     let del = await BSMDelegate(bsm)
-    let fallbackSettings = fallback.buildSettings(for: a, language: .swift)
+    let fallbackSettings = await fallback.buildSettings(for: a, language: .swift)
     await bsm.registerForChangeNotifications(for: a, language: .swift)
     assertEqual(await bsm.buildSettingsInferredFromMainFile(for: a, language: .swift), fallbackSettings)
 

--- a/Tests/SKCoreTests/FallbackBuildSystemTests.swift
+++ b/Tests/SKCoreTests/FallbackBuildSystemTests.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPTestSupport
 import LanguageServerProtocol
-import SKCore
+@_spi(Testing) import SKCore
 import TSCBasic
 import XCTest
 
@@ -19,17 +20,17 @@ import struct PackageModel.BuildFlags
 
 final class FallbackBuildSystemTests: XCTestCase {
 
-  func testSwift() throws {
+  func testSwift() async throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.swift")
 
     let bs = FallbackBuildSystem(buildSetup: .default)
-    bs.sdkpath = sdk
+    await bs.setSdkPath(sdk)
 
-    XCTAssertNil(bs.indexStorePath)
-    XCTAssertNil(bs.indexDatabasePath)
+    assertNil(await bs.indexStorePath)
+    assertNil(await bs.indexDatabasePath)
 
-    let settings = bs.buildSettings(for: source.asURI, language: .swift)!
+    let settings = await bs.buildSettings(for: source.asURI, language: .swift)!
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
@@ -42,17 +43,17 @@ final class FallbackBuildSystemTests: XCTestCase {
       ]
     )
 
-    bs.sdkpath = nil
+    await bs.setSdkPath(nil)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments,
       [
         source.pathString
       ]
     )
   }
 
-  func testSwiftWithCustomFlags() throws {
+  func testSwiftWithCustomFlags() async throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.swift")
 
@@ -66,9 +67,9 @@ final class FallbackBuildSystemTests: XCTestCase {
       ])
     )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
-    bs.sdkpath = sdk
+    await bs.setSdkPath(sdk)
 
-    let args = bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments
+    let args = await bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments
     XCTAssertEqual(
       args,
       [
@@ -80,10 +81,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ]
     )
 
-    bs.sdkpath = nil
+    await bs.setSdkPath(nil)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .swift)?.compilerArguments,
       [
         "-Xfrontend",
         "-debug-constraints",
@@ -92,7 +93,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     )
   }
 
-  func testSwiftWithCustomSDKFlag() throws {
+  func testSwiftWithCustomSDKFlag() async throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.swift")
 
@@ -108,10 +109,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ])
     )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
-    bs.sdkpath = sdk
+    await bs.setSdkPath(sdk)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments,
       [
         "-sdk",
         "/some/custom/sdk",
@@ -121,10 +122,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ]
     )
 
-    bs.sdkpath = nil
+    await bs.setSdkPath(nil)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .swift)!.compilerArguments,
       [
         "-sdk",
         "/some/custom/sdk",
@@ -135,14 +136,14 @@ final class FallbackBuildSystemTests: XCTestCase {
     )
   }
 
-  func testCXX() throws {
+  func testCXX() async throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.cpp")
 
     let bs = FallbackBuildSystem(buildSetup: .default)
-    bs.sdkpath = sdk
+    await bs.setSdkPath(sdk)
 
-    let settings = bs.buildSettings(for: source.asURI, language: .cpp)!
+    let settings = await bs.buildSettings(for: source.asURI, language: .cpp)!
     XCTAssertNil(settings.workingDirectory)
 
     let args = settings.compilerArguments
@@ -155,17 +156,17 @@ final class FallbackBuildSystemTests: XCTestCase {
       ]
     )
 
-    bs.sdkpath = nil
+    await bs.setSdkPath(nil)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
       [
         source.pathString
       ]
     )
   }
 
-  func testCXXWithCustomFlags() throws {
+  func testCXXWithCustomFlags() async throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.cpp")
 
@@ -178,10 +179,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ])
     )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
-    bs.sdkpath = sdk
+    await bs.setSdkPath(sdk)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
       [
         "-v",
         "-isysroot",
@@ -190,10 +191,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ]
     )
 
-    bs.sdkpath = nil
+    await bs.setSdkPath(nil)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
       [
         "-v",
         source.pathString,
@@ -201,7 +202,7 @@ final class FallbackBuildSystemTests: XCTestCase {
     )
   }
 
-  func testCXXWithCustomIsysroot() throws {
+  func testCXXWithCustomIsysroot() async throws {
     let sdk = try AbsolutePath(validating: "/my/sdk")
     let source = try AbsolutePath(validating: "/my/source.cpp")
 
@@ -216,10 +217,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ])
     )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
-    bs.sdkpath = sdk
+    await bs.setSdkPath(sdk)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
       [
         "-isysroot",
         "/my/custom/sdk",
@@ -228,10 +229,10 @@ final class FallbackBuildSystemTests: XCTestCase {
       ]
     )
 
-    bs.sdkpath = nil
+    await bs.setSdkPath(nil)
 
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .cpp)?.compilerArguments,
       [
         "-isysroot",
         "/my/custom/sdk",
@@ -241,19 +242,19 @@ final class FallbackBuildSystemTests: XCTestCase {
     )
   }
 
-  func testC() throws {
+  func testC() async throws {
     let source = try AbsolutePath(validating: "/my/source.c")
     let bs = FallbackBuildSystem(buildSetup: .default)
-    bs.sdkpath = nil
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments,
+    await bs.setSdkPath(nil)
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments,
       [
         source.pathString
       ]
     )
   }
 
-  func testCWithCustomFlags() throws {
+  func testCWithCustomFlags() async throws {
     let source = try AbsolutePath(validating: "/my/source.c")
 
     let buildSetup = BuildSetup(
@@ -265,9 +266,9 @@ final class FallbackBuildSystemTests: XCTestCase {
       ])
     )
     let bs = FallbackBuildSystem(buildSetup: buildSetup)
-    bs.sdkpath = nil
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments,
+    await bs.setSdkPath(nil)
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .c)?.compilerArguments,
       [
         "-v",
         source.pathString,
@@ -275,33 +276,33 @@ final class FallbackBuildSystemTests: XCTestCase {
     )
   }
 
-  func testObjC() throws {
+  func testObjC() async throws {
     let source = try AbsolutePath(validating: "/my/source.m")
     let bs = FallbackBuildSystem(buildSetup: .default)
-    bs.sdkpath = nil
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .objective_c)?.compilerArguments,
+    await bs.setSdkPath(nil)
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .objective_c)?.compilerArguments,
       [
         source.pathString
       ]
     )
   }
 
-  func testObjCXX() throws {
+  func testObjCXX() async throws {
     let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
-    bs.sdkpath = nil
-    XCTAssertEqual(
-      bs.buildSettings(for: source.asURI, language: .objective_cpp)?.compilerArguments,
+    await bs.setSdkPath(nil)
+    assertEqual(
+      await bs.buildSettings(for: source.asURI, language: .objective_cpp)?.compilerArguments,
       [
         source.pathString
       ]
     )
   }
 
-  func testUnknown() throws {
+  func testUnknown() async throws {
     let source = try AbsolutePath(validating: "/my/source.mm")
     let bs = FallbackBuildSystem(buildSetup: .default)
-    XCTAssertNil(bs.buildSettings(for: source.asURI, language: Language(rawValue: "unknown")))
+    assertNil(await bs.buildSettings(for: source.asURI, language: Language(rawValue: "unknown")))
   }
 }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -188,7 +188,9 @@ final class BuildSystemTests: XCTestCase {
 
   func testSwiftDocumentUpdatedBuildSettings() async throws {
     let doc = DocumentURI.for(.swift)
-    let args = FallbackBuildSystem(buildSetup: .default).buildSettings(for: doc, language: .swift)!.compilerArguments
+    let args = await FallbackBuildSystem(buildSetup: .default)
+      .buildSettings(for: doc, language: .swift)!
+      .compilerArguments
 
     buildSystem.buildSettingsByFile[doc] = FileBuildSettings(compilerArguments: args)
 
@@ -257,7 +259,7 @@ final class BuildSystemTests: XCTestCase {
     let doc = DocumentURI.for(.swift)
 
     // Primary settings must be different than the fallback settings.
-    var primarySettings = FallbackBuildSystem(buildSetup: .default).buildSettings(for: doc, language: .swift)!
+    var primarySettings = await FallbackBuildSystem(buildSetup: .default).buildSettings(for: doc, language: .swift)!
     primarySettings.isFallback = false
     primarySettings.compilerArguments.append("-DPRIMARY")
 


### PR DESCRIPTION
Swift 6 mode didn’t find any notable data races. But it’s good to know Swift 6 will prevent future ones.