### PR TITLE
[concurrency] Use nonisolated(unsafe) to quiet an error in runAsync in the tests.

### DIFF
--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -2172,7 +2172,7 @@ private struct ExpectationNotFulfilledError: Error {}
 
 /// Run the given async block and block the current function until `body` terminates.
 private func runAsync<T: Sendable>(_ body: @escaping @Sendable () async throws -> T) throws -> T {
-  var result: Result<T, Error>!
+  nonisolated(unsafe) var result: Result<T, Error>!
   let expectation = XCTestExpectation(description: "")
   Task {
     do {


### PR DESCRIPTION
Specifically, we are already using XCTest expectations to make sure we are waiting long enough. So it is appropriate to put nonisolated(unsafe) since we are synchronizing the code in a way that swift concurrency does not understand.

This came up as part of fixing rdar://164042741.