### PR TITLE
Add devcontainer for building SK-LSP

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM swiftlang/swift:nightly-6.0-jammy
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+    && apt-get -q update \
+    && apt-get -q dist-upgrade -y \
+    && apt-get -q install -y \
+      sqlite3 \
+      libsqlite3-dev \
+      libncurses5-dev \
+      python3      

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+{
+    "name": "Swift",
+    "dockerFile": "Dockerfile",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        },
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so",
+                "swift.buildArguments": [
+                    "-Xcxx",
+                    "-I/usr/lib/swift",
+                    "-Xcxx",
+                    "-I/usr/lib/swift/Block"
+                ]
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "sswg.swift-lang"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
- Uses swiftlang/swift:nightly-6.0-jammy as a base image
- Installs `sqlite3`, `libsqlite3-dev`, `libncurses5-dev` and `python3`.
- Adds build arguments `-Xcxx -I/usr/lib/swift -Xcxx -I/usr/lib/swift/Block`
- Includes swift extension 