### PR TITLE
Add [weak self] in two places.

### DIFF
--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -433,7 +433,7 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
       priority: priority ?? Task.currentPriority,
       description: taskDescription,
       taskPriorityChangedCallback: { [weak self] (newPriority) in
-        Task.detached(priority: newPriority) {
+        Task.detached(priority: newPriority) { [weak self] in
           // If the task's priority got elevated, there might be an execution slot for it now. Poke the scheduler
           // to run the task if possible.
           await self?.poke()
@@ -442,11 +442,11 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
       executionStateChangedCallback: executionStateChangedCallback
     )
     pendingTasks.append(queuedTask)
-    Task.detached(priority: priority ?? Task.currentPriority) {
+    Task.detached(priority: priority ?? Task.currentPriority) { [weak self] in
       // Poke the `TaskScheduler` to execute a new task. If the `TaskScheduler` is already working at its capacity
       // limit, this will not do anything. If there are execution slots available, this will start executing the freshly
       // queued task.
-      await self.poke()
+      await self?.poke()
     }
     return queuedTask
   }


### PR DESCRIPTION
The reason why I am making the first change is because in a separate PR in swiftlang I am fixing a bug that caused certain captured parameters to be treated as sending parameters incorrectly. This allowed for parameters to incorrectly be allowed to be sent from one isolation domain to another.

The specific problem here can be seen with the following swift code:

```swift
actor B {
  init(callback: @escaping @Sendable () -> Void) async {}
}

actor A {
  private func poke() {}
  func schedule() async {
    _ = await B(
      callback: { [weak self] in // closure 1
        Task.detached { // closure 2
          await self?.poke()
        }
      })
  }
}
```

When we capture the weak self from closure 1 in closure 2, we are not actually capturing self directly. Instead we are capturing the var box which contains the weak self. The box (unlike self) is actually non-Sendable. Since closure 2 is not call(once), the compiler must assume semantically that the closure can be invoked potentially multiple times meaning that it cannot allow for self to be used in Task.detached. The fix for this is to perform an inner [weak self] capture. As follows:

```swift
actor A {
  private func poke() {}
  func schedule() async {
    _ = await B(
      callback: { [weak self] in // closure 1
        Task.detached { [weak self] // closure 2
          await self?.poke()
        }
      })
  }
}
```

The reason why this works is that when we form the second weak self binding, we perform a load from the outer weak self giving us an Optional<A>. Then we store that optional value back into a new weak box. Since Optional<A> is Sendable, we know that the two non-Sendable weak var boxes are completely unrelated, so we can send that new var box into the new Task.detached safely.

The second `[weak self]` is just something I noticed later in the function. The `[weak self]` just makes the detached function safer.