### PR TITLE
Standardize file paths when attempting to find toolchains

### DIFF
--- a/Sources/SwiftExtensions/URLExtensions.swift
+++ b/Sources/SwiftExtensions/URLExtensions.swift
@@ -87,6 +87,8 @@ extension URL {
     }
   }
 
+  /// Assuming this URL is a file URL, checks if it looks like a root path. This is a string check, ie. the return
+  /// value for a path of `"/foo/.."` would be `false`. An error will be thrown is this is a non-file URL.
   package var isRoot: Bool {
     get throws {
       let checkPath = try filePath

--- a/Sources/ToolchainRegistry/ToolchainRegistry.swift
+++ b/Sources/ToolchainRegistry/ToolchainRegistry.swift
@@ -60,13 +60,13 @@ package final actor ToolchainRegistry {
   private let toolchainsByIdentifier: [String: [Toolchain]]
 
   /// The toolchains indexed by their path.
-  private let toolchainsByPath: [URL: Toolchain]
+  private var toolchainsByPath: [URL: Toolchain]
 
   /// Map from compiler paths (`clang`, `swift`, `swiftc`) mapping to the toolchain that contained them.
   ///
   /// This allows us to find the toolchain that should be used for semantic functionality based on which compiler it is
   /// built with in the `compile_commands.json`.
-  private let toolchainsByCompiler: [URL: Toolchain]
+  private var toolchainsByCompiler: [URL: Toolchain]
 
   /// The currently selected toolchain identifier on Darwin.
   package let darwinToolchainOverride: String?
@@ -96,17 +96,18 @@ package final actor ToolchainRegistry {
     var toolchainsByPath: [URL: Toolchain] = [:]
     var toolchainsByCompiler: [URL: Toolchain] = [:]
     for (toolchain, reason) in toolchainsAndReasonsParam {
+      // Toolchain should always be unique by path. It isn't particularly useful to log if we already have a toolchain
+      // though, as we could have just found toolchains through symlinks (this is actually quite normal - eg. OSS
+      // toolchains add a `swift-latest.xctoolchain` symlink on macOS).
+      if toolchainsByPath[toolchain.path] != nil {
+        continue
+      }
+
       // Non-XcodeDefault toolchain: disallow all duplicates.
       if toolchainsByIdentifier[toolchain.identifier] != nil,
         toolchain.identifier != ToolchainRegistry.darwinDefaultToolchainIdentifier
       {
         logger.error("Found two toolchains with the same identifier: \(toolchain.identifier)")
-        continue
-      }
-
-      // Toolchain should always be unique by path.
-      if toolchainsByPath[toolchain.path] != nil {
-        logger.fault("Found two toolchains with the same path: \(toolchain.path)")
         continue
       }
 
@@ -218,9 +219,14 @@ package final actor ToolchainRegistry {
       }
     }
 
-    let toolchainsAndReasons = toolchainPaths.compactMap {
-      if let toolchain = Toolchain($0.path) {
-        return (toolchain, $0.reason)
+    let toolchainsAndReasons = toolchainPaths.compactMap { toolchainAndReason in
+      let resolvedPath = orLog("Toolchain realpath") {
+        try toolchainAndReason.path.realpath
+      }
+      if let resolvedPath,
+        let toolchain = Toolchain(resolvedPath)
+      {
+        return (toolchain, toolchainAndReason.reason)
       }
       return nil
     }
@@ -283,7 +289,43 @@ package final actor ToolchainRegistry {
   /// If we have a toolchain in the toolchain registry that contains the compiler with the given URL, return it.
   /// Otherwise, return `nil`.
   package func toolchain(withCompiler compiler: URL) -> Toolchain? {
-    return toolchainsByCompiler[compiler]
+    if let toolchain = toolchainsByCompiler[compiler] {
+      return toolchain
+    }
+
+    // Only canonicalize the folder path, as we don't want to resolve symlinks to eg. `swift-driver`.
+    let resolvedPath = orLog("Compiler realpath") {
+      try compiler.deletingLastPathComponent().realpath
+    }?.appending(component: compiler.lastPathComponent)
+    guard let resolvedPath,
+      let toolchain = toolchainsByCompiler[resolvedPath]
+    else {
+      return nil
+    }
+
+    // Cache mapping of non-realpath to the realpath toolchain for faster subsequent lookups
+    toolchainsByCompiler[compiler] = toolchain
+    return toolchain
+  }
+
+  /// If we have a toolchain in the toolchain registry with the given URL, return it. Otherwise, return `nil`.
+  package func toolchain(withPath path: URL) -> Toolchain? {
+    if let toolchain = toolchainsByPath[path] {
+      return toolchain
+    }
+
+    let resolvedPath = orLog("Toolchain realpath") {
+      try path.realpath
+    }
+    guard let resolvedPath,
+      let toolchain = toolchainsByPath[resolvedPath]
+    else {
+      return nil
+    }
+
+    // Cache mapping of non-realpath to the realpath toolchain for faster subsequent lookups
+    toolchainsByPath[path] = toolchain
+    return toolchain
   }
 }
 
@@ -291,10 +333,6 @@ package final actor ToolchainRegistry {
 extension ToolchainRegistry {
   package func toolchains(withIdentifier identifier: String) -> [Toolchain] {
     return toolchainsByIdentifier[identifier] ?? []
-  }
-
-  package func toolchain(withPath path: URL) -> Toolchain? {
-    return toolchainsByPath[path]
   }
 }
 


### PR DESCRIPTION
`containingXCToolchain` loops infinitely when given eg. `C:\foo\..\bar`. The underlying cause is that `deletingLastPathComponent` does not remove the `..` on Windows. On macOS it's potentially worse - it *adds* `..`. We don't see the infinite loop on macOS/Linux though because `AbsolutePath` already removes them (which is not the case on Windows).

Resolves #2174.