### PR TITLE
Move `LocalConnection` to `LSPTestSupport`

### DIFF
--- a/Sources/LSPTestSupport/LocalConnection.swift
+++ b/Sources/LSPTestSupport/LocalConnection.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import LSPLogging
+import LanguageServerProtocol
+
+/// A connection between two message handlers in the same process.
+///
+/// You must call `start(handler:)` before sending any messages, and must call `close()` when finished to avoid a memory leak.
+///
+/// ```
+/// let client: MessageHandler = ...
+/// let server: MessageHandler = ...
+/// let conn = LocalConnection()
+/// conn.start(handler: server)
+/// conn.send(...) // handled by server
+/// conn.close()
+/// ```
+///
+/// - Note: Unchecked sendable conformance because shared state is guarded by `queue`.
+public final class LocalConnection: Connection, @unchecked Sendable {
+  enum State {
+    case ready, started, closed
+  }
+
+  /// A name of the endpoint for this connection, used for logging, e.g. `clangd`.
+  private let name: String
+
+  /// The queue guarding `_nextRequestID`.
+  let queue: DispatchQueue = DispatchQueue(label: "local-connection-queue")
+
+  var _nextRequestID: Int = 0
+
+  var state: State = .ready
+
+  var handler: MessageHandler? = nil
+
+  public init(name: String) {
+    self.name = name
+  }
+
+  deinit {
+    if state != .closed {
+      close()
+    }
+  }
+
+  public func start(handler: MessageHandler) {
+    precondition(state == .ready)
+    state = .started
+    self.handler = handler
+  }
+
+  public func close() {
+    precondition(state != .closed)
+    handler = nil
+    state = .closed
+  }
+
+  func nextRequestID() -> RequestID {
+    return queue.sync {
+      _nextRequestID += 1
+      return .number(_nextRequestID)
+    }
+  }
+
+  public func send<Notification: NotificationType>(_ notification: Notification) {
+    logger.info(
+      """
+      Sending notification to \(self.name, privacy: .public)
+      \(notification.forLogging)
+      """
+    )
+    self.handler?.handle(notification)
+  }
+
+  public func send<Request: RequestType>(
+    _ request: Request,
+    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+  ) -> RequestID {
+    let id = nextRequestID()
+
+    logger.info(
+      """
+      Sending request to \(self.name, privacy: .public) (id: \(id, privacy: .public)):
+      \(request.forLogging)
+      """
+    )
+
+    guard let handler = self.handler else {
+      logger.info(
+        """
+        Replying to request \(id, privacy: .public) with .serverCancelled because no handler is specified in \(self.name, privacy: .public)
+        """
+      )
+      reply(.failure(.serverCancelled))
+      return id
+    }
+
+    precondition(self.state == .started)
+    handler.handle(request, id: id) { result in
+      switch result {
+      case .success(let response):
+        logger.info(
+          """
+          Received reply for request \(id, privacy: .public) from \(self.name, privacy: .public)
+          \(response.forLogging)
+          """
+        )
+      case .failure(let error):
+        logger.error(
+          """
+          Received error for request \(id, privacy: .public) from \(self.name, privacy: .public)
+          \(error.forLogging)
+          """
+        )
+      }
+      reply(result)
+    }
+
+    return id
+  }
+}

--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -76,9 +76,9 @@ public final class TestJSONRPCConnection: Sendable {
 
 public struct TestLocalConnection {
   public let client: TestClient
-  public let clientConnection: LocalConnection = LocalConnection()
+  public let clientConnection: LocalConnection = LocalConnection(name: "Test")
   public let server: TestServer
-  public let serverConnection: LocalConnection = LocalConnection()
+  public let serverConnection: LocalConnection = LocalConnection(name: "Test")
 
   public init(allowUnexpectedNotification: Bool = true) {
     client = TestClient(connectionToServer: serverConnection, allowUnexpectedNotification: allowUnexpectedNotification)

--- a/Sources/LanguageServerProtocol/Connection.swift
+++ b/Sources/LanguageServerProtocol/Connection.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
-
 /// An abstract connection, allow messages to be sent to a (potentially remote) `MessageHandler`.
 public protocol Connection: AnyObject, Sendable {
 
@@ -46,84 +44,4 @@ public protocol MessageHandler: AnyObject, Sendable {
     id: RequestID,
     reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
   )
-}
-
-/// A connection between two message handlers in the same process.
-///
-/// You must call `start(handler:)` before sending any messages, and must call `close()` when finished to avoid a memory leak.
-///
-/// ```
-/// let client: MessageHandler = ...
-/// let server: MessageHandler = ...
-/// let conn = LocalConnection()
-/// conn.start(handler: server)
-/// conn.send(...) // handled by server
-/// conn.close()
-/// ```
-///
-/// - Note: Unchecked sendable conformance because shared state is guarded by `queue`.
-public final class LocalConnection: Connection, @unchecked Sendable {
-
-  enum State {
-    case ready, started, closed
-  }
-
-  /// The queue guarding `_nextRequestID`.
-  let queue: DispatchQueue = DispatchQueue(label: "local-connection-queue")
-
-  var _nextRequestID: Int = 0
-
-  var state: State = .ready
-
-  var handler: MessageHandler? = nil
-
-  public init() {}
-
-  deinit {
-    if state != .closed {
-      close()
-    }
-  }
-
-  public func start(handler: MessageHandler) {
-    precondition(state == .ready)
-    state = .started
-    self.handler = handler
-  }
-
-  public func close() {
-    precondition(state != .closed)
-    handler = nil
-    state = .closed
-  }
-
-  func nextRequestID() -> RequestID {
-    return queue.sync {
-      _nextRequestID += 1
-      return .number(_nextRequestID)
-    }
-  }
-
-  public func send<Notification>(_ notification: Notification) where Notification: NotificationType {
-    self.handler?.handle(notification)
-  }
-
-  public func send<Request: RequestType>(
-    _ request: Request,
-    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
-  ) -> RequestID {
-    let id = nextRequestID()
-
-    guard let handler = self.handler else {
-      reply(.failure(.serverCancelled))
-      return id
-    }
-
-    precondition(self.state == .started)
-    handler.handle(request, id: id) { result in
-      reply(result)
-    }
-
-    return id
-  }
 }

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -117,7 +117,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
     }
     self.notificationYielder = notificationYielder
 
-    let serverToClientConnection = LocalConnection()
+    let serverToClientConnection = LocalConnection(name: "client")
     self.serverToClientConnection = serverToClientConnection
     server = SourceKitLSPServer(
       client: serverToClientConnection,

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -699,7 +699,6 @@ public actor SourceKitLSPServer {
 
   /// Send the given notification to the editor.
   public func sendNotificationToClient(_ notification: some NotificationType) {
-    logger.log("Sending notification: \(notification.forLogging)")
     client.send(notification)
   }
 


### PR DESCRIPTION
We weren’t logging requests sent to a `TestSourceKitLSPClient` because we were assuming that `JSONRPCConnection` logs those requests in `SourceKitLSPServer`. But no logging happens in `LocalConnection`, which `TestSourceKitLSPClient` uses.

Since `LangaugeServerProtcol` can’t depend on `LSPLogging`, move the type to `LSPTestsSupport`.