### PR TITLE
Flush stdout after issuing message that we re-run tests in serial

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -206,8 +206,8 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
     """
     swiftpm_args = get_swiftpm_options(swift_exec, args, suppress_verbose=True)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
-    # 'swift test' doesn't print os_log output to the command line. Use the 
-    # `NonDarwinLogger` that prints to stderr so we can view the log output in CI test 
+    # 'swift test' doesn't print os_log output to the command line. Use the
+    # `NonDarwinLogger` that prints to stderr so we can view the log output in CI test
     # runs.
     additional_env['SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER'] = '1'
 
@@ -233,6 +233,7 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
         check_call(cmd + ['--parallel'], additional_env=additional_env, verbose=args.verbose)
     except:
         print('--- Running tests in parallel failed. Re-running tests serially to capture more actionable output.')
+        sys.stdout.flush()
         check_call(cmd, additional_env=additional_env, verbose=args.verbose)
         # Return with non-zero exit code even if serial test execution succeeds.
         raise SystemExit(1)
@@ -249,7 +250,7 @@ def install(swift_exec: str, args: argparse.Namespace) -> None:
     swiftpm_args = get_swiftpm_options(swift_exec, args)
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args=swiftpm_args, additional_env=additional_env)
-    
+
     for prefix in args.install_prefixes:
         install_binary('sourcekit-lsp', bin_path, os.path.join(prefix, 'bin'), verbose=args.verbose)
 


### PR DESCRIPTION
For some reason the log message that we’re re-running tests in serial always showed up after the serial run in the build log output. Test if flushing stdout fixes the issue.