### PR TITLE
Set `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER` for parallel test execution

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,11 @@
 			"disableTaskQueue": true,
 			"group": "test",
 			"label": "Run all tests (parallel)",
+			"options": {
+				"env": {
+					"SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1"
+				}
+			},
 			"problemMatcher": [
 				"$swiftc"
 			],
@@ -30,7 +35,8 @@
 			"label": "Run fast tests (parallel)",
 			"options": {
 				"env": {
-					"SKIP_LONG_TESTS": "1"
+					"SKIP_LONG_TESTS": "1",
+					"SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1"
 				}
 			},
 			"problemMatcher": [


### PR DESCRIPTION
Set `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER` to 1 so we generate a log to stderr if parallel test execution fails, which helps diagnose the issue.