### PR TITLE
Revert "Temporarily skip macro tests on Amazon Linux"

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -129,16 +129,6 @@ package actor SkipUnless {
     try XCTSkipUnless(Platform.current == .windows, message)
   }
 
-  package static func platformIsNotAmazonLinux(_ message: String) throws {
-    guard Platform.current == .linux,
-      let release = try? String(contentsOf: URL(filePath: "/etc/system-release"), encoding: .utf8)
-    else {
-      return
-    }
-
-    try XCTSkipUnless(!release.hasPrefix("Amazon"), message)
-  }
-
   package static func platformSupportsTaskPriorityElevation() throws {
     #if os(macOS)
     guard #available(macOS 14.0, *) else {
@@ -159,7 +149,6 @@ package actor SkipUnless {
       Platform.current != .windows,
       "Temporarily skipping as we need to fix these tests to use the cmake-built swift-syntax libraries on Windows."
     )
-    try SkipUnless.platformIsNotAmazonLinux("https://github.com/swiftlang/sourcekit-lsp/issues/2350")
 
     return try await shared.skipUnlessSupported(file: file, line: line) {
       do {


### PR DESCRIPTION
Reverts swiftlang/sourcekit-lsp#2351. The failure was actually in 6.2, which is missing the actual fix (https://github.com/swiftlang/sourcekit-lsp/pull/2269).