### PR TITLE
Port SwiftPMBuildSystemTests to Swift Testing

### DIFF
--- a/Sources/SKTestSupport/Expectations.swift
+++ b/Sources/SKTestSupport/Expectations.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public import Testing
+
+public func expectThrowsError<T>(
+  _ expression: @autoclosure () async throws -> T,
+  _ message: @autoclosure () -> String = "",
+  sourceLocation: SourceLocation = #_sourceLocation,
+  errorHandler: (_ error: Error) -> Void = { _ in }
+) async {
+  do {
+    _ = try await expression()
+    Issue.record("Expression was expected to throw but did not throw", sourceLocation: sourceLocation)
+  } catch {
+    errorHandler(error)
+  }
+}

--- a/Sources/SKTestSupport/PluginPaths.swift
+++ b/Sources/SKTestSupport/PluginPaths.swift
@@ -14,10 +14,17 @@ import Foundation
 package import SourceKitD
 import ToolchainRegistry
 
+// Anchor class to lookup the testing bundle when swiftpm-testing-helper is used.
+private final class TestingAnchor {}
+
 /// The path to the `SwiftSourceKitPluginTests` test bundle. This gives us a hook into the the build directory.
 private let xctestBundle: URL = {
   #if canImport(Darwin)
   for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+    return bundle.bundleURL
+  }
+  let bundle = Bundle(for: TestingAnchor.self)
+  if bundle.bundlePath.hasSuffix(".xctest") {
     return bundle.bundleURL
   }
   preconditionFailure("Failed to find xctest bundle")


### PR DESCRIPTION
This is in preparation for parameterizing these tests to use either SwiftPM's native or Swift Build based build system