### PR TITLE
Avoid crashing when loading client plugins from the same path

### DIFF
--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -100,7 +100,7 @@ package enum SKDError: Error, Equatable {
 /// `set_notification_handler`, which are global state managed internally by this class.
 package actor SourceKitD {
   /// The path to the sourcekitd dylib.
-  package let path: URL
+  nonisolated package let path: URL
 
   /// The handle to the dylib.
   private let dylib: DLHandle

--- a/Sources/SwiftSourceKitPluginCommon/DynamicallyLoadedSourceKitdD+forPlugin.swift
+++ b/Sources/SwiftSourceKitPluginCommon/DynamicallyLoadedSourceKitdD+forPlugin.swift
@@ -17,6 +17,11 @@ import SwiftExtensions
 
 extension SourceKitD {
   private static nonisolated(unsafe) var _forPlugin: SourceKitD?
+
+  package static var isPluginLoaded: Bool {
+    return _forPlugin != nil
+  }
+
   package static var forPlugin: SourceKitD {
     get {
       guard let _forPlugin else {


### PR DESCRIPTION
When `DYLD_(FRAMEWORK|LIBRARY)_PATH` is set, `dlopen` will first check if the basename of the provided path is within any of its search paths. Thus it's possible that only a single library is loaded for each toolchain, rather than a separate like we expect. The paths should be equal in this case, since the client plugin is loaded based on the path of `sourcekitd.framework` (and we should only have one for the same reason). Allow this case and just avoid re-initializing.