### PR TITLE
Classify deinitializers as constructors in document symbols

### DIFF
--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -171,10 +171,11 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
   }
 
   override func visit(_ node: DeinitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+    // LSP doesn't have a destructor kind. constructor is the closest match and also what clangd for destructors.
     return record(
       node: node,
       name: node.deinitKeyword.text,
-      symbolKind: .null,
+      symbolKind: .constructor,
       range: node.rangeWithoutTrivia,
       selection: node.deinitKeyword.rangeWithoutTrivia
     )

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -748,7 +748,7 @@ final class DocumentSymbolTests: XCTestCase {
           children: [
             DocumentSymbol(
               name: "deinit",
-              kind: .null,
+              kind: .constructor,
               range: positions["4️⃣"]..<positions["6️⃣"],
               selectionRange: positions["4️⃣"]..<positions["5️⃣"],
               children: []


### PR DESCRIPTION
LSP doesn't have a destructor kind. constructor is the closest match and also what clangd for destructors.