### PR TITLE
Log each read config

### DIFF
--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -13,7 +13,7 @@
 public import Foundation
 public import LanguageServerProtocol
 import LanguageServerProtocolExtensions
-import SKLogging
+package import SKLogging
 
 import struct TSCBasic.AbsolutePath
 
@@ -500,6 +500,10 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     else {
       return nil
     }
+
+    logger.log("Read options from \(path)")
+    logger.logFullObjectInMultipleLogMessages(header: "Config file options", loggingProxy)
+
     self = decoded
   }
 
@@ -559,5 +563,27 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       return false
     }
     return experimentalFeatures.contains(feature)
+  }
+}
+
+extension SourceKitLSPOptions {
+  /// Options proxy to avoid public import of `SKLogging`.
+  ///
+  /// We can't conform `SourceKitLSPOptions` to `CustomLogStringConvertible` because that would require a public import
+  /// of `SKLogging`. Instead, define a package type that performs the logging of `SourceKitLSPOptions`.
+  package struct LoggingProxy: CustomLogStringConvertible {
+    let options: SourceKitLSPOptions
+
+    package var description: String {
+      options.prettyPrintedJSON
+    }
+
+    package var redactedDescription: String {
+      options.prettyPrintedRedactedJSON
+    }
+  }
+
+  package var loggingProxy: LoggingProxy {
+    LoggingProxy(options: self)
   }
 }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -917,7 +917,7 @@ extension SourceKitLSPServer {
       )
     )
     logger.log("Creating workspace at \(workspaceFolder.forLogging)")
-    logger.logFullObjectInMultipleLogMessages(header: "Options for workspace", options.loggingProxy)
+    logger.logFullObjectInMultipleLogMessages(header: "Workspace options", options.loggingProxy)
 
     let workspace = await Workspace(
       sourceKitLSPServer: self,
@@ -1003,7 +1003,7 @@ extension SourceKitLSPServer {
     }
 
     logger.log("Initialized SourceKit-LSP")
-    logger.logFullObjectInMultipleLogMessages(header: "SourceKit-LSP Options", options.loggingProxy)
+    logger.logFullObjectInMultipleLogMessages(header: "Global options", options.loggingProxy)
 
     await workspaceQueue.async { [hooks] in
       if let workspaceFolders = req.workspaceFolders {
@@ -2805,29 +2805,5 @@ fileprivate extension URL {
       return false
     }
     return other.pathComponents[0..<self.pathComponents.count] == self.pathComponents[...]
-  }
-}
-
-extension SourceKitLSPOptions {
-  /// We can't conform `SourceKitLSPOptions` to `CustomLogStringConvertible` because that would require a public import
-  /// of `SKLogging`. Instead, define an internal type that performs the logging of `SourceKitLSPOptions`.
-  struct LoggingProxy: CustomLogStringConvertible {
-    let options: SourceKitLSPOptions
-
-    var description: String {
-      options.prettyPrintedJSON
-    }
-
-    var redactedDescription: String {
-      options.prettyPrintedRedactedJSON
-    }
-  }
-
-  var loggingProxy: LoggingProxy {
-    LoggingProxy(options: self)
-  }
-
-  var forLogging: CustomLogStringConvertibleWrapper {
-    return self.loggingProxy.forLogging
   }
 }


### PR DESCRIPTION
There's been a couple issue where it is clear from the log of the global configuration that options are being set *somewhere*, but users then have to go searching in all the paths we lookup (which is quite a few). Log each config we read so it's easy to see where the options are coming from.