### PR TITLE
Remove warning message about missing compiler arguments

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -430,20 +430,6 @@ extension SwiftLanguageService {
     }
 
     let buildSettings = await self.buildSettings(for: snapshot.uri)
-    if buildSettings == nil || buildSettings!.isFallback, let fileUrl = notification.textDocument.uri.fileURL {
-      // Do not show this notification for non-file URIs to make sure we don't see this notificaiton for newly created
-      // files (which get opened as with a `untitled:Unitled-1` URI by VS Code.
-      sourceKitLSPServer?.sendNotificationToClient(
-        ShowMessageNotification(
-          type: .warning,
-          message: """
-            Failed to get compiler arguments for \(fileUrl.lastPathComponent).
-            Ensure the source file is part of a Swift package or has compiler arguments in compile_commands.json.
-            Functionality will be limited.
-            """
-        )
-      )
-    }
 
     let req = openDocumentSourcekitdRequest(snapshot: snapshot, compileCommand: buildSettings)
     _ = try? await self.sourcekitd.send(req, fileContents: snapshot.text)

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -287,7 +287,6 @@ final class BuildSystemTests: XCTestCase {
     let documentManager = await self.testClient.server.documentManager
 
     testClient.openDocument(text, uri: doc)
-    _ = try await testClient.nextNotification(ofType: ShowMessageNotification.self)
     let openDiags = try await testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openDiags.diagnostics.count, 1)
     XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)


### PR DESCRIPTION
It turns out that this message was more noise than help. For example, it would often show up when adding a new file to a SwiftPM project: The file gets added before we reload the package and thus we don’t have build settings for the new file for a short while. Since we can’t dismiss the notification we sent to the client, the notification will stick around.

Let’s just remove the message.