### PR TITLE
Fix a couple issue in the `debug reduce-swift-frontend` subcommand

### DIFF
--- a/Sources/Diagnose/MergeSwiftFiles.swift
+++ b/Sources/Diagnose/MergeSwiftFiles.swift
@@ -27,10 +27,11 @@ extension RequestInfo {
 
     progressUpdate(0, "Merging all .swift files into a single file")
 
+    let compilerArgs = compilerArgs.filter { $0 != "-primary-file" && !$0.hasSuffix(".swift") } + ["$FILE"]
     let mergedRequestInfo = RequestInfo(
       requestTemplate: requestTemplate,
       offset: offset,
-      compilerArgs: compilerArgs.filter { !$0.hasSuffix(".swift") } + ["$FILE"],
+      compilerArgs: compilerArgs,
       fileContents: mergedFile
     )
 

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -96,6 +96,9 @@ public struct ReduceFrontendCommand: AsyncParsableCommand {
       reproducerPredicate: nsPredicate
     )
 
+    defer {
+      progressBar.complete(success: true)
+    }
     let reducedRequestInfo = try await reduceFrontendIssue(
       frontendArgs: frontendArgs,
       using: executor
@@ -103,10 +106,8 @@ public struct ReduceFrontendCommand: AsyncParsableCommand {
       progressBar.update(step: Int(progress * 100), total: 100, text: message)
     }
 
-    progressBar.complete(success: true)
-
     print("Reduced compiler arguments:")
-    print(reducedRequestInfo.compilerArgs)
+    print(reducedRequestInfo.compilerArgs.joined(separator: " "))
 
     print("")
     print("Reduced file contents:")

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -121,10 +121,12 @@ public struct RequestInfo: Sendable {
 
     // Inline the file list so we can reduce the compiler arguments by removing individual source files.
     // A couple `output-filelist`-related compiler arguments don't work with the file list inlined. Remove them as they
-    // are unlikely to be responsible for the swift-frontend cache
+    // are unlikely to be responsible for the swift-frontend cache.
+    // `-index-system-modules` is invalid when no output file lists are specified.
     while let frontendArg = iterator.next() {
       switch frontendArg {
-      case "-supplementary-output-file-map", "-output-filelist", "-index-unit-output-path-filelist":
+      case "-supplementary-output-file-map", "-output-filelist", "-index-unit-output-path-filelist",
+        "-index-system-modules":
         _ = iterator.next()
       case "-filelist":
         guard let fileList = iterator.next() else {


### PR DESCRIPTION
- Strip the `-index-system-modules` flag because it doesn’t work if no output file map is passed
- Remove `-primary-file` when we’re merging all `.swift` files into one file
- Fix an issue where errors during reduction would be rendered within the progress bar.