### PR TITLE
Don’t use `Optional.map` or `Optional.flatMap`

### DIFF
--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -50,7 +50,12 @@ package struct ReduceCommand: AsyncParsableCommand {
   )
   var predicate: String?
 
-  private var nsPredicate: NSPredicate? { predicate.map { NSPredicate(format: $0) } }
+  private var nsPredicate: NSPredicate? {
+    guard let predicate else {
+      return nil
+    }
+    return NSPredicate(format: predicate)
+  }
   #else
   private var nsPredicate: NSPredicate? { nil }
   #endif

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -40,7 +40,12 @@ package struct ReduceFrontendCommand: AsyncParsableCommand {
   )
   var predicate: String?
 
-  private var nsPredicate: NSPredicate? { predicate.map { NSPredicate(format: $0) } }
+  private var nsPredicate: NSPredicate? {
+    guard let predicate else {
+      return nil
+    }
+    return NSPredicate(format: predicate)
+  }
   #else
   private var nsPredicate: NSPredicate? { nil }
   #endif

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -521,7 +521,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         indexFiles: indexFiles,
         buildSettings: buildSettings,
         processArguments: args,
-        workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
+        workingDirectory: buildSettings.workingDirectoryPath
       )
     case .singleFile(let file, let buildSettings):
       // We only end up in this case if the file's build settings didn't contain `-index-unit-output-path` and the build
@@ -532,7 +532,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         indexFiles: [file.mainFile],
         buildSettings: buildSettings,
         processArguments: args,
-        workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
+        workingDirectory: buildSettings.workingDirectoryPath
       )
     }
   }
@@ -556,7 +556,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       indexFiles: [uri],
       buildSettings: buildSettings,
       processArguments: args,
-      workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
+      workingDirectory: buildSettings.workingDirectoryPath
     )
   }
 
@@ -777,6 +777,17 @@ fileprivate extension Process {
         workingDirectory: workingDirectory,
         outputRedirection: outputRedirection
       )
+    }
+  }
+}
+
+fileprivate extension FileBuildSettings {
+  var workingDirectoryPath: AbsolutePath? {
+    get throws {
+      guard let workingDirectory else {
+        return nil
+      }
+      return try AbsolutePath(validating: workingDirectory)
     }
   }
 }

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -36,7 +36,10 @@ package final class SKDResponseDictionary: Sendable {
   }
 
   package subscript(key: sourcekitd_api_uid_t) -> String? {
-    return sourcekitd.api.variant_dictionary_get_string(dict, key).map(String.init(cString:))
+    guard let cString = sourcekitd.api.variant_dictionary_get_string(dict, key) else {
+      return nil
+    }
+    return String(cString: cString)
   }
 
   package subscript(key: sourcekitd_api_uid_t) -> Int? {

--- a/Sources/SwiftLanguageService/Diagnostic.swift
+++ b/Sources/SwiftLanguageService/Diagnostic.swift
@@ -442,8 +442,13 @@ extension DiagnosticStage {
     case sourcekitd.values.semaDiagStage:
       self = .sema
     default:
-      let desc = sourcekitd.api.uid_get_string_ptr(uid).map { String(cString: $0) }
-      logger.fault("Unknown diagnostic stage \(desc ?? "nil", privacy: .public)")
+      let uidDescription =
+        if let cString = sourcekitd.api.uid_get_string_ptr(uid) {
+          String(cString: cString)
+        } else {
+          "<nil>"
+        }
+      logger.fault("Unknown diagnostic stage \(uidDescription, privacy: .public)")
       return nil
     }
   }

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -62,8 +62,8 @@ extension SwiftLanguageService {
     let semanticTokens = await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
 
     let range =
-      if let range = range.flatMap({ snapshot.byteSourceRange(of: $0) }) {
-        range
+      if let range {
+        snapshot.byteSourceRange(of: range)
       } else {
         await tree.range
       }

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -651,11 +651,17 @@ extension SwiftLanguageService {
           // Check that the document wasn't modified while we were getting diagnostics. This could happen because we are
           // calling `publishDiagnosticsIfNeeded` outside of `messageHandlingQueue` and thus a concurrent edit is
           // possible while we are waiting for the sourcekitd request to return a result.
+          let latestVersionString =
+            if let version = latestSnapshotID?.version {
+              String(version)
+            } else {
+              "<nil>"
+            }
           logger.log(
             """
             Document was modified while loading diagnostics. \
             Loaded diagnostics for \(snapshot.id.version, privacy: .public), \
-            latest snapshot is \((latestSnapshotID?.version).map(String.init) ?? "<nil>", privacy: .public)
+            latest snapshot is \(latestVersionString, privacy: .public)
             """
           )
           throw CancellationError()

--- a/Sources/SwiftLanguageService/SwiftTestingScanner.swift
+++ b/Sources/SwiftLanguageService/SwiftTestingScanner.swift
@@ -232,7 +232,12 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     let suiteAttribute = node.attributes
       .compactMap { $0.as(AttributeSyntax.self) }
       .first { $0.isNamed("Suite", inModuleNamed: "Testing") }
-    let attributeData = suiteAttribute.map(TestingAttributeData.init(attribute:))
+    let attributeData: TestingAttributeData? =
+      if let suiteAttribute {
+        TestingAttributeData(attribute: suiteAttribute)
+      } else {
+        nil
+      }
 
     if attributeData?.isHidden ?? false {
       return .skipChildren

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
@@ -203,8 +203,13 @@ struct SyntaxHighlightingTokenParser {
         values.stringInterpolation
       ]
       if !ignoredKinds.contains(uid) {
-        let name = api.uid_get_string_ptr(uid).map(String.init(cString:))
-        logger.error("Unknown token kind: \(name ?? "?", privacy: .public)")
+        let name =
+          if let cString = api.uid_get_string_ptr(uid) {
+            String(cString: cString)
+          } else {
+            "<nil>"
+          }
+        logger.error("Unknown token kind: \(name, privacy: .public)")
       }
       return nil
     }

--- a/Sources/SwiftSourceKitPlugin/SKDRequestDictionaryReader.swift
+++ b/Sources/SwiftSourceKitPlugin/SKDRequestDictionaryReader.swift
@@ -73,9 +73,11 @@ final class SKDRequestDictionaryReader: Sendable, CustomStringConvertible {
   }
 
   subscript(key: sourcekitd_api_uid_t) -> String? {
-    return sourcekitd.servicePluginApi.request_dictionary_get_string(sourcekitd_api_object_t(dict), key).map(
-      String.init(cString:)
-    )
+    guard let cString = sourcekitd.servicePluginApi.request_dictionary_get_string(sourcekitd_api_object_t(dict), key)
+    else {
+      return nil
+    }
+    return String(cString: cString)
   }
 
   subscript(key: sourcekitd_api_uid_t) -> Int64? {

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -957,7 +957,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let result = try await project.testClient.send(
       RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"], newName: "height")
     )
-    XCTAssertEqual((result?.changes?.keys).map(Set.init), [uri, try project.uri(for: "Client.swift")])
+    XCTAssertEqual(Set(try XCTUnwrap(result?.changes?.keys)), [uri, try project.uri(for: "Client.swift")])
   }
 
   func testDontPreparePackageManifest() async throws {

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -34,7 +34,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
     )
     let location = try XCTUnwrap(resp?.locations?.only)
     XCTAssertTrue(location.uri.pseudoPath.hasSuffix("Foundation.swiftinterface"))
-    let fileContents = try XCTUnwrap(location.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))
+    let fileContents = try XCTUnwrap(String(contentsOf: try XCTUnwrap(location.uri.fileURL), encoding: .utf8))
     // Smoke test that the generated Swift Interface contains Swift code
     XCTAssert(
       fileContents.hasPrefix("import "),
@@ -173,7 +173,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       )
     let location = try XCTUnwrap(response?.locations?.only)
     XCTAssertTrue(location.uri.pseudoPath.hasSuffix("MyLibrary.swiftinterface"))
-    let fileContents = try XCTUnwrap(location.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))
+    let fileContents = try XCTUnwrap(String(contentsOf: try XCTUnwrap(location.uri.fileURL), encoding: .utf8))
     XCTAssertTrue(
       fileContents.contains(
         """
@@ -420,13 +420,9 @@ private func assertSystemSwiftInterface(
     )
   )
   let location = try XCTUnwrap(definition?.locations?.only)
-  XCTAssert(
-    (location.uri.fileURL?.lastPathComponent).map(swiftInterfaceFiles.contains) ?? false,
-    "Path '\(location.uri.pseudoPath)' did not match any of \(String(reflecting: swiftInterfaceFiles))",
-    line: line
-  )
+  assertContains(swiftInterfaceFiles, try XCTUnwrap(location.uri.fileURL?.lastPathComponent), line: line)
   // load contents of swiftinterface
-  let contents = try XCTUnwrap(location.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))
+  let contents = try XCTUnwrap(String(contentsOf: try XCTUnwrap(location.uri.fileURL), encoding: .utf8))
   let lineTable = LineTable(contents)
   let destinationLine = try XCTUnwrap(lineTable.line(at: location.range.lowerBound.line))
     .trimmingCharacters(in: .whitespaces)


### PR DESCRIPTION
Replace usages of `Optional.map` and `Optional.flatMap` by if expressions or other expressions.

I personally find `Optional.map` to be hard to read because `map` implies mapping a collection to me. Usually the alternative constructs seem clearer to me.