### PR TITLE
[6.2] Fix issue that caused background indexing to be disabled when `sourcekit-lsp` is launched without options

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -169,7 +169,6 @@ struct SourceKitLSP: AsyncParsableCommand {
       ),
       defaultWorkspaceType: defaultWorkspaceType,
       generatedFilesPath: generatedFilesPath,
-      backgroundIndexing: experimentalFeatures.contains("background-indexing"),
       experimentalFeatures: Set(experimentalFeatures.compactMap(ExperimentalFeature.init))
     )
   }


### PR DESCRIPTION
- **Explanation**: When launching sourcekit-lsp without any command-line arguments, we would set `backgroundIndexing = false` in the options. Unless the user overwrites this somehow, this means that background indexing is disabled.
This is not an issue in VS Code, because it explicitly enables background indexing in the initialization request but for all other editors this means that background indexing was likely disabled by default. Simply remove that line since `backgroundIndexing` defaults to `true` by now anyway.
- **Scope**: SourceKit-LSP in editors other than VS Code
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/sourcekit-lsp/pull/2337
- **Risk**: Low, enables the background indexing behavior that people have been using in VS Code by default in all other editors as well.
- **Testing**: n/a
- **Reviewer**: @bnbarham 