### PR TITLE
Add a missing `SourceKitD` import

### DIFF
--- a/Sources/SwiftLanguageService/WithSnapshotFromDiskOpenedInSourcekitd.swift
+++ b/Sources/SwiftLanguageService/WithSnapshotFromDiskOpenedInSourcekitd.swift
@@ -15,6 +15,7 @@ import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SKUtilities
+import SourceKitD
 import SourceKitLSP
 import SwiftExtensions
 


### PR DESCRIPTION
With the Swift compiler fix https://github.com/swiftlang/swift/pull/83934 (which ensures that key paths are diagnosed correctly when `MemberImportVisibility` is enabled) SourceKit no longer builds because the compiler now correctly identifies a missing import of `SourceKitD`. Add the missing import.