### PR TITLE
Add `-` to `swift-format` invocation to indicate that file contents should be read from stdin

### DIFF
--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -190,6 +190,7 @@ extension SwiftLanguageService {
     var args = try [
       swiftFormat.filePath,
       "format",
+      "-",  // Read file contents from stdin
       "--configuration",
       swiftFormatConfiguration(for: textDocument.uri, options: options),
     ]


### PR DESCRIPTION
To match https://github.com/swiftlang/swift-format/pull/914