### PR TITLE
Log when the 10 year wait that’s parking the main thread expires for some reason

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -274,7 +274,10 @@ struct SourceKitLSP: AsyncParsableCommand {
     // Park the main function by sleeping for 10 years.
     // All request handling is done on other threads and sourcekit-lsp exits by calling `_Exit` when it receives a
     // shutdown notification.
-    try await Task.sleep(for: .seconds(60 * 60 * 24 * 365 * 10))
+    while true {
+      try? await Task.sleep(for: .seconds(60 * 60 * 24 * 365 * 10))
+      logger.fault("10 year wait that's parking the main thread expired. Waiting again.")
+    }
   }
 }
 


### PR DESCRIPTION
Not sure if this ever happens but if it does, we should log it. Also, just start waiting again for another 10 years.