### PR TITLE
Log when absolute compilation DB search paths are skipped

### DIFF
--- a/Sources/BuildServerIntegration/DetermineBuildServer.swift
+++ b/Sources/BuildServerIntegration/DetermineBuildServer.swift
@@ -26,8 +26,10 @@ private func searchForCompilationDatabaseConfig(
   options: SourceKitLSPOptions
 ) -> BuildServerSpec? {
   let searchPaths =
-    (options.compilationDatabaseOrDefault.searchPaths ?? []).compactMap {
-      try? RelativePath(validating: $0)
+    (options.compilationDatabaseOrDefault.searchPaths ?? []).compactMap { searchPath in
+      orLog("Compilation DB search path") {
+        try RelativePath(validating: searchPath)
+      }
     } + [
       // These default search paths match the behavior of `clangd`
       try! RelativePath(validating: "."),

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -912,13 +912,7 @@ extension SourceKitLSPServer {
       logger.log("Cannot open workspace before server is initialized")
       throw NoCapabilityRegistryError()
     }
-    let options = SourceKitLSPOptions.merging(
-      base: self.options,
-      override: SourceKitLSPOptions(
-        path: workspaceFolder.fileURL?
-          .appending(components: ".sourcekit-lsp", "config.json")
-      )
-    )
+
     logger.log("Creating workspace at \(workspaceFolder.forLogging)")
     logger.logFullObjectInMultipleLogMessages(header: "Workspace options", options.loggingProxy)
 


### PR DESCRIPTION
Absolute search paths were being ignored without logging, which makes it somewhat difficult to diagnose. Log when they're skipped.

Also remove a duplicate options merging block - both `createWorkspaceWithInferredBuildServer` and `findImplicitWorkspace` (the only callers of `createWorkspace`) already merge in the workspace options.