### PR TITLE
Add tests to rename C++ symbols exposed to Swift

### DIFF
--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -177,7 +177,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
     if !manifest.contains("swift-tools-version") {
       // Tests specify a shorthand package manifest that doesn't contain the tools version boilerplate.
       manifest = """
-        // swift-tools-version: 5.7
+        // swift-tools-version: 5.10
 
         import PackageDescription
 

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -176,10 +176,6 @@ public struct UncheckedIndex: Sendable {
     return CheckedIndex(index: underlyingIndexStoreDB, checkLevel: checkLevel)
   }
 
-  public func symbolProvider(for sourceFilePath: String) -> SymbolProviderKind? {
-    return underlyingIndexStoreDB.symbolProvider(for: sourceFilePath)
-  }
-
   /// Wait for IndexStoreDB to be updated based on new unit files written to disk.
   public func pollForUnitChangesAndWait() {
     self.underlyingIndexStoreDB.pollForUnitChangesAndWait()

--- a/Tests/SourceKitLSPTests/CrossLanguageRenameTests.swift
+++ b/Tests/SourceKitLSPTests/CrossLanguageRenameTests.swift
@@ -23,6 +23,16 @@ private let libAlibBPackageManifest = """
   )
   """
 
+private let libAlibBCxxInteropPackageManifest = """
+  let package = Package(
+    name: "MyLibrary",
+    targets: [
+    .target(name: "LibA"),
+    .target(name: "LibB", dependencies: ["LibA"], swiftSettings: [.interoperabilityMode(.Cxx)]),
+    ]
+  )
+  """
+
 final class CrossLanguageRenameTests: XCTestCase {
   func testZeroArgCFunction() async throws {
     try await SkipUnless.clangdSupportsIndexBasedRename()
@@ -731,6 +741,142 @@ final class CrossLanguageRenameTests: XCTestCase {
         """,
       ],
       manifest: libAlibBPackageManifest
+    )
+  }
+
+  func testRenameCxxClassExposedToSwift() async throws {
+    try await SkipUnless.clangdSupportsIndexBasedRename()
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        struct 1️⃣Foo {};
+        """,
+        "LibA/LibA.cpp": "",
+        "LibB/LibB.swift": """
+        import LibA
+
+        func test(foo: 2️⃣Foo) {}
+        """,
+      ],
+      headerFileLanguage: .cpp,
+      newName: "Bar",
+      expectedPrepareRenamePlaceholder: "Foo",
+      expected: [
+        "LibA/include/LibA.h": """
+        struct Bar {};
+        """,
+        "LibA/LibA.cpp": "",
+        "LibB/LibB.swift": """
+        import LibA
+
+        func test(foo: Bar) {}
+        """,
+      ],
+      manifest: libAlibBCxxInteropPackageManifest
+    )
+  }
+
+  func testRenameCxxMethodExposedToSwift() async throws {
+    try await SkipUnless.clangdSupportsIndexBasedRename()
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          int 1️⃣doStuff() const;
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        int Foo::2️⃣doStuff() const {
+          return 42;
+        }
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+
+        func test(foo: Foo) {
+          foo.3️⃣doStuff()
+        }
+        """,
+      ],
+      headerFileLanguage: .cpp,
+      newName: "doNewStuff",
+      expectedPrepareRenamePlaceholder: "doStuff",
+      expected: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          int doNewStuff() const;
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        int Foo::doNewStuff() const {
+          return 42;
+        }
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+
+        func test(foo: Foo) {
+          foo.doNewStuff()
+        }
+        """,
+      ],
+      manifest: libAlibBCxxInteropPackageManifest
+    )
+  }
+
+  func testRenameSwiftMethodExposedToSwift() async throws {
+    try await SkipUnless.clangdSupportsIndexBasedRename()
+    try await assertMultiFileRename(
+      files: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          int 1️⃣doStuff() const;
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        int Foo::2️⃣doStuff() const {
+          return 42;
+        }
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+
+        func test(foo: Foo) {
+          foo.3️⃣doStuff()
+        }
+        """,
+      ],
+      headerFileLanguage: .cpp,
+      newName: "doNewStuff",
+      expectedPrepareRenamePlaceholder: "doStuff",
+      expected: [
+        "LibA/include/LibA.h": """
+        struct Foo {
+          int doNewStuff() const;
+        };
+        """,
+        "LibA/LibA.cpp": """
+        #include "LibA.h"
+
+        int Foo::doNewStuff() const {
+          return 42;
+        }
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+
+        func test(foo: Foo) {
+          foo.doNewStuff()
+        }
+        """,
+      ],
+      manifest: libAlibBCxxInteropPackageManifest
     )
   }
 }


### PR DESCRIPTION
This exposes an issue where we wouldn’t rename a symbol on the clang side f a symbol was only defined in a header and not a C/C++/... file. In that case we failed to determine the language of the header file because there was no unit file that contained the header file. The cleaner solution here is to ask for the symbol provider of each occurrence directly.

rdar://127391127