### PR TITLE
Fix incorrect command name in `sourcekit-lsp --help` output

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -102,6 +102,7 @@ extension SKSupport.WorkspaceType: @retroactive ExpressibleByArgument {}
 @main
 struct SourceKitLSP: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
+    commandName: "sourcekit-lsp",
     abstract: "Language Server Protocol implementation for Swift and C-based languages",
     subcommands: [
       DiagnoseCommand.self,


### PR DESCRIPTION
Currently the name of the command is `source-kit-lsp` in `sourcekit-lsp --help` output:

```
❯ sourcekit-lsp --help
OVERVIEW: Language Server Protocol implementation for Swift and C-based languages

USAGE: source-kit-lsp <options> <subcommand>
```