### PR TITLE
Time out updating the index store after 2 minutes

### DIFF
--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -321,7 +321,13 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       arguments: processArguments,
       workingDirectory: workingDirectory
     )
-    let result = try await process.waitUntilExitSendingSigIntOnTaskCancellation()
+    // Time out updating of the index store after 2 minutes. We don't expect any single file compilation to take longer
+    // than 2 minutes in practice, so this indicates that the compiler has entered a loop and we probably won't make any
+    // progress here. We will try indexing the file again when it is edited or when the project is re-opened.
+    // 2 minutes have been chosen arbitrarily.
+    let result = try await withTimeout(.seconds(120)) {
+      try await process.waitUntilExitSendingSigIntOnTaskCancellation()
+    }
 
     indexProcessDidProduceResult(
       IndexProcessResult(

--- a/Tests/SKSupportTests/AsyncUtilsTests.swift
+++ b/Tests/SKSupportTests/AsyncUtilsTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPTestSupport
+import SKSupport
+import XCTest
+
+final class AsyncUtilsTests: XCTestCase {
+  func testWithTimeout() async throws {
+    let expectation = self.expectation(description: "withTimeout body finished")
+    await assertThrowsError(
+      try await withTimeout(.seconds(0.1)) {
+        try? await Task.sleep(for: .seconds(10))
+        XCTAssert(Task.isCancelled)
+        expectation.fulfill()
+      }
+    ) { error in
+      XCTAssert(error is TimeoutError, "Received unexpected error \(error)")
+    }
+    try await fulfillmentOfOrThrow([expectation])
+  }
+}


### PR DESCRIPTION
Time out updating of the index store after 2 minutes. We don't expect any single file compilation to take longer than 2 minutes in practice, so this indicates that the compiler has entered some kind of loop. We will try indexing the file again when it is edited or when the project is re-opened.

I did not add a timeout for preparation because it’s much harder to tell what an upper bound could be here. Preparation of a high-level target might take quite a while if none of the lower-level targets have been prepared yet.

rdar://128732571