### PR TITLE
Make passing `--experimental-prepare-for-indexing` to `swift build` an experimental feature

### DIFF
--- a/Sources/Diagnose/IndexCommand.swift
+++ b/Sources/Diagnose/IndexCommand.swift
@@ -74,7 +74,7 @@ public struct IndexCommand: AsyncParsableCommand {
 
   public func run() async throws {
     var serverOptions = SourceKitLSPServer.Options()
-    serverOptions.experimentalFeatures.append(.backgroundIndexing)
+    serverOptions.experimentalFeatures.insert(.backgroundIndexing)
 
     let installPath =
       if let toolchainOverride, let toolchain = Toolchain(try AbsolutePath(validating: toolchainOverride)) {

--- a/Sources/SKCore/CMakeLists.txt
+++ b/Sources/SKCore/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(SKCore STATIC
   CompilationDatabase.swift
   CompilationDatabaseBuildSystem.swift
   Debouncer.swift
+  ExperimentalFeatures.swift
   FallbackBuildSystem.swift
   FileBuildSettings.swift
   IndexProcessResult.swift

--- a/Sources/SKCore/ExperimentalFeatures.swift
+++ b/Sources/SKCore/ExperimentalFeatures.swift
@@ -15,4 +15,7 @@
 public enum ExperimentalFeature: String, Codable, Sendable, CaseIterable {
   /// Enable background indexing.
   case backgroundIndexing = "background-indexing"
+
+  /// Add `--experimental-prepare-for-indexing` to the `swift build` command run to prepare a target for indexing.
+  case swiftpmPrepareForIndexing = "swiftpm-prepare-for-indexing"
 }

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -110,7 +110,7 @@ public final class TestSourceKitLSPClient: MessageHandler {
       serverOptions.buildSetup.flags.swiftCompilerFlags += ["-module-cache-path", globalModuleCache.path]
     }
     if enableBackgroundIndexing {
-      serverOptions.experimentalFeatures.append(.backgroundIndexing)
+      serverOptions.experimentalFeatures.insert(.backgroundIndexing)
     }
 
     var notificationYielder: AsyncStream<any NotificationType>.Continuation!

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(SourceKitLSP STATIC
   CreateBuildSystem.swift
   DocumentManager.swift
   DocumentSnapshot+FromFileContents.swift
-  ExperimentalFeatures.swift
   IndexProgressManager.swift
   IndexStoreDB+MainFilesProvider.swift
   LanguageServerType.swift

--- a/Sources/SourceKitLSP/CreateBuildSystem.swift
+++ b/Sources/SourceKitLSP/CreateBuildSystem.swift
@@ -38,7 +38,7 @@ func createBuildSystem(
       uri: rootUri,
       toolchainRegistry: toolchainRegistry,
       buildSetup: options.buildSetup,
-      isForIndexBuild: options.experimentalFeatures.contains(.backgroundIndexing),
+      experimentalFeatures: options.experimentalFeatures,
       reloadPackageStatusCallback: reloadPackageStatusCallback
     )
   }

--- a/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer+Options.swift
@@ -50,7 +50,7 @@ extension SourceKitLSPServer {
     public var swiftPublishDiagnosticsDebounceDuration: TimeInterval
 
     /// Experimental features that are enabled.
-    public var experimentalFeatures: [ExperimentalFeature]
+    public var experimentalFeatures: Set<ExperimentalFeature>
 
     public var indexTestHooks: IndexTestHooks
 
@@ -62,7 +62,7 @@ extension SourceKitLSPServer {
       completionOptions: SKCompletionOptions = .init(),
       generatedInterfacesPath: AbsolutePath = defaultDirectoryForGeneratedInterfaces,
       swiftPublishDiagnosticsDebounceDuration: TimeInterval = 2, /* 2s */
-      experimentalFeatures: [ExperimentalFeature] = [],
+      experimentalFeatures: Set<ExperimentalFeature> = [],
       indexTestHooks: IndexTestHooks = IndexTestHooks()
     ) {
       self.buildSetup = buildSetup

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -224,7 +224,7 @@ struct SourceKitLSP: AsyncParsableCommand {
     serverOptions.indexOptions.indexPrefixMappings = indexPrefixMappings
     serverOptions.completionOptions.maxResults = completionMaxResults
     serverOptions.generatedInterfacesPath = generatedInterfacesPath
-    serverOptions.experimentalFeatures = experimentalFeatures
+    serverOptions.experimentalFeatures = Set(experimentalFeatures)
 
     return serverOptions
   }

--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
@@ -15,7 +15,7 @@ import LSPTestSupport
 import LanguageServerProtocol
 import PackageModel
 @_spi(Testing) import SKCore
-import SKSwiftPMWorkspace
+@_spi(Testing) import SKSwiftPMWorkspace
 import SKTestSupport
 import SourceKitLSP
 import TSCBasic
@@ -54,7 +54,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
           toolchainRegistry: tr,
           fileSystem: fs,
           buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-          isForIndexBuild: false
+          experimentalFeatures: []
         )
       )
     }
@@ -81,7 +81,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       await assertThrowsError(try await buildSystem.generateBuildGraph(allowFileSystemWrites: false))
     }
@@ -111,7 +111,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
           toolchainRegistry: ToolchainRegistry(toolchains: []),
           fileSystem: fs,
           buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-          isForIndexBuild: false
+          experimentalFeatures: []
         )
       )
     }
@@ -142,7 +142,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -207,7 +207,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: localFileSystem,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -270,7 +270,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: config,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -312,7 +312,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -349,7 +349,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -398,7 +398,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -463,7 +463,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -507,7 +507,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -588,7 +588,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -640,7 +640,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -708,7 +708,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -748,7 +748,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
@@ -789,7 +789,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
 
       assertEqual(await swiftpmBuildSystem.projectRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
@@ -824,7 +824,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         buildSetup: SourceKitLSPServer.Options.testDefault.buildSetup,
-        isForIndexBuild: false
+        experimentalFeatures: []
       )
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 


### PR DESCRIPTION
I’d like to qualify `--experimental-prepare-for-indexing` independently of background indexing using `swift build`. Because of this, I think there is value in using SourceKit-LSP using background indexing but without `--experimental-prepare-for-indexing`. It could also be useful to determine if bugs we may find are due to `--experimental-prepare-for-indexing` or also occur when running plain `swift build` commands.