### PR TITLE
Automatically add `swift-tools-version` and `import PackageDescription` to manifest in SwiftPMTestProject

### DIFF
--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -173,6 +173,17 @@ public class SwiftPMTestProject: MultiFileTestProject {
 
       filesByPath[RelativeFileLocation(directories: directories, fileLocation.fileName)] = contents
     }
+    var manifest = manifest
+    if !manifest.contains("swift-tools-version") {
+      // Tests specify a shorthand package manifest that doesn't contain the tools version boilerplate.
+      manifest = """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        \(manifest)
+        """
+    }
     filesByPath["Package.swift"] = manifest
 
     try await super.init(

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -117,10 +117,6 @@ final class BackgroundIndexingTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -181,10 +177,6 @@ final class BackgroundIndexingTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -231,8 +223,6 @@ final class BackgroundIndexingTests: XCTestCase {
         """
       ],
       manifest: """
-        // swift-tools-version: 5.7
-        import PackageDescription
         let package = Package(
           name: "MyLibrary",
           dependencies: [.package(url: "\(dependencyProject.packageDirectory)", from: "1.0.0")],
@@ -562,10 +552,6 @@ final class BackgroundIndexingTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -686,10 +672,6 @@ final class BackgroundIndexingTests: XCTestCase {
         "LibD/LibD.swift": "",
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -801,10 +783,6 @@ final class BackgroundIndexingTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -909,10 +887,6 @@ final class BackgroundIndexingTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/CrossLanguageRenameTests.swift
+++ b/Tests/SourceKitLSPTests/CrossLanguageRenameTests.swift
@@ -14,10 +14,6 @@ import SKTestSupport
 import XCTest
 
 private let libAlibBPackageManifest = """
-  // swift-tools-version: 5.7
-
-  import PackageDescription
-
   let package = Package(
     name: "MyLibrary",
     targets: [
@@ -564,10 +560,6 @@ final class CrossLanguageRenameTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -622,10 +614,6 @@ final class CrossLanguageRenameTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -680,10 +668,6 @@ final class CrossLanguageRenameTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -165,10 +165,6 @@ class DefinitionTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -272,10 +268,6 @@ class DefinitionTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -323,10 +315,6 @@ class DefinitionTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -452,10 +440,6 @@ class DefinitionTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -29,10 +29,6 @@ final class DependencyTrackingTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -39,10 +39,6 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [.testTarget(name: "MyLibraryTests")]
@@ -142,10 +138,6 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [.testTarget(name: "MyLibraryTests")]
@@ -1295,10 +1287,6 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [.testTarget(name: "MyLibraryTests")]
@@ -1354,10 +1342,6 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [.testTarget(name: "MyLibraryTests")]

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -35,10 +35,6 @@ final class IndexTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -31,10 +31,6 @@ final class MainFilesProviderTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -71,10 +67,6 @@ final class MainFilesProviderTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -123,10 +115,6 @@ final class MainFilesProviderTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -172,10 +160,6 @@ final class MainFilesProviderTests: XCTestCase {
         "Sources/MyFancyLibrary/MyFancyLibrary.c": "",
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -169,10 +169,6 @@ final class PublishDiagnosticsTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -200,10 +200,6 @@ final class PullDiagnosticsTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -287,10 +283,6 @@ final class PullDiagnosticsTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -536,10 +536,6 @@ final class RenameTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -576,10 +572,6 @@ final class RenameTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -627,10 +619,6 @@ final class RenameTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -66,10 +66,6 @@ final class SwiftInterfaceTests: XCTestCase {
         "Exec/main.swift": "import MyLibrary",
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [
@@ -162,10 +158,6 @@ final class SwiftInterfaceTests: XCTestCase {
         "Exec/main.swift": "import 1️⃣MyLibrary",
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -19,10 +19,6 @@ import SKTestSupport
 import XCTest
 
 private let packageManifestWithTestTarget = """
-  // swift-tools-version: 5.7
-
-  import PackageDescription
-
   let package = Package(
     name: "MyLibrary",
     targets: [.testTarget(name: "MyLibraryTests")]
@@ -844,10 +840,6 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         "Test.swift": ""
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           dependencies: [.package(url: "\(dependencyProject.packageDirectory)", from: "1.0.0")],
@@ -925,10 +917,6 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [.testTarget(name: "MyLibraryTests")]
@@ -982,10 +970,6 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         """
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [.testTarget(name: "MyLibraryTests")]

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -568,10 +568,6 @@ final class WorkspaceTests: XCTestCase {
         """,
       ],
       manifest: """
-        // swift-tools-version: 5.7
-
-        import PackageDescription
-
         let package = Package(
           name: "MyLibrary",
           targets: [


### PR DESCRIPTION
This shortens the tests and allows them to focus on the important parts.

rdar://126484621