### PR TITLE
[6.2] Add missing parentheses around logging scope computation

### DIFF
--- a/Sources/SwiftSourceKitPlugin/Plugin.swift
+++ b/Sources/SwiftSourceKitPlugin/Plugin.swift
@@ -58,7 +58,7 @@ final class RequestHandler: Sendable {
     func produceResult(
       body: @escaping @Sendable () async throws -> SKDResponseDictionaryBuilder
     ) -> HandleRequestResult {
-      withLoggingScope("request-\(handle?.numericValue ?? 0 % 100)") {
+      withLoggingScope("request-\((handle?.numericValue ?? 0) % 100)") {
         let start = Date()
         logger.debug(
           """


### PR DESCRIPTION
- **Explanation**: `os_log` only allows creating a limited number of `Logger` objects, after the maximum number is reached, creating a new `Logger` will crash the process. To avoid this happening, we only used the last two digest of request IDs for the logger name for request handling. This computation inside the SourceKit plugin was incorrect due to misinterpreted operator precedence. Add parentheses to fix this
- **Scope**: SourceKit plugin
- **Issue**: rdar://162891887
- **Original PR**: https://github.com/swiftlang/sourcekit-lsp/pull/2329#pullrequestreview-3367629638
- **Risk**: Very low, only changes the name of logging scopes
- **Testing**: none
- **Reviewer**: @bnbarham 
