### PR TITLE
Use `DocumentURI` instead of `URL` in more locations

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -75,6 +75,10 @@ public struct DocumentURI: Codable, Hashable, Sendable {
     assert(self.storage.scheme != nil, "Received invalid URI without a scheme '\(self.storage.absoluteString)'")
   }
 
+  public init(filePath: String, isDirectory: Bool) {
+    self.init(URL(fileURLWithPath: filePath, isDirectory: isDirectory))
+  }
+
   public init(from decoder: Decoder) throws {
     try self.init(string: decoder.singleValueContainer().decode(String.self))
   }

--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -146,8 +146,8 @@ public actor SwiftPMBuildSystem {
     }
   }
 
-  var fileToTarget: [AbsolutePath: SwiftBuildTarget] = [:]
-  var sourceDirToTarget: [AbsolutePath: SwiftBuildTarget] = [:]
+  var fileToTarget: [DocumentURI: SwiftBuildTarget] = [:]
+  var sourceDirToTarget: [DocumentURI: SwiftBuildTarget] = [:]
 
   /// Maps configured targets ids to their SwiftPM build target as well as an index in their topological sorting.
   ///
@@ -286,15 +286,18 @@ public actor SwiftPMBuildSystem {
   ///   - reloadPackageStatusCallback: Will be informed when `reloadPackage` starts and ends executing.
   /// - Returns: nil if `workspacePath` is not part of a package or there is an error.
   public init?(
-    url: URL,
+    uri: DocumentURI,
     toolchainRegistry: ToolchainRegistry,
     buildSetup: BuildSetup,
     isForIndexBuild: Bool,
     reloadPackageStatusCallback: @escaping (ReloadPackageStatus) async -> Void
   ) async {
+    guard let fileURL = uri.fileURL else {
+      return nil
+    }
     do {
       try await self.init(
-        workspacePath: try TSCAbsolutePath(validating: url.path),
+        workspacePath: try TSCAbsolutePath(validating: fileURL.path),
         toolchainRegistry: toolchainRegistry,
         fileSystem: localFileSystem,
         buildSetup: buildSetup,
@@ -304,7 +307,7 @@ public actor SwiftPMBuildSystem {
     } catch Error.noManifest {
       return nil
     } catch {
-      logger.error("failed to create SwiftPMWorkspace at \(url.path): \(error.forLogging)")
+      logger.error("failed to create SwiftPMWorkspace at \(uri.forLogging): \(error.forLogging)")
       return nil
     }
   }
@@ -351,13 +354,13 @@ extension SwiftPMBuildSystem {
       }
     )
 
-    self.fileToTarget = [AbsolutePath: SwiftBuildTarget](
+    self.fileToTarget = [DocumentURI: SwiftBuildTarget](
       modulesGraph.allTargets.flatMap { target in
         return target.sources.paths.compactMap {
           guard let buildTarget = buildDescription.getBuildTarget(for: target, in: modulesGraph) else {
             return nil
           }
-          return (key: $0, value: buildTarget)
+          return (key: DocumentURI($0.asURL), value: buildTarget)
         }
       },
       uniquingKeysWith: { td, _ in
@@ -366,12 +369,12 @@ extension SwiftPMBuildSystem {
       }
     )
 
-    self.sourceDirToTarget = [AbsolutePath: SwiftBuildTarget](
-      modulesGraph.allTargets.compactMap { (target) -> (AbsolutePath, SwiftBuildTarget)? in
+    self.sourceDirToTarget = [DocumentURI: SwiftBuildTarget](
+      modulesGraph.allTargets.compactMap { (target) -> (DocumentURI, SwiftBuildTarget)? in
         guard let buildTarget = buildDescription.getBuildTarget(for: target, in: modulesGraph) else {
           return nil
         }
-        return (key: target.sources.root, value: buildTarget)
+        return (key: DocumentURI(target.sources.root.asURL), value: buildTarget)
       },
       uniquingKeysWith: { td, _ in
         // FIXME: is there  a preferred target?
@@ -387,6 +390,13 @@ extension SwiftPMBuildSystem {
     for testFilesDidChangeCallback in testFilesDidChangeCallbacks {
       await testFilesDidChangeCallback()
     }
+  }
+}
+
+fileprivate struct NonFileURIError: Error, CustomStringConvertible {
+  let uri: DocumentURI
+  var description: String {
+    "Trying to get build settings for non-file URI: \(uri)"
   }
 }
 
@@ -410,8 +420,11 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
 
   /// Return the compiler arguments for the given source file within a target, making any necessary adjustments to
   /// account for differences in the SwiftPM versions being linked into SwiftPM and being installed in the toolchain.
-  private func compilerArguments(for file: URL, in buildTarget: any SwiftBuildTarget) async throws -> [String] {
-    let compileArguments = try buildTarget.compileArguments(for: file)
+  private func compilerArguments(for file: DocumentURI, in buildTarget: any SwiftBuildTarget) async throws -> [String] {
+    guard let fileURL = file.fileURL else {
+      throw NonFileURIError(uri: file)
+    }
+    let compileArguments = try buildTarget.compileArguments(for: fileURL)
 
     #if compiler(>=6.1)
     #warning("When we drop support for Swift 5.10 we no longer need to adjust compiler arguments for the Modules move")
@@ -449,9 +462,10 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
       return nil
     }
 
-    if !buildTarget.sources.contains(url),
+    if !buildTarget.sources.lazy.map(DocumentURI.init).contains(uri),
       let substituteFile = buildTarget.sources.sorted(by: { $0.path < $1.path }).first
     {
+      logger.info("Getting compiler arguments for \(url) using substitute file \(substituteFile)")
       // If `url` is not part of the target's source, it's most likely a header file. Fake compiler arguments for it
       // from a substitute file within the target.
       // Even if the file is not a header, this should give reasonable results: Say, there was a new `.cpp` file in a
@@ -460,13 +474,13 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
       // getting its compiler arguments and then patching up the compiler arguments by replacing the substitute file
       // with the `.cpp` file.
       return FileBuildSettings(
-        compilerArguments: try await compilerArguments(for: substituteFile, in: buildTarget),
+        compilerArguments: try await compilerArguments(for: DocumentURI(substituteFile), in: buildTarget),
         workingDirectory: workspacePath.pathString
       ).patching(newFile: try resolveSymlinks(path).pathString, originalFile: substituteFile.absoluteString)
     }
 
     return FileBuildSettings(
-      compilerArguments: try await compilerArguments(for: url, in: buildTarget),
+      compilerArguments: try await compilerArguments(for: uri, in: buildTarget),
       workingDirectory: workspacePath.pathString
     )
   }
@@ -483,7 +497,7 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
       return []
     }
 
-    if let target = try? buildTarget(for: path) {
+    if let target = buildTarget(for: uri) {
       return [ConfiguredTarget(target)]
     }
 
@@ -626,13 +640,15 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
   }
 
   /// Returns the resolved target description for the given file, if one is known.
-  private func buildTarget(for file: AbsolutePath) throws -> SwiftBuildTarget? {
+  private func buildTarget(for file: DocumentURI) -> SwiftBuildTarget? {
     if let td = fileToTarget[file] {
       return td
     }
 
-    let realpath = try resolveSymlinks(file)
-    if realpath != file, let td = fileToTarget[realpath] {
+    if let fileURL = file.fileURL,
+      let realpath = try? resolveSymlinks(AbsolutePath(validating: fileURL.path)),
+      let td = fileToTarget[DocumentURI(realpath.asURL)]
+    {
       fileToTarget[file] = td
       return td
     }
@@ -675,11 +691,7 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
     // If a Swift file within a target is updated, reload all the other files within the target since they might be
     // referring to a function in the updated file.
     for event in events {
-      guard let url = event.uri.fileURL,
-        url.pathExtension == "swift",
-        let absolutePath = try? AbsolutePath(validating: url.path),
-        let target = fileToTarget[absolutePath]
-      else {
+      guard event.uri.fileURL?.pathExtension == "swift", let target = fileToTarget[event.uri] else {
         continue
       }
       filesWithUpdatedDependencies.formUnion(target.sources.map { DocumentURI($0) })
@@ -695,7 +707,7 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
     // If we have background indexing enabled, this is not necessary because we call `fileDependenciesUpdated` when
     // preparation of a target finishes.
     if !isForIndexBuild, events.contains(where: { $0.uri.fileURL?.pathExtension == "swiftmodule" }) {
-      filesWithUpdatedDependencies.formUnion(self.fileToTarget.keys.map { DocumentURI($0.asURL) })
+      filesWithUpdatedDependencies.formUnion(self.fileToTarget.keys)
     }
     await self.fileDependenciesUpdatedDebouncer.scheduleCall(filesWithUpdatedDependencies)
   }
@@ -708,11 +720,11 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
   }
 
   public func sourceFiles() -> [SourceFileInfo] {
-    return fileToTarget.compactMap { (path, target) -> SourceFileInfo? in
+    return fileToTarget.compactMap { (uri, target) -> SourceFileInfo? in
       // We should only set mayContainTests to `true` for files from test targets
       // (https://github.com/apple/sourcekit-lsp/issues/1174).
       return SourceFileInfo(
-        uri: DocumentURI(path.asURL),
+        uri: uri,
         isPartOfRootProject: target.isPartOfRootPackage,
         mayContainTests: true
       )
@@ -753,7 +765,7 @@ extension SwiftPMBuildSystem {
     func impl(_ path: AbsolutePath) throws -> ConfiguredTarget? {
       var dir = path.parentDirectory
       while !dir.isRoot {
-        if let buildTarget = sourceDirToTarget[dir] {
+        if let buildTarget = sourceDirToTarget[DocumentURI(dir.asURL)] {
           return ConfiguredTarget(buildTarget)
         }
         dir = dir.parentDirectory

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -70,12 +70,14 @@ public actor SkipUnless {
         )
       } else if toolchainSwiftVersion == requiredSwiftVersion {
         logger.info("Checking if feature '\(featureName)' is supported")
+        defer {
+          logger.info("Done checking if feature '\(featureName)' is supported")
+        }
         if try await !featureCheck() {
           return .featureUnsupported(skipMessage: "Skipping because toolchain doesn't contain \(featureName)")
         } else {
           return .featureSupported
         }
-        logger.info("Done checking if feature '\(featureName)' is supported")
       } else {
         return .featureSupported
       }

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -19,9 +19,9 @@ import LanguageServerProtocol
 ///
 /// Protocol is needed because the `SemanticIndex` module is lower-level than the `SourceKitLSP` module.
 public protocol InMemoryDocumentManager {
-  /// Returns true if the file at the given URL has a different content in the document manager than on-disk. This is
+  /// Returns true if the file at the given URI has a different content in the document manager than on-disk. This is
   /// the case if the user made edits to the file but didn't save them yet.
-  func fileHasInMemoryModifications(_ url: URL) -> Bool
+  func fileHasInMemoryModifications(_ uri: DocumentURI) -> Bool
 }
 
 public enum IndexCheckLevel {
@@ -105,7 +105,7 @@ public final class CheckedIndex {
   }
 
   public func symbols(inFilePath path: String) -> [Symbol] {
-    guard self.hasUpToDateUnit(for: URL(fileURLWithPath: path, isDirectory: false)) else {
+    guard self.hasUpToDateUnit(for: DocumentURI(filePath: path, isDirectory: false)) else {
       return []
     }
     return index.symbols(inFilePath: path)
@@ -121,11 +121,11 @@ public final class CheckedIndex {
   /// If `crossLanguage` is set to `true`, Swift files that import a header through a module will also be reported.
   public func mainFilesContainingFile(uri: DocumentURI, crossLanguage: Bool = false) -> [DocumentURI] {
     return index.mainFilesContainingFile(path: uri.pseudoPath, crossLanguage: crossLanguage).compactMap {
-      let url = URL(fileURLWithPath: $0)
-      guard checker.indexHasUpToDateUnit(for: url, mainFile: nil, index: self.index) else {
+      let uri = DocumentURI(filePath: $0, isDirectory: false)
+      guard checker.indexHasUpToDateUnit(for: uri, mainFile: nil, index: self.index) else {
         return nil
       }
-      return DocumentURI(url)
+      return uri
     }
   }
 
@@ -141,16 +141,16 @@ public final class CheckedIndex {
   /// If `mainFile` is passed, then `url` is a header file that won't have a unit associated with it. `mainFile` is
   /// assumed to be a file that imports `url`. To check that `url` has an up-to-date unit, check that the latest unit
   /// for `mainFile` is newer than the mtime of the header file at `url`.
-  public func hasUpToDateUnit(for url: URL, mainFile: URL? = nil) -> Bool {
-    return checker.indexHasUpToDateUnit(for: url, mainFile: mainFile, index: index)
+  public func hasUpToDateUnit(for uri: DocumentURI, mainFile: DocumentURI? = nil) -> Bool {
+    return checker.indexHasUpToDateUnit(for: uri, mainFile: mainFile, index: index)
   }
 
-  /// Returns true if the file at the given URL has a different content in the document manager than on-disk. This is
+  /// Returns true if the file at the given URI has a different content in the document manager than on-disk. This is
   /// the case if the user made edits to the file but didn't save them yet.
   ///
   /// - Important: This must only be called on a `CheckedIndex` with a `checkLevel` of `inMemoryModifiedFiles`
-  public func fileHasInMemoryModifications(_ url: URL) -> Bool {
-    return checker.fileHasInMemoryModifications(url)
+  public func fileHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
+    return checker.fileHasInMemoryModifications(uri)
   }
 }
 
@@ -212,14 +212,14 @@ private struct IndexOutOfDateChecker {
     }
   }
 
-  /// Caches whether a file URL has modifications in `documentManager` that haven't been saved to disk yet.
-  private var fileHasInMemoryModificationsCache: [URL: Bool] = [:]
+  /// Caches whether a document has modifications in `documentManager` that haven't been saved to disk yet.
+  private var fileHasInMemoryModificationsCache: [DocumentURI: Bool] = [:]
 
-  /// File URLs to modification times that have already been computed.
-  private var modTimeCache: [URL: ModificationTime] = [:]
+  /// Document URIs to modification times that have already been computed.
+  private var modTimeCache: [DocumentURI: ModificationTime] = [:]
 
-  /// File URLs to whether they exist on the file system
-  private var fileExistsCache: [URL: Bool] = [:]
+  /// Document URIs to whether they exist on the file system
+  private var fileExistsCache: [DocumentURI: Bool] = [:]
 
   init(checkLevel: IndexCheckLevel) {
     self.checkLevel = checkLevel
@@ -230,16 +230,16 @@ private struct IndexOutOfDateChecker {
   /// Returns `true` if the source file for the given symbol location exists and has not been modified after it has been
   /// indexed.
   mutating func isUpToDate(_ symbolLocation: SymbolLocation) -> Bool {
-    let url = URL(fileURLWithPath: symbolLocation.path, isDirectory: false)
+    let uri = DocumentURI(filePath: symbolLocation.path, isDirectory: false)
     switch checkLevel {
     case .inMemoryModifiedFiles(let documentManager):
-      if fileHasInMemoryModifications(url, documentManager: documentManager) {
+      if fileHasInMemoryModifications(uri, documentManager: documentManager) {
         return false
       }
       fallthrough
     case .modifiedFiles:
       do {
-        let sourceFileModificationDate = try modificationDate(of: url)
+        let sourceFileModificationDate = try modificationDate(of: uri)
         switch sourceFileModificationDate {
         case .fileDoesNotExist:
           return false
@@ -251,7 +251,7 @@ private struct IndexOutOfDateChecker {
         return true
       }
     case .deletedFiles:
-      return fileExists(at: url)
+      return fileExists(at: uri)
     }
   }
 
@@ -262,7 +262,7 @@ private struct IndexOutOfDateChecker {
   /// If `mainFile` is passed, then `filePath` is a header file that won't have a unit associated with it. `mainFile` is
   /// assumed to be a file that imports `url`. To check that `url` has an up-to-date unit, check that the latest unit
   /// for `mainFile` is newer than the mtime of the header file at `url`.
-  mutating func indexHasUpToDateUnit(for filePath: URL, mainFile: URL?, index: IndexStoreDB) -> Bool {
+  mutating func indexHasUpToDateUnit(for filePath: DocumentURI, mainFile: DocumentURI?, index: IndexStoreDB) -> Bool {
     switch checkLevel {
     case .inMemoryModifiedFiles(let documentManager):
       if fileHasInMemoryModifications(filePath, documentManager: documentManager) {
@@ -273,7 +273,9 @@ private struct IndexOutOfDateChecker {
       // If there are no in-memory modifications check if there are on-disk modifications.
       fallthrough
     case .modifiedFiles:
-      guard let lastUnitDate = index.dateOfLatestUnitFor(filePath: (mainFile ?? filePath).path) else {
+      guard let fileURL = (mainFile ?? filePath).fileURL,
+        let lastUnitDate = index.dateOfLatestUnitFor(filePath: fileURL.path)
+      else {
         return false
       }
       do {
@@ -300,23 +302,25 @@ private struct IndexOutOfDateChecker {
   /// `documentManager` must always be the same between calls to `hasFileInMemoryModifications` since it is not part of
   /// the cache key. This is fine because we always assume the `documentManager` to come from the associated value of
   /// `CheckLevel.imMemoryModifiedFiles`, which is constant.
-  private mutating func fileHasInMemoryModifications(_ url: URL, documentManager: InMemoryDocumentManager) -> Bool {
-    if let cached = fileHasInMemoryModificationsCache[url] {
+  private mutating func fileHasInMemoryModifications(_ uri: DocumentURI, documentManager: InMemoryDocumentManager)
+    -> Bool
+  {
+    if let cached = fileHasInMemoryModificationsCache[uri] {
       return cached
     }
-    let hasInMemoryModifications = documentManager.fileHasInMemoryModifications(url)
-    fileHasInMemoryModificationsCache[url] = hasInMemoryModifications
+    let hasInMemoryModifications = documentManager.fileHasInMemoryModifications(uri)
+    fileHasInMemoryModificationsCache[uri] = hasInMemoryModifications
     return hasInMemoryModifications
   }
 
-  /// Returns true if the file at the given URL has a different content in the document manager than on-disk. This is
+  /// Returns true if the file at the given URI has a different content in the document manager than on-disk. This is
   /// the case if the user made edits to the file but didn't save them yet.
   ///
   /// - Important: This must only be called on an `IndexOutOfDateChecker` with a `checkLevel` of `inMemoryModifiedFiles`
-  mutating func fileHasInMemoryModifications(_ url: URL) -> Bool {
+  mutating func fileHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
     switch checkLevel {
     case .inMemoryModifiedFiles(let documentManager):
-      return fileHasInMemoryModifications(url, documentManager: documentManager)
+      return fileHasInMemoryModifications(uri, documentManager: documentManager)
     case .modifiedFiles, .deletedFiles:
       logger.fault(
         "fileHasInMemoryModifications(at:) must only be called on an `IndexOutOfDateChecker` with check level .inMemoryModifiedFiles"
@@ -325,9 +329,12 @@ private struct IndexOutOfDateChecker {
     }
   }
 
-  private func modificationDateUncached(of url: URL) throws -> ModificationTime {
+  private func modificationDateUncached(of uri: DocumentURI) throws -> ModificationTime {
     do {
-      let attributes = try FileManager.default.attributesOfItem(atPath: url.resolvingSymlinksInPath().path)
+      guard let fileURL = uri.fileURL else {
+        return .fileDoesNotExist
+      }
+      let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.resolvingSymlinksInPath().path)
       guard let modificationDate = attributes[FileAttributeKey.modificationDate] as? Date else {
         throw Error.fileAttributesDontHaveModificationDate
       }
@@ -337,21 +344,26 @@ private struct IndexOutOfDateChecker {
     }
   }
 
-  private mutating func modificationDate(of url: URL) throws -> ModificationTime {
-    if let cached = modTimeCache[url] {
+  private mutating func modificationDate(of uri: DocumentURI) throws -> ModificationTime {
+    if let cached = modTimeCache[uri] {
       return cached
     }
-    let modTime = try modificationDateUncached(of: url)
-    modTimeCache[url] = modTime
+    let modTime = try modificationDateUncached(of: uri)
+    modTimeCache[uri] = modTime
     return modTime
   }
 
-  private mutating func fileExists(at url: URL) -> Bool {
-    if let cached = fileExistsCache[url] {
+  private mutating func fileExists(at uri: DocumentURI) -> Bool {
+    if let cached = fileExistsCache[uri] {
       return cached
     }
-    let fileExists = FileManager.default.fileExists(atPath: url.path)
-    fileExistsCache[url] = fileExists
+    let fileExists =
+      if let fileUrl = uri.fileURL {
+        FileManager.default.fileExists(atPath: fileUrl.path)
+      } else {
+        false
+      }
+    fileExistsCache[uri] = fileExists
     return fileExists
   }
 }

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -260,13 +260,7 @@ public final actor SemanticIndexManager {
         await testHooks.buildGraphGenerationDidFinish?()
         let index = index.checked(for: .modifiedFiles)
         let filesToIndex = await self.buildSystemManager.sourceFiles().lazy.map(\.uri)
-          .filter { uri in
-            guard let url = uri.fileURL else {
-              // The URI is not a file, so there's nothing we can index.
-              return false
-            }
-            return !index.hasUpToDateUnit(for: url)
-          }
+          .filter { !index.hasUpToDateUnit(for: $0) }
         await scheduleBackgroundIndex(files: filesToIndex)
         generateBuildGraphTask = nil
       }

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -206,11 +206,7 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       // If we know that the file is up-to-date without having ot hit the index, do that because it's fastest.
       return
     }
-    guard let sourceFileUrl = file.sourceFile.fileURL else {
-      // The URI is not a file, so there's nothing we can index.
-      return
-    }
-    guard !index.checked(for: .modifiedFiles).hasUpToDateUnit(for: sourceFileUrl, mainFile: file.mainFile.fileURL)
+    guard !index.checked(for: .modifiedFiles).hasUpToDateUnit(for: file.sourceFile, mainFile: file.mainFile)
     else {
       logger.debug("Not indexing \(file.forLogging) because index has an up-to-date unit")
       // We consider a file's index up-to-date if we have any up-to-date unit. Changing build settings does not

--- a/Sources/SourceKitLSP/CreateBuildSystem.swift
+++ b/Sources/SourceKitLSP/CreateBuildSystem.swift
@@ -33,9 +33,9 @@ func createBuildSystem(
     )
     return nil
   }
-  func createSwiftPMBuildSystem(rootUrl: URL) async -> SwiftPMBuildSystem? {
+  func createSwiftPMBuildSystem(rootUri: DocumentURI) async -> SwiftPMBuildSystem? {
     return await SwiftPMBuildSystem(
-      url: rootUrl,
+      uri: rootUri,
       toolchainRegistry: toolchainRegistry,
       buildSetup: options.buildSetup,
       isForIndexBuild: options.indexOptions.enableBackgroundIndexing,
@@ -58,14 +58,14 @@ func createBuildSystem(
     switch options.buildSetup.defaultWorkspaceType {
     case .buildServer: await createBuildServerBuildSystem(rootPath: rootPath)
     case .compilationDatabase: createCompilationDatabaseBuildSystem(rootPath: rootPath)
-    case .swiftPM: await createSwiftPMBuildSystem(rootUrl: rootUrl)
+    case .swiftPM: await createSwiftPMBuildSystem(rootUri: rootUri)
     case nil: nil
     }
   if let defaultBuildSystem {
     return defaultBuildSystem
   } else if let buildServer = await createBuildServerBuildSystem(rootPath: rootPath) {
     return buildServer
-  } else if let swiftpm = await createSwiftPMBuildSystem(rootUrl: rootUrl) {
+  } else if let swiftpm = await createSwiftPMBuildSystem(rootUri: rootUri) {
     return swiftpm
   } else if let compdb = createCompilationDatabaseBuildSystem(rootPath: rootPath) {
     return compdb

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -191,12 +191,12 @@ public final class DocumentManager: InMemoryDocumentManager, Sendable {
     }
   }
 
-  public func fileHasInMemoryModifications(_ url: URL) -> Bool {
-    guard let document = try? latestSnapshot(DocumentURI(url)) else {
+  public func fileHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
+    guard let document = try? latestSnapshot(uri), let fileURL = uri.fileURL else {
       return false
     }
 
-    guard let onDiskFileContents = try? String(contentsOf: url, encoding: .utf8) else {
+    guard let onDiskFileContents = try? String(contentsOf: fileURL, encoding: .utf8) else {
       // If we can't read the file on disk, it can't match any on-disk state, so it's in-memory state
       return true
     }

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -24,7 +24,7 @@ extension UncheckedIndex {
       mainFiles = Set(
         mainFilePaths
           .filter { FileManager.default.fileExists(atPath: $0) }
-          .map({ DocumentURI(URL(fileURLWithPath: $0, isDirectory: false)) })
+          .map({ DocumentURI(filePath: $0, isDirectory: false) })
       )
     } else {
       mainFiles = []

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -75,7 +75,7 @@ struct CursorInfo {
         // FIXME: we need to convert the utf8/utf16 column, which may require reading the file!
         utf16index: column - 1
       )
-      location = Location(uri: DocumentURI(URL(fileURLWithPath: filepath)), range: Range(position))
+      location = Location(uri: DocumentURI(filePath: filepath, isDirectory: false), range: Range(position))
     } else {
       location = nil
     }
@@ -134,7 +134,7 @@ extension SwiftLanguageService {
   /// USR, and declaration location. This request does minimal processing of the result.
   ///
   /// - Parameters:
-  ///   - url: Document URL in which to perform the request. Must be an open document.
+  ///   - url: Document URI in which to perform the request. Must be an open document.
   ///   - range: The position range within the document to lookup the symbol at.
   ///   - completion: Completion block to asynchronously receive the CursorInfo, or error.
   func cursorInfo(

--- a/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactoring.swift
@@ -33,7 +33,7 @@ struct SemanticRefactoring {
   /// - Parameters:
   ///   - title: The title of the refactoring action.
   ///   - dict: Response dictionary to extract information from.
-  ///   - url: The client URL that triggered the `semantic_refactoring` request.
+  ///   - snapshot: The snapshot that triggered the `semantic_refactoring` request.
   ///   - keys: The sourcekitd key set to use for looking up into `dict`.
   init?(_ title: String, _ dict: SKDResponseDictionary, _ snapshot: DocumentSnapshot, _ keys: sourcekitd_api_keys) {
     guard let categorizedEdits: SKDResponseArray = dict[keys.categorizedEdits] else {
@@ -108,9 +108,7 @@ extension SwiftLanguageService {
   /// Wraps the information returned by sourcekitd's `semantic_refactoring` request, such as the necessary edits and placeholder locations.
   ///
   /// - Parameters:
-  ///   - url: Document URL in which to perform the request. Must be an open document.
-  ///   - command: The semantic refactor `Command` that triggered this request.
-  ///   - completion: Completion block to asynchronously receive the SemanticRefactoring data, or error.
+  ///   - refactorCommand: The semantic refactor `Command` that triggered this request.
   func semanticRefactoring(
     _ refactorCommand: SemanticRefactorCommand
   ) async throws -> SemanticRefactoring {

--- a/Sources/SourceKitLSP/SymbolLocation+DocumentURI.swift
+++ b/Sources/SourceKitLSP/SymbolLocation+DocumentURI.swift
@@ -15,6 +15,6 @@ import LanguageServerProtocol
 
 extension SymbolLocation {
   var documentUri: DocumentURI {
-    return DocumentURI(URL(fileURLWithPath: self.path))
+    return DocumentURI(filePath: self.path, isDirectory: false)
   }
 }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -140,7 +140,7 @@ public final class Workspace: Sendable {
     }
   }
 
-  /// Creates a workspace for a given root `URL`, inferring the `ExternalWorkspace` if possible.
+  /// Creates a workspace for a given root `DocumentURI`, inferring the `ExternalWorkspace` if possible.
   ///
   /// - Parameters:
   ///   - url: The root directory of the workspace, which must be a valid path.

--- a/Tests/SKCoreTests/CompilationDatabaseTests.swift
+++ b/Tests/SKCoreTests/CompilationDatabaseTests.swift
@@ -157,9 +157,9 @@ final class CompilationDatabaseTests: XCTestCase {
 
     let db = JSONCompilationDatabase([cmd1, cmd2, cmd3])
 
-    XCTAssertEqual(db[URL(fileURLWithPath: "b")], [cmd1])
-    XCTAssertEqual(db[URL(fileURLWithPath: "/c/b")], [cmd2])
-    XCTAssertEqual(db[URL(fileURLWithPath: "/b")], [cmd3])
+    XCTAssertEqual(db[DocumentURI(filePath: "b", isDirectory: false)], [cmd1])
+    XCTAssertEqual(db[DocumentURI(filePath: "/c/b", isDirectory: false)], [cmd2])
+    XCTAssertEqual(db[DocumentURI(filePath: "/b", isDirectory: false)], [cmd3])
   }
 
   func testJSONCompilationDatabaseFromDirectory() throws {
@@ -255,7 +255,7 @@ final class CompilationDatabaseTests: XCTestCase {
     XCTAssertNotNil(db)
 
     XCTAssertEqual(
-      db![URL(fileURLWithPath: "/a/b")],
+      db![DocumentURI(filePath: "/a/b", isDirectory: false)],
       [
         CompilationDatabase.Command(
           directory: try AbsolutePath(validating: "/a").pathString,


### PR DESCRIPTION
The originator for this change was that I noticed that we weren’t able to index files that contain a `+` because we wouldn’t get build settings for them. This is because `SwiftPMBuildSystem` had a URL comparison to check if the file that we are requesting build settings for is part of the target’s source files. Now, the target’s source files represented the `+` as a literal `+` while the requested file name had it escaped as `%2B`, so we incorrectly inferred that the source file was not part of the target.

`DocumentURI` accounts for this and compares the scheme + normalized path separately. So, the solution is to work in terms of `DocumentURI` in `SwiftPMBuildSystem`.

While doing this, I also changed other files to use `DocumentURI` instead of `URL` in case they have similar issues.