### PR TITLE
Save sourcekit-lsp diagnose bundles in subdirectories of temporary directory

### DIFF
--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -368,7 +368,9 @@ public struct DiagnoseCommand: AsyncParsableCommand {
       if let bundleOutputPath = self.bundleOutputPath {
         URL(fileURLWithPath: bundleOutputPath)
       } else {
-        FileManager.default.temporaryDirectory.appendingPathComponent("sourcekit-lsp-diagnose-\(date)")
+        FileManager.default.temporaryDirectory
+          .appendingPathComponent("sourcekit-lsp-diagnose")
+          .appendingPathComponent("sourcekit-lsp-diagnose-\(date)")
       }
     try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
 


### PR DESCRIPTION
Finder seems to generally struggle opening a temporary directory with many subfolders and eg. hang when zipping the diagnose bundle. Place the diagnose folders in a dedicated subfolder to avoid this.