### PR TITLE
Remove TODO that `filterText` of override completions should not contain `func` in filterText

### DIFF
--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -339,7 +339,6 @@ final class SwiftCompletionTests: XCTestCase {
       XCTFail("No completion item with label 'foo()'")
       return
     }
-    // TODO: The filter text should be "foo()" (https://github.com/swiftlang/sourcekit-lsp/issues/1599)
     XCTAssertEqual(item.filterText, "func foo()")
     XCTAssertEqual(
       item.textEdit,


### PR DESCRIPTION
The current behavior is the correct one. Otherwise you don’t get any override completions in VS Code after typing `func <something>`.