### PR TITLE
Skip testImportPreparedModuleWithFunctionBodiesSkipped if toolchain doesn’t support rename

### DIFF
--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -889,6 +889,7 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testImportPreparedModuleWithFunctionBodiesSkipped() async throws {
+    try await SkipUnless.sourcekitdSupportsRename()
     // This test case was crashing the indexing compiler invocation for Client if Lib was built for index preparation
     // (using `-enable-library-evolution -experimental-skip-all-function-bodies -experimental-lazy-typecheck`) but x
     // Client was not indexed with `-experimental-allow-module-with-compiler-errors`. rdar://129071600


### PR DESCRIPTION
The test uses rename and should thus be skipped if sourcekitd doesn’t support rename.

This makes the tests pass with Xcode 15.4.