### PR TITLE
Make tests pass with Xcode 15.4

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -363,6 +363,9 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
   private func compilerArguments(for file: URL, in buildTarget: any SwiftBuildTarget) async throws -> [String] {
     let compileArguments = try buildTarget.compileArguments(for: file)
 
+    #if compiler(>=6.1)
+    #warning("When we drop support for Swift 5.10 we no longer need to adjust compiler arguments for the Modules move")
+    #endif
     // Fix up compiler arguments that point to a `/Modules` subdirectory if the Swift version in the toolchain is less
     // than 6.0 because it places the modules one level higher up.
     let toolchainVersion = await orLog("Getting Swift version") { try await toolchainRegistry.default?.swiftVersion }

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -50,6 +50,9 @@ final class DependencyTrackingTests: XCTestCase {
     // Semantic analysis: expect module import error.
     XCTAssertEqual(initialDiags.diagnostics.count, 1)
     if let diagnostic = initialDiags.diagnostics.first {
+      #if compiler(>=6.1)
+      #warning("When we drop support for Swift 5.10 we no longer need to check for the Objective-C error message")
+      #endif
       XCTAssert(
         diagnostic.message.contains("Could not build Objective-C module")
           || diagnostic.message.contains("No such module"),

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -186,7 +186,14 @@ final class PublishDiagnosticsTests: XCTestCase {
 
     _ = try project.openDocument("LibB.swift")
     let diagnosticsBeforeBuilding = try await project.testClient.nextDiagnosticsNotification()
-    XCTAssert(diagnosticsBeforeBuilding.diagnostics.contains(where: { $0.message == "No such module 'LibA'" }))
+    XCTAssert(
+      diagnosticsBeforeBuilding.diagnostics.contains(where: {
+        #if compiler(>=6.1)
+        #warning("When we drop support for Swift 5.10 we no longer need to check for the Objective-C error message")
+        #endif
+        return $0.message == "No such module 'LibA'" || $0.message == "Could not build Objective-C module 'LibA'"
+      })
+    )
 
     try await SwiftPMTestProject.build(at: project.scratchDirectory)
 

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -222,7 +222,14 @@ final class PullDiagnosticsTests: XCTestCase {
       XCTFail("Expected full diagnostics report")
       return
     }
-    XCTAssert(fullReportBeforeBuilding.items.contains(where: { $0.message == "No such module 'LibA'" }))
+    XCTAssert(
+      fullReportBeforeBuilding.items.contains(where: {
+        #if compiler(>=6.1)
+        #warning("When we drop support for Swift 5.10 we no longer need to check for the Objective-C error message")
+        #endif
+        return $0.message == "No such module 'LibA'" || $0.message == "Could not build Objective-C module 'LibA'"
+      })
+    )
 
     let diagnosticsRefreshRequestReceived = self.expectation(description: "DiagnosticsRefreshRequest received")
     project.testClient.handleSingleRequest { (request: DiagnosticsRefreshRequest) in


### PR DESCRIPTION
We are no longer skipping these tests, which means that we need to make them account for different error messages emitted by Swift 5.10.

I added warnings behind `#if compiler(>=6.1)` to give us a reminder that we can remove these checks when we no longer support running SourceKit-LSP with SwiftPM from Swift 5.10. Swift 6.1 doesn’t have to be this cut-off point but it’s the most likely candidate for now if we want to support the current and last Swift version from tip SourceKit-LSP.