### PR TITLE
Unify `withLock` implementations

### DIFF
--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -14,15 +14,6 @@ import Foundation
 
 import struct TSCBasic.AbsolutePath
 
-extension NSLock {
-  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
-  internal func withLock<T>(_ body: () throws -> T) rethrows -> T {
-    lock()
-    defer { unlock() }
-    return try body()
-  }
-}
-
 /// The set of known SourceKitD instances, uniqued by path.
 ///
 /// It is not generally safe to have two instances of SourceKitD for the same libsourcekitd, so

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -24,15 +24,6 @@ import struct TSCBasic.AbsolutePath
 import WinSDK
 #endif
 
-extension NSLock {
-  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
-  fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
-    lock()
-    defer { unlock() }
-    return try body()
-  }
-}
-
 /// A thin wrapper over a connection to a clangd server providing build setting handling.
 ///
 /// In addition, it also intercepts notifications and replies from clangd in order to do things

--- a/Sources/SwiftExtensions/AsyncQueue.swift
+++ b/Sources/SwiftExtensions/AsyncQueue.swift
@@ -26,15 +26,6 @@ extension Task: AnyTask {
   }
 }
 
-fileprivate extension NSLock {
-  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
-  func withLock<T>(_ body: () throws -> T) rethrows -> T {
-    lock()
-    defer { unlock() }
-    return try body()
-  }
-}
-
 /// A type that is able to track dependencies between tasks.
 public protocol DependencyTracker: Sendable {
   /// Whether the task described by `self` needs to finish executing before

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(SwiftExtensions STATIC
   AsyncUtils.swift
   Collection+Only.swift
   Collection+PartitionIntoBatches.swift
+  NSLock+WithLock.swift
   Sequence+AsyncMap.swift
   Task+WithPriorityChangedHandler.swift
   ThreadSafeBox.swift

--- a/Sources/SwiftExtensions/NSLock+WithLock.swift
+++ b/Sources/SwiftExtensions/NSLock+WithLock.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension NSLock {
+  func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try body()
+  }
+}

--- a/Sources/SwiftExtensions/ThreadSafeBox.swift
+++ b/Sources/SwiftExtensions/ThreadSafeBox.swift
@@ -12,15 +12,6 @@
 
 import Foundation
 
-extension NSLock {
-  /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
-  fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
-    lock()
-    defer { unlock() }
-    return try body()
-  }
-}
-
 /// A thread safe container that contains a value of type `T`.
 ///
 /// - Note: Unchecked sendable conformance because value is guarded by a lock.


### PR DESCRIPTION
Turns out that also most of the `withLock` definitions were never used.