### PR TITLE
Add an extension to the LogMessageNotification to add a message to a specific log in the client

### DIFF
--- a/Sources/LanguageServerProtocol/Notifications/LogMessageNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/LogMessageNotification.swift
@@ -24,8 +24,15 @@ public struct LogMessageNotification: NotificationType, Hashable {
   /// The contents of the message.
   public var message: String
 
-  public init(type: WindowMessageType, message: String) {
+  /// If specified, the client should log the message to a log with this name instead of the standard log for this LSP
+  /// server.
+  ///
+  /// **(LSP Extension)**
+  public var logName: String?
+
+  public init(type: WindowMessageType, message: String, logName: String?) {
     self.type = type
     self.message = message
+    self.logName = logName
   }
 }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -845,7 +845,8 @@ extension SourceKitLSPServer {
           \(result.taskDescription) finished in \(result.duration)
           \(result.command)
           \(result.output)
-          """
+          """,
+        logName: "SourceKit-LSP: Indexing"
       )
     )
   }


### PR DESCRIPTION
If the editor has support for this LSP extension, it can create a separate output view for the index log.

For example, in VS Code, we could have one output view for the standard LSP logging (which are the messages between VS Code and SourceKit-LSP if verbose logging is enabled in VS Code) and a separate log that shows information about background indexing.

rdar://128572032