### PR TITLE
Write log messages to files on non-Darwin platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -161,7 +161,8 @@ let package = Package(
     .target(
       name: "LSPLogging",
       dependencies: [
-        .product(name: "Crypto", package: "swift-crypto")
+        "SwiftExtensions",
+        .product(name: "Crypto", package: "swift-crypto"),
       ],
       exclude: ["CMakeLists.txt"],
       swiftSettings: lspLoggingSwiftSettings + [.enableExperimentalFeature("StrictConcurrency")]

--- a/Sources/LSPLogging/CMakeLists.txt
+++ b/Sources/LSPLogging/CMakeLists.txt
@@ -5,10 +5,12 @@ add_library(LSPLogging STATIC
   LoggingScope.swift
   NonDarwinLogging.swift
   OrLog.swift
+  SetGlobalLogFileHandler.swift
   SplitLogMessage.swift)
 set_target_properties(LSPLogging PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(LSPLogging PRIVATE
+  SwiftExtensions
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 target_link_libraries(LSPLogging PUBLIC
   Crypto)

--- a/Sources/LSPLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/LSPLogging/SetGlobalLogFileHandler.swift
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import RegexBuilder
+
+#if os(Windows)
+import WinSDK
+#endif
+
+#if !canImport(os) || SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+fileprivate struct FailedToCreateFileError: Error, CustomStringConvertible {
+  let logFile: URL
+
+  var description: String {
+    return "Failed to create log file at \(logFile)"
+  }
+}
+
+/// The number of log file handles that have been created by this process.
+///
+/// See comment on `logFileHandle`.
+@LogHandlerActor
+fileprivate var logRotateIndex = 0
+
+/// The file handle to the current log file. When the file managed by this handle reaches its maximum size, we increment
+/// the `logRotateIndex` by 1 and set the `logFileHandle` to `nil`. This causes a new log file handle with index
+/// `logRotateIndex % logRotateCount` to be created on the next log call.
+@LogHandlerActor
+fileprivate var logFileHandle: FileHandle?
+
+@LogHandlerActor
+func getOrCreateLogFileHandle(logDirectory: URL, logRotateCount: Int) -> FileHandle {
+  if let logFileHandle {
+    return logFileHandle
+  }
+
+  // Name must match the regex in `cleanOldLogFiles` and the prefix in `DiagnoseCommand.addNonDarwinLogs`.
+  let logFileUrl = logDirectory.appendingPathComponent(
+    "sourcekit-lsp-\(ProcessInfo.processInfo.processIdentifier).\(logRotateIndex % logRotateCount).log"
+  )
+
+  do {
+    try FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true)
+    if !FileManager.default.fileExists(atPath: logFileUrl.path) {
+      guard FileManager.default.createFile(atPath: logFileUrl.path, contents: nil) else {
+        throw FailedToCreateFileError(logFile: logFileUrl)
+      }
+    }
+    let newFileHandle = try FileHandle(forWritingTo: logFileUrl)
+    logFileHandle = newFileHandle
+    try newFileHandle.truncate(atOffset: 0)
+    return newFileHandle
+  } catch {
+    // If we fail to create a file handle for the log file, log one message about it to stderr and then log to stderr.
+    // We will try creating a log file again once this section of the log reaches `maxLogFileSize` but that means that
+    // we'll only log this error every `maxLogFileSize` bytes, which is a lot less spammy than logging it on every log
+    // call.
+    fputs("Failed to open file handle for log file at \(logFileUrl.path): \(error)", stderr)
+    logFileHandle = FileHandle.standardError
+    return FileHandle.standardError
+  }
+}
+
+/// Log the given message to a log file in the given log directory.
+///
+/// The name of the log file includes the PID of the current process to make sure it is exclusively writing to the file.
+/// When a log file reaches `logFileMaxBytes`, it will be rotated, with at most `logRotateCount` different log files
+/// being created.
+@LogHandlerActor
+private func logToFile(message: String, logDirectory: URL, logFileMaxBytes: Int, logRotateCount: Int) throws {
+
+  guard let data = message.data(using: .utf8) else {
+    fputs(
+      """
+      Failed to convert log message to UTF-8 data
+      \(message)
+
+      """,
+      stderr
+    )
+    return
+  }
+  let logFileHandleUnwrapped = getOrCreateLogFileHandle(logDirectory: logDirectory, logRotateCount: logRotateCount)
+  try logFileHandleUnwrapped.write(contentsOf: data)
+
+  // If this log file has exceeded the maximum size, start writing to a new log file.
+  if try logFileHandleUnwrapped.offset() > logFileMaxBytes {
+    logRotateIndex += 1
+    // Resetting `logFileHandle` will cause a new logFileHandle to be created on the next log call.
+    logFileHandle = nil
+  }
+}
+
+/// If the file at the given path is writable, redirect log messages handled by `NonDarwinLogHandler` to the given file.
+///
+/// Occasionally checks that the log does not exceed `targetLogSize` (in bytes) and truncates the beginning of the log
+/// when it does.
+@LogHandlerActor
+private func setUpGlobalLogFileHandlerImpl(logFileDirectory: URL, logFileMaxBytes: Int, logRotateCount: Int) {
+  logHandler = { @LogHandlerActor message in
+    do {
+      try logToFile(
+        message: message,
+        logDirectory: logFileDirectory,
+        logFileMaxBytes: logFileMaxBytes,
+        logRotateCount: logRotateCount
+      )
+    } catch {
+      fputs(
+        """
+        Failed to write message to log file: \(error)
+        \(message)
+
+        """,
+        stderr
+      )
+    }
+  }
+}
+
+/// Returns `true` if a process with the given PID still exists and is alive.
+private func isProcessAlive(pid: Int32) -> Bool {
+  #if os(Windows)
+  if let handle = OpenProcess(UInt32(PROCESS_QUERY_INFORMATION), /*bInheritHandle=*/ false, UInt32(pid)) {
+    CloseHandle(handle)
+    return true
+  }
+  return false
+  #else
+  return kill(pid, 0) == 0
+  #endif
+}
+
+private func cleanOldLogFilesImpl(logFileDirectory: URL, maxAge: TimeInterval) {
+  let enumerator = FileManager.default.enumerator(at: logFileDirectory, includingPropertiesForKeys: nil)
+  while let url = enumerator?.nextObject() as? URL {
+    let name = url.lastPathComponent
+    let regex = Regex {
+      "sourcekit-lsp-"
+      Capture(ZeroOrMore(.digit))
+      "."
+      ZeroOrMore(.digit)
+      ".log"
+    }
+    guard let match = name.matches(of: regex).only, let pid = Int32(match.1) else {
+      continue
+    }
+    if isProcessAlive(pid: pid) {
+      // Process that owns this log file is still alive. Don't delete it.
+      continue
+    }
+    guard
+      let modificationDate = orLog(
+        "Getting mtime of old log file",
+        { try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] }
+      ) as? Date,
+      Date().timeIntervalSince(modificationDate) > maxAge
+    else {
+      // File has been modified in the last hour. Don't delete it because it's useful to diagnose issues after
+      // sourcekit-lsp has exited.
+      continue
+    }
+    orLog("Deleting old log file") { try FileManager.default.removeItem(at: url) }
+  }
+}
+#endif
+
+/// If the file at the given path is writable, redirect log messages handled by `NonDarwinLogHandler` to the given file.
+///
+/// Occasionally checks that the log does not exceed `targetLogSize` (in bytes) and truncates the beginning of the log
+/// when it does.
+///
+/// No-op when using OSLog.
+public func setUpGlobalLogFileHandler(logFileDirectory: URL, logFileMaxBytes: Int, logRotateCount: Int) async {
+  #if !canImport(os) || SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+  await setUpGlobalLogFileHandlerImpl(
+    logFileDirectory: logFileDirectory,
+    logFileMaxBytes: logFileMaxBytes,
+    logRotateCount: logRotateCount
+  )
+  #endif
+}
+
+/// Deletes all sourcekit-lsp log files in `logFilesDirectory` that are not associated with a running process and that
+/// haven't been modified within the last hour.
+///
+/// No-op when using OSLog.
+public func cleanOldLogFiles(logFileDirectory: URL, maxAge: TimeInterval) {
+  #if !canImport(os) || SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+  cleanOldLogFilesImpl(logFileDirectory: logFileDirectory, maxAge: maxAge)
+  #endif
+}

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -242,6 +242,15 @@ struct SourceKitLSP: AsyncParsableCommand {
 
     let realStdoutHandle = FileHandle(fileDescriptor: realStdout, closeOnDealloc: false)
 
+    // Directory should match the directory we are searching for logs in `DiagnoseCommand.addNonDarwinLogs`.
+    let logFileDirectoryURL = URL(fileURLWithPath: ("~/.sourcekit-lsp/logs" as NSString).expandingTildeInPath)
+    await setUpGlobalLogFileHandler(
+      logFileDirectory: logFileDirectoryURL,
+      logFileMaxBytes: 5_000_000,
+      logRotateCount: 10
+    )
+    cleanOldLogFiles(logFileDirectory: logFileDirectoryURL, maxAge: 60 * 60 /* 1h */)
+
     let clientConnection = JSONRPCConnection(
       name: "client",
       protocol: MessageRegistry.lspProtocol,

--- a/Tests/LSPLoggingTests/LoggingTests.swift
+++ b/Tests/LSPLoggingTests/LoggingTests.swift
@@ -21,7 +21,7 @@ fileprivate func assertLogging(
   _ body: (NonDarwinLogger) -> Void,
   file: StaticString = #filePath,
   line: UInt = #line
-) {
+) async {
   // nonisolated(unsafe) because calls of `assertLogging` do not log to `logHandler` concurrently.
   nonisolated(unsafe) var messages: [String] = []
   let logger = NonDarwinLogger(
@@ -29,10 +29,10 @@ fileprivate func assertLogging(
     category: "test",
     logLevel: logLevel,
     privacyLevel: privacyLevel,
-    logHandler: { messages.append($0) }
+    overrideLogHandler: { messages.append($0) }
   )
   body(logger)
-  NonDarwinLogger.flush()
+  await NonDarwinLogger.flush()
   guard messages.count == expected.count else {
     XCTFail(
       """
@@ -77,7 +77,7 @@ final class LoggingTests: XCTestCase {
     let logger = NonDarwinLogger(
       subsystem: LoggingScope.subsystem,
       category: "test",
-      logHandler: {
+      overrideLogHandler: {
         message = $0
         expectation.fulfill()
       }
@@ -91,27 +91,27 @@ final class LoggingTests: XCTestCase {
     XCTAssert(message.hasSuffix("\nmy message\n---"), "Message did not have expected body. Received \n\(message)")
   }
 
-  func testLoggingBasic() {
-    assertLogging(
+  func testLoggingBasic() async {
+    await assertLogging(
       expected: ["a"],
       {
         $0.log("a")
       }
     )
 
-    assertLogging(
+    await assertLogging(
       expected: [],
       { _ in
       }
     )
 
-    assertLogging(expected: ["b\n\nc"]) {
+    await assertLogging(expected: ["b\n\nc"]) {
       $0.log("b\n\nc")
     }
   }
 
-  func testLogLevels() {
-    assertLogging(
+  func testLogLevels() async {
+    await assertLogging(
       logLevel: .default,
       expected: ["d", "e", "f"]
     ) {
@@ -122,7 +122,7 @@ final class LoggingTests: XCTestCase {
       $0.debug("h")
     }
 
-    assertLogging(
+    await assertLogging(
       logLevel: .error,
       expected: ["d", "e"]
     ) {
@@ -133,7 +133,7 @@ final class LoggingTests: XCTestCase {
       $0.debug("h")
     }
 
-    assertLogging(
+    await assertLogging(
       logLevel: .fault,
       expected: ["d"]
     ) {
@@ -145,23 +145,23 @@ final class LoggingTests: XCTestCase {
     }
   }
 
-  func testPrivacyMaskingLevels() {
-    assertLogging(expected: ["password is <private>"]) {
+  func testPrivacyMaskingLevels() async {
+    await assertLogging(expected: ["password is <private>"]) {
       let password: String = "1234"
       $0.log("password is \(password, privacy: .sensitive)")
     }
 
-    assertLogging(expected: ["username is root"]) {
+    await assertLogging(expected: ["username is root"]) {
       let username: String = "root"
       $0.log("username is \(username, privacy: .private)")
     }
 
-    assertLogging(expected: ["username is root"]) {
+    await assertLogging(expected: ["username is root"]) {
       let username: String = "root"
       $0.log("username is \(username)")
     }
 
-    assertLogging(
+    await assertLogging(
       privacyLevel: .public,
       expected: ["username is <private>"]
     ) {
@@ -169,7 +169,7 @@ final class LoggingTests: XCTestCase {
       $0.log("username is \(username, privacy: .private)")
     }
 
-    assertLogging(
+    await assertLogging(
       privacyLevel: .public,
       expected: ["username is <private>"]
     ) {
@@ -178,15 +178,15 @@ final class LoggingTests: XCTestCase {
     }
   }
 
-  func testPrivacyMaskingTypes() {
-    assertLogging(
+  func testPrivacyMaskingTypes() async {
+    await assertLogging(
       privacyLevel: .public,
       expected: ["logging a static string"]
     ) {
       $0.log("logging a \("static string")")
     }
 
-    assertLogging(
+    await assertLogging(
       privacyLevel: .public,
       expected: ["logging from LSPLoggingTests.LoggingTests"]
     ) {
@@ -198,14 +198,14 @@ final class LoggingTests: XCTestCase {
       var redactedDescription: String = "redacted description"
     }
 
-    assertLogging(
+    await assertLogging(
       privacyLevel: .public,
       expected: ["got redacted description"]
     ) {
       $0.log("got \(LogStringConvertible().forLogging)")
     }
 
-    assertLogging(
+    await assertLogging(
       privacyLevel: .private,
       expected: ["got full description"]
     ) {


### PR DESCRIPTION
Instead of logging to `stderr`, write log messages to files in `/var/log/sourcekit-lsp/sourcekit-lsp-<pid>.log`.

This allows us to retrieve the log messages from `sourcekit-lsp diagnose`.

Fixes #1286
rdar://127138318