### PR TITLE
[6.0][SwiftPMBuildSystem] Adjust `BuildParameters` use to indicate a desti…

### DIFF
--- a/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/SKSwiftPMWorkspaceTests/SwiftPMBuildSystemTests.swift
@@ -147,7 +147,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.destinationBuildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
       assertEqual(await swiftpmBuildSystem.buildPath, build)
@@ -212,7 +212,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
       let aPlusSomething = packageRoot.appending(components: "Sources", "lib", "a+something.swift")
-      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.destinationBuildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
       assertEqual(await swiftpmBuildSystem.buildPath, build)
@@ -275,7 +275,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
-      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.destinationBuildParameters.triple
       let build = buildPath(root: packageRoot, config: config, platform: hostTriple.platformBuildPathComponent)
 
       assertEqual(await swiftpmBuildSystem.buildPath, build)
@@ -514,7 +514,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let acxx = packageRoot.appending(components: "Sources", "lib", "a.cpp")
       let bcxx = packageRoot.appending(components: "Sources", "lib", "b.cpp")
       let header = packageRoot.appending(components: "Sources", "lib", "include", "a.h")
-      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.destinationBuildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
       assertEqual(await swiftpmBuildSystem.buildPath, build)
@@ -596,7 +596,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let arguments = try await unwrap(swiftpmBuildSystem.buildSettings(for: aswift.asURI, language: .swift))
         .compilerArguments
       assertArgumentsContain("-target", arguments: arguments)  // Only one!
-      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.destinationBuildParameters.triple
 
       #if os(macOS)
       assertArgumentsContain(
@@ -829,7 +829,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       try await swiftpmBuildSystem.generateBuildGraph(allowFileSystemWrites: false)
 
       let aswift = packageRoot.appending(components: "Plugins", "MyPlugin", "a.swift")
-      let hostTriple = await swiftpmBuildSystem.buildParameters.triple
+      let hostTriple = await swiftpmBuildSystem.destinationBuildParameters.triple
       let build = buildPath(root: packageRoot, platform: hostTriple.platformBuildPathComponent)
 
       assertEqual(await swiftpmBuildSystem.buildPath, build)


### PR DESCRIPTION
…nation

- Explanation:

  [We are cherry-picking cross-compilation changes for SwiftPM to 6.0 branch](https://github.com/apple/swift-package-manager/pull/7640) which requires few API tweaks in sourcekit-lsp. 

- Scope: `BuildPlan` API changes.

- Main Branch PR: https://github.com/apple/sourcekit-lsp/pull/1361

- Risk: Very Low

- Reviewed By: @ahoppen 

(cherry picked from commit 12b848ed58ad1aa1a49234a329213d2d34173a4c)