### PR TITLE
[6.2] Always try to render some documentation for Swift files

### DIFF
--- a/Sources/DocCDocumentation/DoccDocumentationError.swift
+++ b/Sources/DocCDocumentation/DoccDocumentationError.swift
@@ -14,14 +14,17 @@ import Foundation
 package import LanguageServerProtocol
 
 package enum DocCDocumentationError: LocalizedError {
-  case noDocumentation
+  case unsupportedLanguage(Language)
+  case noDocumentableSymbols
   case indexNotAvailable
   case symbolNotFound(String)
 
   var errorDescription: String? {
     switch self {
-    case .noDocumentation:
-      return "No documentation could be rendered for the position in this document"
+    case .unsupportedLanguage(let language):
+      return "Documentation preview is not available for \(language.description) files"
+    case .noDocumentableSymbols:
+      return "No documentable symbols were found in this Swift file"
     case .indexNotAvailable:
       return "The index is not availble to complete the request"
     case .symbolNotFound(let symbolName):

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -488,7 +488,12 @@ extension ClangLanguageService {
 
   #if canImport(DocCDocumentation)
   func doccDocumentation(_ req: DoccDocumentationRequest) async throws -> DoccDocumentationResponse {
-    throw ResponseError.requestFailed(doccDocumentationError: .noDocumentation)
+    guard let sourceKitLSPServer else {
+      throw ResponseError.unknown("Connection to the editor closed")
+    }
+
+    let snapshot = try sourceKitLSPServer.documentManager.latestSnapshot(req.textDocument.uri)
+    throw ResponseError.requestFailed(doccDocumentationError: .unsupportedLanguage(snapshot.language))
   }
   #endif
 

--- a/Sources/SourceKitLSP/Documentation/DoccDocumentationHandler.swift
+++ b/Sources/SourceKitLSP/Documentation/DoccDocumentationHandler.swift
@@ -105,7 +105,7 @@ extension DocumentationLanguageService {
         catalogURL: catalogURL
       )
     default:
-      throw ResponseError.requestFailed(doccDocumentationError: .noDocumentation)
+      throw ResponseError.requestFailed(doccDocumentationError: .unsupportedLanguage(snapshot.language))
     }
   }
 }


### PR DESCRIPTION
Cherry pick of #2198 to 6.2

* **Explanation:** Adds better error handling to `textDocument/doccDocumentation` requests
* **Scope:** Affects SwiftDocC live preview for Swift doc comments
* **Issue:** rdar://155986296
* **Risk:** Low, only affects a new experimental feature
* **Testing:** Tests have been added to ensure new functionality works as intended
* **Reviewer:** Ben Barham