### PR TITLE
Fix all warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -244,8 +244,6 @@ var targets: [Target] = [
       "BuildServerIntegration",
       "BuildServerProtocol",
       "LanguageServerProtocol",
-
-      "SemanticIndex",
       "SemanticIndex",
       "SKLogging",
       "SKUtilities",

--- a/Sources/CompletionScoringTestSupport/TestExtensions.swift
+++ b/Sources/CompletionScoringTestSupport/TestExtensions.swift
@@ -110,7 +110,7 @@ extension XCTestCase {
           at: URL(fileURLWithPath: path).deletingLastPathComponent(),
           withIntermediateDirectories: true
         )
-        FileManager.default.createFile(atPath: path, contents: Data())
+        try FileManager.default.createFile(at: URL(fileURLWithPath: path), contents: Data())
       }
       let logFD = try FileHandle(forWritingAtPath: path).unwrap(orThrow: "Opening \(path) failed")
       try logFD.seekToEnd()

--- a/Sources/Csourcekitd/include/plugin.h
+++ b/Sources/Csourcekitd/include/plugin.h
@@ -233,13 +233,23 @@ typedef struct {
     _Null_unspecified sourcekitd_api_plugin_initialize_params_t
   );
 
-  _Null_unspecified SWIFT_SENDABLE sourcekitd_api_uid_get_from_cstr_t (*_Nonnull plugin_initialize_uid_get_from_cstr)(
+  // The following would be more idiomatically written as follows but marking `sourcekitd_api_uid_get_from_cstr_t` as
+  // `Sendable` hits https://github.com/swiftlang/swift/issues/83892.
+  // _Null_unspecified SWIFT_SENDABLE sourcekitd_api_uid_get_from_cstr_t (*_Nonnull plugin_initialize_uid_get_from_cstr)(
+  //   _Null_unspecified sourcekitd_api_plugin_initialize_params_t
+  // );
+  _Null_unspecified sourcekitd_api_uid_t (*_Null_unspecified SWIFT_SENDABLE (*_Nonnull plugin_initialize_uid_get_from_cstr)(
     _Null_unspecified sourcekitd_api_plugin_initialize_params_t
-  );
+  ))(const char *_Null_unspecified string);
 
-  _Null_unspecified SWIFT_SENDABLE sourcekitd_api_uid_get_string_ptr_t (*_Nonnull plugin_initialize_uid_get_string_ptr)(
+  // The following would be more idiomatically written as follows but marking `sourcekitd_api_uid_get_string_ptr_t` as
+  // `Sendable` hits https://github.com/swiftlang/swift/issues/83892.
+  // _Null_unspecified SWIFT_SENDABLE sourcekitd_api_uid_get_string_ptr_t (*_Nonnull plugin_initialize_uid_get_string_ptr)(
+  //   _Null_unspecified sourcekitd_api_plugin_initialize_params_t
+  // );
+  const char *_Null_unspecified (*_Null_unspecified SWIFT_SENDABLE (*_Nonnull plugin_initialize_uid_get_string_ptr)(
     _Null_unspecified sourcekitd_api_plugin_initialize_params_t
-  );
+  ))(_Null_unspecified sourcekitd_api_uid_t);
 
   void (*_Nonnull plugin_initialize_register_custom_buffer)(
     _Nonnull sourcekitd_api_plugin_initialize_params_t,

--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -219,9 +219,7 @@ package struct DiagnoseCommand: AsyncParsableCommand {
     #if os(macOS)
     reportProgress(.collectingLogMessages(progress: 0), message: "Collecting log messages")
     let outputFileUrl = bundlePath.appendingPathComponent("log.txt")
-    guard FileManager.default.createFile(atPath: try outputFileUrl.filePath, contents: nil) else {
-      throw GenericError("Failed to create log.txt")
-    }
+    try FileManager.default.createFile(at: outputFileUrl, contents: nil)
     let fileHandle = try FileHandle(forWritingTo: outputFileUrl)
     let bytesCollected = AtomicInt32(initialValue: 0)
     let processExited = AtomicBool(initialValue: false)
@@ -320,9 +318,7 @@ package struct DiagnoseCommand: AsyncParsableCommand {
   @MainActor
   private func addSwiftVersion(toBundle bundlePath: URL) async throws {
     let outputFileUrl = bundlePath.appendingPathComponent("swift-versions.txt")
-    guard FileManager.default.createFile(atPath: try outputFileUrl.filePath, contents: nil) else {
-      throw GenericError("Failed to create file at \(outputFileUrl)")
-    }
+    try FileManager.default.createFile(at: outputFileUrl, contents: nil)
     let fileHandle = try FileHandle(forWritingTo: outputFileUrl)
 
     let toolchains = try await toolchainRegistry.toolchains

--- a/Sources/SKLogging/CustomLogStringConvertible.swift
+++ b/Sources/SKLogging/CustomLogStringConvertible.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import Foundation
+public import Foundation
 
 #if !NO_CRYPTO_DEPENDENCY
 import Crypto
@@ -33,14 +33,21 @@ package protocol CustomLogStringConvertible: CustomStringConvertible, Sendable {
 /// There currently is no way to get equivalent functionality in pure Swift. We
 /// thus pass this object to OSLog, which just forwards to `description` or
 /// `redactedDescription` of an object that implements `CustomLogStringConvertible`.
-package final class CustomLogStringConvertibleWrapper: NSObject, Sendable {
+public final class CustomLogStringConvertibleWrapper: NSObject, Sendable {
+  // `CustomLogStringConvertibleWrapper` is marked as `public` to work around
+  // https://github.com/swiftlang/swift/issues/83893
   private let underlyingObject: any CustomLogStringConvertible
+  #if compiler(>=6.4)
+  #warning(
+    "Mark CustomLogStringConvertibleWrapper as `package` if https://github.com/swiftlang/swift/issues/83893 is fixed"
+  )
+  #endif
 
   fileprivate init(_ underlyingObject: any CustomLogStringConvertible) {
     self.underlyingObject = underlyingObject
   }
 
-  package override var description: String {
+  public override var description: String {
     return underlyingObject.description
   }
 

--- a/Sources/SKLogging/Logging.swift
+++ b/Sources/SKLogging/Logging.swift
@@ -19,9 +19,17 @@ package typealias LogLevel = os.OSLogType
 package typealias Logger = os.Logger
 package typealias Signposter = OSSignposter
 
-extension OSSignposter: @retroactive @unchecked Sendable {}
-extension OSSignpostID: @retroactive @unchecked Sendable {}
+// -user-module-version of the 'os' module is 1062.100.1 in Xcode 16.3, which added the conformance of
+// `OSSignpostIntervalState` to `Sendable`
+#if !canImport(os, _version: 1062.100)
 extension OSSignpostIntervalState: @retroactive @unchecked Sendable {}
+#endif
+
+#if compiler(>=6.4)
+#warning(
+  "Remove retroactive conformance of OSSignpostIntervalState to Sendable if we no longer need to support building SourceKit-LSP with SDKs from Xcode <16.3"
+)
+#endif
 
 extension os.Logger {
   package func makeSignposter() -> Signposter {

--- a/Sources/SKLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/SKLogging/SetGlobalLogFileHandler.swift
@@ -25,14 +25,6 @@ import WinSDK
 #endif
 
 #if !canImport(os) || SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
-private struct FailedToCreateFileError: Error, CustomStringConvertible {
-  let logFile: URL
-
-  var description: String {
-    return "Failed to create log file at \(logFile)"
-  }
-}
-
 /// The number of log file handles that have been created by this process.
 ///
 /// See comment on `logFileHandle`.
@@ -59,9 +51,7 @@ func getOrCreateLogFileHandle(logDirectory: URL, logRotateCount: Int) -> FileHan
   do {
     try FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true)
     if !FileManager.default.fileExists(at: logFileUrl) {
-      guard FileManager.default.createFile(atPath: try logFileUrl.filePath, contents: nil) else {
-        throw FailedToCreateFileError(logFile: logFileUrl)
-      }
+      try FileManager.default.createFile(at: logFileUrl, contents: nil)
     }
     let newFileHandle = try FileHandle(forWritingTo: logFileUrl)
     logFileHandle = newFileHandle

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -219,9 +219,7 @@ package actor SkipUnless {
         .appendingPathComponent("swift-frontend")
       return try await withTestScratchDir { scratchDirectory in
         let input = scratchDirectory.appendingPathComponent("Input.swift")
-        guard FileManager.default.createFile(atPath: input.path, contents: nil) else {
-          throw GenericError("Failed to create input file")
-        }
+        try FileManager.default.createFile(at: input, contents: nil)
         // If we can't compile for wasm, this fails complaining that it can't find the stdlib for wasm.
         let result = try await withTimeout(defaultTimeoutDuration) {
           try await Process.run(

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -537,7 +537,7 @@ fileprivate extension Process {
           try FileManager.default.removeItem(at: responseFile)
         }
       }
-      FileManager.default.createFile(atPath: try responseFile.filePath, contents: nil)
+      try FileManager.default.createFile(at: responseFile, contents: nil)
       let handle = try FileHandle(forWritingTo: responseFile)
       for argument in arguments.dropFirst() {
         handle.write(Data((argument.spm_shellEscaped() + "\n").utf8))

--- a/Sources/SwiftExtensions/FileManagerExtensions.swift
+++ b/Sources/SwiftExtensions/FileManagerExtensions.swift
@@ -33,4 +33,19 @@ extension FileManager {
     var isDirectory: ObjCBool = false
     return self.fileExists(atPath: url.path, isDirectory: &isDirectory) && !isDirectory.boolValue
   }
+
+  /// Same as `createFile(atPath:data:attributes)` but throws an error when file creation fails instead of returning
+  /// `false`.
+  package func createFile(at url: URL, contents data: Data?, attributes: [FileAttributeKey: Any]? = nil) throws {
+    struct FileCreationFailed: Error, CustomStringConvertible {
+      let url: URL
+      var description: String {
+        "Failed to create file at '\(url)'"
+      }
+    }
+    let successful = createFile(atPath: try url.filePath, contents: data, attributes: attributes)
+    guard successful else {
+      throw FileCreationFailed(url: url)
+    }
+  }
 }

--- a/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
+++ b/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
@@ -183,7 +183,7 @@ final class Connection {
         // FIXME: move line:column translation into C++ impl. so that we can avoid reading the file an extra time here.
         do {
           logger.log("Received code completion request for file that wasn't open. Reading file contents from disk.")
-          let contents = try String(contentsOfFile: loc.path)
+          let contents = try String(contentsOfFile: loc.path, encoding: .utf8)
           let lineTable = LineTable(contents)
           return lineTable.utf8OffsetOf(line: loc.line - 1, utf8Column: loc.utf8Column - 1)
         } catch {

--- a/Sources/SwiftSourceKitPlugin/CompletionProvider.swift
+++ b/Sources/SwiftSourceKitPlugin/CompletionProvider.swift
@@ -126,7 +126,7 @@ actor CompletionProvider {
     } else if let file: String = request[keys.sourceFile] {
       logger.info("Document open request missing source text. Reading contents of '\(file)' from disk.")
       do {
-        content = try String(contentsOfFile: file)
+        content = try String(contentsOfFile: file, encoding: .utf8)
       } catch {
         self.logger.error("error: dropping request editor.open: failed to read \(file): \(String(describing: error))")
         return

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -222,7 +222,7 @@ struct SourceKitLSP: AsyncParsableCommand {
 
     logger.log("Mirroring input to \(inputMirrorURL)")
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-    FileManager.default.createFile(atPath: try inputMirrorURL.filePath, contents: nil)
+    try FileManager.default.createFile(at: inputMirrorURL, contents: nil)
 
     return try FileHandle(forWritingTo: inputMirrorURL)
   }

--- a/Tests/SourceKitLSPTests/BuildServerTests.swift
+++ b/Tests/SourceKitLSPTests/BuildServerTests.swift
@@ -134,7 +134,7 @@ final class BuildServerTests: XCTestCase {
 
     await buildServer.setBuildSettings(for: doc, to: TextDocumentSourceKitOptionsResponse(compilerArguments: args))
 
-    let documentManager = await self.testClient.server.documentManager
+    let documentManager = self.testClient.server.documentManager
 
     testClient.openDocument(text, uri: doc)
 
@@ -173,7 +173,7 @@ final class BuildServerTests: XCTestCase {
       foo()
       """
 
-    let documentManager = await self.testClient.server.documentManager
+    let documentManager = self.testClient.server.documentManager
 
     testClient.openDocument(text, uri: doc)
     let diags1 = try await testClient.nextDiagnosticsNotification()
@@ -204,7 +204,7 @@ final class BuildServerTests: XCTestCase {
         }
       """
 
-    let documentManager = await self.testClient.server.documentManager
+    let documentManager = self.testClient.server.documentManager
 
     testClient.openDocument(text, uri: doc)
     let openDiags = try await testClient.nextDiagnosticsNotification()
@@ -245,7 +245,7 @@ final class BuildServerTests: XCTestCase {
         func
       """
 
-    let documentManager = await self.testClient.server.documentManager
+    let documentManager = self.testClient.server.documentManager
 
     testClient.openDocument(text, uri: doc)
     let openDiags = try await testClient.nextDiagnosticsNotification()

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -39,7 +39,7 @@ final class LocalSwiftTests: XCTestCase {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = DocumentURI(for: .swift)
 
-    let documentManager = await testClient.server.documentManager
+    let documentManager = testClient.server.documentManager
 
     testClient.openDocument("func", uri: uri, version: 12)
 
@@ -162,7 +162,7 @@ final class LocalSwiftTests: XCTestCase {
     let testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
     let uri = try DocumentURI(string: "urn:uuid:A1B08909-E791-469E-BF0F-F5790977E051")
 
-    let documentManager = await testClient.server.documentManager
+    let documentManager = testClient.server.documentManager
 
     testClient.openDocument("func", uri: uri, language: .swift)
 


### PR DESCRIPTION
Fixes all warnings when building on macOS and Linux using Swift 6.1, Swift 6.2 and SDKs from Xcode 16.2 and Xcode 16.3