### PR TITLE
Fix a non-deterministic test failure in the task scheduler

### DIFF
--- a/Tests/SKCoreTests/TaskSchedulerTests.swift
+++ b/Tests/SKCoreTests/TaskSchedulerTests.swift
@@ -195,7 +195,6 @@ final class TaskSchedulerTests: XCTestCase {
       }
     )
   }
-
 }
 
 // MARK: - Test helpers
@@ -354,8 +353,11 @@ fileprivate extension TaskScheduler<ClosureTaskDescription> {
       body,
       dependencies: dependencies
     )
+    // Make sure that we call `schedule` outside of the `Task` because the execution order of `Task`s is not guaranteed
+    // and if we called `schedule` inside `Task`, Swift concurrency can re-order the order that we schedule tasks in.
+    let queuedTask = await self.schedule(priority: priority, taskDescription)
     return Task(priority: priority) {
-      await self.schedule(priority: priority, taskDescription).waitToFinishPropagatingCancellation()
+      await queuedTask.waitToFinishPropagatingCancellation()
     }
   }
 }


### PR DESCRIPTION
We were calling `TaskScheduler.schedule` inside a `Task` in `TaskSchedulerTests`. This means that Swift concurrency could re-order the execution of those tasks and thus change the order in which tasks were enqueued to the `TaskScheduler`.

Caused by https://github.com/ahoppen/sourcekit-lsp/commit/e295a4e95a2014183f49c421f4f155f550f54230#diff-6a451b3244d65ded9386e2816360b7b1debbe6a519e3795d2046c7dbefa7a7d7R351