### PR TITLE
Show “Preparing targets” as index status if we only have preparation tasks and no index tasks

### DIFF
--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -98,7 +98,11 @@ actor IndexProgressManager {
       // `indexTasksWereScheduled` calls yet but the semantic index managers already track them in their in-progress tasks.
       // Clip the finished tasks to 0 because showing a negative number there looks stupid.
       let finishedTasks = max(queuedIndexTasks - indexTasks.count, 0)
-      message = "\(finishedTasks) / \(queuedIndexTasks)"
+      if indexTasks.isEmpty {
+        message = "Preparing targets"
+      } else {
+        message = "\(finishedTasks) / \(queuedIndexTasks)"
+      }
       if await sourceKitLSPServer.options.experimentalFeatures.contains(.showActivePreparationTasksInProgress) {
         var inProgressTasks: [String] = []
         inProgressTasks += preparationTasks.filter { $0.value == .executing }


### PR DESCRIPTION
I was wondering for a while why we were showing “Indexing 0 / 0” as the index progress. I think it’s if we only have a preparation task but no index tasks running. I’m not entirely sure how this happens because preparation should only happen for two reasons:
- We are preparing a target so we can index a files -> We should have an active index task
- We are preparing a file for editor functionality of the current file -> we should have a `inProgressPrepareForEditorTask`

Maybe I’ll understand it once we have this change in. It seems like a worthwhile change in any way.