### PR TITLE
Change static method `DocumentURI.for(_:testName:)` to an initializer `DocumentURI.init(for:testName:)`

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -103,7 +103,7 @@ public actor SkipUnless {
   ) async throws {
     try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(5, 11), file: file, line: line) {
       let testClient = try await TestSourceKitLSPClient()
-      let uri = DocumentURI.for(.swift)
+      let uri = DocumentURI(for: .swift)
       testClient.openDocument("0.bitPattern", uri: uri)
       let response = try unwrap(
         await testClient.send(DocumentSemanticTokensRequest(textDocument: TextDocumentIdentifier(uri)))
@@ -134,7 +134,7 @@ public actor SkipUnless {
   ) async throws {
     try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(5, 11), file: file, line: line) {
       let testClient = try await TestSourceKitLSPClient()
-      let uri = DocumentURI.for(.swift)
+      let uri = DocumentURI(for: .swift)
       let positions = testClient.openDocument("func 1️⃣test() {}", uri: uri)
       do {
         _ = try await testClient.send(
@@ -154,7 +154,7 @@ public actor SkipUnless {
   ) async throws {
     try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(5, 11), file: file, line: line) {
       let testClient = try await TestSourceKitLSPClient()
-      let uri = DocumentURI.for(.c)
+      let uri = DocumentURI(for: .c)
       let positions = testClient.openDocument("void 1️⃣test() {}", uri: uri)
       do {
         _ = try await testClient.send(
@@ -214,7 +214,7 @@ public actor SkipUnless {
     return try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(6, 0), file: file, line: line) {
       // The XML-based doc comment conversion did not preserve `Precondition`.
       let testClient = try await TestSourceKitLSPClient()
-      let uri = DocumentURI.for(.swift)
+      let uri = DocumentURI(for: .swift)
       let positions = testClient.openDocument(
         """
         /// - Precondition: Must have an apple

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -36,8 +36,8 @@ extension Language {
 }
 
 extension DocumentURI {
-  /// Create a unique URI for a document of the given language.
-  public static func `for`(_ language: Language, testName: String = #function) -> DocumentURI {
+  /// Construct a `DocumentURI` by creating a unique URI for a document of the given language.
+  public init(for language: Language, testName: String = #function) {
     let testBaseName = testName.prefix(while: \.isLetter)
 
     #if os(Windows)
@@ -45,7 +45,8 @@ extension DocumentURI {
     #else
     let url = URL(fileURLWithPath: "/\(testBaseName)/\(UUID())/test.\(language.fileExtension)")
     #endif
-    return DocumentURI(url)
+
+    self.init(url)
   }
 }
 

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -52,7 +52,7 @@ final class CrashRecoveryTests: XCTestCase {
       capabilities: ClientCapabilities(window: WindowClientCapabilities(workDoneProgress: true)),
       usePullDiagnostics: false
     )
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -150,7 +150,7 @@ final class CrashRecoveryTests: XCTestCase {
     try SkipUnless.longTestsEnabled()
 
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.cpp)
+    let uri = DocumentURI(for: .cpp)
 
     let positions = testClient.openDocument("1️⃣", uri: uri)
 
@@ -256,7 +256,7 @@ final class CrashRecoveryTests: XCTestCase {
     try SkipUnless.longTestsEnabled()
 
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.cpp)
+    let uri = DocumentURI(for: .cpp)
 
     let positions = testClient.openDocument("1️⃣", uri: uri)
 

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -30,7 +30,7 @@ final class SourceKitDTests: XCTestCase {
     let sourcekitdPath = await ToolchainRegistry.forTesting.default!.sourcekitd!
     let sourcekitd = try await DynamicallyLoadedSourceKitD.getOrCreate(dylibPath: sourcekitdPath)
     let keys = sourcekitd.keys
-    let path = DocumentURI.for(.swift).pseudoPath
+    let path = DocumentURI(for: .swift).pseudoPath
 
     let isExpectedNotification = { @Sendable (response: SKDResponse) -> Bool in
       if let notification: sourcekitd_api_uid_t = response.value?[keys.notification],

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -159,7 +159,7 @@ final class BuildSystemTests: XCTestCase {
   func testClangdDocumentUpdatedBuildSettings() async throws {
     guard haveClangd else { return }
 
-    let doc = DocumentURI.for(.objective_c)
+    let doc = DocumentURI(for: .objective_c)
     let args = [doc.pseudoPath, "-DDEBUG"]
     let text = """
       #ifdef FOO
@@ -201,7 +201,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentUpdatedBuildSettings() async throws {
-    let doc = DocumentURI.for(.swift)
+    let doc = DocumentURI(for: .swift)
     let args = await FallbackBuildSystem(buildSetup: .default)
       .buildSettings(for: doc, language: .swift)!
       .compilerArguments
@@ -236,7 +236,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testClangdDocumentFallbackWithholdsDiagnostics() async throws {
-    let doc = DocumentURI.for(.objective_c)
+    let doc = DocumentURI(for: .objective_c)
     let args = [doc.pseudoPath, "-DDEBUG"]
     let text = """
         #ifdef FOO
@@ -270,7 +270,7 @@ final class BuildSystemTests: XCTestCase {
   }
 
   func testSwiftDocumentFallbackWithholdsSemanticDiagnostics() async throws {
-    let doc = DocumentURI.for(.swift)
+    let doc = DocumentURI(for: .swift)
 
     // Primary settings must be different than the fallback settings.
     var primarySettings = await FallbackBuildSystem(buildSetup: .default).buildSettings(for: doc, language: .swift)!

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -191,7 +191,7 @@ final class CodeActionTests: XCTestCase {
 
   func testEmptyCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func foo() -> String {
@@ -214,7 +214,7 @@ final class CodeActionTests: XCTestCase {
 
   func testSemanticRefactorLocalRenameResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func localRename() {
@@ -240,7 +240,7 @@ final class CodeActionTests: XCTestCase {
 
   func testSemanticRefactorLocationCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func foo() -> String {
@@ -297,7 +297,7 @@ final class CodeActionTests: XCTestCase {
 
   func testJSONCodableCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
          1️⃣{
@@ -339,7 +339,7 @@ final class CodeActionTests: XCTestCase {
 
   func testSemanticRefactorRangeCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func foo() -> String {
@@ -410,7 +410,7 @@ final class CodeActionTests: XCTestCase {
       capabilities: clientCapabilitiesWithCodeActionSupport,
       usePullDiagnostics: false
     )
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -497,7 +497,7 @@ final class CodeActionTests: XCTestCase {
 
   func testAddDocumentationCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       2️⃣func refacto1️⃣r(syntax: DeclSyntax, in context: Void) -> DeclSyntax? { }3️⃣
@@ -576,7 +576,7 @@ final class CodeActionTests: XCTestCase {
 
   func testPackageManifestEditingCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       // swift-tools-version: 5.5
@@ -650,7 +650,7 @@ final class CodeActionTests: XCTestCase {
 
   func testPackageManifestEditingCodeActionNoTestResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       // swift-tools-version: 5.5
@@ -1014,7 +1014,7 @@ final class CodeActionTests: XCTestCase {
     line: UInt = #line
   ) async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(markedText, uri: uri)
 
     var ranges = ranges

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -19,7 +19,7 @@ import enum PackageLoading.Platform
 class DefinitionTests: XCTestCase {
   func testJumpToDefinitionAtEndOfIdentifier() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -200,7 +200,7 @@ class DefinitionTests: XCTestCase {
 
   func testReportInitializerOnDefinitionForType() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct 1️⃣Foo {
@@ -353,7 +353,7 @@ class DefinitionTests: XCTestCase {
 
   func testDefinitionOfImplicitInitializer() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/DocumentColorTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentColorTests.swift
@@ -22,7 +22,7 @@ final class DocumentColorTests: XCTestCase {
   private func performDocumentColorRequest(text: String) async throws -> [ColorInformation] {
     let testClient = try await TestSourceKitLSPClient()
 
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(text, uri: uri)
 
@@ -37,7 +37,7 @@ final class DocumentColorTests: XCTestCase {
   ) async throws -> [ColorPresentation] {
     let testClient = try await TestSourceKitLSPClient()
 
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(text, uri: uri)
 

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -738,7 +738,7 @@ fileprivate func assertDocumentSymbols(
   line: UInt = #line
 ) async throws {
   let testClient = try await TestSourceKitLSPClient()
-  let uri = DocumentURI.for(.swift)
+  let uri = DocumentURI(for: .swift)
 
   let positions = testClient.openDocument(markedText, uri: uri)
   let symbols = try unwrap(try await testClient.send(DocumentSymbolRequest(textDocument: TextDocumentIdentifier(uri))))

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -81,7 +81,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSyntacticDocumentTestsSwift() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -197,7 +197,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingDocumentTests() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -286,7 +286,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testNestedSwiftTestingSuites() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -343,7 +343,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testParameterizedSwiftTestingTest() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -388,7 +388,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testParameterizedSwiftTestingTestWithAnonymousArgument() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -433,7 +433,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testParameterizedSwiftTestingTestWithCommentInSignature() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -478,7 +478,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingSuiteWithNoTests() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -510,7 +510,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingSuiteWithCustomName() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -542,7 +542,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTestWithCustomName() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -575,7 +575,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testDisabledSwiftTestingTest() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -608,7 +608,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTestInDisabledSuite() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -654,7 +654,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testHiddenSwiftTestingTest() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """
@@ -677,7 +677,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTestWithTags() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -723,7 +723,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTestWithCustomTags() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -785,7 +785,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTestsWithExtension() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -846,7 +846,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTestSuitesWithExtension() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -901,7 +901,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testXCTestTestsWithExtension() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -945,7 +945,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingNestedTestSuiteWithExtension() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -1012,7 +1012,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingExtensionOfTypeInAnotherFile() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -1057,7 +1057,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingExtensionOfNestedType() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -1106,7 +1106,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testSwiftTestingTwoExtensionsNoDeclaration() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -1161,7 +1161,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
 
   func testFullyQualifySwiftTestingTestAttribute() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
@@ -19,7 +19,7 @@ import XCTest
 final class ExecuteCommandTests: XCTestCase {
   func testLocationSemanticRefactoring() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -74,7 +74,7 @@ final class ExecuteCommandTests: XCTestCase {
 
   func testRangeSemanticRefactoring() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/FoldingRangeTests.swift
+++ b/Tests/SourceKitLSPTests/FoldingRangeTests.swift
@@ -57,7 +57,7 @@ func assertFoldingRanges(
     )
   )
   let testClient = try await TestSourceKitLSPClient(capabilities: capabilities)
-  let uri = DocumentURI.for(.swift)
+  let uri = DocumentURI(for: .swift)
   let positions = testClient.openDocument(markedSource, uri: uri)
   let foldingRanges = try unwrap(await testClient.send(FoldingRangeRequest(textDocument: TextDocumentIdentifier(uri))))
   if foldingRanges.count != expectedRanges.count {

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -21,7 +21,7 @@ final class FormattingTests: XCTestCase {
   func testFormatting() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -55,7 +55,7 @@ final class FormattingTests: XCTestCase {
   func testFormattingNoEdits() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """
@@ -219,7 +219,7 @@ final class FormattingTests: XCTestCase {
   func testInsertAndRemove() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """
@@ -251,7 +251,7 @@ final class FormattingTests: XCTestCase {
   func testMultiLineStringInsertion() async throws {
     try await SkipUnless.toolchainContainsSwiftFormat()
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       #"""

--- a/Tests/SourceKitLSPTests/HoverTests.swift
+++ b/Tests/SourceKitLSPTests/HoverTests.swift
@@ -181,7 +181,7 @@ private func assertHover(
   line: UInt = #line
 ) async throws {
   let testClient = try await TestSourceKitLSPClient()
-  let uri = DocumentURI.for(.swift)
+  let uri = DocumentURI(for: .swift)
 
   let positions = testClient.openDocument(markedSource, uri: uri)
 

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -21,7 +21,7 @@ final class InlayHintTests: XCTestCase {
 
   func performInlayHintRequest(text: String, range: Range<Position>? = nil) async throws -> [InlayHint] {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(text, uri: uri)
 

--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -41,7 +41,7 @@ final class LifecycleTests: XCTestCase {
 
   func testCancellation() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       class Foo {

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -21,7 +21,7 @@ final class LocalClangTests: XCTestCase {
 
   func testSymbolInfo() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.cpp)
+    let uri = DocumentURI(for: .cpp)
 
     let locations = testClient.openDocument(
       """
@@ -96,7 +96,7 @@ final class LocalClangTests: XCTestCase {
 
   func testFoldingRange() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.cpp)
+    let uri = DocumentURI(for: .cpp)
 
     testClient.openDocument(
       """
@@ -133,7 +133,7 @@ final class LocalClangTests: XCTestCase {
         )
       )
     )
-    let uri = DocumentURI.for(.cpp)
+    let uri = DocumentURI(for: .cpp)
 
     testClient.openDocument(
       """
@@ -161,7 +161,7 @@ final class LocalClangTests: XCTestCase {
 
   func testCodeAction() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI.for(.cpp)
+    let uri = DocumentURI(for: .cpp)
     let positions = testClient.openDocument(
       """
       enum Color { RED, GREEN, BLUE };
@@ -284,7 +284,7 @@ final class LocalClangTests: XCTestCase {
 
   func testSemanticHighlighting() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI.for(.c)
+    let uri = DocumentURI(for: .c)
 
     testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -35,7 +35,7 @@ final class LocalSwiftTests: XCTestCase {
 
   func testEditing() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let documentManager = await testClient.server._documentManager
 

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -18,7 +18,7 @@ import XCTest
 final class PublishDiagnosticsTests: XCTestCase {
   func testUnknownIdentifierDiagnostic() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """
@@ -39,7 +39,7 @@ final class PublishDiagnosticsTests: XCTestCase {
 
   func testRangeShiftAfterNewlineAdded() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """
@@ -80,7 +80,7 @@ final class PublishDiagnosticsTests: XCTestCase {
 
   func testRangeShiftAfterNewlineRemoved() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -18,7 +18,7 @@ import XCTest
 final class PullDiagnosticsTests: XCTestCase {
   func testUnknownIdentifierDiagnostic() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """
@@ -50,7 +50,7 @@ final class PullDiagnosticsTests: XCTestCase {
         )
       )
     )
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/RenameAssertions.swift
+++ b/Tests/SourceKitLSPTests/RenameAssertions.swift
@@ -44,7 +44,7 @@ func assertSingleFileRename(
 ) async throws {
   try await SkipUnless.sourcekitdSupportsRename()
   let testClient = try await TestSourceKitLSPClient()
-  let uri = DocumentURI.for(language, testName: testName)
+  let uri = DocumentURI(for: language, testName: testName)
   let positions = testClient.openDocument(markedSource, uri: uri, language: language)
   guard !positions.allMarkers.isEmpty else {
     XCTFail("Test case did not contain any markers at which to invoke the rename", file: file, line: line)

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -658,7 +658,7 @@ final class RenameTests: XCTestCase {
   func testPrepeareRenameOnDefinition() async throws {
     try await SkipUnless.sourcekitdSupportsRename()
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func 1️⃣foo2️⃣(3️⃣a: Int) {}
@@ -677,7 +677,7 @@ final class RenameTests: XCTestCase {
   func testPrepeareRenameOnReference() async throws {
     try await SkipUnless.sourcekitdSupportsRename()
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func foo(a: Int, b: Int = 1) {}

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -63,7 +63,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionBasic(options: SKCompletionOptions) async throws {
     let testClient = try await TestSourceKitLSPClient(initializationOptions: initializationOptions(for: options))
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     testClient.openDocument(text, uri: uri)
 
@@ -129,7 +129,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionSnippetSupport() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(text, uri: uri)
 
     func getTestMethodCompletion(_ position: Position, label: String) async throws -> CompletionItem? {
@@ -183,7 +183,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionNoSnippetSupport() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(text, uri: uri)
 
     func getTestMethodCompletion(_ position: Position, label: String) async throws -> CompletionItem? {
@@ -232,7 +232,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionPositionServerFilter() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument("foo", uri: uri)
 
     for col in 0...3 {
@@ -265,7 +265,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOptional() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       struct Foo {
@@ -301,7 +301,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOverride() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       class Base {
@@ -339,7 +339,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testCompletionOverrideInNewLine() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       class Base {
@@ -378,7 +378,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testMaxResults() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       struct S {
@@ -511,7 +511,7 @@ final class SwiftCompletionTests: XCTestCase {
         for: SKCompletionOptions(maxResults: 20)
       )
     )
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       struct S {
@@ -630,7 +630,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testRefilterAfterIncompleteResultsWithEdits() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       struct S {
@@ -784,7 +784,7 @@ final class SwiftCompletionTests: XCTestCase {
   /// close waits for its respective open to finish to prevent a session geting stuck open.
   func testSessionCloseWaitsforOpen() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     testClient.openDocument(
       """
       struct S {
@@ -888,7 +888,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testTriggerFromIncompleteAfterStartingStringLiteral() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       func foo(_ x: String) {}
@@ -947,7 +947,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testNonAsciiCompletionFilter() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct Foo {
@@ -981,7 +981,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testExpandClosurePlaceholder() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct MyArray {
@@ -1029,7 +1029,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testExpandClosurePlaceholderOnOptional() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct MyArray {
@@ -1077,7 +1077,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testExpandMultipleClosurePlaceholders() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct MyArray {
@@ -1129,7 +1129,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testExpandMultipleClosurePlaceholdersWithLabel() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct MyArray {
@@ -1181,7 +1181,7 @@ final class SwiftCompletionTests: XCTestCase {
 
   func testInferIndentationWhenExpandingClosurePlaceholder() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
       struct MyArray {

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -212,7 +212,7 @@ final class SwiftInterfaceTests: XCTestCase {
 
   func testJumpToSynthesizedExtensionMethodInSystemModuleWithoutIndex() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -626,7 +626,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
 
   func testInMemoryFileWithFallbackBuildSystem() async throws {
     let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI.for(.swift)
+    let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(
       """


### PR DESCRIPTION
This changes the static method `DocumentURI.for(_:testName:)` to a more swifty initializer `DocumentURI.init(for:testName:)`.

rdar://126486535
Fixes https://github.com/apple/sourcekit-lsp/issues/1281