### PR TITLE
Move debug subcommands of sourcekit-lsp to a `debug` subcommand and unhide them

### DIFF
--- a/Sources/Diagnose/CMakeLists.txt
+++ b/Sources/Diagnose/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(Diagnose STATIC
   CommandConfiguration+Sendable.swift
   CommandLineArgumentsReducer.swift
+  DebugCommand.swift
   DiagnoseCommand.swift
   IndexCommand.swift
   MergeSwiftFiles.swift

--- a/Sources/Diagnose/DebugCommand.swift
+++ b/Sources/Diagnose/DebugCommand.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+
+public struct DebugCommand: ParsableCommand {
+  public static let configuration = CommandConfiguration(
+    commandName: "debug",
+    abstract: "Commands to debug sourcekit-lsp. Intended for developers of sourcekit-lsp",
+    subcommands: [
+      IndexCommand.self,
+      ReduceCommand.self,
+      ReduceFrontendCommand.self,
+      RunSourceKitdRequestCommand.self,
+    ]
+  )
+
+  public init() {}
+}

--- a/Sources/Diagnose/IndexCommand.swift
+++ b/Sources/Diagnose/IndexCommand.swift
@@ -55,8 +55,7 @@ private actor IndexLogMessageHandler: MessageHandler {
 public struct IndexCommand: AsyncParsableCommand {
   public static let configuration: CommandConfiguration = CommandConfiguration(
     commandName: "index",
-    abstract: "Index a project and print all the processes executed for it as well as their outputs",
-    shouldDisplay: false
+    abstract: "Index a project and print all the processes executed for it as well as their outputs"
   )
 
   @Option(

--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -22,8 +22,7 @@ import class TSCUtility.PercentProgressAnimation
 public struct ReduceCommand: AsyncParsableCommand {
   public static let configuration: CommandConfiguration = CommandConfiguration(
     commandName: "reduce",
-    abstract: "Reduce a single sourcekitd crash",
-    shouldDisplay: false
+    abstract: "Reduce a single sourcekitd crash"
   )
 
   @Option(name: .customLong("request-file"), help: "Path to a sourcekitd request to reduce.")

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -22,8 +22,7 @@ import class TSCUtility.PercentProgressAnimation
 public struct ReduceFrontendCommand: AsyncParsableCommand {
   public static let configuration: CommandConfiguration = CommandConfiguration(
     commandName: "reduce-frontend",
-    abstract: "Reduce a single swift-frontend crash",
-    shouldDisplay: false
+    abstract: "Reduce a single swift-frontend crash"
   )
 
   #if canImport(Darwin)

--- a/Sources/Diagnose/RunSourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/RunSourcekitdRequestCommand.swift
@@ -21,8 +21,7 @@ import struct TSCBasic.AbsolutePath
 public struct RunSourceKitdRequestCommand: AsyncParsableCommand {
   public static let configuration = CommandConfiguration(
     commandName: "run-sourcekitd-request",
-    abstract: "Run a sourcekitd request and print its result",
-    shouldDisplay: false
+    abstract: "Run a sourcekitd request and print its result"
   )
 
   @Option(

--- a/Sources/Diagnose/SourceKitDRequestExecutor.swift
+++ b/Sources/Diagnose/SourceKitDRequestExecutor.swift
@@ -161,6 +161,7 @@ public class OutOfProcessSourceKitRequestExecutor: SourceKitRequestExecutor {
     let process = Process(
       arguments: [
         ProcessInfo.processInfo.arguments[0],
+        "debug",
         "run-sourcekitd-request",
         "--sourcekitd",
         sourcekitd.path,

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -105,10 +105,7 @@ struct SourceKitLSP: AsyncParsableCommand {
     abstract: "Language Server Protocol implementation for Swift and C-based languages",
     subcommands: [
       DiagnoseCommand.self,
-      IndexCommand.self,
-      ReduceCommand.self,
-      ReduceFrontendCommand.self,
-      RunSourceKitdRequestCommand.self,
+      DebugCommand.self,
     ]
   )
 


### PR DESCRIPTION
We have a few subcommands on sourcekit-lsp that are intended for debugging sourcekit-lsp and that are thus hidden. This moves them all to a `debug` subcommand (eg. `sourcekit-lsp debug run-sourcekitd-request`) and unhides them. That makes them more discoverable for interested users and also helps developers of sourcekit-lsp remember what they are called.

rdar://128443298