### PR TITLE
Remove `showActivePreparationTasksInProgress` experimental feature

### DIFF
--- a/Sources/SourceKitLSP/ExperimentalFeatures.swift
+++ b/Sources/SourceKitLSP/ExperimentalFeatures.swift
@@ -15,12 +15,4 @@
 public enum ExperimentalFeature: String, Codable, Sendable, CaseIterable {
   /// Enable background indexing.
   case backgroundIndexing = "background-indexing"
-
-  /// Show the files that are currently being indexed / the targets that are currently being prepared in the work done
-  /// progress.
-  ///
-  /// This is an option because VS Code tries to render a multi-line work done progress into a single line text field in
-  /// the status bar, which looks broken. But at the same time, it is very useful to get a feeling about what's
-  /// currently happening indexing-wise.
-  case showActivePreparationTasksInProgress = "show-active-preparation-tasks-in-progress"
 }

--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LSPLogging
 import LanguageServerProtocol
 import SKCore
 import SKSupport
@@ -100,19 +101,11 @@ actor IndexProgressManager {
       let finishedTasks = max(queuedIndexTasks - indexTasks.count, 0)
       if indexTasks.isEmpty {
         message = "Preparing targets"
+        if preparationTasks.isEmpty {
+          logger.fault("Indexer status is 'indexing' but there is no update indexstore or preparation task")
+        }
       } else {
         message = "\(finishedTasks) / \(queuedIndexTasks)"
-      }
-      if await sourceKitLSPServer.options.experimentalFeatures.contains(.showActivePreparationTasksInProgress) {
-        var inProgressTasks: [String] = []
-        inProgressTasks += preparationTasks.filter { $0.value == .executing }
-          .map { "- Preparing \($0.key.targetID)" }
-          .sorted()
-        inProgressTasks += indexTasks.filter { $0.value == .executing }
-          .map { "- Indexing \($0.key.fileURL?.lastPathComponent ?? $0.key.pseudoPath)" }
-          .sorted()
-
-        message += "\n\n" + inProgressTasks.joined(separator: "\n")
       }
       if queuedIndexTasks != 0 {
         percentage = Int(Double(finishedTasks) / Double(queuedIndexTasks) * 100)


### PR DESCRIPTION
The `showActivePreparationTasksInProgress` didn’t turn out to be terribly useful and with the streaming index log (https://github.com/apple/sourcekit-lsp/pull/1382), we should have the functionality to view which index tasks are currently running. So, we should remove the feature.

rdar://129109830