### PR TITLE
Skip `testJumpToSatisfiedProtocolRequirementInExtension` if the toolchain does not mark overridable function declarations as dynamic

### DIFF
--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -603,6 +603,8 @@ class DefinitionTests: XCTestCase {
   }
 
   func testJumpToSatisfiedProtocolRequirementInExtension() async throws {
+    try await SkipUnless.sourcekitdReportsOverridableFunctionDefinitionsAsDynamic()
+
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       protocol TestProtocol {


### PR DESCRIPTION
This test requires https://github.com/apple/swift/pull/74080 and should be skipped if the host toolchain does not have that change. 

Fixes a test failure when running SourceKit-LSP tests using Xcode 15.4.