### PR TITLE
When a JSON-RPC connection is closed, send an error response to all outstanding requests

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -165,6 +165,9 @@ public final class JSONRPCConnection: Connection {
     ioGroup.notify(queue: queue) { [weak self] in
       guard let self = self else { return }
       Task {
+        for outstandingRequest in self.outstandingRequests.values {
+          outstandingRequest.replyHandler(LSPResult.failure(ResponseError.internalError("JSON-RPC Connection closed")))
+        }
         await self.closeHandler?()
         self.receiveHandler = nil  // break retain cycle
       }


### PR DESCRIPTION
Re-apply #1688 after it was reverted by #1706.