### PR TITLE
Android: use the right setpriority() signature for Bionic

### DIFF
--- a/Sources/SKSupport/Process+Run.swift
+++ b/Sources/SKSupport/Process+Run.swift
@@ -127,7 +127,7 @@ private func setProcessPriority(pid: Process.ProcessID, newPriority: TaskPriorit
   if !SetPriorityClass(handle, UInt32(newPriority.windowsProcessPriority)) {
     logger.error("Failed to set process priority of \(pid) to \(newPriority.rawValue): \(GetLastError())")
   }
-  #elseif canImport(Darwin)
+  #elseif canImport(Darwin) || canImport(Android)
   // `setpriority` is only able to decrease a process's priority and cannot elevate it. Since Swift task’s priorities
   // can only be elevated, this means that we can effectively only change a process's priority once, when it is created.
   // All subsequent calls to `setpriority` will fail. Because of this, don't log an error.


### PR DESCRIPTION
I had to apply [a similar patch to keep this repo cross-compiling for Android](https://github.com/finagolfin/swift-android-sdk/commit/80a4fee0f8d0c0e517d6e4cdd2c38218844d75cb#diff-2d4e6bc96862356bd7129ebabe486bb38286f6f16b855df629879a4d617de4ba) on my daily CI.