### PR TITLE
Use 3 emoji markers in the index log

### DIFF
--- a/Sources/SKCore/IndexTaskID.swift
+++ b/Sources/SKCore/IndexTaskID.swift
@@ -36,11 +36,12 @@ public enum IndexTaskID: Sendable {
   public var emojiRepresentation: String {
     // Multiply by 2 and optionally add 1 to make sure preparation and update index store have distinct IDs.
     // Run .hashValue to make sure we semi-randomly pick new emoji markers for new tasks
+    let numEmojis = 3
     switch self {
     case .preparation(id: let id):
-      return Self.numberToEmojis((id * 2).hashValue, numEmojis: 2)
+      return Self.numberToEmojis((id * 2).hashValue, numEmojis: numEmojis)
     case .updateIndexStore(id: let id):
-      return Self.numberToEmojis((id * 2 + 1).hashValue, numEmojis: 2)
+      return Self.numberToEmojis((id * 2 + 1).hashValue, numEmojis: numEmojis)
     }
   }
 }


### PR DESCRIPTION
I found that 2 markers sometimes chooses very close color combinations like red-yellow and red-orange. Let’s add a third emoji marker to make it even easier to tell the log lanes apart.