### PR TITLE
Add infrastructure to test which targets are being prepared

### DIFF
--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -84,6 +84,7 @@ public class MultiFileTestProject {
     serverOptions: SourceKitLSPServer.Options = .testDefault,
     usePullDiagnostics: Bool = true,
     preInitialization: ((TestSourceKitLSPClient) -> Void)? = nil,
+    cleanUp: (() -> Void)? = nil,
     testName: String = #function
   ) async throws {
     scratchDirectory = try testScratchDir(testName: testName)
@@ -122,6 +123,7 @@ public class MultiFileTestProject {
         if cleanScratchDirectories {
           try? FileManager.default.removeItem(at: scratchDirectory)
         }
+        cleanUp?()
       }
     )
   }

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -47,6 +47,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
     pollIndex: Bool = true,
     preInitialization: ((TestSourceKitLSPClient) -> Void)? = nil,
     usePullDiagnostics: Bool = true,
+    cleanUp: (() -> Void)? = nil,
     testName: String = #function
   ) async throws {
     var filesByPath: [RelativeFileLocation: String] = [:]
@@ -72,6 +73,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
       serverOptions: serverOptions,
       usePullDiagnostics: usePullDiagnostics,
       preInitialization: preInitialization,
+      cleanUp: cleanUp,
       testName: testName
     )
 

--- a/Sources/SemanticIndex/CMakeLists.txt
+++ b/Sources/SemanticIndex/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(SemanticIndex STATIC
   IndexTaskDescription.swift
   PreparationTaskDescription.swift
   SemanticIndexManager.swift
+  TestHooks.swift
   UpdateIndexStoreTaskDescription.swift
 )
 set_target_properties(SemanticIndex PROPERTIES

--- a/Sources/SemanticIndex/PreparationTaskDescription.swift
+++ b/Sources/SemanticIndex/PreparationTaskDescription.swift
@@ -35,6 +35,9 @@ public struct PreparationTaskDescription: IndexTaskDescription {
   /// The build system manager that is used to get the toolchain and build settings for the files to index.
   private let buildSystemManager: BuildSystemManager
 
+  /// Test hooks that should be called when the preparation task finishes.
+  private let testHooks: IndexTestHooks
+
   /// The task is idempotent because preparing the same target twice produces the same result as preparing it once.
   public var isIdempotent: Bool { true }
 
@@ -50,10 +53,12 @@ public struct PreparationTaskDescription: IndexTaskDescription {
 
   init(
     targetsToPrepare: [ConfiguredTarget],
-    buildSystemManager: BuildSystemManager
+    buildSystemManager: BuildSystemManager,
+    testHooks: IndexTestHooks
   ) {
     self.targetsToPrepare = targetsToPrepare
     self.buildSystemManager = buildSystemManager
+    self.testHooks = testHooks
   }
 
   public func execute() async {
@@ -79,6 +84,7 @@ public struct PreparationTaskDescription: IndexTaskDescription {
           "Preparation failed: \(error.forLogging)"
         )
       }
+      testHooks.preparationTaskDidFinish?(self)
       logger.log(
         "Finished preparation in \(Date().timeIntervalSince(startDate) * 1000, privacy: .public)ms: \(targetsToPrepareDescription)"
       )

--- a/Sources/SemanticIndex/PreparationTaskDescription.swift
+++ b/Sources/SemanticIndex/PreparationTaskDescription.swift
@@ -30,7 +30,7 @@ public struct PreparationTaskDescription: IndexTaskDescription {
   public let id = preparationIDForLogging.fetchAndIncrement()
 
   /// The targets that should be prepared.
-  private let targetsToPrepare: [ConfiguredTarget]
+  public let targetsToPrepare: [ConfiguredTarget]
 
   /// The build system manager that is used to get the toolchain and build settings for the files to index.
   private let buildSystemManager: BuildSystemManager
@@ -84,7 +84,7 @@ public struct PreparationTaskDescription: IndexTaskDescription {
           "Preparation failed: \(error.forLogging)"
         )
       }
-      testHooks.preparationTaskDidFinish?(self)
+      await testHooks.preparationTaskDidFinish?(self)
       logger.log(
         "Finished preparation in \(Date().timeIntervalSince(startDate) * 1000, privacy: .public)ms: \(targetsToPrepareDescription)"
       )

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -38,6 +38,19 @@ private enum IndexStatus<T> {
   }
 }
 
+/// See `SemanticIndexManager.preparationStatus`
+private struct PreparationTaskStatusData {
+  /// A UUID to track the task. This is used to ensure that status updates from this task don't update
+  /// `preparationStatus` for targets that are tracked by a different task.
+  let taskID: UUID
+
+  /// The list of targets that are being prepared in a joint preparation operation.
+  let targets: [ConfiguredTarget]
+
+  /// The task that prepares the target
+  let task: Task<Void, Never>
+}
+
 /// Schedules index tasks and keeps track of the index status of files.
 public final actor SemanticIndexManager {
   /// The underlying index. This is used to check if the index of a file is already up-to-date, in which case it doesn't
@@ -54,13 +67,7 @@ public final actor SemanticIndexManager {
   /// The preparation status of the targets that the `SemanticIndexManager` has started preparation for.
   ///
   /// Targets will be removed from this dictionary when they are no longer known to be up-to-date.
-  ///
-  /// The associated values of the `IndexStatus` are:
-  ///  - A UUID to track the task. This is used to ensure that status updates from this task don't update
-  ///    `preparationStatus` for targets that are tracked by a different task.
-  ///  - The list of targets that are being prepared in a joint preparation operation
-  ///  - The task that prepares the target
-  private var preparationStatus: [ConfiguredTarget: IndexStatus<(UUID, [ConfiguredTarget], Task<Void, Never>)>] = [:]
+  private var preparationStatus: [ConfiguredTarget: IndexStatus<PreparationTaskStatusData>] = [:]
 
   /// The index status of the source files that the `SemanticIndexManager` knows about.
   ///
@@ -268,7 +275,7 @@ public final actor SemanticIndexManager {
       switch preparationStatus[target] {
       case .upToDate:
         break
-      case .scheduled((_, let existingTaskTargets, let task)), .executing((_, let existingTaskTargets, let task)):
+      case .scheduled(let existingTaskData), .executing(let existingTaskData):
         // If we already have a task scheduled that prepares fewer targets, await that instead of overriding the
         // target's preparation status with a longer-running task. The key benefit here is that when we get many
         // preparation requests for the same target (eg. one for every text document request sent to a file), we don't
@@ -276,8 +283,8 @@ public final actor SemanticIndexManager {
         // requests await the same task. At the same time, if we have a multi-file preparation request and then get a
         // single-file preparation request, we will override the preparation of that target with the single-file
         // preparation task, ensuring that the task gets prepared as quickly as possible.
-        if existingTaskTargets.count <= targets.count {
-          preparationTasksToAwait.append(task)
+        if existingTaskData.targets.count <= targets.count {
+          preparationTasksToAwait.append(existingTaskData.task)
         } else {
           targetsToPrepare.append(target)
         }
@@ -301,20 +308,22 @@ public final actor SemanticIndexManager {
         switch newState {
         case .executing:
           for target in targetsToPrepare {
-            if case .scheduled((taskID, let targets, let task)) = self.preparationStatus[target] {
-              self.preparationStatus[target] = .executing((taskID, targets, task))
+            if case .scheduled(let existingTaskData) = self.preparationStatus[target], existingTaskData.taskID == taskID
+            {
+              self.preparationStatus[target] = .executing(existingTaskData)
             }
           }
         case .cancelledToBeRescheduled:
           for target in targetsToPrepare {
-            if case .executing((taskID, let targets, let task)) = self.preparationStatus[target] {
-              self.preparationStatus[target] = .scheduled((taskID, targets, task))
+            if case .executing(let existingTaskData) = self.preparationStatus[target], existingTaskData.taskID == taskID
+            {
+              self.preparationStatus[target] = .scheduled(existingTaskData)
             }
           }
         case .finished:
           for target in targetsToPrepare {
             switch self.preparationStatus[target] {
-            case .executing((taskID, _, _)):
+            case .executing(let existingTaskData) where existingTaskData.taskID == taskID:
               self.preparationStatus[target] = .upToDate
             default:
               break
@@ -324,14 +333,16 @@ public final actor SemanticIndexManager {
         }
       }
       for target in targetsToPrepare {
-        preparationStatus[target] = .scheduled((taskID, targetsToPrepare, preparationTask))
+        preparationStatus[target] = .scheduled(
+          PreparationTaskStatusData(taskID: taskID, targets: targetsToPrepare, task: preparationTask)
+        )
       }
       preparationTasksToAwait.append(preparationTask)
     }
     await withTaskGroup(of: Void.self) { taskGroup in
       for task in preparationTasksToAwait {
         taskGroup.addTask {
-          await task.value
+          await task.valuePropagatingCancellation
         }
       }
       await taskGroup.waitForAll()

--- a/Sources/SemanticIndex/TestHooks.swift
+++ b/Sources/SemanticIndex/TestHooks.swift
@@ -12,14 +12,14 @@
 
 /// Callbacks that allow inspection of internal state modifications during testing.
 public struct IndexTestHooks: Sendable {
-  public var preparationTaskDidFinish: (@Sendable (PreparationTaskDescription) -> Void)?
+  public var preparationTaskDidFinish: (@Sendable (PreparationTaskDescription) async -> Void)?
 
   /// A callback that is called when an index task finishes.
-  public var updateIndexStoreTaskDidFinish: (@Sendable (UpdateIndexStoreTaskDescription) -> Void)?
+  public var updateIndexStoreTaskDidFinish: (@Sendable (UpdateIndexStoreTaskDescription) async -> Void)?
 
   public init(
-    preparationTaskDidFinish: (@Sendable (PreparationTaskDescription) -> Void)? = nil,
-    updateIndexStoreTaskDidFinish: (@Sendable (UpdateIndexStoreTaskDescription) -> Void)? = nil
+    preparationTaskDidFinish: (@Sendable (PreparationTaskDescription) async -> Void)? = nil,
+    updateIndexStoreTaskDidFinish: (@Sendable (UpdateIndexStoreTaskDescription) async -> Void)? = nil
   ) {
     self.preparationTaskDidFinish = preparationTaskDidFinish
     self.updateIndexStoreTaskDidFinish = updateIndexStoreTaskDidFinish

--- a/Sources/SemanticIndex/TestHooks.swift
+++ b/Sources/SemanticIndex/TestHooks.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Callbacks that allow inspection of internal state modifications during testing.
+public struct IndexTestHooks: Sendable {
+  public var preparationTaskDidFinish: (@Sendable (PreparationTaskDescription) -> Void)?
+
+  /// A callback that is called when an index task finishes.
+  public var updateIndexStoreTaskDidFinish: (@Sendable (UpdateIndexStoreTaskDescription) -> Void)?
+
+  public init(
+    preparationTaskDidFinish: (@Sendable (PreparationTaskDescription) -> Void)? = nil,
+    updateIndexStoreTaskDidFinish: (@Sendable (UpdateIndexStoreTaskDescription) -> Void)? = nil
+  ) {
+    self.preparationTaskDidFinish = preparationTaskDidFinish
+    self.updateIndexStoreTaskDidFinish = updateIndexStoreTaskDidFinish
+  }
+}

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -49,6 +49,9 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
   /// case we don't need to index it again.
   private let index: UncheckedIndex
 
+  /// Test hooks that should be called when the index task finishes.
+  private let testHooks: IndexTestHooks
+
   /// The task is idempotent because indexing the same file twice produces the same result as indexing it once.
   public var isIdempotent: Bool { true }
 
@@ -65,11 +68,13 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
   init(
     filesToIndex: Set<FileToIndex>,
     buildSystemManager: BuildSystemManager,
-    index: UncheckedIndex
+    index: UncheckedIndex,
+    testHooks: IndexTestHooks
   ) {
     self.filesToIndex = filesToIndex
     self.buildSystemManager = buildSystemManager
     self.index = index
+    self.testHooks = testHooks
   }
 
   public func execute() async {
@@ -94,6 +99,7 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       for file in filesToIndex {
         await updateIndexStoreForSingleFile(file)
       }
+      testHooks.updateIndexStoreTaskDidFinish?(self)
       logger.log(
         "Finished updating index store in \(Date().timeIntervalSince(startDate) * 1000, privacy: .public)ms: \(filesToIndexDescription)"
       )

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -99,7 +99,7 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       for file in filesToIndex {
         await updateIndexStoreForSingleFile(file)
       }
-      testHooks.updateIndexStoreTaskDidFinish?(self)
+      await testHooks.updateIndexStoreTaskDidFinish?(self)
       logger.log(
         "Finished updating index store in \(Date().timeIntervalSince(startDate) * 1000, privacy: .public)ms: \(filesToIndexDescription)"
       )

--- a/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
@@ -14,6 +14,7 @@ import Foundation
 import LanguageServerProtocol
 import SKCore
 import SKSupport
+import SemanticIndex
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
@@ -22,16 +23,6 @@ extension SourceKitLSPServer {
 
   /// Configuration options for the SourceKitServer.
   public struct Options: Sendable {
-    /// Callbacks that allow inspection of internal state modifications during testing.
-    public struct TestHooks: Sendable {
-      /// A callback that is called when an index task finishes.
-      public var indexTaskDidFinish: (@Sendable () -> Void)?
-
-      public init(indexTaskDidFinish: (@Sendable () -> Void)? = nil) {
-        self.indexTaskDidFinish = indexTaskDidFinish
-      }
-    }
-
     /// Additional compiler flags (e.g. `-Xswiftc` for SwiftPM projects) and other build-related
     /// configuration.
     public var buildSetup: BuildSetup
@@ -58,7 +49,7 @@ extension SourceKitLSPServer {
     /// notification when running unit tests.
     public var swiftPublishDiagnosticsDebounceDuration: TimeInterval
 
-    public var testHooks: TestHooks
+    public var indexTestHooks: IndexTestHooks
 
     public init(
       buildSetup: BuildSetup = .default,
@@ -68,7 +59,7 @@ extension SourceKitLSPServer {
       completionOptions: SKCompletionOptions = .init(),
       generatedInterfacesPath: AbsolutePath = defaultDirectoryForGeneratedInterfaces,
       swiftPublishDiagnosticsDebounceDuration: TimeInterval = 2, /* 2s */
-      testHooks: TestHooks = TestHooks()
+      indexTestHooks: IndexTestHooks = IndexTestHooks()
     ) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
@@ -77,7 +68,7 @@ extension SourceKitLSPServer {
       self.completionOptions = completionOptions
       self.generatedInterfacesPath = generatedInterfacesPath
       self.swiftPublishDiagnosticsDebounceDuration = swiftPublishDiagnosticsDebounceDuration
-      self.testHooks = testHooks
+      self.indexTestHooks = indexTestHooks
     }
   }
 }

--- a/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
@@ -22,6 +22,15 @@ extension SourceKitLSPServer {
 
   /// Configuration options for the SourceKitServer.
   public struct Options: Sendable {
+    /// Callbacks that allow inspection of internal state modifications during testing.
+    public struct TestHooks: Sendable {
+      /// A callback that is called when an index task finishes.
+      public var indexTaskDidFinish: (@Sendable () -> Void)?
+
+      public init(indexTaskDidFinish: (@Sendable () -> Void)? = nil) {
+        self.indexTaskDidFinish = indexTaskDidFinish
+      }
+    }
 
     /// Additional compiler flags (e.g. `-Xswiftc` for SwiftPM projects) and other build-related
     /// configuration.
@@ -49,10 +58,7 @@ extension SourceKitLSPServer {
     /// notification when running unit tests.
     public var swiftPublishDiagnosticsDebounceDuration: TimeInterval
 
-    /// A callback that is called when an index task finishes.
-    ///
-    /// Intended for testing purposes.
-    public var indexTaskDidFinish: (@Sendable () -> Void)?
+    public var testHooks: TestHooks
 
     public init(
       buildSetup: BuildSetup = .default,
@@ -61,7 +67,8 @@ extension SourceKitLSPServer {
       indexOptions: IndexOptions = .init(),
       completionOptions: SKCompletionOptions = .init(),
       generatedInterfacesPath: AbsolutePath = defaultDirectoryForGeneratedInterfaces,
-      swiftPublishDiagnosticsDebounceDuration: TimeInterval = 2 /* 2s */
+      swiftPublishDiagnosticsDebounceDuration: TimeInterval = 2, /* 2s */
+      testHooks: TestHooks = TestHooks()
     ) {
       self.buildSetup = buildSetup
       self.clangdOptions = clangdOptions
@@ -70,6 +77,7 @@ extension SourceKitLSPServer {
       self.completionOptions = completionOptions
       self.generatedInterfacesPath = generatedInterfacesPath
       self.swiftPublishDiagnosticsDebounceDuration = swiftPublishDiagnosticsDebounceDuration
+      self.testHooks = testHooks
     }
   }
 }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1211,7 +1211,7 @@ extension SourceKitLSPServer {
       logger.log("Cannot open workspace before server is initialized")
       return nil
     }
-    let indexTaskDidFinishCallback = options.indexTaskDidFinish
+    let indexTaskDidFinishCallback = options.testHooks.indexTaskDidFinish
     var options = self.options
     options.buildSetup = self.options.buildSetup.merging(buildSetup(for: workspaceFolder))
     return try? await Workspace(
@@ -1286,7 +1286,7 @@ extension SourceKitLSPServer {
       if self.workspaces.isEmpty {
         logger.error("no workspace found")
 
-        let indexTaskDidFinishCallback = self.options.indexTaskDidFinish
+        let indexTaskDidFinishCallback = self.options.testHooks.indexTaskDidFinish
         let workspace = await Workspace(
           documentManager: self.documentManager,
           rootUri: req.rootURI,

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1211,7 +1211,6 @@ extension SourceKitLSPServer {
       logger.log("Cannot open workspace before server is initialized")
       return nil
     }
-    let indexTaskDidFinishCallback = options.testHooks.indexTaskDidFinish
     var options = self.options
     options.buildSetup = self.options.buildSetup.merging(buildSetup(for: workspaceFolder))
     return try? await Workspace(
@@ -1237,7 +1236,6 @@ extension SourceKitLSPServer {
       },
       indexTaskDidFinish: { [weak self] in
         self?.indexProgressManager.indexStatusDidChange()
-        indexTaskDidFinishCallback?()
       }
     )
   }
@@ -1286,7 +1284,6 @@ extension SourceKitLSPServer {
       if self.workspaces.isEmpty {
         logger.error("no workspace found")
 
-        let indexTaskDidFinishCallback = self.options.testHooks.indexTaskDidFinish
         let workspace = await Workspace(
           documentManager: self.documentManager,
           rootUri: req.rootURI,
@@ -1302,7 +1299,6 @@ extension SourceKitLSPServer {
           },
           indexTaskDidFinish: { [weak self] in
             self?.indexProgressManager.indexStatusDidChange()
-            indexTaskDidFinishCallback?()
           }
         )
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -112,6 +112,7 @@ public final class Workspace: Sendable {
       self.semanticIndexManager = SemanticIndexManager(
         index: uncheckedIndex,
         buildSystemManager: buildSystemManager,
+        testHooks: options.indexTestHooks,
         indexTaskScheduler: indexTaskScheduler,
         indexTasksWereScheduled: indexTasksWereScheduled,
         indexTaskDidFinish: indexTaskDidFinish

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -165,11 +165,11 @@ final class BackgroundIndexingTests: XCTestCase {
 
   func testBackgroundIndexingHappensWithLowPriority() async throws {
     var serverOptions = backgroundIndexingOptions
-    serverOptions.testHooks.indexTaskDidFinish = {
-      XCTAssert(
-        Task.currentPriority == .low,
-        "An index task ran with priority \(Task.currentPriority)"
-      )
+    serverOptions.indexTestHooks.preparationTaskDidFinish = { taskDescription in
+      XCTAssert(Task.currentPriority == .low, "\(taskDescription) ran with priority \(Task.currentPriority)")
+    }
+    serverOptions.indexTestHooks.updateIndexStoreTaskDidFinish = { taskDescription in
+      XCTAssert(Task.currentPriority == .low, "\(taskDescription) ran with priority \(Task.currentPriority)")
     }
     let project = try await SwiftPMTestProject(
       files: [

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -165,7 +165,7 @@ final class BackgroundIndexingTests: XCTestCase {
 
   func testBackgroundIndexingHappensWithLowPriority() async throws {
     var serverOptions = backgroundIndexingOptions
-    serverOptions.indexTaskDidFinish = {
+    serverOptions.testHooks.indexTaskDidFinish = {
       XCTAssert(
         Task.currentPriority == .low,
         "An index task ran with priority \(Task.currentPriority)"


### PR DESCRIPTION
Mostly infrastructure commits to allow us to write tests about which targets are being prepared. This will probably continue to develop as I start using it more.