### PR TITLE
Set experimental features from the command line in `SourceKitLSPServer.Options`

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -224,6 +224,7 @@ struct SourceKitLSP: AsyncParsableCommand {
     serverOptions.indexOptions.indexPrefixMappings = indexPrefixMappings
     serverOptions.completionOptions.maxResults = completionMaxResults
     serverOptions.generatedInterfacesPath = generatedInterfacesPath
+    serverOptions.experimentalFeatures = experimentalFeatures
 
     return serverOptions
   }


### PR DESCRIPTION
I forgot to actually set the experimental features form the command line in the `SourceKitLSPServer.Options` that get used.