### PR TITLE
Log when a sourcekitd request gets cancelled

### DIFF
--- a/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
+++ b/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
@@ -31,7 +31,6 @@ extension sourcekitd_api_values: @unchecked Sendable {}
 /// Users of this class should not call the api functions `initialize`, `shutdown`, or
 /// `set_notification_handler`, which are global state managed internally by this class.
 public actor DynamicallyLoadedSourceKitD: SourceKitD {
-
   /// The path to the sourcekitd dylib.
   public let path: AbsolutePath
 
@@ -142,6 +141,16 @@ public actor DynamicallyLoadedSourceKitD: SourceKitD {
     }
   }
 
+  public nonisolated func logRequestCancellation(request: SKDRequestDictionary) {
+    // We don't need to log which request has been cancelled because we can associate the cancellation log message with
+    // the send message via the log
+    logger.info(
+      """
+      Cancelling sourcekitd request:
+      \(request.forLogging)
+      """
+    )
+  }
 }
 
 struct WeakSKDNotificationHandler: Sendable {

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -59,6 +59,9 @@ public protocol SourceKitD: AnyObject, Sendable {
   /// This log call is issued during normal operation. It is acceptable for the logger to truncate the log message
   /// to achieve good performance.
   func log(response: SKDResponse)
+
+  /// Log that the given request has been cancelled.
+  func logRequestCancellation(request: SKDRequestDictionary)
 }
 
 public enum SKDError: Error, Equatable {
@@ -97,6 +100,7 @@ extension SourceKitD {
       return handle
     } cancel: { handle in
       if let handle {
+        logRequestCancellation(request: req)
         api.cancel_request(handle)
       }
     }

--- a/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
@@ -80,4 +80,5 @@ final class FakeSourceKitD: SourceKitD {
   public func log(request: SKDRequestDictionary) {}
   public func log(response: SKDResponse) {}
   public func log(crashedRequest: SKDRequestDictionary, fileContents: String?) {}
+  public func logRequestCancellation(request: SKDRequestDictionary) {}
 }


### PR DESCRIPTION
I saw a failure in CI where a sourcekitd diagnostic request got cancelled without an LSP cancellation request. I am suspecting that there is some implicit cancellation going on in sourcekitd despite `key.cancel_builds: 0`, which doesn’t make sense to me. Adding some explicit logging to sourcekit-lsp to check if we cancel the request for some reason.