### PR TITLE
Fix issue that caused background indexing to be disabled when `sourcekit-lsp` is launched without options

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -170,7 +170,6 @@ struct SourceKitLSP: AsyncParsableCommand {
       ),
       defaultWorkspaceType: defaultWorkspaceType,
       generatedFilesPath: generatedFilesPath,
-      backgroundIndexing: experimentalFeatures.contains("background-indexing"),
       experimentalFeatures: Set(experimentalFeatures.compactMap(ExperimentalFeature.init))
     )
   }


### PR DESCRIPTION
When launching sourcekit-lsp without any command-line arguments, we would set `backgroundIndexing = false` in the options. Unless the user overwrites this somehow, this means that background indexing is disabled.

This is not an issue in VS Code, because it explicitly enables background indexing in the initialization request but for all other editors this means that background indexing was likely disabled by default.

Simply remove that line since `backgroundIndexing` defaults to `true` by now anyway.

I’ll open a follow-up PR to fix this kind of issue for other settings, defaulting to `nil` instead of empty arrays but I think those don’t have real-world impact because the default value in the command-line arguments and in `SourceKitLSPOptions` line up.