### PR TITLE
Watch for changes to `Package.resolved`

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -691,7 +691,7 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
         packageGraph: self.modulesGraph
       )
     case .changed:
-      return fileURL.lastPathComponent == "Package.swift"
+      return fileURL.lastPathComponent == "Package.swift" || fileURL.lastPathComponent == "Package.resolved"
     default:  // Unknown file change type
       return false
     }

--- a/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
+++ b/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LSPTestSupport
+import XCTest
+
+/// Runs the body repeatedly once per second until it returns `true`, giving up after `timeout`.
+///
+/// This is useful to test some request that requires global state to be updated but will eventually converge on the
+/// correct result.
+///
+/// If `bodyHasOneSecondDelay` is true, it is assume that the body already has a one-second delay between iterations.
+public func repeatUntilExpectedResult(
+  _ body: () async throws -> Bool,
+  bodyHasOneSecondDelay: Bool = false,
+  timeout: TimeInterval = defaultTimeout,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async throws {
+  for _ in 0..<Int(timeout) {
+    if try await body() {
+      return
+    }
+    if !bodyHasOneSecondDelay {
+      try await Task.sleep(for: .seconds(1))
+    }
+  }
+  XCTFail("Failed to get expected result", file: file, line: line)
+}

--- a/Sources/SKTestSupport/SwiftPMDependencyProject.swift
+++ b/Sources/SKTestSupport/SwiftPMDependencyProject.swift
@@ -86,15 +86,20 @@ public class SwiftPMDependencyProject {
     }
 
     try await runGitCommand(["init"], workingDirectory: packageDirectory)
+    try await tag(changedFiles: files.keys.map { $0.url(relativeTo: packageDirectory) }, version: "1.0.0")
+  }
+
+  public func tag(changedFiles: [URL], version: String) async throws {
     try await runGitCommand(
-      ["add"] + files.keys.map { $0.url(relativeTo: packageDirectory).path },
+      ["add"] + changedFiles.map(\.path),
       workingDirectory: packageDirectory
     )
     try await runGitCommand(
-      ["-c", "user.name=Dummy", "-c", "user.email=noreply@swift.org", "commit", "-m", "Initial commit"],
+      ["-c", "user.name=Dummy", "-c", "user.email=noreply@swift.org", "commit", "-m", "Version \(version)"],
       workingDirectory: packageDirectory
     )
-    try await runGitCommand(["tag", "1.0.0"], workingDirectory: packageDirectory)
+
+    try await runGitCommand(["tag", version], workingDirectory: self.packageDirectory)
   }
 
   deinit {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1189,6 +1189,7 @@ extension SourceKitLSPServer {
       return FileSystemWatcher(globPattern: "**/*.\(fileExtension)", kind: [.create, .change, .delete])
     }
     watchers.append(FileSystemWatcher(globPattern: "**/Package.swift", kind: [.change]))
+    watchers.append(FileSystemWatcher(globPattern: "**/Package.resolved", kind: [.change]))
     watchers.append(FileSystemWatcher(globPattern: "**/compile_commands.json", kind: [.create, .change, .delete]))
     watchers.append(FileSystemWatcher(globPattern: "**/compile_flags.txt", kind: [.create, .change, .delete]))
     // Watch for changes to `.swiftmodule` files to detect updated modules during a build.

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -187,15 +187,10 @@ final class BuildSystemTests: XCTestCase {
 
     await buildSystem.delegate?.fileBuildSettingsChanged([doc])
 
-    var receivedCorrectDiagnostic = false
-    for _ in 0..<Int(defaultTimeout) {
+    try await repeatUntilExpectedResult {
       let refreshedDiags = try await testClient.nextDiagnosticsNotification(timeout: .seconds(1))
-      if refreshedDiags.diagnostics.count == 0, try text == documentManager.latestSnapshot(doc).text {
-        receivedCorrectDiagnostic = true
-        break
-      }
+      return try text == documentManager.latestSnapshot(doc).text && refreshedDiags.diagnostics.count == 0
     }
-    XCTAssert(receivedCorrectDiagnostic)
   }
 
   func testSwiftDocumentUpdatedBuildSettings() async throws {

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -201,16 +201,12 @@ final class MainFilesProviderTests: XCTestCase {
     // `clangd` may return diagnostics from the old build settings sometimes (I believe when it's still building the
     // preamble for shared.h when the new build settings come in). Check that it eventually returns the correct
     // diagnostics.
-    var receivedCorrectDiagnostic = false
-    for _ in 0..<Int(defaultTimeout) {
+    try await repeatUntilExpectedResult {
       let refreshedDiags = try await project.testClient.nextDiagnosticsNotification(timeout: .seconds(1))
-      if let diagnostic = refreshedDiags.diagnostics.only,
-        diagnostic.message == "Unused variable 'fromMyFancyLibrary'"
-      {
-        receivedCorrectDiagnostic = true
-        break
+      guard let diagnostic = refreshedDiags.diagnostics.only else {
+        return false
       }
+      return diagnostic.message == "Unused variable 'fromMyFancyLibrary'"
     }
-    XCTAssert(receivedCorrectDiagnostic)
   }
 }


### PR DESCRIPTION
We need to watch for changes to `Package.resolved` so that we can update the dependency checkouts in `.index-build` when the user runs `swift package update`.

rdar://130103181