### PR TITLE
Switch most tests to use background indexing instead of building the project

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -183,10 +183,8 @@ public actor SkipUnless {
     line: UInt = #line
   ) async throws {
     try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(5, 11), file: file, line: line) {
-      let workspace = try await SwiftPMTestProject(
-        files: ["test.swift": ""],
-        build: true
-      )
+      let workspace = try await SwiftPMTestProject(files: ["test.swift": ""])
+      try await SwiftPMTestProject.build(at: workspace.scratchDirectory)
       let modulesDirectory = workspace.scratchDirectory
         .appendingPathComponent(".build")
         .appendingPathComponent("debug")

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -40,8 +40,6 @@ public class SwiftPMTestProject: MultiFileTestProject {
     files: [RelativeFileLocation: String],
     manifest: String = SwiftPMTestProject.defaultPackageManifest,
     workspaces: (URL) async throws -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
-    build: Bool = false,
-    allowBuildFailure: Bool = false,
     capabilities: ClientCapabilities = ClientCapabilities(),
     serverOptions: SourceKitLSPServer.Options = .testDefault,
     enableBackgroundIndexing: Bool = false,
@@ -79,13 +77,6 @@ public class SwiftPMTestProject: MultiFileTestProject {
       testName: testName
     )
 
-    if build {
-      if allowBuildFailure {
-        try? await Self.build(at: self.scratchDirectory)
-      } else {
-        try await Self.build(at: self.scratchDirectory)
-      }
-    }
     if pollIndex {
       // Wait for the indexstore-db to finish indexing
       _ = try await testClient.send(PollIndexRequest())

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -200,7 +200,7 @@ final class CallHierarchyTests: XCTestCase {
         void FilePathIndex::2️⃣foo() {}
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
     let (uri, positions) = try project.openDocument("lib.h", language: .cpp)
     let result = try await project.testClient.send(

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -126,7 +126,7 @@ class DefinitionTests: XCTestCase {
         }
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
     let (uri, positions) = try project.openDocument("test.cpp")
 
@@ -177,7 +177,7 @@ class DefinitionTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("main.swift")
@@ -391,8 +391,7 @@ class DefinitionTests: XCTestCase {
         }
         """,
       ],
-      build: true,
-      allowBuildFailure: true
+      enableBackgroundIndexing: true
     )
 
     let (bUri, bPositions) = try project.openDocument("FileB.swift")
@@ -428,12 +427,11 @@ class DefinitionTests: XCTestCase {
       .locations([Location(uri: aUri, range: Range(updatedAPositions["2️⃣"]))])
     )
 
-    try await SwiftPMTestProject.build(at: project.scratchDirectory)
-    let afterBuilding = try await project.testClient.send(
+    let afterChange = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(bUri), position: bPositions["1️⃣"])
     )
     XCTAssertEqual(
-      afterBuilding,
+      afterChange,
       .locations([Location(uri: aUri, range: Range(updatedAPositions["2️⃣"]))])
     )
   }
@@ -518,7 +516,7 @@ class DefinitionTests: XCTestCase {
         }
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let definitionUri = try project.uri(for: "definition.swift")
@@ -549,8 +547,6 @@ class DefinitionTests: XCTestCase {
         FileEvent(uri: definitionUri, type: .deleted), FileEvent(uri: movedDefinitionUri, type: .created),
       ])
     )
-
-    try await SwiftPMTestProject.build(at: project.scratchDirectory)
 
     let resultAfterFileMove = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(callerUri), position: callerPositions["2️⃣"])

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -51,8 +51,6 @@ final class DependencyTrackingTests: XCTestCase {
     // Semantic analysis: expect module import error.
     XCTAssertEqual(initialDiags.diagnostics.count, 1)
     if let diagnostic = initialDiags.diagnostics.first {
-      // FIXME: The error message for the missing module is misleading on Darwin
-      // https://github.com/apple/swift-package-manager/issues/5925
       XCTAssert(
         diagnostic.message.contains("Could not build Objective-C module")
           || diagnostic.message.contains("No such module"),

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -48,7 +48,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
           targets: [.testTarget(name: "MyLibraryTests")]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("MyTests.swift")
@@ -1304,7 +1304,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
           targets: [.testTarget(name: "MyLibraryTests")]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("Test.m")
@@ -1363,7 +1363,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
           targets: [.testTarget(name: "MyLibraryTests")]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("Test.m")

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -296,7 +296,7 @@ final class ImplementationTests: XCTestCase {
         struct MyStruct: 2️⃣MyProto {}
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (aUri, aPositions) = try project.openDocument("a.swift")

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -49,7 +49,7 @@ final class IndexTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (libAUri, libAPositions) = try project.openDocument("LibA.swift")

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -45,7 +45,6 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: false,
       usePullDiagnostics: false
     )
 
@@ -86,7 +85,6 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: false,
       usePullDiagnostics: false
     )
 
@@ -143,7 +141,7 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: true,
+      enableBackgroundIndexing: true,
       usePullDiagnostics: false
     )
 
@@ -192,7 +190,7 @@ final class MainFilesProviderTests: XCTestCase {
           ]
         )
         """,
-      build: true,
+      enableBackgroundIndexing: true,
       usePullDiagnostics: false
     )
 
@@ -208,10 +206,11 @@ final class MainFilesProviderTests: XCTestCase {
     let newFancyLibraryContents = """
       #include "\(project.scratchDirectory.path)/Sources/shared.h"
       """
-    let fancyLibraryURL = try project.uri(for: "MyFancyLibrary.c").fileURL!
-    try newFancyLibraryContents.write(to: fancyLibraryURL, atomically: false, encoding: .utf8)
-
-    try await SwiftPMTestProject.build(at: project.scratchDirectory)
+    let fancyLibraryUri = try project.uri(for: "MyFancyLibrary.c")
+    try newFancyLibraryContents.write(to: try XCTUnwrap(fancyLibraryUri.fileURL), atomically: false, encoding: .utf8)
+    project.testClient.send(
+      DidChangeWatchedFilesNotification(changes: [FileEvent(uri: fancyLibraryUri, type: .changed)])
+    )
 
     // 'MyFancyLibrary.c' now also includes 'shared.h'. Since it lexicographically preceeds MyLibrary, we should use its
     // build settings.

--- a/Tests/SourceKitLSPTests/RenameAssertions.swift
+++ b/Tests/SourceKitLSPTests/RenameAssertions.swift
@@ -145,7 +145,7 @@ func assertMultiFileRename(
   let project = try await SwiftPMTestProject(
     files: files,
     manifest: manifest,
-    build: true,
+    enableBackgroundIndexing: true,
     testName: testName
   )
   try preRenameActions(project)

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -1114,7 +1114,7 @@ final class RenameTests: XCTestCase {
         }
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let definitionUri = try project.uri(for: "definition.swift")
@@ -1157,7 +1157,6 @@ final class RenameTests: XCTestCase {
       ])
     )
 
-    try await SwiftPMTestProject.build(at: project.scratchDirectory)
     _ = try await project.testClient.send(PollIndexRequest())
 
     let resultAfterFileMove = try await project.testClient.send(
@@ -1250,7 +1249,7 @@ final class RenameTests: XCTestCase {
         }
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
     let (uri, positions) = try project.openDocument("FileA.swift")
     let result = try await project.testClient.send(

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -79,7 +79,7 @@ final class SwiftInterfaceTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (mainUri, _) = try project.openDocument("main.swift")
@@ -176,7 +176,7 @@ final class SwiftInterfaceTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (mainUri, mainPositions) = try project.openDocument("main.swift")

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -31,7 +31,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
         }
         """,
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (otherUri, otherPositions) = try project.openDocument("Other.swift")
@@ -101,7 +101,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
         }
         """
       ],
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let newFileUrl = project.scratchDirectory

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -60,10 +60,9 @@ class WorkspaceSymbolsTests: XCTestCase {
       ],
       workspaces: {
         return [WorkspaceFolder(uri: DocumentURI($0.appendingPathComponent("packageB")))]
-      }
+      },
+      enableBackgroundIndexing: true
     )
-
-    try await SwiftPMTestProject.build(at: project.scratchDirectory.appendingPathComponent("packageB"))
 
     _ = try await project.testClient.send(PollIndexRequest())
     let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "funcFrom"))

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -46,7 +46,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: packageManifestWithTestTarget,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let tests = try await project.testClient.send(WorkspaceTestsRequest())
@@ -141,7 +141,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: packageManifestWithTestTarget,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let myTestsUri = try project.uri(for: "MyTests.swift")
@@ -304,8 +304,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: packageManifestWithTestTarget,
-      build: true,
-      allowBuildFailure: true
+      enableBackgroundIndexing: true
     )
 
     let tests = try await project.testClient.send(WorkspaceTestsRequest())
@@ -371,7 +370,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: packageManifestWithTestTarget,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("MyTests.swift")
@@ -464,7 +463,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """,
       ],
       manifest: packageManifestWithTestTarget,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("MyFirstTests.swift")
@@ -536,7 +535,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: packageManifestWithTestTarget,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let uri = try project.uri(for: "MyTests.swift")
@@ -935,7 +934,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
           targets: [.testTarget(name: "MyLibraryTests")]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let tests = try await project.testClient.send(WorkspaceTestsRequest())
@@ -992,7 +991,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
           targets: [.testTarget(name: "MyLibraryTests")]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
 
     let (uri, positions) = try project.openDocument("Test.m")

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -76,11 +76,10 @@ final class WorkspaceTests: XCTestCase {
           WorkspaceFolder(uri: DocumentURI(scratchDir.appendingPathComponent("PackageA"))),
           WorkspaceFolder(uri: DocumentURI(scratchDir.appendingPathComponent("PackageB"))),
         ]
-      }
+      },
+      enableBackgroundIndexing: true
     )
-
-    try await SwiftPMTestProject.build(at: project.scratchDirectory.appendingPathComponent("PackageA"))
-    try await SwiftPMTestProject.build(at: project.scratchDirectory.appendingPathComponent("PackageB"))
+    _ = try await project.testClient.send(PollIndexRequest())
 
     let (bUri, bPositions) = try project.openDocument("execB.swift")
 
@@ -228,11 +227,13 @@ final class WorkspaceTests: XCTestCase {
         """,
 
         "PackageA/Package.swift": packageManifest,
-      ]
+      ],
+      enableBackgroundIndexing: true
     )
-    try await SwiftPMTestProject.build(at: project.scratchDirectory.appendingPathComponent("PackageA"))
 
     let (uri, positions) = try project.openDocument("execA.swift")
+
+    _ = try await project.testClient.send(PollIndexRequest())
 
     let otherCompletions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
@@ -321,11 +322,11 @@ final class WorkspaceTests: XCTestCase {
         Lib().2️⃣foo()
         """,
         "Package.swift": packageManifest,
-      ]
+      ],
+      enableBackgroundIndexing: true
     )
 
-    try await SwiftPMTestProject.build(at: project.scratchDirectory.appendingPathComponent("PackageA"))
-    try await SwiftPMTestProject.build(at: project.scratchDirectory)
+    _ = try await project.testClient.send(PollIndexRequest())
 
     let (bUri, bPositions) = try project.openDocument("execB.swift")
 
@@ -366,6 +367,8 @@ final class WorkspaceTests: XCTestCase {
     )
 
     let (aUri, aPositions) = try project.openDocument("execA.swift")
+
+    _ = try await project.testClient.send(PollIndexRequest())
 
     let otherCompletions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(aUri), position: aPositions["1️⃣"])
@@ -820,10 +823,9 @@ final class WorkspaceTests: XCTestCase {
           ]
         )
         """,
-      build: true
+      enableBackgroundIndexing: true
     )
     let (mainUri, mainPositions) = try project.openDocument("main.swift")
-    _ = try await project.testClient.send(PollIndexRequest())
 
     let fooDefinitionResponse = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(mainUri), position: mainPositions["3️⃣"])


### PR DESCRIPTION
There are still a few tests left that explicitly check the before and after build state, which I didn’t modify. 

rdar://128697501