### PR TITLE
Populate inProgressRequest with the same priority that we cancel requests

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -612,7 +612,7 @@ extension SourceKitLSPServer: MessageHandler {
     // Keep track of the ID -> Task management with low priority. Once we cancel
     // a request, the cancellation task runs with a high priority and depends on
     // this task, which will elevate this task's priority.
-    cancellationMessageHandlingQueue.async(priority: .background) {
+    cancellationMessageHandlingQueue.async(priority: .high) {
       await self.setInProgressRequest(for: id, task: task)
     }
   }


### PR DESCRIPTION
Others, this could lead to interesting priority inversions: We would handle the cancellation with higher priority than the population of inProgressRequest`, which means that we wouldn’t actually cancel the request, logging `Cannot cancel request <request-id> because it hasn't been scheduled for execution yet or because the request already returned a response`.