### PR TITLE
Relax `testMainFileChangesIfIncludeIsAdded` to allow `clangd` to return diagnostics from old build settings

### DIFF
--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -214,9 +214,19 @@ final class MainFilesProviderTests: XCTestCase {
 
     // 'MyFancyLibrary.c' now also includes 'shared.h'. Since it lexicographically preceeds MyLibrary, we should use its
     // build settings.
-    let postEditDiags = try await project.testClient.nextDiagnosticsNotification()
-    XCTAssertEqual(postEditDiags.diagnostics.count, 1)
-    let postEditDiag = try XCTUnwrap(postEditDiags.diagnostics.first)
-    XCTAssertEqual(postEditDiag.message, "Unused variable 'fromMyFancyLibrary'")
+    // `clangd` may return diagnostics from the old build settings sometimes (I believe when it's still building the
+    // preamble for shared.h when the new build settings come in). Check that it eventually returns the correct
+    // diagnostics.
+    var receivedCorrectDiagnostic = false
+    for _ in 0..<Int(defaultTimeout) {
+      let refreshedDiags = try await project.testClient.nextDiagnosticsNotification(timeout: 1)
+      if let diagnostic = refreshedDiags.diagnostics.only,
+        diagnostic.message == "Unused variable 'fromMyFancyLibrary'"
+      {
+        receivedCorrectDiagnostic = true
+        break
+      }
+    }
+    XCTAssert(receivedCorrectDiagnostic)
   }
 }


### PR DESCRIPTION
`clangd` may return diagnostics from the old build settings sometimes (I believe when it's still building the preamble for shared.h when the new build settings come in). Check that it eventually returns the correct diagnostics and allow it to return outdated diagnostics for a short while.