### PR TITLE
Rename `note` to `notification` throughout the codebase wherever necessary

### DIFF
--- a/Sources/LSPTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/LSPTestSupport/TestJSONRPCConnection.swift
@@ -111,11 +111,11 @@ public actor TestClient: MessageHandler {
   }
 
   public func appendOneShotNotificationHandler<N: NotificationType>(_ handler: @escaping (N) -> Void) {
-    oneShotNotificationHandlers.append({ anyNote in
-      guard let note = anyNote as? N else {
-        fatalError("received notification of the wrong type \(anyNote); expected \(N.self)")
+    oneShotNotificationHandlers.append({ anyNotification in
+      guard let notification = anyNotification as? N else {
+        fatalError("received notification of the wrong type \(anyNotification); expected \(N.self)")
       }
-      handler(note)
+      handler(notification)
     })
   }
 

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -464,30 +464,30 @@ extension ClangLanguageService {
 
   // MARK: - Text synchronization
 
-  public func openDocument(_ note: DidOpenTextDocumentNotification) async {
-    openDocuments[note.textDocument.uri] = note.textDocument.language
+  public func openDocument(_ notification: DidOpenTextDocumentNotification) async {
+    openDocuments[notification.textDocument.uri] = notification.textDocument.language
     // Send clangd the build settings for the new file. We need to do this before
     // sending the open notification, so that the initial diagnostics already
     // have build settings.
-    await documentUpdatedBuildSettings(note.textDocument.uri)
-    clangd.send(note)
+    await documentUpdatedBuildSettings(notification.textDocument.uri)
+    clangd.send(notification)
   }
 
-  public func closeDocument(_ note: DidCloseTextDocumentNotification) {
-    openDocuments[note.textDocument.uri] = nil
-    clangd.send(note)
+  public func closeDocument(_ notification: DidCloseTextDocumentNotification) {
+    openDocuments[notification.textDocument.uri] = nil
+    clangd.send(notification)
   }
 
-  public func changeDocument(_ note: DidChangeTextDocumentNotification) {
-    clangd.send(note)
+  public func changeDocument(_ notification: DidChangeTextDocumentNotification) {
+    clangd.send(notification)
   }
 
-  public func willSaveDocument(_ note: WillSaveTextDocumentNotification) {
+  public func willSaveDocument(_ notification: WillSaveTextDocumentNotification) {
 
   }
 
-  public func didSaveDocument(_ note: DidSaveTextDocumentNotification) {
-    clangd.send(note)
+  public func didSaveDocument(_ notification: DidSaveTextDocumentNotification) {
+    clangd.send(notification)
   }
 
   // MARK: - Build System Integration
@@ -505,13 +505,13 @@ extension ClangLanguageService {
     if let compileCommand = clangBuildSettings?.compileCommand,
       let pathString = (try? AbsolutePath(validating: url.path))?.pathString
     {
-      let note = DidChangeConfigurationNotification(
+      let notification = DidChangeConfigurationNotification(
         settings: .clangd(
           ClangWorkspaceSettings(
             compilationDatabaseChanges: [pathString: compileCommand])
         )
       )
-      clangd.send(note)
+      clangd.send(notification)
     }
   }
 
@@ -519,12 +519,12 @@ extension ClangLanguageService {
     // In order to tell clangd to reload an AST, we send it an empty `didChangeTextDocument`
     // with `forceRebuild` set in case any missing header files have been added.
     // This works well for us as the moment since clangd ignores the document version.
-    let note = DidChangeTextDocumentNotification(
+    let notification = DidChangeTextDocumentNotification(
       textDocument: VersionedTextDocumentIdentifier(uri, version: 0),
       contentChanges: [],
       forceRebuild: true
     )
-    clangd.send(note)
+    clangd.send(notification)
   }
 
   // MARK: - Text Document

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -210,17 +210,17 @@ extension DocumentManager {
 
   /// Convenience wrapper for `open(_:language:version:text:)` that logs on failure.
   @discardableResult
-  func open(_ note: DidOpenTextDocumentNotification) -> DocumentSnapshot? {
-    let doc = note.textDocument
+  func open(_ notification: DidOpenTextDocumentNotification) -> DocumentSnapshot? {
+    let doc = notification.textDocument
     return orLog("failed to open document", level: .error) {
       try open(doc.uri, language: doc.language, version: doc.version, text: doc.text)
     }
   }
 
   /// Convenience wrapper for `close(_:)` that logs on failure.
-  func close(_ note: DidCloseTextDocumentNotification) {
+  func close(_ notification: DidCloseTextDocumentNotification) {
     orLog("failed to close document", level: .error) {
-      try close(note.textDocument.uri)
+      try close(notification.textDocument.uri)
     }
   }
 
@@ -228,13 +228,13 @@ extension DocumentManager {
   /// that logs on failure.
   @discardableResult
   func edit(
-    _ note: DidChangeTextDocumentNotification
+    _ notification: DidChangeTextDocumentNotification
   ) -> (preEditSnapshot: DocumentSnapshot, postEditSnapshot: DocumentSnapshot, edits: [SourceEdit])? {
     return orLog("failed to edit document", level: .error) {
       return try edit(
-        note.textDocument.uri,
-        newVersion: note.textDocument.version,
-        edits: note.contentChanges
+        notification.textDocument.uri,
+        newVersion: notification.textDocument.version,
+        edits: notification.contentChanges
       )
     }
   }

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -98,13 +98,13 @@ public protocol LanguageService: AnyObject, Sendable {
   /// Sent to open up a document on the Language Server.
   /// This may be called before or after a corresponding
   /// `documentUpdatedBuildSettings` call for the same document.
-  func openDocument(_ note: DidOpenTextDocumentNotification) async
+  func openDocument(_ notification: DidOpenTextDocumentNotification) async
 
   /// Sent to close a document on the Language Server.
-  func closeDocument(_ note: DidCloseTextDocumentNotification) async
-  func changeDocument(_ note: DidChangeTextDocumentNotification) async
-  func willSaveDocument(_ note: WillSaveTextDocumentNotification) async
-  func didSaveDocument(_ note: DidSaveTextDocumentNotification) async
+  func closeDocument(_ notification: DidCloseTextDocumentNotification) async
+  func changeDocument(_ notification: DidChangeTextDocumentNotification) async
+  func willSaveDocument(_ notification: WillSaveTextDocumentNotification) async
+  func didSaveDocument(_ notification: DidSaveTextDocumentNotification) async
 
   // MARK: - Build System Integration
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1269,12 +1269,12 @@ extension SourceKitLSPServer {
     await openDocument(notification, workspace: workspace)
   }
 
-  private func openDocument(_ note: DidOpenTextDocumentNotification, workspace: Workspace) async {
+  private func openDocument(_ notification: DidOpenTextDocumentNotification, workspace: Workspace) async {
     // Immediately open the document even if the build system isn't ready. This is important since
     // we check that the document is open when we receive messages from the build system.
-    documentManager.open(note)
+    documentManager.open(notification)
 
-    let textDocument = note.textDocument
+    let textDocument = notification.textDocument
     let uri = textDocument.uri
     let language = textDocument.language
 
@@ -1286,7 +1286,7 @@ extension SourceKitLSPServer {
     await workspace.buildSystemManager.registerForChangeNotifications(for: uri, language: language)
 
     // If the document is ready, we can immediately send the notification.
-    await service.openDocument(note)
+    await service.openDocument(notification)
   }
 
   func closeDocument(_ notification: DidCloseTextDocumentNotification) async {
@@ -1300,16 +1300,16 @@ extension SourceKitLSPServer {
     await self.closeDocument(notification, workspace: workspace)
   }
 
-  func closeDocument(_ note: DidCloseTextDocumentNotification, workspace: Workspace) async {
+  func closeDocument(_ notification: DidCloseTextDocumentNotification, workspace: Workspace) async {
     // Immediately close the document. We need to be sure to clear our pending work queue in case
     // the build system still isn't ready.
-    documentManager.close(note)
+    documentManager.close(notification)
 
-    let uri = note.textDocument.uri
+    let uri = notification.textDocument.uri
 
     await workspace.buildSystemManager.unregisterForChangeNotifications(for: uri)
 
-    await workspace.documentService.value[uri]?.closeDocument(note)
+    await workspace.documentService.value[uri]?.closeDocument(notification)
   }
 
   func changeDocument(_ notification: DidChangeTextDocumentNotification) async {
@@ -1336,10 +1336,10 @@ extension SourceKitLSPServer {
   }
 
   func didSaveDocument(
-    _ note: DidSaveTextDocumentNotification,
+    _ notification: DidSaveTextDocumentNotification,
     languageService: LanguageService
   ) async {
-    await languageService.didSaveDocument(note)
+    await languageService.didSaveDocument(notification)
   }
 
   func didChangeWorkspaceFolders(_ notification: DidChangeWorkspaceFoldersNotification) async {

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -64,8 +64,10 @@ class ConnectionTests: XCTestCase {
     let notification1 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
     let notification2 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
 
-    let notification1Str: String = "Content-Length: \(notification1.count)\r\n\r\n\(String(data: notification1, encoding: .utf8)!)"
-    let notfication2Str: String = "Content-Length: \(notification2.count)\r\n\r\n\(String(data: notification2, encoding: .utf8)!)"
+    let notification1Str =
+      "Content-Length: \(notification1.count)\r\n\r\n\(String(data: notification1, encoding: .utf8)!)"
+    let notfication2Str =
+      "Content-Length: \(notification2.count)\r\n\r\n\(String(data: notification2, encoding: .utf8)!)"
 
     for b in notification1Str.utf8.dropLast() {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -54,37 +54,37 @@ class ConnectionTests: XCTestCase {
   func testMessageBuffer() async throws {
     let client = connection.client
     let clientConnection = connection.clientToServerConnection
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notfication received")
 
-    await client.appendOneShotNotificationHandler { (note: EchoNotification) in
-      XCTAssertEqual(note.string, "hello!")
+    await client.appendOneShotNotificationHandler { (notification: EchoNotification) in
+      XCTAssertEqual(notification.string, "hello!")
       expectation.fulfill()
     }
 
-    let note1 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
-    let note2 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
+    let notification1 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "hello!")))
+    let notification2 = try JSONEncoder().encode(JSONRPCMessage.notification(EchoNotification(string: "no way!")))
 
-    let note1Str: String = "Content-Length: \(note1.count)\r\n\r\n\(String(data: note1, encoding: .utf8)!)"
-    let note2Str: String = "Content-Length: \(note2.count)\r\n\r\n\(String(data: note2, encoding: .utf8)!)"
+    let notification1Str: String = "Content-Length: \(notification1.count)\r\n\r\n\(String(data: notification1, encoding: .utf8)!)"
+    let notfication2Str: String = "Content-Length: \(notification2.count)\r\n\r\n\(String(data: notification2, encoding: .utf8)!)"
 
-    for b in note1Str.utf8.dropLast() {
+    for b in notification1Str.utf8.dropLast() {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })
     }
 
     clientConnection.send(
-      _rawData: [note1Str.utf8.last!, note2Str.utf8.first!].withUnsafeBytes { DispatchData(bytes: $0) }
+      _rawData: [notification1Str.utf8.last!, notfication2Str.utf8.first!].withUnsafeBytes { DispatchData(bytes: $0) }
     )
 
     try await fulfillmentOfOrThrow([expectation])
 
-    let expectation2 = self.expectation(description: "note received")
+    let expectation2 = self.expectation(description: "notification received")
 
-    await client.appendOneShotNotificationHandler { (note: EchoNotification) in
-      XCTAssertEqual(note.string, "no way!")
+    await client.appendOneShotNotificationHandler { (notification: EchoNotification) in
+      XCTAssertEqual(notification.string, "no way!")
       expectation2.fulfill()
     }
 
-    for b in note2Str.utf8.dropFirst() {
+    for b in notfication2Str.utf8.dropFirst() {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })
     }
 
@@ -117,12 +117,12 @@ class ConnectionTests: XCTestCase {
     try await fulfillmentOfOrThrow([expectation, expectation2])
   }
 
-  func testEchoNote() async throws {
+  func testEchoNotification() async throws {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    await client.appendOneShotNotificationHandler { (note: EchoNotification) in
-      XCTAssertEqual(note.string, "hello!")
+    await client.appendOneShotNotificationHandler { (notification: EchoNotification) in
+      XCTAssertEqual(notification.string, "hello!")
       expectation.fulfill()
     }
 
@@ -150,13 +150,13 @@ class ConnectionTests: XCTestCase {
 
   func testUnknownNotification() async throws {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    struct UnknownNote: NotificationType {
+    struct UnknownNotification: NotificationType {
       static let method: String = "unknown"
     }
 
-    client.send(UnknownNote())
+    client.send(UnknownNotification())
 
     // Nothing bad should happen; check that the next request works.
 
@@ -191,7 +191,7 @@ class ConnectionTests: XCTestCase {
 
   func testSendAfterClose() async throws {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
     connection.clientToServerConnection.close()
 
@@ -214,7 +214,7 @@ class ConnectionTests: XCTestCase {
     let server = connection.server
 
     let expectation = self.expectation(description: "received notification")
-    await client.appendOneShotNotificationHandler { (note: EchoNotification) in
+    await client.appendOneShotNotificationHandler { (notification: EchoNotification) in
       expectation.fulfill()
     }
 
@@ -281,8 +281,8 @@ class ConnectionTests: XCTestCase {
 
   func testMessageWithMissingParameter() async throws {
     let expectation = self.expectation(description: "Received ShowMessageNotification")
-    await connection.client.appendOneShotNotificationHandler { (note: ShowMessageNotification) in
-      XCTAssertEqual(note.type, .error)
+    await connection.client.appendOneShotNotificationHandler { (notification: ShowMessageNotification) in
+      XCTAssertEqual(notification.type, .error)
       expectation.fulfill()
     }
 

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -60,12 +60,12 @@ class ConnectionTests: XCTestCase {
     try await fulfillmentOfOrThrow([expectation, expectation2])
   }
 
-  func testEchoNote() async throws {
+  func testEchoNotification() async throws {
     let client = connection.client
-    let expectation = self.expectation(description: "note received")
+    let expectation = self.expectation(description: "notification received")
 
-    await client.appendOneShotNotificationHandler { (note: EchoNotification) in
-      XCTAssertEqual(note.string, "hello!")
+    await client.appendOneShotNotificationHandler { (notification: EchoNotification) in
+      XCTAssertEqual(notification.string, "hello!")
       expectation.fulfill()
     }
 

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -419,7 +419,7 @@ final class LocalSwiftTests: XCTestCase {
     )
   }
 
-  func testFixitsAreIncludedInPublishDiagnosticsNotes() async throws {
+  func testFixitsAreIncludedInPublishDiagnosticsNotifications() async throws {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
@@ -585,7 +585,7 @@ final class LocalSwiftTests: XCTestCase {
     )
   }
 
-  func testFixitsAreReturnedFromCodeActionsNotes() async throws {
+  func testFixitsAreReturnedFromCodeActionsNotifications() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities, usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
@@ -691,7 +691,7 @@ final class LocalSwiftTests: XCTestCase {
     )
   }
 
-  func testMuliEditFixitCodeActionNote() async throws {
+  func testMuliEditFixitCodeActionNotifications() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: quickFixCapabilities, usePullDiagnostics: false)
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)


### PR DESCRIPTION
This changes all the occurences of `note` in the code base to `notification` wherever it doesn't refer to diagnostics information.

This change aims to maintain clarity across the codebase and sorts out any confusion / ambiguity with the terminology.

*Rectified Terminology:*
- `note`: Diagnostics Information
- `notification`: Notification

rdar://116703667
Fixes https://github.com/apple/sourcekit-lsp/issues/865