### PR TITLE
When setting a working directory on process launch is not supported, set it using `sh`

### DIFF
--- a/Sources/SKTestSupport/FindTool.swift
+++ b/Sources/SKTestSupport/FindTool.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+import class TSCBasic.Process
+
+#if os(Windows)
+import WinSDK
+#endif
+
+// Returns the path to the given tool, as found by `xcrun --find` on macOS, or `which` on Linux.
+public func findTool(name: String) async -> URL? {
+  #if os(macOS)
+  let cmd = ["/usr/bin/xcrun", "--find", name]
+  #elseif os(Windows)
+  var buf = [WCHAR](repeating: 0, count: Int(MAX_PATH))
+  GetWindowsDirectoryW(&buf, DWORD(MAX_PATH))
+  var wherePath = String(decodingCString: &buf, as: UTF16.self)
+    .appendingPathComponent("system32")
+    .appendingPathComponent("where.exe")
+  let cmd = [wherePath, name]
+  #elseif os(Android)
+  let cmd = ["/system/bin/which", name]
+  #else
+  let cmd = ["/usr/bin/which", name]
+  #endif
+
+  guard let result = try? await Process.run(arguments: cmd, workingDirectory: nil) else {
+    return nil
+  }
+  guard var path = try? String(bytes: result.output.get(), encoding: .utf8) else {
+    return nil
+  }
+  #if os(Windows)
+  path = String((path.split { $0.isNewline })[0])
+  #endif
+  path = path.trimmingCharacters(in: .whitespacesAndNewlines)
+  return URL(fileURLWithPath: path, isDirectory: false)
+}

--- a/Sources/SKTestSupport/SwiftPMDependencyProject.swift
+++ b/Sources/SKTestSupport/SwiftPMDependencyProject.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import ISDBTibs
+import SKSupport
 import XCTest
 
 import struct TSCBasic.AbsolutePath
@@ -35,7 +35,7 @@ public class SwiftPMDependencyProject {
       case cannotFindGit
       case processedTerminatedWithNonZeroExitCode(ProcessResult)
     }
-    guard let toolUrl = findTool(name: "git") else {
+    guard let git = await findTool(name: "git") else {
       if ProcessEnv.block["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // Never skip the test in CI, similar to what SkipUnless does.
         throw XCTSkip("git cannot be found")
@@ -45,7 +45,7 @@ public class SwiftPMDependencyProject {
     // We can't use `workingDirectory` because Amazon Linux doesn't support working directories (or at least
     // TSCBasic.Process doesn't support working directories on Amazon Linux)
     let process = TSCBasic.Process(
-      arguments: [toolUrl.path, "-C", workingDirectory.path] + arguments
+      arguments: [git.path, "-C", workingDirectory.path] + arguments
     )
     try process.launch()
     let processResult = try await process.waitUntilExit()

--- a/Tests/SKSupportTests/ProcessRunTests.swift
+++ b/Tests/SKSupportTests/ProcessRunTests.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPTestSupport
+import SKSupport
+import SKTestSupport
+import XCTest
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+
+final class ProcessLaunchTests: XCTestCase {
+  func testWorkingDirectory() async throws {
+    let project = try await MultiFileTestProject(files: [
+      "parent dir/subdir A/a.txt": "",
+      "parent dir/subdir B/b.txt": "",
+      "parent dir/subdir C/c.txt": "",
+    ])
+
+    let ls = try await unwrap(findTool(name: "ls"))
+
+    let result = try await Process.run(
+      arguments: [ls.path, "subdir A", "subdir B"],
+      workingDirectory: AbsolutePath(validating: project.scratchDirectory.path).appending(component: "parent dir")
+    )
+    let stdout = try unwrap(String(bytes: result.output.get(), encoding: .utf8))
+    XCTAssert(stdout.contains("a.txt"), "Directory did not contain a.txt:\n\(stdout)")
+    XCTAssert(stdout.contains("b.txt"), "Directory did not contain b.txt:\n\(stdout)")
+    XCTAssert(!stdout.contains("c.txt"), "Directory contained c.txt:\n\(stdout)")
+  }
+}

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -12,7 +12,6 @@
 
 import Foundation
 import ISDBTestSupport
-import ISDBTibs
 import LSPTestSupport
 import LanguageServerProtocol
 @_spi(Testing) import SKCore


### PR DESCRIPTION
In particular, this affects Amazon Linux 2, which has a glibc that doesn’t support `posix_spawn_file_actions_addchdir_np`.

rdar://128016626