### PR TITLE
Resolve symlinks in toolchain path when creating sourcekitd reproducer bundle

### DIFF
--- a/Sources/Diagnose/ReproducerBundle.swift
+++ b/Sources/Diagnose/ReproducerBundle.swift
@@ -26,7 +26,7 @@ func makeReproducerBundle(for requestInfo: RequestInfo, toolchain: Toolchain, bu
     encoding: .utf8
   )
   if let toolchainPath = toolchain.path {
-    try toolchainPath.pathString
+    try toolchainPath.asURL.resolvingSymlinksInPath().path
       .write(
         to: bundlePath.appendingPathComponent("toolchain.txt"),
         atomically: true,


### PR DESCRIPTION
The realpath will be more useful than eg. `/Library/Developer/Toolchains/swift-latest.xctoolchain`.