### PR TITLE
Plugins: install DLL to `bin`, import library to `lib`

### DIFF
--- a/Sources/SwiftSourceKitClientPlugin/CMakeLists.txt
+++ b/Sources/SwiftSourceKitClientPlugin/CMakeLists.txt
@@ -17,4 +17,7 @@ target_link_libraries(SwiftSourceKitClientPlugin PRIVATE
   SwiftSourceKitPluginCommon
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 
-install(TARGETS SwiftSourceKitClientPlugin DESTINATION lib)
+install(TARGETS SwiftSourceKitClientPlugin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/SwiftSourceKitPlugin/CMakeLists.txt
+++ b/Sources/SwiftSourceKitPlugin/CMakeLists.txt
@@ -50,4 +50,7 @@ target_link_libraries(SwiftSourceKitPlugin PRIVATE
   SwiftToolsProtocols::_ToolsProtocolsSwiftExtensionsForPlugin
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 
-install(TARGETS SwiftSourceKitPlugin DESTINATION lib)
+install(TARGETS SwiftSourceKitPlugin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)


### PR DESCRIPTION
Adjust the install rules to account for the different installation expectations on Windows. DLL files are installed into the `bin` and import libraries are to be installed in `lib`.