### PR TITLE
Allow prefixing of the token for a `WorkDoneProgress` with a custom string

### DIFF
--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -127,6 +127,7 @@ actor IndexProgressManager {
     } else {
       workDoneProgress = await WorkDoneProgressManager(
         server: sourceKitLSPServer,
+        tokenPrefix: "indexing",
         initialDebounce: sourceKitLSPServer.options.workDoneProgressDebounceDuration,
         title: "Indexing",
         message: message,

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -132,40 +132,8 @@ public actor SwiftLanguageService: LanguageService, Sendable {
   nonisolated var requests: sourcekitd_api_requests { return sourcekitd.requests }
   nonisolated var values: sourcekitd_api_values { return sourcekitd.values }
 
-  /// When sourcekitd is crashed, a `WorkDoneProgressManager` that display the sourcekitd crash status in the client.
-  private var sourcekitdCrashedWorkDoneProgress: WorkDoneProgressManager?
-
-  private var state: LanguageServerState {
-    didSet {
-      for handler in stateChangeHandlers {
-        handler(oldValue, state)
-      }
-
-      guard let sourceKitLSPServer else {
-        Task {
-          await sourcekitdCrashedWorkDoneProgress?.end()
-        }
-        sourcekitdCrashedWorkDoneProgress = nil
-        return
-      }
-      switch state {
-      case .connected:
-        Task {
-          await sourcekitdCrashedWorkDoneProgress?.end()
-        }
-        sourcekitdCrashedWorkDoneProgress = nil
-      case .connectionInterrupted, .semanticFunctionalityDisabled:
-        if sourcekitdCrashedWorkDoneProgress == nil {
-          sourcekitdCrashedWorkDoneProgress = WorkDoneProgressManager(
-            server: sourceKitLSPServer,
-            capabilityRegistry: capabilityRegistry,
-            title: "SourceKit-LSP: Restoring functionality",
-            message: "Please run 'sourcekit-lsp diagnose' to file an issue"
-          )
-        }
-      }
-    }
-  }
+  /// - Important: Use `setState` to change the state, which notifies the state change handlers
+  private var state: LanguageServerState
 
   private var stateChangeHandlers: [(_ oldState: LanguageServerState, _ newState: LanguageServerState) -> Void] = []
 
@@ -255,6 +223,30 @@ public actor SwiftLanguageService: LanguageService, Sendable {
   public nonisolated func canHandle(workspace: Workspace) -> Bool {
     // We have a single sourcekitd instance for all workspaces.
     return true
+  }
+
+  private func setState(_ newState: LanguageServerState) async {
+    let oldState = state
+    state = newState
+    for handler in stateChangeHandlers {
+      handler(oldState, newState)
+    }
+
+    guard let sourceKitLSPServer else {
+      return
+    }
+    switch (oldState, newState) {
+    case (.connected, .connectionInterrupted), (.connected, .semanticFunctionalityDisabled):
+      await sourceKitLSPServer.sourcekitdCrashedWorkDoneProgress.start()
+    case (.connectionInterrupted, .connected), (.semanticFunctionalityDisabled, .connected):
+      await sourceKitLSPServer.sourcekitdCrashedWorkDoneProgress.end()
+    case (.connected, .connected),
+      (.connectionInterrupted, .connectionInterrupted),
+      (.connectionInterrupted, .semanticFunctionalityDisabled),
+      (.semanticFunctionalityDisabled, .connectionInterrupted),
+      (.semanticFunctionalityDisabled, .semanticFunctionalityDisabled):
+      break
+    }
   }
 
   public func addStateChangeHandler(
@@ -982,13 +974,14 @@ extension SwiftLanguageService: SKDNotificationHandler {
     )
     // Check if we need to update our `state` based on the contents of the notification.
     if notification.value?[self.keys.notification] == self.values.semaEnabledNotification {
-      self.state = .connected
+      await self.setState(.connected)
+      return
     }
 
     if self.state == .connectionInterrupted {
       // If we get a notification while we are restoring the connection, it means that the server has restarted.
       // We still need to wait for semantic functionality to come back up.
-      self.state = .semanticFunctionalityDisabled
+      await self.setState(.semanticFunctionalityDisabled)
 
       // Ask our parent to re-open all of our documents.
       if let sourceKitLSPServer {
@@ -999,7 +992,7 @@ extension SwiftLanguageService: SKDNotificationHandler {
     }
 
     if notification.error == .connectionInterrupted {
-      self.state = .connectionInterrupted
+      await self.setState(.connectionInterrupted)
 
       // We don't have any open documents anymore after sourcekitd crashed.
       // Reset the document manager to reflect that.

--- a/Sources/SourceKitLSP/WorkDoneProgressManager.swift
+++ b/Sources/SourceKitLSP/WorkDoneProgressManager.swift
@@ -20,7 +20,7 @@ import SwiftExtensions
 ///
 /// The work done progress is started when the object is created and ended when the object is destroyed.
 /// In between, updates can be sent to the client.
-final actor WorkDoneProgressManager {
+actor WorkDoneProgressManager {
   private enum Status: Equatable {
     case inProgress(message: String?, percentage: Int?)
     case done
@@ -35,6 +35,15 @@ final actor WorkDoneProgressManager {
   private let progressUpdateQueue = AsyncQueue<Serial>()
 
   private weak var server: SourceKitLSPServer?
+
+  /// A string with which the `token` of the generated `WorkDoneProgress` sent to the client starts.
+  ///
+  /// A UUID will be appended to this prefix to make the token unique. The token prefix can be used to classify the work
+  /// done progress into a category, which makes debugging easier because the tokens have semantic meaning and also
+  /// allows clients to interpret what the `WorkDoneProgress` represents (for example Swift for VS Code explicitly
+  /// recognizes work done progress that indicates that sourcekitd has crashed to offer a diagnostic bundle to be
+  /// generated).
+  private let tokenPrefix: String
 
   private let title: String
 
@@ -58,6 +67,7 @@ final actor WorkDoneProgressManager {
 
   init?(
     server: SourceKitLSPServer,
+    tokenPrefix: String,
     initialDebounce: Duration? = nil,
     title: String,
     message: String? = nil,
@@ -69,6 +79,7 @@ final actor WorkDoneProgressManager {
     self.init(
       server: server,
       capabilityRegistry: capabilityRegistry,
+      tokenPrefix: tokenPrefix,
       initialDebounce: initialDebounce,
       title: title,
       message: message,
@@ -79,6 +90,7 @@ final actor WorkDoneProgressManager {
   init?(
     server: SourceKitLSPServer,
     capabilityRegistry: CapabilityRegistry,
+    tokenPrefix: String,
     initialDebounce: Duration? = nil,
     title: String,
     message: String? = nil,
@@ -87,6 +99,7 @@ final actor WorkDoneProgressManager {
     guard capabilityRegistry.clientCapabilities.window?.workDoneProgress ?? false else {
       return nil
     }
+    self.tokenPrefix = tokenPrefix
     self.server = server
     self.title = title
     self.pendingStatus = .inProgress(message: message, percentage: percentage)
@@ -121,7 +134,7 @@ final actor WorkDoneProgressManager {
           )
         )
       } else {
-        let token = ProgressToken.string(UUID().uuidString)
+        let token = ProgressToken.string("\(tokenPrefix).\(UUID().uuidString)")
         do {
           _ = try await server.client.send(CreateWorkDoneProgressRequest(token: token))
         } catch {
@@ -174,6 +187,71 @@ final actor WorkDoneProgressManager {
       if let token {
         server?.sendNotificationToClient(WorkDoneProgress(token: token, value: .end(WorkDoneProgressEnd())))
       }
+    }
+  }
+}
+
+/// A `WorkDoneProgressManager` that essentially has two states. If any operation tracked by this type is currently
+/// running, it displays a work done progress in the client. If multiple operations are running at the same time, it
+/// doesn't show multiple work done progress in the client. For example, we only want to show one progress indicator
+/// when sourcekitd has crashed, not one per `SwiftLanguageService`.
+actor SharedWorkDoneProgressManager {
+  private weak var sourceKitLSPServer: SourceKitLSPServer?
+
+  /// The number of in-progress operations. When greater than 0 `workDoneProgress` non-nil and a work done progress is
+  /// displayed to the user.
+  private var inProgressOperations = 0
+  private var workDoneProgress: WorkDoneProgressManager?
+
+  private let tokenPrefix: String
+  private let title: String
+  private let message: String?
+
+  public init(
+    sourceKitLSPServer: SourceKitLSPServer,
+    tokenPrefix: String,
+    title: String,
+    message: String? = nil
+  ) {
+    self.sourceKitLSPServer = sourceKitLSPServer
+    self.tokenPrefix = tokenPrefix
+    self.title = title
+    self.message = message
+  }
+
+  func start() async {
+    guard let sourceKitLSPServer else {
+      return
+    }
+    // Do all asynchronous operations up-front so that incrementing `inProgressOperations` and setting `workDoneProgress`
+    // cannot be interrupted by an `await` call
+    let initialDebounce = await sourceKitLSPServer.options.workDoneProgressDebounceDuration
+    let capabilityRegistry = await sourceKitLSPServer.capabilityRegistry
+
+    inProgressOperations += 1
+    if let capabilityRegistry, workDoneProgress == nil {
+      workDoneProgress = WorkDoneProgressManager(
+        server: sourceKitLSPServer,
+        capabilityRegistry: capabilityRegistry,
+        tokenPrefix: tokenPrefix,
+        initialDebounce: initialDebounce,
+        title: title,
+        message: message
+      )
+    }
+  }
+
+  func end() async {
+    if inProgressOperations > 0 {
+      inProgressOperations -= 1
+    } else {
+      logger.fault(
+        "Unbalanced calls to SharedWorkDoneProgressManager.start and end for \(self.tokenPrefix, privacy: .public)"
+      )
+    }
+    if inProgressOperations == 0, let workDoneProgress {
+      self.workDoneProgress = nil
+      await workDoneProgress.end()
     }
   }
 }


### PR DESCRIPTION
This allows VS Code to detect when sourcekitd has crashed and prompt the user to gather a diagnostic report + file an issue about the crash.

I took this opportunity to refactor the WorkDoneProgress that effectively counts how many tasks of this kind are going on, into a separate type. I’m not quite happy with the name `SharedWorkDoneProgressManager`. Happy for better suggestions if anyone has some.

rdar://129678779
Fixes #1476