### PR TITLE
Fix a non-deterministic test failure of `testTaskSuspension`

### DIFF
--- a/Tests/SKCoreTests/TaskSchedulerTests.swift
+++ b/Tests/SKCoreTests/TaskSchedulerTests.swift
@@ -155,7 +155,13 @@ final class TaskSchedulerTests: XCTestCase {
         )
       },
       validate: { (recordings: [Set<TaskID>]) in
-        XCTAssertEqual(recordings.filter({ !$0.isEmpty }), [[suspendedTaskId], [suspenderTaskId], [suspendedTaskId]])
+        let nonEmptyRecordings = recordings.filter({ !$0.isEmpty })
+        // The suspended task might get cancelled to be rescheduled before or after we run the body. Allow either.
+        XCTAssert(
+          nonEmptyRecordings == [[suspendedTaskId], [suspenderTaskId], [suspendedTaskId]]
+            || nonEmptyRecordings == [[suspenderTaskId], [suspendedTaskId]],
+          "Recordings did not match expected: \(nonEmptyRecordings)"
+        )
       }
     )
   }


### PR DESCRIPTION
Non-deterministic failure was caused by https://github.com/apple/sourcekit-lsp/pull/1323/files#diff-eda28b2edced99c0b48d38feb5b11dbcf496435c0d5135efec656a88e7dfe7f3R247