### PR TITLE
Resolve `/usr/bin/*` shims on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -526,13 +526,14 @@ var targets: [Target] = [
       "SourceKitDForPlugin",
       "SwiftExtensionsForPlugin",
       "SwiftSourceKitPluginCommon",
+      .product(name: "_SKLoggingForPlugin", package: "swift-tools-protocols"),
     ],
     exclude: ["CMakeLists.txt"],
     swiftSettings: [
       .unsafeFlags([
+        "-module-alias", "SKLogging=_SKLoggingForPlugin",
         "-module-alias", "SourceKitD=SourceKitDForPlugin",
         "-module-alias", "SwiftExtensions=SwiftExtensionsForPlugin",
-        "-module-alias", "ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin",
       ])
     ],
     linkerSettings: sourcekitLSPLinkSettings
@@ -546,15 +547,12 @@ var targets: [Target] = [
       "Csourcekitd",
       "SourceKitDForPlugin",
       "SwiftExtensionsForPlugin",
-      .product(name: "_SKLoggingForPlugin", package: "swift-tools-protocols"),
     ],
     exclude: ["CMakeLists.txt"],
     swiftSettings: [
       .unsafeFlags([
         "-module-alias", "SourceKitD=SourceKitDForPlugin",
         "-module-alias", "SwiftExtensions=SwiftExtensionsForPlugin",
-        "-module-alias", "ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin",
-        "-module-alias", "SKLogging=_SKLoggingForPlugin",
       ])
     ]
   ),
@@ -577,9 +575,9 @@ var targets: [Target] = [
     swiftSettings: [
       .unsafeFlags([
         "-module-alias", "CompletionScoring=CompletionScoringForPlugin",
+        "-module-alias", "SKLogging=_SKLoggingForPlugin",
         "-module-alias", "SKUtilities=SKUtilitiesForPlugin",
         "-module-alias", "SourceKitD=SourceKitDForPlugin",
-        "-module-alias", "SKLogging=_SKLoggingForPlugin",
         "-module-alias", "SwiftExtensions=SwiftExtensionsForPlugin",
         "-module-alias", "ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin",
       ])

--- a/Sources/BuildServerIntegration/CMakeLists.txt
+++ b/Sources/BuildServerIntegration/CMakeLists.txt
@@ -20,8 +20,8 @@ add_library(BuildServerIntegration STATIC
   LegacyBuildServer.swift
   MainFilesProvider.swift
   SplitShellCommand.swift
-  SwiftlyResolver.swift
-  SwiftPMBuildServer.swift)
+  SwiftPMBuildServer.swift
+  SwiftToolchainResolver.swift)
 set_target_properties(BuildServerIntegration PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(BuildServerIntegration PUBLIC

--- a/Sources/BuildServerIntegration/SwiftToolchainResolver.swift
+++ b/Sources/BuildServerIntegration/SwiftToolchainResolver.swift
@@ -18,10 +18,10 @@ import TSCExtensions
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 
-/// Given a path to a compiler, which might be a symlink to `swiftly`, this type determines the compiler executable in
-/// an actual toolchain. It also caches the results. The client needs to invalidate the cache if the path that swiftly
-/// might resolve to has changed, eg. because `.swift-version` has been updated.
-actor SwiftlyResolver {
+/// Given a path to a compiler, which might be a symlink to `swiftly` or `/usr/bin` on macOS, this type determines the
+/// compiler executable in an actual toolchain and caches the result. The client needs to invalidate the cache if the
+/// path that this may resolve to has changed, eg. because `.swift-version` or `SDKROOT` has been updated.
+actor SwiftToolchainResolver {
   private struct CacheKey: Hashable {
     let compiler: URL
     let workingDirectory: URL?
@@ -29,31 +29,37 @@ actor SwiftlyResolver {
 
   private var cache: LRUCache<CacheKey, Result<URL?, any Error>> = LRUCache(capacity: 100)
 
-  /// Check if `compiler` is a symlink to `swiftly`. If so, find the executable in the toolchain that swiftly resolves
-  /// to within the given working directory and return the URL of the corresponding compiler in that toolchain.
-  /// If `compiler` does not resolve to `swiftly`, return `nil`.
+  /// Check if `compiler` is a symlink to `swiftly` or in `/usr/bin` on macOS. If so, find the executable in the
+  /// toolchain that would be resolved to within the given working directory and return the URL of the corresponding
+  /// compiler in that toolchain. If `compiler` does not resolve to `swiftly` or `/usr/bin` on macOS, return `nil`.
   func resolve(compiler: URL, workingDirectory: URL?) async throws -> URL? {
     let cacheKey = CacheKey(compiler: compiler, workingDirectory: workingDirectory)
     if let cached = cache[cacheKey] {
       return try cached.get()
     }
+
     let computed: Result<URL?, any Error>
     do {
-      computed = .success(
-        try await resolveSwiftlyTrampolineImpl(compiler: compiler, workingDirectory: workingDirectory)
-      )
+      var resolved = try await resolveSwiftlyTrampoline(compiler: compiler, workingDirectory: workingDirectory)
+      if resolved == nil {
+        resolved = try await resolveXcrunTrampoline(compiler: compiler, workingDirectory: workingDirectory)
+      }
+
+      computed = .success(resolved)
     } catch {
       computed = .failure(error)
     }
+
     cache[cacheKey] = computed
     return try computed.get()
   }
 
-  private func resolveSwiftlyTrampolineImpl(compiler: URL, workingDirectory: URL?) async throws -> URL? {
+  private func resolveSwiftlyTrampoline(compiler: URL, workingDirectory: URL?) async throws -> URL? {
     let realpath = try compiler.realpath
     guard realpath.lastPathComponent == "swiftly" else {
       return nil
     }
+
     let swiftlyResult = try await Process.run(
       arguments: [realpath.filePath, "use", "-p"],
       workingDirectory: try AbsolutePath(validatingOrNil: workingDirectory?.filePath)
@@ -61,7 +67,27 @@ actor SwiftlyResolver {
     let swiftlyToolchain = URL(
       fileURLWithPath: try swiftlyResult.utf8Output().trimmingCharacters(in: .whitespacesAndNewlines)
     )
+
     let resolvedCompiler = swiftlyToolchain.appending(components: "usr", "bin", compiler.lastPathComponent)
+    if FileManager.default.fileExists(at: resolvedCompiler) {
+      return resolvedCompiler
+    }
+    return nil
+  }
+
+  private func resolveXcrunTrampoline(compiler: URL, workingDirectory: URL?) async throws -> URL? {
+    guard Platform.current == .darwin, compiler.deletingLastPathComponent() == URL(filePath: "/usr/bin/") else {
+      return nil
+    }
+
+    let xcrunResult = try await Process.run(
+      arguments: ["xcrun", "-f", compiler.lastPathComponent],
+      workingDirectory: try AbsolutePath(validatingOrNil: workingDirectory?.filePath)
+    )
+
+    let resolvedCompiler = URL(
+      fileURLWithPath: try xcrunResult.utf8Output().trimmingCharacters(in: .whitespacesAndNewlines)
+    )
     if FileManager.default.fileExists(at: resolvedCompiler) {
       return resolvedCompiler
     }

--- a/Sources/SwiftSourceKitClientPlugin/CMakeLists.txt
+++ b/Sources/SwiftSourceKitClientPlugin/CMakeLists.txt
@@ -5,15 +5,15 @@ set_target_properties(SwiftSourceKitClientPlugin PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_compile_options(SwiftSourceKitClientPlugin PRIVATE 
   $<$<COMPILE_LANGUAGE:Swift>:
+    "SHELL:-module-alias SKLogging=_SKLoggingForPlugin"
     "SHELL:-module-alias SourceKitD=SourceKitDForPlugin"
     "SHELL:-module-alias SwiftExtensions=SwiftExtensionsForPlugin"
-    "SHELL:-module-alias ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin"
   >)
 target_link_libraries(SwiftSourceKitClientPlugin PRIVATE
   Csourcekitd
   SourceKitD
   SwiftExtensions
-  SwiftToolsProtocols::ToolsProtocolsSwiftExtensions
+  SwiftToolsProtocols::_SKLoggingForPlugin
   SwiftSourceKitPluginCommon
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 

--- a/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
+++ b/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
@@ -12,6 +12,7 @@
 
 public import Csourcekitd
 import Foundation
+@_spi(SourceKitLSP) import SKLogging
 import SourceKitD
 import SwiftExtensions
 import SwiftSourceKitPluginCommon
@@ -20,7 +21,8 @@ import SwiftSourceKitPluginCommon
 /// loaded from.
 @_cdecl("sourcekitd_plugin_initialize")
 public func sourcekitd_plugin_initialize(_ params: sourcekitd_api_plugin_initialize_params_t) {
-  fatalError("sourcekitd_plugin_initialize has been removed in favor of sourcekitd_plugin_initialize_2")
+  LoggingScope.configureDefaultLoggingSubsystem("org.swift.sourcekit-lsp.client-plugin")
+  logger.fault("sourcekitd_plugin_initialize has been removed in favor of sourcekitd_plugin_initialize_2")
 }
 
 @_cdecl("sourcekitd_plugin_initialize_2")

--- a/Sources/SwiftSourceKitPlugin/CMakeLists.txt
+++ b/Sources/SwiftSourceKitPlugin/CMakeLists.txt
@@ -33,9 +33,9 @@ set_target_properties(SwiftSourceKitPlugin PROPERTIES
 target_compile_options(SwiftSourceKitPlugin PRIVATE 
   $<$<COMPILE_LANGUAGE:Swift>:
     "SHELL:-module-alias CompletionScoring=CompletionScoringForPlugin"
+    "SHELL:-module-alias SKLogging=_SKLoggingForPlugin"
     "SHELL:-module-alias SKUtilities=SKUtilitiesForPlugin"
     "SHELL:-module-alias SourceKitD=SourceKitDForPlugin"
-    "SHELL:-module-alias SKLogging=_SKLoggingForPlugin"
     "SHELL:-module-alias SwiftExtensions=SwiftExtensionsForPlugin"
     "SHELL:-module-alias ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin"
   >)

--- a/Sources/SwiftSourceKitPlugin/Plugin.swift
+++ b/Sources/SwiftSourceKitPlugin/Plugin.swift
@@ -162,7 +162,8 @@ final class RequestHandler: Sendable {
 /// loaded from.
 @_cdecl("sourcekitd_plugin_initialize")
 public func sourcekitd_plugin_initialize(_ params: sourcekitd_api_plugin_initialize_params_t) {
-  fatalError("sourcekitd_plugin_initialize has been removed in favor of sourcekitd_plugin_initialize_2")
+  LoggingScope.configureDefaultLoggingSubsystem("org.swift.sourcekit-lsp.service-plugin")
+  logger.fault("sourcekitd_plugin_initialize has been removed in favor of sourcekitd_plugin_initialize_2")
 }
 
 #if canImport(Darwin)
@@ -210,7 +211,8 @@ public func sourcekitd_plugin_initialize_2(
   _ params: sourcekitd_api_plugin_initialize_params_t,
   _ parentLibraryPath: UnsafePointer<CChar>
 ) {
-  LoggingScope.configureDefaultLoggingSubsystem("org.swift.sourcekit-lsp.plugin")
+  LoggingScope.configureDefaultLoggingSubsystem("org.swift.sourcekit-lsp.service-plugin")
+
   let parentLibraryPath = String(cString: parentLibraryPath)
   #if canImport(Darwin)
   if parentLibraryPath == "SOURCEKIT_LSP_PLUGIN_PARENT_LIBRARY_RTLD_DEFAULT" {

--- a/Sources/SwiftSourceKitPluginCommon/CMakeLists.txt
+++ b/Sources/SwiftSourceKitPluginCommon/CMakeLists.txt
@@ -5,16 +5,13 @@ add_library(SwiftSourceKitPluginCommon STATIC
 target_compile_options(SwiftSourceKitPluginCommon PRIVATE 
   $<$<COMPILE_LANGUAGE:Swift>:
     "SHELL:-module-alias SourceKitD=SourceKitDForPlugin"
-    "SHELL:-module-alias SKLogging=_SKLoggingForPlugin"
     "SHELL:-module-alias SwiftExtensions=SwiftExtensionsForPlugin"
-    "SHELL:-module-alias ToolsProtocolsSwiftExtensions=_ToolsProtocolsSwiftExtensionsForPlugin"
   >)
 set_target_properties(SwiftSourceKitPluginCommon PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SwiftSourceKitPluginCommon PRIVATE
   Csourcekitd
   SourceKitDForPlugin
-  SwiftToolsProtocols::_SKLoggingForPlugin
   SwiftExtensionsForPlugin
   SwiftToolsProtocols::_ToolsProtocolsSwiftExtensionsForPlugin
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)

--- a/Sources/SwiftSourceKitPluginCommon/DynamicallyLoadedSourceKitdD+forPlugin.swift
+++ b/Sources/SwiftSourceKitPluginCommon/DynamicallyLoadedSourceKitdD+forPlugin.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-@_spi(SourceKitLSP) import SKLogging
 package import SourceKitD
 import SwiftExtensions
 


### PR DESCRIPTION
CMake was previously doing this itself before 4.0, but seems to be inserting `/usr/bin/*` now. Resolve the `/usr/bin` trampoline ourselves in a similar fashion to swiftly (but with xcrun).

Resolves rdar://163462990.