### PR TITLE
Replace an assertion by a fault log in `WorkDoneProgressState`

### DIFF
--- a/Sources/SourceKitLSP/WorkDoneProgressState.swift
+++ b/Sources/SourceKitLSP/WorkDoneProgressState.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPLogging
 import LanguageServerProtocol
 import SKSupport
 
@@ -108,7 +109,10 @@ final actor WorkDoneProgressState {
   }
 
   func endProgressImpl(server: SourceKitLSPServer) async {
-    assert(activeTasks > 0, "Unbalanced startProgress/endProgress calls")
+    guard activeTasks > 0 else {
+      logger.fault("Unbalanced startProgress/endProgress calls")
+      return
+    }
     activeTasks -= 1
     guard await server.capabilityRegistry?.clientCapabilities.window?.workDoneProgress ?? false else {
       return


### PR DESCRIPTION
We didn’t hit this assertion but I noticed it and the best practice in sourcekit-lsp is to log a fault instead of throwing an assertion for any kind of recoverable error.