### PR TITLE
A couple of improvements for generated interfaces

### DIFF
--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -58,7 +58,7 @@ public let builtinRequests: [_RequestType.Type] = [
   InlineValueRequest.self,
   LinkedEditingRangeRequest.self,
   MonikersRequest.self,
-  OpenInterfaceRequest.self,
+  OpenGeneratedInterfaceRequest.self,
   PollIndexRequest.self,
   PrepareRenameRequest.self,
   ReferencesRequest.self,

--- a/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/OpenInterfaceRequest.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Request a textual interface of a module to display in the IDE.
+/// Request a generated interface of a module to display in the IDE.
 /// **(LSP Extension)**
-public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
+public struct OpenGeneratedInterfaceRequest: TextDocumentRequest, Hashable {
   public static let method: String = "textDocument/openInterface"
-  public typealias Response = InterfaceDetails?
+  public typealias Response = GeneratedInterfaceDetails?
 
   /// The document whose compiler arguments should be used to generate the interface.
   public var textDocument: TextDocumentIdentifier
@@ -45,7 +45,7 @@ public struct OpenInterfaceRequest: TextDocumentRequest, Hashable {
 }
 
 /// The textual output of a module interface.
-public struct InterfaceDetails: ResponseType, Hashable {
+public struct GeneratedInterfaceDetails: ResponseType, Hashable {
 
   public var uri: DocumentURI
   public var position: Position?

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -578,7 +578,7 @@ extension ClangLanguageService {
     return try await forwardRequestToClangd(req)
   }
 
-  func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails? {
+  func openGeneratedInterface(_ request: OpenGeneratedInterfaceRequest) async throws -> GeneratedInterfaceDetails? {
     throw ResponseError.unknown("unsupported method")
   }
 

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -146,7 +146,7 @@ public protocol LanguageService: AnyObject, Sendable {
   func completion(_ req: CompletionRequest) async throws -> CompletionList
   func hover(_ req: HoverRequest) async throws -> HoverResponse?
   func symbolInfo(_ request: SymbolInfoRequest) async throws -> [SymbolDetails]
-  func openInterface(_ request: OpenInterfaceRequest) async throws -> InterfaceDetails?
+  func openGeneratedInterface(_ request: OpenGeneratedInterfaceRequest) async throws -> GeneratedInterfaceDetails?
 
   /// - Note: Only called as a fallback if the definition could not be found in the index.
   func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse?

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -711,8 +711,8 @@ extension SourceKitLSPServer: MessageHandler {
       await self.handleRequest(for: request, requestHandler: self.completion)
     case let request as RequestAndReply<HoverRequest>:
       await self.handleRequest(for: request, requestHandler: self.hover)
-    case let request as RequestAndReply<OpenInterfaceRequest>:
-      await self.handleRequest(for: request, requestHandler: self.openInterface)
+    case let request as RequestAndReply<OpenGeneratedInterfaceRequest>:
+      await self.handleRequest(for: request, requestHandler: self.openGeneratedInterface)
     case let request as RequestAndReply<DeclarationRequest>:
       await self.handleRequest(for: request, requestHandler: self.declaration)
     case let request as RequestAndReply<DefinitionRequest>:
@@ -1466,12 +1466,12 @@ extension SourceKitLSPServer {
     return try await languageService.hover(req)
   }
 
-  func openInterface(
-    _ req: OpenInterfaceRequest,
+  func openGeneratedInterface(
+    _ req: OpenGeneratedInterfaceRequest,
     workspace: Workspace,
     languageService: LanguageService
-  ) async throws -> InterfaceDetails? {
-    return try await languageService.openInterface(req)
+  ) async throws -> GeneratedInterfaceDetails? {
+    return try await languageService.openGeneratedInterface(req)
   }
 
   /// Find all symbols in the workspace that include a string in their name.
@@ -1808,13 +1808,13 @@ extension SourceKitLSPServer {
     originatorUri: DocumentURI,
     languageService: LanguageService
   ) async throws -> Location {
-    let openInterface = OpenInterfaceRequest(
+    let openInterface = OpenGeneratedInterfaceRequest(
       textDocument: TextDocumentIdentifier(originatorUri),
       name: moduleName,
       groupName: groupName,
       symbolUSR: symbolUSR
     )
-    guard let interfaceDetails = try await languageService.openInterface(openInterface) else {
+    guard let interfaceDetails = try await languageService.openGeneratedInterface(openInterface) else {
       throw ResponseError.unknown("Could not generate Swift Interface for \(moduleName)")
     }
     let position = interfaceDetails.position ?? Position(line: 0, utf16index: 0)

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -391,7 +391,7 @@ extension SwiftLanguageService {
     ])
   }
 
-  private func closeDocumentSourcekitdRequest(uri: DocumentURI) -> SKDRequestDictionary {
+  func closeDocumentSourcekitdRequest(uri: DocumentURI) -> SKDRequestDictionary {
     return sourcekitd.dictionary([
       keys.request: requests.editorClose,
       keys.name: uri.pseudoPath,

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -73,7 +73,7 @@ final class SwiftInterfaceTests: XCTestCase {
     )
 
     let (mainUri, _) = try project.openDocument("main.swift")
-    let openInterface = OpenInterfaceRequest(
+    let openInterface = OpenGeneratedInterfaceRequest(
       textDocument: TextDocumentIdentifier(mainUri),
       name: "MyLibrary",
       groupName: nil,


### PR DESCRIPTION
- Rename methods to highlight that we’re talking about generated interfaces here, not `.swiftinterface` files
- Don’t open the generated interface in `documentManager`. Opening documents in `documentManager` should only be done by the `textDocument/didOpen` notification from the LSP client. Otherwise we might indefinitely keep the document in the document manager
- After getting the generated interface from sourcekitd, close the document in sourcekitd again. We don’t provide semantic functionality in the generated interface yet, so we can’t interact with the generated interface path. Before, we left it open in sourcekitd indefinitely.
- A couple of code simplifications.

Fixes #878
rdar://116705653