### PR TITLE
Use a `ThreadSafeBox` for the `reusedNodes` variable in `testIncrementalParse`

### DIFF
--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -16,6 +16,7 @@ import LanguageServerProtocol
 import SKCore
 import SKTestSupport
 import SourceKitLSP
+import SwiftExtensions
 import SwiftParser
 import SwiftSyntax
 import XCTest
@@ -1352,14 +1353,12 @@ final class LocalSwiftTests: XCTestCase {
     let uri = DocumentURI(url)
 
     let reusedNodeCallback = self.expectation(description: "reused node callback called")
-    // nonisolated(unsafe) is fine because the variable will only be read after all writes from reusedNodeCallback are
-    // done.
-    nonisolated(unsafe) var reusedNodes: [Syntax] = []
+    let reusedNodes = ThreadSafeBox<[Syntax]>(initialValue: [])
     let swiftLanguageService =
       await testClient.server._languageService(for: uri, .swift, in: testClient.server.workspaceForDocument(uri: uri)!)
       as! SwiftLanguageService
     await swiftLanguageService.setReusedNodeCallback {
-      reusedNodes.append($0)
+      reusedNodes.value.append($0)
       reusedNodeCallback.fulfill()
     }
 
@@ -1386,9 +1385,8 @@ final class LocalSwiftTests: XCTestCase {
     )
     try await fulfillmentOfOrThrow([reusedNodeCallback])
 
-    XCTAssertEqual(reusedNodes.count, 1)
-
-    let firstNode = try XCTUnwrap(reusedNodes.first)
+    XCTAssertEqual(reusedNodes.value.count, 1)
+    let firstNode = try XCTUnwrap(reusedNodes.value.first)
     XCTAssertEqual(
       firstNode.description,
       """


### PR DESCRIPTION
Fixes an error found by thread sanitizer.