### PR TITLE
When performing jump-to-definition on a method implementing a protocol requirement, jump to the requirement

### DIFF
--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -338,6 +338,10 @@ actor ClangLanguageService: LanguageService, MessageHandler {
     return try await clangd.send(request)
   }
 
+  public func canonicalDeclarationPosition(of position: Position, in uri: DocumentURI) async -> Position? {
+    return nil
+  }
+
   func _crash() {
     // Since `clangd` doesn't have a method to crash it, kill it.
     #if os(Windows)

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -132,7 +132,7 @@ public protocol LanguageService: AnyObject, Sendable {
 
   // MARK: - Build System Integration
 
-  /// Sent when the `BuildSystem` has resolved build settings, such as for the intial build settings
+  /// Sent when the `BuildSystem` has resolved build settings, such as for the initial build settings
   /// or when the settings have changed (e.g. modified build system files). This may be sent before
   /// the respective `DocumentURI` has been opened.
   func documentUpdatedBuildSettings(_ uri: DocumentURI) async
@@ -225,6 +225,16 @@ public protocol LanguageService: AnyObject, Sendable {
   ///
   /// A return value of `nil` indicates that this language service does not support syntactic test discovery.
   func syntacticDocumentTests(for uri: DocumentURI, in workspace: Workspace) async throws -> [AnnotatedTestItem]?
+
+  /// A position that is canonical for all positions within a declaration. For example, if we have the following
+  /// declaration, then all `|` markers should return the same canonical position.
+  /// ```
+  /// func |fo|o(|ba|r: Int)
+  /// ```
+  /// The actual position returned by the method does not matter. All that's relevant is the canonicalization.
+  ///
+  /// Returns `nil` if no canonical position could be determined.
+  func canonicalDeclarationPosition(of position: Position, in uri: DocumentURI) async -> Position?
 
   /// Crash the language server. Should be used for crash recovery testing only.
   func _crash() async

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxRefactoringCodeActionProvider.swift
@@ -121,13 +121,13 @@ extension RemoveSeparatorsFromIntegerLiteral: SyntaxRefactoringCodeActionProvide
   }
 }
 
-extension Syntax {
+extension SyntaxProtocol {
   /// Finds the innermost parent of the given type while not walking outside of nodes that satisfy `stoppingIf`.
   func findParentOfSelf<ParentType: SyntaxProtocol>(
     ofType: ParentType.Type,
     stoppingIf: (Syntax) -> Bool
   ) -> ParentType? {
-    var node: Syntax? = self
+    var node: Syntax? = Syntax(self)
     while let unwrappedNode = node, !stoppingIf(unwrappedNode) {
       if let expectedType = unwrappedNode.as(ParentType.self) {
         return expectedType


### PR DESCRIPTION
rdar://129412482