### PR TITLE
Reset the state of `WorkDoneProgressState` when the progress has ended

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -201,6 +201,7 @@ final actor WorkDoneProgressState {
     }
     if state == .created && activeTasks == 0 {
       server.client.send(WorkDoneProgress(token: token, value: .end(WorkDoneProgressEnd())))
+      self.state = .noProgress
     }
   }
 }


### PR DESCRIPTION
Otherwise, we will never show the progress again.