### PR TITLE
Make the `Diagnose` module build in Swift 6 mode

### DIFF
--- a/Sources/Diagnose/CMakeLists.txt
+++ b/Sources/Diagnose/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(Diagnose STATIC
+  CommandConfiguration+Sendable.swift
   CommandLineArgumentsReducer.swift
   DiagnoseCommand.swift
   MergeSwiftFiles.swift
@@ -11,9 +12,10 @@ add_library(Diagnose STATIC
   ReproducerBundle.swift
   RequestInfo.swift
   SourceKitD+RunWithYaml.swift
+  SourcekitdRequestCommand.swift
   SourceKitDRequestExecutor.swift
   SourceReducer.swift
-  SourcekitdRequestCommand.swift
+  StderrStreamConcurrencySafe.swift
   SwiftFrontendCrashScraper.swift
   Toolchain+SwiftFrontend.swift)
 

--- a/Sources/Diagnose/CommandConfiguration+Sendable.swift
+++ b/Sources/Diagnose/CommandConfiguration+Sendable.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+
+// If `CommandConfiguration` is not sendable, commands can't have static `configuration` properties.
+// Needed until we update Swift CI to swift-argument-parser 1.3.1, which has this conformance (rdar://128042447).
+extension CommandConfiguration: @unchecked @retroactive Sendable {}

--- a/Sources/Diagnose/CommandLineArgumentsReducer.swift
+++ b/Sources/Diagnose/CommandLineArgumentsReducer.swift
@@ -16,6 +16,7 @@ import LSPLogging
 // MARK: - Entry point
 
 extension RequestInfo {
+  @MainActor
   func reduceCommandLineArguments(
     using executor: SourceKitRequestExecutor,
     progressUpdate: (_ progress: Double, _ message: String) -> Void
@@ -49,6 +50,7 @@ fileprivate class CommandLineArgumentReducer {
     self.progressUpdate = progressUpdate
   }
 
+  @MainActor
   func run(initialRequestInfo: RequestInfo) async throws -> RequestInfo {
     var requestInfo = initialRequestInfo
     requestInfo = try await reduce(initialRequestInfo: requestInfo, simultaneousRemove: 10)
@@ -113,6 +115,7 @@ fileprivate class CommandLineArgumentReducer {
     return requestInfo
   }
 
+  @MainActor
   private func tryRemoving(
     _ argumentsToRemove: ClosedRange<Int>,
     from requestInfo: RequestInfo

--- a/Sources/Diagnose/MergeSwiftFiles.swift
+++ b/Sources/Diagnose/MergeSwiftFiles.swift
@@ -17,6 +17,7 @@ extension RequestInfo {
   /// Check if the issue reproduces when merging all `.swift` input files into a single file.
   ///
   /// Returns `nil` if the issue didn't reproduce with all `.swift` files merged.
+  @MainActor
   func mergeSwiftFiles(
     using executor: SourceKitRequestExecutor,
     progressUpdate: (_ progress: Double, _ message: String) -> Void

--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -20,7 +20,7 @@ import var TSCBasic.stderrStream
 import class TSCUtility.PercentProgressAnimation
 
 public struct ReduceCommand: AsyncParsableCommand {
-  public static var configuration: CommandConfiguration = CommandConfiguration(
+  public static let configuration: CommandConfiguration = CommandConfiguration(
     commandName: "reduce",
     abstract: "Reduce a single sourcekitd crash",
     shouldDisplay: false
@@ -56,6 +56,7 @@ public struct ReduceCommand: AsyncParsableCommand {
   private var nsPredicate: NSPredicate? { nil }
   #endif
 
+  @MainActor
   var toolchain: Toolchain? {
     get async throws {
       if let toolchainOverride {
@@ -68,6 +69,7 @@ public struct ReduceCommand: AsyncParsableCommand {
 
   public init() {}
 
+  @MainActor
   public func run() async throws {
     guard let sourcekitd = try await toolchain?.sourcekitd else {
       throw ReductionError("Unable to find sourcekitd.framework")

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -20,7 +20,7 @@ import var TSCBasic.stderrStream
 import class TSCUtility.PercentProgressAnimation
 
 public struct ReduceFrontendCommand: AsyncParsableCommand {
-  public static var configuration: CommandConfiguration = CommandConfiguration(
+  public static let configuration: CommandConfiguration = CommandConfiguration(
     commandName: "reduce-frontend",
     abstract: "Reduce a single swift-frontend crash",
     shouldDisplay: false
@@ -64,6 +64,7 @@ public struct ReduceFrontendCommand: AsyncParsableCommand {
   )
   var frontendArgs: [String]
 
+  @MainActor
   var toolchain: Toolchain? {
     get async throws {
       if let toolchainOverride {
@@ -76,6 +77,7 @@ public struct ReduceFrontendCommand: AsyncParsableCommand {
 
   public init() {}
 
+  @MainActor
   public func run() async throws {
     guard let sourcekitd = try await toolchain?.sourcekitd else {
       throw ReductionError("Unable to find sourcekitd.framework")
@@ -84,7 +86,10 @@ public struct ReduceFrontendCommand: AsyncParsableCommand {
       throw ReductionError("Unable to find swift-frontend")
     }
 
-    let progressBar = PercentProgressAnimation(stream: stderrStream, header: "Reducing swift-frontend crash")
+    let progressBar = PercentProgressAnimation(
+      stream: stderrStream,
+      header: "Reducing swift-frontend crash"
+    )
 
     let executor = OutOfProcessSourceKitRequestExecutor(
       sourcekitd: sourcekitd.asURL,

--- a/Sources/Diagnose/ReduceSourceKitDRequest.swift
+++ b/Sources/Diagnose/ReduceSourceKitDRequest.swift
@@ -12,6 +12,7 @@
 
 extension RequestInfo {
   /// Reduce the input file of this request and the command line arguments.
+  @MainActor
   func reduce(
     using executor: SourceKitRequestExecutor,
     progressUpdate: (_ progress: Double, _ message: String) -> Void

--- a/Sources/Diagnose/ReduceSwiftFrontend.swift
+++ b/Sources/Diagnose/ReduceSwiftFrontend.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@MainActor
 @_spi(Testing)
 public func reduceFrontendIssue(
   frontendArgs: [String],

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -15,7 +15,7 @@ import RegexBuilder
 
 /// All the information necessary to replay a sourcektid request.
 @_spi(Testing)
-public struct RequestInfo {
+public struct RequestInfo: Sendable {
   /// The JSON request object. Contains the following dynamic placeholders:
   ///  - `$OFFSET`: To be replaced by `offset` before running the request
   ///  - `$FILE`: Will be replaced with a path to the file that contains the reduced source code.
@@ -51,7 +51,7 @@ public struct RequestInfo {
   }
 
   /// A fake value that is used to indicate that we are reducing a `swift-frontend` issue instead of a sourcekitd issue.
-  static var fakeRequestTemplateForFrontendIssues = """
+  static let fakeRequestTemplateForFrontendIssues = """
     {
       key.request: sourcekit-lsp-fake-request-for-frontend-crash
       key.compilerargs: [

--- a/Sources/Diagnose/SourceKitDRequestExecutor.swift
+++ b/Sources/Diagnose/SourceKitDRequestExecutor.swift
@@ -19,7 +19,7 @@ import struct TSCBasic.ProcessResult
 
 /// The different states in which a sourcekitd request can finish.
 @_spi(Testing)
-public enum SourceKitDRequestResult {
+public enum SourceKitDRequestResult: Sendable {
   /// The request succeeded.
   case success(response: String)
 
@@ -46,11 +46,12 @@ fileprivate extension String {
 /// An executor that can run a sourcekitd request and indicate whether the request reprodes a specified issue.
 @_spi(Testing)
 public protocol SourceKitRequestExecutor {
-  func runSourceKitD(request: RequestInfo) async throws -> SourceKitDRequestResult
-  func runSwiftFrontend(request: RequestInfo) async throws -> SourceKitDRequestResult
+  @MainActor func runSourceKitD(request: RequestInfo) async throws -> SourceKitDRequestResult
+  @MainActor func runSwiftFrontend(request: RequestInfo) async throws -> SourceKitDRequestResult
 }
 
 extension SourceKitRequestExecutor {
+  @MainActor
   func run(request: RequestInfo) async throws -> SourceKitDRequestResult {
     if request.requestTemplate == RequestInfo.fakeRequestTemplateForFrontendIssues {
       return try await runSwiftFrontend(request: request)

--- a/Sources/Diagnose/SourceReducer.swift
+++ b/Sources/Diagnose/SourceReducer.swift
@@ -21,6 +21,7 @@ import SwiftSyntax
 
 extension RequestInfo {
   @_spi(Testing)
+  @MainActor
   public func reduceInputFile(
     using executor: SourceKitRequestExecutor,
     progressUpdate: (_ progress: Double, _ message: String) -> Void
@@ -61,6 +62,7 @@ fileprivate enum ReductionStepResult {
 }
 
 /// Reduces an input source file while continuing to reproduce the crash
+@MainActor
 fileprivate class SourceReducer {
   /// The executor that is used to run a sourcekitd request and check whether it
   /// still crashes.
@@ -84,6 +86,7 @@ fileprivate class SourceReducer {
   }
 
   /// Reduce the file contents in `initialRequest` to a smaller file that still reproduces a crash.
+  @MainActor
   func run(initialRequestInfo: RequestInfo) async throws -> RequestInfo {
     var requestInfo = initialRequestInfo
     self.initialImportCount = Parser.parse(source: requestInfo.fileContents).numberOfImports
@@ -242,6 +245,7 @@ fileprivate class SourceReducer {
   ///
   /// If the request still crashes after applying the edits computed by `reduce`, return the reduced request info.
   /// Otherwise, return `nil`
+  @MainActor
   private func runReductionStep(
     requestInfo: RequestInfo,
     reportProgress: Bool = true,
@@ -608,6 +612,7 @@ fileprivate class FirstImportFinder: SyntaxAnyVisitor {
 /// the file that imports the module. If `areFallbackArgs` is set, we have synthesized fallback arguments that only
 /// contain a target and SDK. This is useful when reducing a swift-frontend crash because sourcekitd requires driver
 /// arguments but the swift-frontend crash has frontend args.
+@MainActor
 fileprivate func getSwiftInterface(
   _ moduleName: String,
   executor: SourceKitRequestExecutor,
@@ -680,6 +685,7 @@ fileprivate func getSwiftInterface(
   return try JSONDecoder().decode(String.self, from: sanitizedData)
 }
 
+@MainActor
 fileprivate func inlineFirstImport(
   in tree: SourceFileSyntax,
   executor: SourceKitRequestExecutor,

--- a/Sources/Diagnose/SourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/SourcekitdRequestCommand.swift
@@ -18,7 +18,7 @@ import SourceKitD
 import struct TSCBasic.AbsolutePath
 
 public struct SourceKitdRequestCommand: AsyncParsableCommand {
-  public static var configuration = CommandConfiguration(
+  public static let configuration = CommandConfiguration(
     commandName: "run-sourcekitd-request",
     abstract: "Run a sourcekitd request and print its result",
     shouldDisplay: false

--- a/Sources/Diagnose/StderrStreamConcurrencySafe.swift
+++ b/Sources/Diagnose/StderrStreamConcurrencySafe.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCLibc
+
+import class TSCBasic.LocalFileOutputByteStream
+import class TSCBasic.ThreadSafeOutputByteStream
+
+// A version of `stderrStream` from `TSCBasic` that is a `let` and can thus be used from Swift 6.
+let stderrStreamConcurrencySafe: ThreadSafeOutputByteStream = try! ThreadSafeOutputByteStream(
+  LocalFileOutputByteStream(
+    filePointer: TSCLibc.stderr,
+    closeOnDeinit: false
+  )
+)

--- a/Tests/DiagnoseTests/DiagnoseTests.swift
+++ b/Tests/DiagnoseTests/DiagnoseTests.swift
@@ -114,7 +114,7 @@ final class DiagnoseTests: XCTestCase {
         let foo = 1️⃣Foo()
       }
 
-      /* 
+      /*
        Block comment
        With another line
       */
@@ -146,6 +146,7 @@ final class DiagnoseTests: XCTestCase {
     )
   }
 
+  @MainActor
   func testReduceFrontend() async throws {
     try await withTestScratchDir { scratchDir in
       let fileAContents = """
@@ -227,6 +228,7 @@ final class DiagnoseTests: XCTestCase {
 ///     - `$OFFSET`: The UTF-8 offset of the 1️⃣ location marker in `markedFileContents`
 ///   - reproducerPredicate: A predicate that indicates whether a run request reproduces the issue.
 ///   - expectedReducedFileContents: The contents of the file that the reducer is expected to produce.
+@MainActor
 private func assertReduceSourceKitD(
   _ markedFileContents: String,
   request: String,


### PR DESCRIPTION
This was mostly about slapping `@MainActor` on a bunch of declarations since `diagnose` doesn’t leverage concurrency at the moment.