### PR TITLE
Add infrastructure to write tests for Swift macros

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -381,6 +381,10 @@ let package = Package(
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+        // Depend on `SwiftCompilerPlugin` and `SwiftSyntaxMacros` so the modules are built before running tests and can
+        // be used by test cases that test macros (see `SwiftPMTestProject.macroPackageManifest`).
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
       ]
     ),
   ]

--- a/Sources/SKTestSupport/TestBundle.swift
+++ b/Sources/SKTestSupport/TestBundle.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// The bundle of the currently executing test.
+public let testBundle: Bundle = {
+  #if os(macOS)
+  if let bundle = Bundle.allBundles.first(where: { $0.bundlePath.hasSuffix(".xctest") }) {
+    return bundle
+  }
+  fatalError("couldn't find the test bundle")
+  #else
+  return Bundle.main
+  #endif
+}()
+
+/// The path to the built products directory, ie. `.build/debug/arm64-apple-macosx` or the platform-specific equivalent.
+public let productsDirectory: URL = {
+  #if os(macOS)
+  return testBundle.bundleURL.deletingLastPathComponent()
+  #else
+  return testBundle.bundleURL
+  #endif
+}()

--- a/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
+++ b/Tests/SKCoreTests/BuildServerBuildSystemTests.swift
@@ -20,27 +20,6 @@ import SKTestSupport
 import TSCBasic
 import XCTest
 
-/// The bundle of the currently executing test.
-private let testBundle: Bundle = {
-  #if os(macOS)
-  if let bundle = Bundle.allBundles.first(where: { $0.bundlePath.hasSuffix(".xctest") }) {
-    return bundle
-  }
-  fatalError("couldn't find the test bundle")
-  #else
-  return Bundle.main
-  #endif
-}()
-
-/// The path to the built products directory.
-private let productsDirectory: URL = {
-  #if os(macOS)
-  return testBundle.bundleURL.deletingLastPathComponent()
-  #else
-  return testBundle.bundleURL
-  #endif
-}()
-
 /// The path to the INPUTS directory of shared test projects.
 private let skTestSupportInputsDirectory: URL = {
   #if os(macOS)

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
@@ -772,6 +772,53 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       assertArgumentsContain(aswift.pathString, arguments: arguments)
     }
   }
+
+  func testBuildMacro() async throws {
+    try await SkipUnless.canBuildMacroUsingSwiftSyntaxFromSourceKitLSPBuild()
+    // This test is just a dummy to show how to create a `SwiftPMTestProject` that builds a macro using the SwiftSyntax
+    // modules that were already built during the build of SourceKit-LSP.
+    // It should be removed once we have a real test that tests macros (like macro expansion).
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyMacros/MyMacros.swift": #"""
+        import SwiftCompilerPlugin
+        import SwiftSyntax
+        import SwiftSyntaxBuilder
+        import SwiftSyntaxMacros
+
+        public struct StringifyMacro: ExpressionMacro {
+          public static func expansion(
+            of node: some FreestandingMacroExpansionSyntax,
+            in context: some MacroExpansionContext
+          ) -> ExprSyntax {
+            guard let argument = node.argumentList.first?.expression else {
+              fatalError("compiler bug: the macro does not have any arguments")
+            }
+
+            return "(\(argument), \(literal: argument.description))"
+          }
+        }
+
+        @main
+        struct MyMacroPlugin: CompilerPlugin {
+            let providingMacros: [Macro.Type] = [
+                StringifyMacro.self,
+            ]
+        }
+        """#,
+        "MyMacroClient/MyMacroClient.swift": """
+        @freestanding(expression)
+        public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacros", type: "StringifyMacro")
+
+        func test() {
+          #stringify(1 + 2)
+        }
+        """,
+      ],
+      manifest: SwiftPMTestProject.macroPackageManifest
+    )
+    try await SwiftPMTestProject.build(at: project.scratchDirectory)
+  }
 }
 
 private func assertArgumentsDoNotContain(


### PR DESCRIPTION
Add a default package manifest that defines two targets:
 - A macro target named `MyMacro`
 - And executable target named `MyMacroClient`

It builds the macro using the swift-syntax that was already built as part of the SourceKit-LSP build.
Re-using the SwiftSyntax modules that are already built is significantly faster than building swift-syntax in each test case run and does not require internet access.