### PR TITLE
Improve `BuildServerBuildSystemTests.testCrashRecovery`

### DIFF
--- a/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
+++ b/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
@@ -16,12 +16,9 @@ import XCTest
 ///
 /// This is useful to test some request that requires global state to be updated but will eventually converge on the
 /// correct result.
-///
-/// If `bodyHasOneSecondDelay` is true, it is assume that the body already has a one-second delay between iterations.
 package func repeatUntilExpectedResult(
-  _ body: () async throws -> Bool,
-  bodyHasOneSecondDelay: Bool = false,
   timeout: TimeInterval = defaultTimeout,
+  _ body: () async throws -> Bool,
   file: StaticString = #filePath,
   line: UInt = #line
 ) async throws {
@@ -29,9 +26,7 @@ package func repeatUntilExpectedResult(
     if try await body() {
       return
     }
-    if !bodyHasOneSecondDelay {
-      try await Task.sleep(for: .seconds(1))
-    }
+    try await Task.sleep(for: .seconds(1))
   }
   XCTFail("Failed to get expected result", file: file, line: line)
 }


### PR DESCRIPTION
The original idea behind this test was that only opening `Crash.swift` would retrieve build settings for `Crash.swift`. But that wasn’t actually true: Scanning for tests also retrieved build settings (to get the test’s module name). This caused test failures if we set `SOURCEKIT_LSP_TEST_TIMEOUT: 10`, like we do in `settings.json`.

Improve the test to actually check that the BSP server has crashed and increase timeout to be bigger than the 10s restart delay.