### PR TITLE
Show work done progress while a source file is being prepared for editor functionality

### DIFF
--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -18,11 +18,11 @@ import SemanticIndex
 /// Listens for index status updates from `SemanticIndexManagers`. From that information, it manages a
 /// `WorkDoneProgress` that communicates the index progress to the editor.
 actor IndexProgressManager {
-  /// A queue on which `indexTaskWasQueued` and `indexStatusDidChange` are handled.
+  /// A queue on which `indexTaskWasQueued` and `indexProgressStatusDidChange` are handled.
   ///
-  /// This allows the two functions two be `nonisolated` (and eg. the caller of `indexStatusDidChange` doesn't have to
+  /// This allows the two functions two be `nonisolated` (and eg. the caller of `indexProgressStatusDidChange` doesn't have to
   /// wait for the work done progress to be updated) while still guaranteeing that there is only one
-  /// `indexStatusDidChangeImpl` running at a time, preventing race conditions that would cause two
+  /// `indexProgressStatusDidChangeImpl` running at a time, preventing race conditions that would cause two
   /// `WorkDoneProgressManager`s to be created.
   private let queue = AsyncQueue<Serial>()
 
@@ -64,74 +64,64 @@ actor IndexProgressManager {
 
   private func indexTasksWereScheduledImpl(count: Int) async {
     queuedIndexTasks += count
-    await indexStatusDidChangeImpl()
+    await indexProgressStatusDidChangeImpl()
   }
 
   /// Called when a `SemanticIndexManager` finishes indexing a file. Adjusts the done index count, eg. the 1 in `1/3`.
-  nonisolated func indexStatusDidChange() {
+  nonisolated func indexProgressStatusDidChange() {
     queue.async {
-      await self.indexStatusDidChangeImpl()
+      await self.indexProgressStatusDidChangeImpl()
     }
   }
 
-  private func indexStatusDidChangeImpl() async {
+  private func indexProgressStatusDidChangeImpl() async {
     guard let sourceKitLSPServer else {
       workDoneProgress = nil
       return
     }
-    var isGeneratingBuildGraph = false
-    var indexTasks: [DocumentURI: IndexTaskStatus] = [:]
-    var preparationTasks: [ConfiguredTarget: IndexTaskStatus] = [:]
+    var status = IndexProgressStatus.upToDate
     for indexManager in await sourceKitLSPServer.workspaces.compactMap({ $0.semanticIndexManager }) {
-      let inProgress = await indexManager.inProgressTasks
-      isGeneratingBuildGraph = isGeneratingBuildGraph || inProgress.isGeneratingBuildGraph
-      indexTasks.merge(inProgress.indexTasks) { lhs, rhs in
-        return max(lhs, rhs)
-      }
-      preparationTasks.merge(inProgress.preparationTasks) { lhs, rhs in
-        return max(lhs, rhs)
-      }
+      status = status.merging(with: await indexManager.progressStatus)
     }
 
-    if indexTasks.isEmpty && !isGeneratingBuildGraph {
+    var message: String
+    let percentage: Int
+    switch status {
+    case .preparingFileForEditorFunctionality:
+      message = "Preparing current file"
+      percentage = 0
+    case .generatingBuildGraph:
+      message = "Generating build graph"
+      percentage = 0
+    case .indexing(preparationTasks: let preparationTasks, indexTasks: let indexTasks):
+      // We can get into a situation where queuedIndexTasks < indexTasks.count if we haven't processed all
+      // `indexTasksWereScheduled` calls yet but the semantic index managers already track them in their in-progress tasks.
+      // Clip the finished tasks to 0 because showing a negative number there looks stupid.
+      let finishedTasks = max(queuedIndexTasks - indexTasks.count, 0)
+      message = "\(finishedTasks) / \(queuedIndexTasks)"
+      if await sourceKitLSPServer.options.indexOptions.showActivePreparationTasksInProgress {
+        var inProgressTasks: [String] = []
+        inProgressTasks += preparationTasks.filter { $0.value == .executing }
+          .map { "- Preparing \($0.key.targetID)" }
+          .sorted()
+        inProgressTasks += indexTasks.filter { $0.value == .executing }
+          .map { "- Indexing \($0.key.fileURL?.lastPathComponent ?? $0.key.pseudoPath)" }
+          .sorted()
+
+        message += "\n\n" + inProgressTasks.joined(separator: "\n")
+      }
+      if queuedIndexTasks != 0 {
+        percentage = Int(Double(finishedTasks) / Double(queuedIndexTasks) * 100)
+      } else {
+        percentage = 0
+      }
+    case .upToDate:
       // Nothing left to index. Reset the target count and dismiss the work done progress.
       queuedIndexTasks = 0
       workDoneProgress = nil
       return
     }
 
-    // We can get into a situation where queuedIndexTasks < indexTasks.count if we haven't processed all
-    // `indexTasksWereScheduled` calls yet but the semantic index managers already track them in their in-progress tasks.
-    // Clip the finished tasks to 0 because showing a negative number there looks stupid.
-    let finishedTasks = max(queuedIndexTasks - indexTasks.count, 0)
-    var message: String
-    if isGeneratingBuildGraph {
-      message = "Generating build graph"
-    } else {
-      message = "\(finishedTasks) / \(queuedIndexTasks)"
-    }
-
-    if await sourceKitLSPServer.options.indexOptions.showActivePreparationTasksInProgress {
-      var inProgressTasks: [String] = []
-      if isGeneratingBuildGraph {
-        inProgressTasks.append("- Generating build graph")
-      }
-      inProgressTasks += preparationTasks.filter { $0.value == .executing }
-        .map { "- Preparing \($0.key.targetID)" }
-        .sorted()
-      inProgressTasks += indexTasks.filter { $0.value == .executing }
-        .map { "- Indexing \($0.key.fileURL?.lastPathComponent ?? $0.key.pseudoPath)" }
-        .sorted()
-
-      message += "\n\n" + inProgressTasks.joined(separator: "\n")
-    }
-
-    let percentage: Int
-    if queuedIndexTasks != 0 {
-      percentage = Int(Double(finishedTasks) / Double(queuedIndexTasks) * 100)
-    } else {
-      percentage = 0
-    }
     if let workDoneProgress {
       workDoneProgress.update(message: message, percentage: percentage)
     } else {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -510,7 +510,7 @@ public actor SourceKitLSPServer {
       uriToWorkspaceCache = [:]
       // `indexProgressManager` iterates over all workspaces in the SourceKitLSPServer. Modifying workspaces might thus
       // update the index progress status.
-      indexProgressManager.indexStatusDidChange()
+      indexProgressManager.indexProgressStatusDidChange()
     }
   }
 
@@ -1257,8 +1257,8 @@ extension SourceKitLSPServer {
       indexTasksWereScheduled: { [weak self] count in
         self?.indexProgressManager.indexTasksWereScheduled(count: count)
       },
-      indexStatusDidChange: { [weak self] in
-        self?.indexProgressManager.indexStatusDidChange()
+      indexProgressStatusDidChange: { [weak self] in
+        self?.indexProgressManager.indexProgressStatusDidChange()
       }
     )
   }
@@ -1323,8 +1323,8 @@ extension SourceKitLSPServer {
           indexTasksWereScheduled: { [weak self] count in
             self?.indexProgressManager.indexTasksWereScheduled(count: count)
           },
-          indexStatusDidChange: { [weak self] in
-            self?.indexProgressManager.indexStatusDidChange()
+          indexProgressStatusDidChange: { [weak self] in
+            self?.indexProgressManager.indexProgressStatusDidChange()
           }
         )
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -96,7 +96,7 @@ public final class Workspace: Sendable {
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
     indexProcessDidProduceResult: @escaping @Sendable (IndexProcessResult) -> Void,
     indexTasksWereScheduled: @escaping @Sendable (Int) -> Void,
-    indexStatusDidChange: @escaping @Sendable () -> Void
+    indexProgressStatusDidChange: @escaping @Sendable () -> Void
   ) async {
     self.documentManager = documentManager
     self.buildSetup = options.buildSetup
@@ -117,7 +117,7 @@ public final class Workspace: Sendable {
         indexTaskScheduler: indexTaskScheduler,
         indexProcessDidProduceResult: indexProcessDidProduceResult,
         indexTasksWereScheduled: indexTasksWereScheduled,
-        indexStatusDidChange: indexStatusDidChange
+        indexProgressStatusDidChange: indexProgressStatusDidChange
       )
     } else {
       self.semanticIndexManager = nil
@@ -156,7 +156,7 @@ public final class Workspace: Sendable {
     indexProcessDidProduceResult: @escaping @Sendable (IndexProcessResult) -> Void,
     reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void,
     indexTasksWereScheduled: @Sendable @escaping (Int) -> Void,
-    indexStatusDidChange: @Sendable @escaping () -> Void
+    indexProgressStatusDidChange: @Sendable @escaping () -> Void
   ) async throws {
     var buildSystem: BuildSystem? = nil
 
@@ -263,7 +263,7 @@ public final class Workspace: Sendable {
       indexTaskScheduler: indexTaskScheduler,
       indexProcessDidProduceResult: indexProcessDidProduceResult,
       indexTasksWereScheduled: indexTasksWereScheduled,
-      indexStatusDidChange: indexStatusDidChange
+      indexProgressStatusDidChange: indexProgressStatusDidChange
     )
   }
 

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -141,7 +141,7 @@ final class BuildSystemTests: XCTestCase {
       indexTaskScheduler: .forTesting,
       indexProcessDidProduceResult: { _ in },
       indexTasksWereScheduled: { _ in },
-      indexStatusDidChange: {}
+      indexProgressStatusDidChange: {}
     )
 
     await server.setWorkspaces([(workspace: workspace, isImplicit: false)])


### PR DESCRIPTION
While `SemanticIndexManager.inProgressPrepareForEditorTask` is not `nil`, show a work done progress in the editor that the current file is being prepared for editor functionality.

I decided to use the indexing progress indicator for this for now because I think it’s too spammy if SourceKit-LSP has two different progress indicators for preparation and indexing. I’ll need to see how this feels like in practice.

rdar://128722609