### PR TITLE
Skip `testLibraryUsedByExecutableTargetAndPackagePlugin` if SwiftPM can’t handle modules for the target and host properly

### DIFF
--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1001,6 +1001,7 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testLibraryUsedByExecutableTargetAndPackagePlugin() async throws {
+    try await SkipUnless.swiftPMStoresModulesForTargetAndHostInSeparateFolders()
     let project = try await SwiftPMTestProject(
       files: [
         "Lib/MyFile.swift": """


### PR DESCRIPTION
This fixes a test failure in Xcode 15.4.