### PR TITLE
Only report log collection progress in `sourcekit-lsp diagnose` if we’ve made meaningful progress

### DIFF
--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -25,6 +25,12 @@ import class TSCUtility.PercentProgressAnimation
 @MainActor
 private var progressBar: PercentProgressAnimation? = nil
 
+/// The last progress that was reported on the progress bar. This ensures that when the progress indicator uses the
+/// `MultiLinePercentProgressAnimation` (eg. because stderr is redirected to a file) we don't emit status updates
+/// without making any real progress.
+@MainActor
+private var lastProgress: (Int, String)? = nil
+
 /// A component of the diagnostic bundle that's collected in independent stages.
 fileprivate enum BundleComponent: String, CaseIterable, ExpressibleByArgument {
   case crashReports = "crash-reports"
@@ -292,7 +298,11 @@ public struct DiagnoseCommand: AsyncParsableCommand {
 
   @MainActor
   private func reportProgress(_ state: DiagnoseProgressState, message: String) {
-    progressBar?.update(step: Int(state.progress * 100), total: 100, text: message)
+    let progress: (step: Int, message: String) = (Int(state.progress * 100), message)
+    if lastProgress == nil || progress != lastProgress! {
+      progressBar?.update(step: Int(state.progress * 100), total: 100, text: message)
+      lastProgress = progress
+    }
   }
 
   @MainActor


### PR DESCRIPTION
Especially when we didn’t have a redrawing progress indicator, we would spam the output with out making progress that was visible to the user because the overall progress just shows a percentage without any decimal digits. To fix this, only report progress when we’ve made at least 1% of progress in log collection.