### PR TITLE
Use default toolchain in `sourcekit-lsp run-sourcekitd-request` if no sourcekitd is specified

### DIFF
--- a/Sources/Diagnose/CMakeLists.txt
+++ b/Sources/Diagnose/CMakeLists.txt
@@ -12,8 +12,8 @@ add_library(Diagnose STATIC
   ReductionError.swift
   ReproducerBundle.swift
   RequestInfo.swift
+  RunSourcekitdRequestCommand.swift
   SourceKitD+RunWithYaml.swift
-  SourcekitdRequestCommand.swift
   SourceKitDRequestExecutor.swift
   SourceReducer.swift
   StderrStreamConcurrencySafe.swift

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -108,7 +108,7 @@ struct SourceKitLSP: AsyncParsableCommand {
       IndexCommand.self,
       ReduceCommand.self,
       ReduceFrontendCommand.self,
-      SourceKitdRequestCommand.self,
+      RunSourceKitdRequestCommand.self,
     ]
   )
 


### PR DESCRIPTION
This makes local reduction of failing sourcekitd requests easier if you don’t always need to add the `--sourcekitd` parameter.