### PR TITLE
Implement `sourcekit-lsp --version` option

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import struct Basics.SwiftVersion
 import Csourcekitd  // Not needed here, but fixes debugging...
 import Diagnose
 import Dispatch
@@ -103,6 +104,7 @@ extension SKSupport.WorkspaceType: @retroactive ExpressibleByArgument {}
 struct SourceKitLSP: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     abstract: "Language Server Protocol implementation for Swift and C-based languages",
+    version: "sourcekit-lsp \(Basics.SwiftVersion.current.displayString)",
     subcommands: [
       DiagnoseCommand.self,
       DebugCommand.self,


### PR DESCRIPTION
Currently `sourcekit-lsp --version` is an invalid option, which makes it harder to debug issues with SourceKit-LSP, as one can't even easily know which version is installed:

```
❯ sourcekit-lsp --version
Error: Unknown option '--version'
```