### PR TITLE
Produce an index log for the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 default.profraw
 Package.resolved
 /.build
-/.index-build
-/.linux-build
+/.*-build
 /Packages
 /*.xcodeproj
 /*.sublime-project

--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -289,7 +289,10 @@ extension BuildServerBuildSystem: BuildSystem {
     return nil
   }
 
-  public func prepare(targets: [ConfiguredTarget]) async throws {
+  public func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
     throw PrepareNotSupportedError()
   }
 

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -158,7 +158,10 @@ public protocol BuildSystem: AnyObject, Sendable {
 
   /// Prepare the given targets for indexing and semantic functionality. This should build all swift modules of target
   /// dependencies.
-  func prepare(targets: [ConfiguredTarget]) async throws
+  func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws
 
   /// If the build system has knowledge about the language that this document should be compiled in, return it.
   ///

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -231,8 +231,11 @@ extension BuildSystemManager {
     return await buildSystem?.targets(dependingOn: targets)
   }
 
-  public func prepare(targets: [ConfiguredTarget]) async throws {
-    try await buildSystem?.prepare(targets: targets)
+  public func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
+    try await buildSystem?.prepare(targets: targets, indexProcessDidProduceResult: indexProcessDidProduceResult)
   }
 
   public func registerForChangeNotifications(for uri: DocumentURI, language: Language) async {

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(SKCore STATIC
   Debouncer.swift
   FallbackBuildSystem.swift
   FileBuildSettings.swift
+  IndexProcessResult.swift
   MainFilesProvider.swift
   PathPrefixMapping.swift
   SplitShellCommand.swift

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -125,7 +125,10 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     return [ConfiguredTarget(targetID: "dummy", runDestinationID: "dummy")]
   }
 
-  public func prepare(targets: [ConfiguredTarget]) async throws {
+  public func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
     throw PrepareNotSupportedError()
   }
 

--- a/Sources/SKCore/IndexProcessResult.swift
+++ b/Sources/SKCore/IndexProcessResult.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct TSCBasic.ProcessResult
+
+/// Result of a process that prepares a target or updates the index store. To be shown in the build log.
+///
+/// Abstracted over a `ProcessResult` to facilitate build systems that don't spawn a new process to prepare a target but
+/// prepare it from a build graph they have loaded in-process.
+public struct IndexProcessResult {
+  /// A human-readable description of what the process was trying to achieve, like `Preparing MyTarget`
+  public let taskDescription: String
+
+  /// The command that was run to produce the result.
+  public let command: String
+
+  /// The output that the process produced.
+  public let output: String
+
+  /// Whether the process failed.
+  public let failed: Bool
+
+  /// The duration it took for the process to execute.
+  public let duration: Duration
+
+  public init(taskDescription: String, command: String, output: String, failed: Bool, duration: Duration) {
+    self.taskDescription = taskDescription
+    self.command = command
+    self.output = output
+    self.failed = failed
+    self.duration = duration
+  }
+
+  public init(taskDescription: String, processResult: ProcessResult, start: ContinuousClock.Instant) {
+    let stdout = (try? String(bytes: processResult.output.get(), encoding: .utf8)) ?? "<failed to decode stdout>"
+    let stderr = (try? String(bytes: processResult.stderrOutput.get(), encoding: .utf8)) ?? "<failed to decode stderr>"
+    var outputComponents: [String] = []
+    if !stdout.isEmpty {
+      outputComponents.append(
+        """
+        Stdout:
+        \(stdout)
+        """
+      )
+    }
+    if !stderr.isEmpty {
+      outputComponents.append(
+        """
+        Stderr:
+        \(stderr)
+        """
+      )
+    }
+    self.init(
+      taskDescription: taskDescription,
+      command: processResult.arguments.joined(separator: " "),
+      output: outputComponents.joined(separator: "\n\n"),
+      failed: processResult.exitStatus != .terminated(code: 0),
+      duration: start.duration(to: .now)
+    )
+  }
+}

--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -459,17 +459,23 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
     }
   }
 
-  public func prepare(targets: [ConfiguredTarget]) async throws {
+  public func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
     // TODO (indexing): Support preparation of multiple targets at once.
     // https://github.com/apple/sourcekit-lsp/issues/1262
     for target in targets {
-      try await prepare(singleTarget: target)
+      try await prepare(singleTarget: target, indexProcessDidProduceResult: indexProcessDidProduceResult)
     }
     let filesInPreparedTargets = targets.flatMap { self.targets[$0]?.buildTarget.sources ?? [] }
     await fileDependenciesUpdatedDebouncer.scheduleCall(Set(filesInPreparedTargets.map(DocumentURI.init)))
   }
 
-  private func prepare(singleTarget target: ConfiguredTarget) async throws {
+  private func prepare(
+    singleTarget target: ConfiguredTarget,
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
     // TODO (indexing): Add a proper 'prepare' job in SwiftPM instead of building the target.
     // https://github.com/apple/sourcekit-lsp/issues/1254
     guard let toolchain = await toolchainRegistry.default else {
@@ -492,8 +498,16 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
     if Task.isCancelled {
       return
     }
+    let start = ContinuousClock.now
     let process = try Process.launch(arguments: arguments, workingDirectory: nil)
     let result = try await process.waitUntilExitSendingSigIntOnTaskCancellation()
+    indexProcessDidProduceResult(
+      IndexProcessResult(
+        taskDescription: "Preparing \(target.targetID) for \(target.runDestinationID)",
+        processResult: result,
+        start: start
+      )
+    )
     switch result.exitStatus.exhaustivelySwitchable {
     case .terminated(code: 0):
       break

--- a/Sources/SemanticIndex/PreparationTaskDescription.swift
+++ b/Sources/SemanticIndex/PreparationTaskDescription.swift
@@ -37,6 +37,9 @@ public struct PreparationTaskDescription: IndexTaskDescription {
 
   private let preparationUpToDateStatus: IndexUpToDateStatusManager<ConfiguredTarget>
 
+  /// See `SemanticIndexManager.indexProcessDidProduceResult`
+  private let indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+
   /// Test hooks that should be called when the preparation task finishes.
   private let testHooks: IndexTestHooks
 
@@ -57,11 +60,13 @@ public struct PreparationTaskDescription: IndexTaskDescription {
     targetsToPrepare: [ConfiguredTarget],
     buildSystemManager: BuildSystemManager,
     preparationUpToDateStatus: IndexUpToDateStatusManager<ConfiguredTarget>,
+    indexProcessDidProduceResult: @escaping @Sendable (IndexProcessResult) -> Void,
     testHooks: IndexTestHooks
   ) {
     self.targetsToPrepare = targetsToPrepare
     self.buildSystemManager = buildSystemManager
     self.preparationUpToDateStatus = preparationUpToDateStatus
+    self.indexProcessDidProduceResult = indexProcessDidProduceResult
     self.testHooks = testHooks
   }
 
@@ -89,7 +94,10 @@ public struct PreparationTaskDescription: IndexTaskDescription {
       )
       let startDate = Date()
       do {
-        try await buildSystemManager.prepare(targets: targetsToPrepare)
+        try await buildSystemManager.prepare(
+          targets: targetsToPrepare,
+          indexProcessDidProduceResult: indexProcessDidProduceResult
+        )
       } catch {
         logger.error(
           "Preparation failed: \(error.forLogging)"

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -108,6 +108,12 @@ public final actor SemanticIndexManager {
   /// workspaces.
   private let indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>
 
+  /// Callback to be called when the process to prepare a target finishes.
+  ///
+  /// Allows an index log to be displayed to the user that includes the command line invocations of all index-related
+  /// process launches, as well as their output.
+  private let indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+
   /// Called when files are scheduled to be indexed.
   ///
   /// The parameter is the number of files that were scheduled to be indexed.
@@ -150,6 +156,7 @@ public final actor SemanticIndexManager {
     buildSystemManager: BuildSystemManager,
     testHooks: IndexTestHooks,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
+    indexProcessDidProduceResult: @escaping @Sendable (IndexProcessResult) -> Void,
     indexTasksWereScheduled: @escaping @Sendable (Int) -> Void,
     indexStatusDidChange: @escaping @Sendable () -> Void
   ) {
@@ -157,6 +164,7 @@ public final actor SemanticIndexManager {
     self.buildSystemManager = buildSystemManager
     self.testHooks = testHooks
     self.indexTaskScheduler = indexTaskScheduler
+    self.indexProcessDidProduceResult = indexProcessDidProduceResult
     self.indexTasksWereScheduled = indexTasksWereScheduled
     self.indexStatusDidChange = indexStatusDidChange
   }
@@ -350,6 +358,7 @@ public final actor SemanticIndexManager {
         targetsToPrepare: targetsToPrepare,
         buildSystemManager: self.buildSystemManager,
         preparationUpToDateStatus: preparationUpToDateStatus,
+        indexProcessDidProduceResult: indexProcessDidProduceResult,
         testHooks: testHooks
       )
     )
@@ -396,6 +405,7 @@ public final actor SemanticIndexManager {
         buildSystemManager: self.buildSystemManager,
         index: index,
         indexStoreUpToDateStatus: indexStoreUpToDateStatus,
+        indexProcessDidProduceResult: indexProcessDidProduceResult,
         testHooks: testHooks
       )
     )

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1233,9 +1233,9 @@ extension SourceKitLSPServer {
         }
       },
       indexTasksWereScheduled: { [weak self] count in
-        self?.indexProgressManager.indexTaskWasQueued(count: count)
+        self?.indexProgressManager.indexTasksWereScheduled(count: count)
       },
-      indexTaskDidFinish: { [weak self] in
+      indexStatusDidChange: { [weak self] in
         self?.indexProgressManager.indexStatusDidChange()
       }
     )
@@ -1296,9 +1296,9 @@ extension SourceKitLSPServer {
           indexDelegate: nil,
           indexTaskScheduler: self.indexTaskScheduler,
           indexTasksWereScheduled: { [weak self] count in
-            self?.indexProgressManager.indexTaskWasQueued(count: count)
+            self?.indexProgressManager.indexTasksWereScheduled(count: count)
           },
-          indexTaskDidFinish: { [weak self] in
+          indexStatusDidChange: { [weak self] in
             self?.indexProgressManager.indexStatusDidChange()
           }
         )

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -94,6 +94,7 @@ public final class Workspace: Sendable {
     index uncheckedIndex: UncheckedIndex?,
     indexDelegate: SourceKitIndexDelegate?,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
+    indexProcessDidProduceResult: @escaping @Sendable (IndexProcessResult) -> Void,
     indexTasksWereScheduled: @escaping @Sendable (Int) -> Void,
     indexStatusDidChange: @escaping @Sendable () -> Void
   ) async {
@@ -114,6 +115,7 @@ public final class Workspace: Sendable {
         buildSystemManager: buildSystemManager,
         testHooks: options.indexTestHooks,
         indexTaskScheduler: indexTaskScheduler,
+        indexProcessDidProduceResult: indexProcessDidProduceResult,
         indexTasksWereScheduled: indexTasksWereScheduled,
         indexStatusDidChange: indexStatusDidChange
       )
@@ -151,6 +153,7 @@ public final class Workspace: Sendable {
     compilationDatabaseSearchPaths: [RelativePath],
     indexOptions: IndexOptions = IndexOptions(),
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
+    indexProcessDidProduceResult: @escaping @Sendable (IndexProcessResult) -> Void,
     reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void,
     indexTasksWereScheduled: @Sendable @escaping (Int) -> Void,
     indexStatusDidChange: @Sendable @escaping () -> Void
@@ -258,6 +261,7 @@ public final class Workspace: Sendable {
       index: UncheckedIndex(index),
       indexDelegate: indexDelegate,
       indexTaskScheduler: indexTaskScheduler,
+      indexProcessDidProduceResult: indexProcessDidProduceResult,
       indexTasksWereScheduled: indexTasksWereScheduled,
       indexStatusDidChange: indexStatusDidChange
     )

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -95,7 +95,7 @@ public final class Workspace: Sendable {
     indexDelegate: SourceKitIndexDelegate?,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
     indexTasksWereScheduled: @escaping @Sendable (Int) -> Void,
-    indexTaskDidFinish: @escaping @Sendable () -> Void
+    indexStatusDidChange: @escaping @Sendable () -> Void
   ) async {
     self.documentManager = documentManager
     self.buildSetup = options.buildSetup
@@ -115,7 +115,7 @@ public final class Workspace: Sendable {
         testHooks: options.indexTestHooks,
         indexTaskScheduler: indexTaskScheduler,
         indexTasksWereScheduled: indexTasksWereScheduled,
-        indexTaskDidFinish: indexTaskDidFinish
+        indexStatusDidChange: indexStatusDidChange
       )
     } else {
       self.semanticIndexManager = nil
@@ -153,7 +153,7 @@ public final class Workspace: Sendable {
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
     reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void,
     indexTasksWereScheduled: @Sendable @escaping (Int) -> Void,
-    indexTaskDidFinish: @Sendable @escaping () -> Void
+    indexStatusDidChange: @Sendable @escaping () -> Void
   ) async throws {
     var buildSystem: BuildSystem? = nil
 
@@ -259,7 +259,7 @@ public final class Workspace: Sendable {
       indexDelegate: indexDelegate,
       indexTaskScheduler: indexTaskScheduler,
       indexTasksWereScheduled: indexTasksWereScheduled,
-      indexTaskDidFinish: indexTaskDidFinish
+      indexStatusDidChange: indexStatusDidChange
     )
   }
 
@@ -316,13 +316,22 @@ public struct IndexOptions: Sendable {
   /// Setting this to a value < 1 ensures that background indexing doesn't use all CPU resources.
   public var maxCoresPercentageToUseForBackgroundIndexing: Double
 
+  /// Whether to show the files that are currently being indexed / the targets that are currently being prepared in the
+  /// work done progress.
+  ///
+  /// This is an option because VS Code tries to render a multi-line work done progress into a single line text field in
+  /// the status bar, which looks broken. But at the same time, it is very useful to get a feeling about what's
+  /// currently happening indexing-wise.
+  public var showActivePreparationTasksInProgress: Bool
+
   public init(
     indexStorePath: AbsolutePath? = nil,
     indexDatabasePath: AbsolutePath? = nil,
     indexPrefixMappings: [PathPrefixMapping]? = nil,
     listenToUnitEvents: Bool = true,
     enableBackgroundIndexing: Bool = false,
-    maxCoresPercentageToUseForBackgroundIndexing: Double = 1
+    maxCoresPercentageToUseForBackgroundIndexing: Double = 1,
+    showActivePreparationTasksInProgress: Bool = false
   ) {
     self.indexStorePath = indexStorePath
     self.indexDatabasePath = indexDatabasePath
@@ -330,5 +339,6 @@ public struct IndexOptions: Sendable {
     self.listenToUnitEvents = listenToUnitEvents
     self.enableBackgroundIndexing = enableBackgroundIndexing
     self.maxCoresPercentageToUseForBackgroundIndexing = maxCoresPercentageToUseForBackgroundIndexing
+    self.showActivePreparationTasksInProgress = showActivePreparationTasksInProgress
   }
 }

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -203,7 +203,15 @@ struct SourceKitLSP: AsyncParsableCommand {
   @Flag(
     help: "Enable background indexing. This feature is still under active development and may be incomplete."
   )
-  var enableExperimentalBackgroundIndexing = false
+  var experimentalEnableBackgroundIndexing = false
+
+  @Flag(
+    help: """
+      Show which index tasks are currently running in the indexing work done progress. \
+      This produces a multi-line work done progress, which might render incorrectly depending in the editor.
+      """
+  )
+  var experimentalShowActivePreparationTasksInProgress = false
 
   func mapOptions() -> SourceKitLSPServer.Options {
     var serverOptions = SourceKitLSPServer.Options()
@@ -220,7 +228,8 @@ struct SourceKitLSP: AsyncParsableCommand {
     serverOptions.indexOptions.indexStorePath = indexStorePath
     serverOptions.indexOptions.indexDatabasePath = indexDatabasePath
     serverOptions.indexOptions.indexPrefixMappings = indexPrefixMappings
-    serverOptions.indexOptions.enableBackgroundIndexing = enableExperimentalBackgroundIndexing
+    serverOptions.indexOptions.enableBackgroundIndexing = experimentalEnableBackgroundIndexing
+    serverOptions.indexOptions.showActivePreparationTasksInProgress = experimentalShowActivePreparationTasksInProgress
     serverOptions.completionOptions.maxResults = completionMaxResults
     serverOptions.generatedInterfacesPath = generatedInterfacesPath
 

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -467,7 +467,10 @@ class ManualBuildSystem: BuildSystem {
     return [ConfiguredTarget(targetID: "dummy", runDestinationID: "dummy")]
   }
 
-  public func prepare(targets: [ConfiguredTarget]) async throws {
+  public func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
     throw PrepareNotSupportedError()
   }
 

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -462,7 +462,7 @@ final class BackgroundIndexingTests: XCTestCase {
       return
     }
     var didGetEndWorkDoneProgress = false
-    for _ in 0..<3 {
+    for _ in 0..<5 {
       let workEndProgress = try await project.testClient.nextNotification(ofType: WorkDoneProgress.self)
       switch workEndProgress.value {
       case .begin:

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -780,4 +780,23 @@ final class BackgroundIndexingTests: XCTestCase {
     allDocumentsOpened.fulfill()
     try await self.fulfillmentOfOrThrow([libDPreparedForEditing])
   }
+
+  public func testProduceIndexLog() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyFile.swift": ""
+      ],
+      serverOptions: backgroundIndexingOptions
+    )
+    let targetPrepareNotification = try await project.testClient.nextNotification(ofType: LogMessageNotification.self)
+    XCTAssert(
+      targetPrepareNotification.message.hasPrefix("Preparing MyLibrary"),
+      "\(targetPrepareNotification.message) does not have the expected prefix"
+    )
+    let indexFileNotification = try await project.testClient.nextNotification(ofType: LogMessageNotification.self)
+    XCTAssert(
+      indexFileNotification.message.hasPrefix("Indexing \(try project.uri(for: "MyFile.swift").pseudoPath)"),
+      "\(indexFileNotification.message) does not have the expected prefix"
+    )
+  }
 }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -137,7 +137,7 @@ final class BuildSystemTests: XCTestCase {
       indexDelegate: nil,
       indexTaskScheduler: .forTesting,
       indexTasksWereScheduled: { _ in },
-      indexTaskDidFinish: {}
+      indexStatusDidChange: {}
     )
 
     await server.setWorkspaces([(workspace: workspace, isImplicit: false)])

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -59,7 +59,10 @@ actor TestBuildSystem: BuildSystem {
     return [ConfiguredTarget(targetID: "dummy", runDestinationID: "dummy")]
   }
 
-  public func prepare(targets: [ConfiguredTarget]) async throws {
+  public func prepare(
+    targets: [ConfiguredTarget],
+    indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
+  ) async throws {
     throw PrepareNotSupportedError()
   }
 
@@ -136,6 +139,7 @@ final class BuildSystemTests: XCTestCase {
       index: nil,
       indexDelegate: nil,
       indexTaskScheduler: .forTesting,
+      indexProcessDidProduceResult: { _ in },
       indexTasksWereScheduled: { _ in },
       indexStatusDidChange: {}
     )


### PR DESCRIPTION
This allows a user of SourceKit-LSP to inspect the result of background indexing. I think this gives useful insights into what SourceKit-LSP is indexing and why/how it fails, if it fails, also for users of SourceKit-LSP.

rdar://127474136
rdar://128071435
Fixes #1265
Fixes #1299