### PR TITLE
Don’t run a `swift build` command to prepare a package manifest

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -550,6 +550,11 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
     singleTarget target: ConfiguredTarget,
     indexProcessDidProduceResult: @Sendable (IndexProcessResult) -> Void
   ) async throws {
+    if target == .forPackageManifest {
+      // Nothing to prepare for package manifests.
+      return
+    }
+
     // TODO (indexing): Add a proper 'prepare' job in SwiftPM instead of building the target.
     // https://github.com/apple/sourcekit-lsp/issues/1254
     guard let toolchain = await toolchainRegistry.default else {

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -90,7 +90,7 @@ final class CrashRecoveryTests: XCTestCase {
 
     await swiftLanguageService._crash()
 
-    let crashedNotification = try await testClient.nextNotification(ofType: WorkDoneProgress.self, timeout: 5)
+    let crashedNotification = try await testClient.nextNotification(ofType: WorkDoneProgress.self, timeout: .seconds(5))
     XCTAssertEqual(
       crashedNotification.value,
       .begin(
@@ -107,7 +107,7 @@ final class CrashRecoveryTests: XCTestCase {
     _ = try? await testClient.send(hoverRequest)
     let semanticFunctionalityRestoredNotification = try await testClient.nextNotification(
       ofType: WorkDoneProgress.self,
-      timeout: 30
+      timeout: .seconds(30)
     )
     XCTAssertEqual(semanticFunctionalityRestoredNotification.value, .end(WorkDoneProgressEnd()))
 

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -930,4 +930,27 @@ final class BackgroundIndexingTests: XCTestCase {
     )
     XCTAssertEqual((result?.changes?.keys).map(Set.init), [uri, try project.uri(for: "Client.swift")])
   }
+
+  func testDontPreparePackageManifest() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Lib.swift": ""
+      ],
+      enableBackgroundIndexing: true
+    )
+
+    _ = try await project.testClient.nextNotification(
+      ofType: LogMessageNotification.self,
+      satisfying: { $0.message.contains("Preparing MyLibrary") }
+    )
+
+    // Opening the package manifest shouldn't cause any `swift build` calls to prepare them because they are not part of
+    // a target that can be prepared.
+    let (uri, _) = try project.openDocument("Package.swift")
+    _ = try await project.testClient.send(DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri)))
+    try await project.testClient.assertDoesNotReceiveNotification(
+      ofType: LogMessageNotification.self,
+      satisfying: { $0.message.contains("Preparing") }
+    )
+  }
 }

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -193,7 +193,7 @@ final class BuildSystemTests: XCTestCase {
 
     var receivedCorrectDiagnostic = false
     for _ in 0..<Int(defaultTimeout) {
-      let refreshedDiags = try await testClient.nextDiagnosticsNotification(timeout: 1)
+      let refreshedDiags = try await testClient.nextDiagnosticsNotification(timeout: .seconds(1))
       if refreshedDiags.diagnostics.count == 0, try text == documentManager.latestSnapshot(doc).text {
         receivedCorrectDiagnostic = true
         break

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1427,6 +1427,6 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(diag.message, "Cannot find 'bar' in scope")
 
     // Ensure that we don't get a second `PublishDiagnosticsNotification`
-    await assertThrowsError(try await testClient.nextDiagnosticsNotification(timeout: 2))
+    await assertThrowsError(try await testClient.nextDiagnosticsNotification(timeout: .seconds(2)))
   }
 }

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -219,7 +219,7 @@ final class MainFilesProviderTests: XCTestCase {
     // diagnostics.
     var receivedCorrectDiagnostic = false
     for _ in 0..<Int(defaultTimeout) {
-      let refreshedDiags = try await project.testClient.nextDiagnosticsNotification(timeout: 1)
+      let refreshedDiags = try await project.testClient.nextDiagnosticsNotification(timeout: .seconds(1))
       if let diagnostic = refreshedDiags.diagnostics.only,
         diagnostic.message == "Unused variable 'fromMyFancyLibrary'"
       {


### PR DESCRIPTION
Package manifests don’t have an associated target to prepare and are represented by a `ConfiguredTarget` with an empty target ID. We were mistakingly running `swift build` with an empty target name to prepare them, which failed. There is nothing to prepare.