### PR TITLE
Demote two log messages issued on the `error` level

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1764,7 +1764,7 @@ extension SourceKitLSPServer {
     // `SwiftLanguageService` will always respond with `unsupported method`. Thus, only log such a failure instead of
     // returning it to the client.
     if indexBasedResponse.isEmpty {
-      return await orLog("Fallback definition request") {
+      return await orLog("Fallback definition request", level: .info) {
         return try await languageService.definition(req)
       }
     }

--- a/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
@@ -178,6 +178,11 @@ actor SyntacticTestIndex {
     guard !removedFiles.contains(uri) else {
       return
     }
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      // File no longer exists. Probably deleted since we scheduled it for indexing. Nothing to worry about.
+      logger.info("Not indexing \(uri.forLogging) for tests because it does not exist")
+      return
+    }
     guard
       let fileModificationDate = try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]
         as? Date


### PR DESCRIPTION
Just two cases where we were logging an error that wasn’t strictly necessary and was just spamming the log at the high log levels.