### PR TITLE
Return after handling a `CancelRequestNotification`

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -551,6 +551,7 @@ extension SourceKitLSPServer: MessageHandler {
         // are currently handling. Ordering is not important here. We thus don't
         // need to execute it on `messageHandlingQueue`.
         self.cancelRequest(params)
+        return
       }
 
       let signposter = Logger(subsystem: LoggingScope.subsystem, category: "message-handling")


### PR DESCRIPTION
We were dispatching the notification to `messageHandlingQueue`, which then didn’t do anything with it. That’s not necessary.