### PR TITLE
Show message if background indexing is enabled but the workspace doesn’t support background indexing 

### DIFF
--- a/Sources/SKCore/BuildServerBuildSystem.swift
+++ b/Sources/SKCore/BuildServerBuildSystem.swift
@@ -259,6 +259,8 @@ private func readReponseDataKey(data: LSPAny?, key: String) -> String? {
 }
 
 extension BuildServerBuildSystem: BuildSystem {
+  public nonisolated var supportsPreparation: Bool { false }
+
   /// The build settings for the given file.
   ///
   /// Returns `nil` if no build settings have been received from the build

--- a/Sources/SKCore/BuildSystem.swift
+++ b/Sources/SKCore/BuildSystem.swift
@@ -121,6 +121,10 @@ public protocol BuildSystem: AnyObject, Sendable {
   ///   context.
   func setDelegate(_ delegate: BuildSystemDelegate?) async
 
+  /// Whether the build system is capable of preparing a target for indexing, ie. if the `prepare` methods has been
+  /// implemented.
+  var supportsPreparation: Bool { get }
+
   /// Retrieve build settings for the given document with the given source
   /// language.
   ///

--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -68,6 +68,10 @@ public actor BuildSystemManager {
     }
   }
 
+  public var supportsPreparation: Bool {
+    return buildSystem?.supportsPreparation ?? false
+  }
+
   /// Create a BuildSystemManager that wraps the given build system. The new
   /// manager will modify the delegate of the underlying build system.
   public init(

--- a/Sources/SKCore/CompilationDatabaseBuildSystem.swift
+++ b/Sources/SKCore/CompilationDatabaseBuildSystem.swift
@@ -93,6 +93,8 @@ public actor CompilationDatabaseBuildSystem {
 }
 
 extension CompilationDatabaseBuildSystem: BuildSystem {
+  public nonisolated var supportsPreparation: Bool { false }
+
   public var indexDatabasePath: AbsolutePath? {
     indexStorePath?.parentDirectory.appending(component: "IndexDatabase")
   }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -342,6 +342,7 @@ extension SwiftPMBuildSystem {
 }
 
 extension SwiftPMBuildSystem: SKCore.BuildSystem {
+  public nonisolated var supportsPreparation: Bool { true }
 
   public var buildPath: TSCAbsolutePath {
     return TSCAbsolutePath(buildParameters.buildPath)

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -405,7 +405,7 @@ extension SwiftLanguageService {
     if buildSettings == nil || buildSettings!.isFallback, let fileUrl = note.textDocument.uri.fileURL {
       // Do not show this notification for non-file URIs to make sure we don't see this notificaiton for newly created
       // files (which get opened as with a `untitled:Unitled-1` URI by VS Code.
-      await sourceKitLSPServer?.sendNotificationToClient(
+      sourceKitLSPServer?.sendNotificationToClient(
         ShowMessageNotification(
           type: .warning,
           message: """

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -108,7 +108,10 @@ public final class Workspace: Sendable {
       mainFilesProvider: uncheckedIndex,
       toolchainRegistry: toolchainRegistry
     )
-    if let uncheckedIndex, options.indexOptions.enableBackgroundIndexing {
+    if options.indexOptions.enableBackgroundIndexing,
+      let uncheckedIndex,
+      await buildSystemManager.supportsPreparation
+    {
       self.semanticIndexManager = SemanticIndexManager(
         index: uncheckedIndex,
         buildSystemManager: buildSystemManager,

--- a/Tests/SKCoreTests/BuildSystemManagerTests.swift
+++ b/Tests/SKCoreTests/BuildSystemManagerTests.swift
@@ -455,6 +455,8 @@ class ManualBuildSystem: BuildSystem {
     self.delegate = delegate
   }
 
+  public nonisolated var supportsPreparation: Bool { false }
+
   func buildSettings(for uri: DocumentURI, in buildTarget: ConfiguredTarget, language: Language) -> FileBuildSettings? {
     return map[uri]
   }

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -862,4 +862,15 @@ final class BackgroundIndexingTests: XCTestCase {
       "No file should exist at \(nestedIndexBuildURL)"
     )
   }
+
+  func testShowMessageWhenOpeningAProjectThatDoesntSupportBackgroundIndexing() async throws {
+    let project = try await MultiFileTestProject(
+      files: [
+        "compile_commands.json": ""
+      ],
+      enableBackgroundIndexing: true
+    )
+    let message = try await project.testClient.nextNotification(ofType: ShowMessageNotification.self)
+    XCTAssert(message.message.contains("Background indexing"), "Received unexpected message: \(message.message)")
+  }
 }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -43,6 +43,8 @@ actor TestBuildSystem: BuildSystem {
     buildSettingsByFile[uri] = buildSettings
   }
 
+  public nonisolated var supportsPreparation: Bool { false }
+
   func buildSettings(
     for document: DocumentURI,
     in buildTarget: ConfiguredTarget,


### PR DESCRIPTION
If the user has enabled background indexing in sourcekit-lsp but opens a project that doesn’t support background indexing (compilation database, build server), we should show a message after opening the workspace, informing the user that background indexing is only supported in SwiftPM projects at the moment.

Fixes #1255
rdar://127474711