### PR TITLE
Show inlay hints of `#if` conditions at their corresponding `#endif` directives

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/InlayHint.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/InlayHint.swift
@@ -68,8 +68,8 @@ public struct InlayHintKind: RawRepresentable, Codable, Hashable, Sendable {
 
   /// A type annotation.
   public static let type: InlayHintKind = InlayHintKind(rawValue: 1)
-  /// A parameter label. Note that this case is not used by
-  /// Swift, since Swift already has explicit parameter labels.
+
+  /// A parameter label.
   public static let parameter: InlayHintKind = InlayHintKind(rawValue: 2)
 }
 

--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -1,51 +1,51 @@
 add_library(SwiftLanguageService STATIC
-  SemanticRefactoring.swift
-  SwiftTestingScanner.swift
-  FoldingRange.swift
-  CMakeLists.txt
-  SymbolInfo.swift
-  RefactoringEdit.swift
-  CodeActions/ConvertStringConcatenationToStringInterpolation.swift
-  CodeActions/SyntaxRefactoringCodeActionProvider.swift
+  AdjustPositionToStartOfArgument.swift
+  AdjustPositionToStartOfIdentifier.swift
+  ClosureCompletionFormat.swift
+  CodeActions/AddDocumentation.swift
+  CodeActions/ConvertIntegerLiteral.swift
   CodeActions/ConvertJSONToCodableStruct.swift
+  CodeActions/ConvertStringConcatenationToStringInterpolation.swift
+  CodeActions/PackageManifestEdits.swift
   CodeActions/SyntaxCodeActionProvider.swift
   CodeActions/SyntaxCodeActions.swift
-  CodeActions/ConvertIntegerLiteral.swift
-  CodeActions/PackageManifestEdits.swift
-  CodeActions/AddDocumentation.swift
-  RefactoringResponse.swift
-  SyntacticSwiftXCTestScanner.swift
-  CommentXML.swift
-  SymbolGraph.swift
-  ClosureCompletionFormat.swift
-  SemanticRefactorCommand.swift
-  DocumentFormatting.swift
-  DiagnosticReportManager.swift
-  SemanticTokens.swift
-  ExpandMacroCommand.swift
-  Diagnostic.swift
+  CodeActions/SyntaxRefactoringCodeActionProvider.swift
   CodeCompletion.swift
-  SwiftCodeLensScanner.swift
-  SwiftCommand.swift
-  RelatedIdentifiers.swift
-  VariableTypeInfo.swift
   CodeCompletionSession.swift
-  SyntaxTreeManager.swift
+  CommentXML.swift
+  CursorInfo.swift
+  Diagnostic.swift
+  DiagnosticReportManager.swift
+  DocumentFormatting.swift
+  DocumentSymbols.swift
+  ExpandMacroCommand.swift
+  FoldingRange.swift
+  GeneratedInterfaceManager.swift
+  InlayHints.swift
+  MacroExpansion.swift
+  OpenInterface.swift
+  RefactoringEdit.swift
+  RefactoringResponse.swift
+  RelatedIdentifiers.swift
   Rename.swift
   RewriteSourceKitPlaceholders.swift
-  SwiftLanguageService.swift
-  TestDiscovery.swift
-  OpenInterface.swift
-  SyntaxHighlightingToken.swift
-  MacroExpansion.swift
-  AdjustPositionToStartOfIdentifier.swift
-  SyntaxHighlightingTokenParser.swift
-  CursorInfo.swift
-  DocumentSymbols.swift
-  SyntaxHighlightingTokens.swift
-  GeneratedInterfaceManager.swift
+  SemanticRefactorCommand.swift
+  SemanticRefactoring.swift
+  SemanticTokens.swift
   SignatureHelp.swift
-  AdjustPositionToStartOfArgument.swift
+  SwiftCodeLensScanner.swift
+  SwiftCommand.swift
+  SwiftLanguageService.swift
+  SwiftTestingScanner.swift
+  SymbolGraph.swift
+  SymbolInfo.swift
+  SyntacticSwiftXCTestScanner.swift
+  SyntaxHighlightingToken.swift
+  SyntaxHighlightingTokenParser.swift
+  SyntaxHighlightingTokens.swift
+  SyntaxTreeManager.swift
+  TestDiscovery.swift
+  VariableTypeInfo.swift
 )
 set_target_properties(SwiftLanguageService PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SwiftLanguageService/InlayHints.swift
+++ b/Sources/SwiftLanguageService/InlayHints.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import LanguageServerProtocol
+import SourceKitLSP
+import SwiftExtensions
+import SwiftSyntax
+
+private class IfConfigCollector: SyntaxVisitor {
+  private var ifConfigDecls: [IfConfigDeclSyntax] = []
+
+  override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+    ifConfigDecls.append(node)
+
+    return .visitChildren
+  }
+
+  static func collectIfConfigDecls(in tree: some SyntaxProtocol) -> [IfConfigDeclSyntax] {
+    let visitor = IfConfigCollector(viewMode: .sourceAccurate)
+    visitor.walk(tree)
+    return visitor.ifConfigDecls
+  }
+}
+
+extension SwiftLanguageService {
+  package func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint] {
+    let uri = req.textDocument.uri
+    let infos = try await variableTypeInfos(uri, req.range)
+    let typeHints = infos
+      .lazy
+      .filter { !$0.hasExplicitType }
+      .map { info -> InlayHint in
+        let position = info.range.upperBound
+        let label = ": \(info.printedType)"
+        let textEdits: [TextEdit]?
+        if info.canBeFollowedByTypeAnnotation {
+          textEdits = [TextEdit(range: position..<position, newText: label)]
+        } else {
+          textEdits = nil
+        }
+        return InlayHint(
+          position: position,
+          label: .string(label),
+          kind: .type,
+          textEdits: textEdits
+        )
+      }
+
+    let snapshot = try await self.latestSnapshot(for: uri)
+    let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    let ifConfigDecls = IfConfigCollector.collectIfConfigDecls(in: syntaxTree)
+    let ifConfigHints = ifConfigDecls.compactMap { (ifConfigDecl) -> InlayHint? in
+      // Do not show inlay hints for if config clauses that have a `#elseif` of `#else` clause since it is unclear which
+      // `#if`, `#elseif`, or `#else` clause the `#endif` now refers to.
+      guard let condition = ifConfigDecl.clauses.only?.condition else {
+        return nil
+      }
+      guard !ifConfigDecl.poundEndif.trailingTrivia.contains(where: { $0.isComment }) else {
+        // If a comment already exists (eg. because the user inserted it), don't show an inlay hint.
+        return nil
+      }
+      let hintPosition = snapshot.position(of: ifConfigDecl.poundEndif.endPositionBeforeTrailingTrivia)
+      let label = " // \(condition.trimmedDescription)"
+      return InlayHint(
+        position: hintPosition,
+        label: .string(label),
+        kind: .type,  // For the lack of a better kind, pretend this comment is a type
+        textEdits: [TextEdit(range: Range(hintPosition), newText: label)],
+        tooltip: .string("Condition of this conditional compilation clause")
+      )
+    }
+
+    return Array(typeHints + ifConfigHints)
+  }
+}

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -1032,32 +1032,6 @@ extension SwiftLanguageService {
     return codeActions
   }
 
-  package func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint] {
-    let uri = req.textDocument.uri
-    let infos = try await variableTypeInfos(uri, req.range)
-    let hints = infos
-      .lazy
-      .filter { !$0.hasExplicitType }
-      .map { info -> InlayHint in
-        let position = info.range.upperBound
-        let label = ": \(info.printedType)"
-        let textEdits: [TextEdit]?
-        if info.canBeFollowedByTypeAnnotation {
-          textEdits = [TextEdit(range: position..<position, newText: label)]
-        } else {
-          textEdits = nil
-        }
-        return InlayHint(
-          position: position,
-          label: .string(label),
-          kind: .type,
-          textEdits: textEdits
-        )
-      }
-
-    return Array(hints)
-  }
-
   package func codeLens(_ req: CodeLensRequest) async throws -> [CodeLens] {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
     var targetDisplayName: String? = nil

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -224,4 +224,46 @@ final class InlayHintTests: XCTestCase {
       ]
     )
   }
+
+  func testIfConfigHints() async throws {
+    let (positions, hints) = try await performInlayHintRequest(
+      markedText: """
+        #if DEBUG
+        #endif1️⃣
+        """
+    )
+    XCTAssertEqual(
+      hints,
+      [
+        InlayHint(
+          position: positions["1️⃣"],
+          label: " // DEBUG",
+          kind: .type,
+          textEdits: [TextEdit(range: Range(positions["1️⃣"]), newText: " // DEBUG")],
+          tooltip: .string("Condition of this conditional compilation clause")
+        )
+      ]
+    )
+  }
+
+  func testIfConfigHintDoesNotShowIfCommentExits() async throws {
+    let (_, hints) = try await performInlayHintRequest(
+      markedText: """
+        #if DEBUG
+        #endif // DEBUG
+        """
+    )
+    XCTAssertEqual(hints, [])
+  }
+
+  func testIfConfigHintDoesNotShowIfElseClauseExists() async throws {
+    let (_, hints) = try await performInlayHintRequest(
+      markedText: """
+        #if DEBUG
+        #else
+        #endif
+        """
+    )
+    XCTAssertEqual(hints, [])
+  }
 }


### PR DESCRIPTION
While at it, also migrate the InlayType tests to use position markers.

Fixes #2221