### PR TITLE
Mark closures of `CheckedIndex.forEach*` as non-escaping

### DIFF
--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -64,7 +64,7 @@ public final class CheckedIndex {
   public func forEachSymbolOccurrence(
     byUSR usr: String,
     roles: SymbolRole,
-    _ body: @escaping (SymbolOccurrence) -> Bool
+    _ body: (SymbolOccurrence) -> Bool
   ) -> Bool {
     index.forEachSymbolOccurrence(byUSR: usr, roles: roles) { occurrence in
       guard self.checker.isUpToDate(occurrence.location) else {
@@ -88,7 +88,7 @@ public final class CheckedIndex {
     anchorEnd: Bool,
     subsequence: Bool,
     ignoreCase: Bool,
-    body: @escaping (SymbolOccurrence) -> Bool
+    body: (SymbolOccurrence) -> Bool
   ) -> Bool {
     index.forEachCanonicalSymbolOccurrence(
       containing: pattern,


### PR DESCRIPTION
With https://github.com/apple/indexstore-db/pull/198, they no longer need to be marked as escpaing.