### PR TITLE
Share module cache between test projects

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -574,6 +574,30 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
       "--disable-index-store",
       "--target", target.targetID,
     ]
+    if self.toolsBuildParameters.configuration != self.destinationBuildParameters.configuration {
+      logger.fault(
+        """
+        Preparation is assuming that tools and destination are built using the same configuration, \
+        got tools: \(String(describing: self.toolsBuildParameters.configuration), privacy: .public), \
+        destination: \(String(describing: self.destinationBuildParameters.configuration), privacy: .public)
+        """
+      )
+    }
+    arguments += ["-c", self.destinationBuildParameters.configuration.rawValue]
+    if self.toolsBuildParameters.flags != self.destinationBuildParameters.flags {
+      logger.fault(
+        """
+        Preparation is assuming that tools and destination are built using the same build flags, \
+        got tools: \(String(describing: self.toolsBuildParameters.flags)), \
+        destination: \(String(describing: self.destinationBuildParameters.configuration))
+        """
+      )
+    }
+    arguments += self.destinationBuildParameters.flags.cCompilerFlags.flatMap { ["-Xcc", $0] }
+    arguments += self.destinationBuildParameters.flags.cxxCompilerFlags.flatMap { ["-Xcxx", $0] }
+    arguments += self.destinationBuildParameters.flags.swiftCompilerFlags.flatMap { ["-Xswiftc", $0] }
+    arguments += self.destinationBuildParameters.flags.linkerFlags.flatMap { ["-Xlinker", $0] }
+    arguments += self.destinationBuildParameters.flags.xcbuildFlags?.flatMap { ["-Xxcbuild", $0] } ?? []
     if await swiftBuildSupportsPrepareForIndexing {
       arguments.append("--experimental-prepare-for-indexing")
     }

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -61,6 +61,11 @@ public struct IndexedSingleSwiftFileTestProject {
       "-index-store-path", indexURL.path,
       "-typecheck",
     ]
+    if let globalModuleCache {
+      compilerArguments += [
+        "-module-cache-path", globalModuleCache.path,
+      ]
+    }
     if !indexSystemModules {
       compilerArguments.append("-index-ignore-system-modules")
     }

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -209,7 +209,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
     guard let swift = await ToolchainRegistry.forTesting.default?.swift?.asURL else {
       throw Error.swiftNotFound
     }
-    let arguments = [
+    var arguments = [
       swift.path,
       "build",
       "--package-path", path.path,
@@ -217,6 +217,11 @@ public class SwiftPMTestProject: MultiFileTestProject {
       "-Xswiftc", "-index-ignore-system-modules",
       "-Xcc", "-index-ignore-system-symbols",
     ]
+    if let globalModuleCache {
+      arguments += [
+        "-Xswiftc", "-module-cache-path", "-Xswiftc", globalModuleCache.path,
+      ]
+    }
     var environment = ProcessEnv.block
     // FIXME: SwiftPM does not index-while-building on non-Darwin platforms for C-family files (rdar://117744039).
     // Force-enable index-while-building with the environment variable.

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -112,3 +112,15 @@ fileprivate extension URL {
     #endif
   }
 }
+
+var globalModuleCache: URL? = {
+  if let customModuleCache = ProcessInfo.processInfo.environment["SOURCEKIT_LSP_TEST_MODULE_CACHE"] {
+    if customModuleCache.isEmpty {
+      return nil
+    }
+    return URL(fileURLWithPath: customModuleCache)
+  }
+  return FileManager.default.temporaryDirectory.realpath
+    .appendingPathComponent("sourcekit-lsp-test-scratch")
+    .appendingPathComponent("shared-module-cache")
+}()

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -22,12 +22,7 @@ import XCTest
 
 final class SwiftInterfaceTests: XCTestCase {
   func testSystemModuleInterface() async throws {
-    // This is the only test that references modules from the SDK (Foundation).
-    // `testSystemModuleInterface` has been flaky for a long while and a
-    // hypothesis is that it was failing because of a malformed global module
-    // cache that might still be present from previous CI runs. If we use a
-    // local module cache, we define away that source of bugs.
-    let testClient = try await TestSourceKitLSPClient(useGlobalModuleCache: false)
+    let testClient = try await TestSourceKitLSPClient()
     let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
     let uri = DocumentURI(url)
 


### PR DESCRIPTION
This improves serial test execution time of eg. `DocumentTestDiscoveryTests` from 36s to 22s because we don’t need to re-build the XCTest module from its interface when using an open source toolchain.

This also uncovered that we weren‘t passing the build setup flags to the prepare command.

rdar://126493151