### PR TITLE
Ensure the string passed to `PathIsRelativeW` is null terminated

### DIFF
--- a/Sources/BuildServerIntegration/CompilationDatabase.swift
+++ b/Sources/BuildServerIntegration/CompilationDatabase.swift
@@ -206,8 +206,9 @@ enum CompilationDatabaseDecodingError: Error {
 fileprivate extension String {
   var isAbsolutePath: Bool {
     #if os(Windows)
-    Array(self.utf16).withUnsafeBufferPointer { buffer in
-      return !PathIsRelativeW(buffer.baseAddress)
+    // PathIsRelativeW requires a null-terminated UTF16 encoded string
+    return withCString(encodedAs: UTF16.self) { ptr in
+      return !PathIsRelativeW(ptr)
     }
     #else
     return self.hasPrefix("/")


### PR DESCRIPTION
`CompilationDatabaseTests` have been flakey on Windows since https://github.com/swiftlang/sourcekit-lsp/pull/2334. This didn't really introduce the failure though - it just added tests that now catch it.

The underlying cause is that `filename.isAbsolutePath` sometimes returns `true` for a relative path, which then causes the CWD to be prepended instead of the given `compileCommandsDirectory`.

`PathIsRelativeW` requires a null terminated string, so presumably we were hitting junk after the initial path that sometimes turned it into an absolute path. From the Windows docs:
> A pointer to a null-terminated string of maximum length MAX_PATH that
contains the path to search.

Fixes #2360
Resolves rdar://165006835