### PR TITLE
Forward all errors that translate to `.cancelled` from document diagnostics request

### DIFF
--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -337,7 +337,7 @@ final class PullDiagnosticsTests: XCTestCase {
     let requestID = project.testClient.send(
       DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
     ) { result in
-      XCTAssertEqual(result.failure?.code, .cancelled)
+      XCTAssertEqual(result, .failure(ResponseError.cancelled))
       diagnosticResponseReceived.fulfill()
     }
     project.testClient.send(CancelRequestNotification(id: requestID))


### PR DESCRIPTION
We were only forwarding `CancellationError` but depending on when cancellation happens, we would get `SKDError.cancelled`, which we would translate to empty diagnostics, causing the test to fail.