### PR TITLE
[6.0] Re-apply #1227 Merge tests defined in extensions

### DIFF
--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -200,7 +200,7 @@ public protocol LanguageService: AnyObject, Sendable {
   /// This is used as a fallback to show the test cases in a file if the index for a given file is not up-to-date.
   ///
   /// A return value of `nil` indicates that this language service does not support syntactic test discovery.
-  func syntacticDocumentTests(for uri: DocumentURI, in workspace: Workspace) async throws -> [TestItem]?
+  func syntacticDocumentTests(for uri: DocumentURI, in workspace: Workspace) async throws -> [AnnotatedTestItem]?
 
   /// Crash the language server. Should be used for crash recovery testing only.
   func _crash() async

--- a/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftTestingScanner.swift
@@ -177,9 +177,13 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
   private let parentTypeNames: [String]
 
   /// The discovered test items.
-  private var result: [TestItem] = []
+  private var result: [AnnotatedTestItem] = []
 
-  private init(snapshot: DocumentSnapshot, allTestsDisabled: Bool, parentTypeNames: [String]) {
+  private init(
+    snapshot: DocumentSnapshot,
+    allTestsDisabled: Bool,
+    parentTypeNames: [String]
+  ) {
     self.snapshot = snapshot
     self.allTestsDisabled = allTestsDisabled
     self.parentTypeNames = parentTypeNames
@@ -190,7 +194,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
   public static func findTestSymbols(
     in snapshot: DocumentSnapshot,
     syntaxTreeManager: SyntaxTreeManager
-  ) async -> [TestItem] {
+  ) async -> [AnnotatedTestItem] {
     guard snapshot.text.contains("Suite") || snapshot.text.contains("Test") else {
       // If the file contains swift-testing tests, it must contain a `@Suite` or `@Test` attribute.
       // Only check for the attribute name because the attribute may be module qualified and contain an arbitrary amount
@@ -199,7 +203,11 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
       return []
     }
     let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
-    let visitor = SyntacticSwiftTestingTestScanner(snapshot: snapshot, allTestsDisabled: false, parentTypeNames: [])
+    let visitor = SyntacticSwiftTestingTestScanner(
+      snapshot: snapshot,
+      allTestsDisabled: false,
+      parentTypeNames: []
+    )
     visitor.walk(syntaxTree)
     return visitor.result
   }
@@ -241,14 +249,18 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     }
 
     let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
-    let testItem = TestItem(
-      id: (parentTypeNames + typeNames).joined(separator: "/"),
-      label: attributeData?.displayName ?? typeNames.last!,
-      disabled: (attributeData?.isDisabled ?? false) || allTestsDisabled,
-      style: TestStyle.swiftTesting,
-      location: Location(uri: snapshot.uri, range: range),
-      children: memberScanner.result,
-      tags: attributeData?.tags.map(TestTag.init(id:)) ?? []
+    // Members won't be extensions since extensions will only be at the top level.
+    let testItem = AnnotatedTestItem(
+      testItem: TestItem(
+        id: (parentTypeNames + typeNames).joined(separator: "/"),
+        label: attributeData?.displayName ?? typeNames.last!,
+        disabled: (attributeData?.isDisabled ?? false) || allTestsDisabled,
+        style: TestStyle.swiftTesting,
+        location: Location(uri: snapshot.uri, range: range),
+        children: memberScanner.result.map(\.testItem),
+        tags: attributeData?.tags.map(TestTag.init(id:)) ?? []
+      ),
+      isExtension: node.is(ExtensionDeclSyntax.self)
     )
     result.append(testItem)
     return .skipChildren
@@ -295,14 +307,17 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
       node.name.text + "(" + node.signature.parameterClause.parameters.map { "\($0.firstName.text):" }.joined() + ")"
 
     let range = snapshot.range(of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia)
-    let testItem = TestItem(
-      id: (parentTypeNames + [name]).joined(separator: "/"),
-      label: attributeData.displayName ?? name,
-      disabled: attributeData.isDisabled || allTestsDisabled,
-      style: TestStyle.swiftTesting,
-      location: Location(uri: snapshot.uri, range: range),
-      children: [],
-      tags: attributeData.tags.map(TestTag.init(id:))
+    let testItem = AnnotatedTestItem(
+      testItem: TestItem(
+        id: (parentTypeNames + [name]).joined(separator: "/"),
+        label: attributeData.displayName ?? name,
+        disabled: attributeData.isDisabled || allTestsDisabled,
+        style: TestStyle.swiftTesting,
+        location: Location(uri: snapshot.uri, range: range),
+        children: [],
+        tags: attributeData.tags.map(TestTag.init(id:))
+      ),
+      isExtension: false
     )
     result.append(testItem)
     return .visitChildren

--- a/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
@@ -51,7 +51,7 @@ fileprivate enum TaskMetadata: DependencyTracker, Equatable {
 /// Data from a syntactic scan of a source file for tests.
 fileprivate struct IndexedTests {
   /// The tests within the source file.
-  let tests: [TestItem]
+  let tests: [AnnotatedTestItem]
 
   /// The modification date of the source file when it was scanned. A file won't get re-scanned if its modification date
   /// is older or the same as this date.
@@ -63,7 +63,7 @@ fileprivate struct IndexedTests {
 /// Does not write the results to the index.
 ///
 /// The order of the returned tests is not defined. The results should be sorted before being returned to the editor.
-fileprivate func testItems(in url: URL) async -> [TestItem] {
+fileprivate func testItems(in url: URL) async -> [AnnotatedTestItem] {
   guard url.pathExtension == "swift" else {
     return []
   }
@@ -79,6 +79,7 @@ fileprivate func testItems(in url: URL) async -> [TestItem] {
     syntaxTreeManager: syntaxTreeManager
   )
   async let xcTests = SyntacticSwiftXCTestScanner.findTestSymbols(in: snapshot, syntaxTreeManager: syntaxTreeManager)
+
   return await swiftTestingTests + xcTests
 }
 
@@ -206,7 +207,7 @@ actor SyntacticTestIndex {
   /// Gets all the tests in the syntactic index.
   ///
   /// This waits for any pending document updates to be indexed before returning a result.
-  nonisolated func tests() async -> [TestItem] {
+  nonisolated func tests() async -> [AnnotatedTestItem] {
     let readTask = indexingQueue.async(metadata: .read) {
       return await self.indexedTests.values.flatMap { $0.tests }
     }

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -827,17 +827,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
               tags: []
-            )
-          ],
-          tags: []
-        ),
-        TestItem(
-          id: "MyTests",
-          label: "MyTests",
-          disabled: false,
-          style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["5️⃣"]..<positions["8️⃣"]),
-          children: [
+            ),
             TestItem(
               id: "MyTests/twoIsThree()",
               label: "twoIsThree()",
@@ -846,10 +836,176 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               location: Location(uri: uri, range: positions["6️⃣"]..<positions["7️⃣"]),
               children: [],
               tags: []
+            ),
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingTestSuitesWithExtension() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import XCTest
+
+      1️⃣@Suite struct MyTests {
+        2️⃣@Test func oneIsTwo() {}3️⃣
+      }4️⃣
+
+      extension MyTests {
+        5️⃣@Test func twoIsThree() {}6️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
+              children: [],
+              tags: []
+            ),
+            TestItem(
+              id: "MyTests/twoIsThree()",
+              label: "twoIsThree()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"]),
+              children: [],
+              tags: []
+            ),
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testXCTestTestsWithExtension() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import XCTest
+
+      1️⃣final class MyTests: XCTestCase {}2️⃣
+
+      extension MyTests {
+        3️⃣func testOneIsTwo() {}4️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.xcTest,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/testOneIsTwo()",
+              label: "testOneIsTwo()",
+              disabled: false,
+              style: TestStyle.xcTest,
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
+              children: [],
+              tags: []
             )
           ],
           tags: []
-        ),
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingNestedTestSuiteWithExtension() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣@Suite struct Outer {
+        3️⃣@Suite struct Inner {
+          5️⃣@Test func oneIsTwo {}6️⃣
+        }4️⃣
+      }2️⃣
+
+      extension Outer.Inner {
+        7️⃣@Test func twoIsThree() {}8️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "Outer",
+          label: "Outer",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [
+            TestItem(
+              id: "Outer/Inner",
+              label: "Inner",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
+              children: [
+                TestItem(
+                  id: "Outer/Inner/oneIsTwo()",
+                  label: "oneIsTwo()",
+                  disabled: false,
+                  style: TestStyle.swiftTesting,
+                  location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"]),
+                  children: [],
+                  tags: []
+                ),
+                TestItem(
+                  id: "Outer/Inner/twoIsThree()",
+                  label: "twoIsThree()",
+                  disabled: false,
+                  style: TestStyle.swiftTesting,
+                  location: Location(uri: uri, range: positions["7️⃣"]..<positions["8️⃣"]),
+                  children: [],
+                  tags: []
+                ),
+              ],
+              tags: []
+            )
+          ],
+          tags: []
+        )
       ]
     )
   }
@@ -941,6 +1097,61 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               children: [],
               tags: []
             )
+          ],
+          tags: []
+        )
+      ]
+    )
+  }
+
+  func testSwiftTestingTwoExtensionsNoDeclaration() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI.for(.swift)
+
+    let positions = testClient.openDocument(
+      """
+      import Testing
+
+      1️⃣extension MyTests {
+        3️⃣@Test func oneIsTwo() {}4️⃣
+      }2️⃣
+
+      extension MyTests {
+        5️⃣@Test func twoIsThree() {}6️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let tests = try await testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyTests",
+          label: "MyTests",
+          disabled: false,
+          style: TestStyle.swiftTesting,
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
+          children: [
+            TestItem(
+              id: "MyTests/oneIsTwo()",
+              label: "oneIsTwo()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
+              children: [],
+              tags: []
+            ),
+            TestItem(
+              id: "MyTests/twoIsThree()",
+              label: "twoIsThree()",
+              disabled: false,
+              style: TestStyle.swiftTesting,
+              location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"]),
+              children: [],
+              tags: []
+            ),
           ],
           tags: []
         )


### PR DESCRIPTION
We reverted #1227 because it was hitting issues in debug info generation (rdar://128155050), which have been fixed. Re-apply the PR.

This reverts commit ff5db5f5e3fc283f9b9dca476b560a38c7c3f793.

rdar://128159962