### PR TITLE
Show container name in call hierarchy item name instead of detail field

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1851,11 +1851,28 @@ extension SourceKitLSPServer {
     containerName: String?,
     location: Location
   ) -> CallHierarchyItem {
-    CallHierarchyItem(
-      name: symbol.name,
+    let name: String
+    if let containerName {
+      switch symbol.language {
+      case .objc where symbol.kind == .instanceMethod || symbol.kind == .instanceProperty:
+        name = "-[\(containerName) \(symbol.name)]"
+      case .objc where symbol.kind == .classMethod || symbol.kind == .classProperty:
+        name = "+[\(containerName) \(symbol.name)]"
+      case .cxx, .c, .objc:
+        // C shouldn't have container names for call hierarchy and Objective-C should be covered above.
+        // Fall back to using the C++ notation using `::`.
+        name = "\(containerName)::\(symbol.name)"
+      case .swift:
+        name = "\(containerName).\(symbol.name)"
+      }
+    } else {
+      name = symbol.name
+    }
+    return CallHierarchyItem(
+      name: name,
       kind: symbol.kind.asLspSymbolKind(),
       tags: nil,
-      detail: containerName,
+      detail: nil,
       uri: location.uri,
       range: location.range,
       selectionRange: location.range,
@@ -2289,8 +2306,15 @@ extension IndexSymbolKind {
       return .struct
     case .parameter:
       return .typeParameter
-
-    default:
+    case .module, .namespace:
+      return .namespace
+    case .field:
+      return .property
+    case .constructor:
+      return .constructor
+    case .destructor:
+      return .null
+    case .commentTag, .concept, .extension, .macro, .namespaceAlias, .typealias, .union, .unknown, .using:
       return .null
     }
   }


### PR DESCRIPTION
The container name isn’t displayed very prominently and it’s easy to miss. I think the call hierarchy looks nicer when we prepend the container name with language-specific logic.

Before
<img width="545" alt="Screenshot 2024-06-01 at 16 53 23" src="https://github.com/apple/sourcekit-lsp/assets/4062178/cd4a66b7-51f9-422b-9435-890b95db6432">

After
<img width="543" alt="Screenshot 2024-06-01 at 16 59 05" src="https://github.com/apple/sourcekit-lsp/assets/4062178/bf86f13d-2327-4c26-a95a-065c51907528">


rdar://128396648