### PR TITLE
Add missing parentheses around logging scope computation

### DIFF
--- a/Sources/SwiftSourceKitPlugin/Plugin.swift
+++ b/Sources/SwiftSourceKitPlugin/Plugin.swift
@@ -58,7 +58,7 @@ final class RequestHandler: Sendable {
     func produceResult(
       body: @escaping @Sendable () async throws -> SKDResponseDictionaryBuilder
     ) -> HandleRequestResult {
-      withLoggingScope("request-\(handle?.numericValue ?? 0 % 100)") {
+      withLoggingScope("request-\((handle?.numericValue ?? 0) % 100)") {
         let start = Date()
         logger.debug(
           """


### PR DESCRIPTION
The modulo operator associated `0` and `100`, so the computation here was essentially `handle?.numericValue ?? (0 % 100)`, equivalent to `handle?.numericValue ?? 0`, which means that we didn’t acutally perform modulo operations on the numeric value, which means that we would exceed the maximum number of `os_log_t` objects after some time.

rdar://162891887