### PR TITLE
[6.2] Pass objects to linker flags as is in macro test projects

### DIFF
--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -133,7 +133,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
 
       let linkerFlags = objectFiles.map {
         """
-        "-l", "\($0)",
+        "\($0)",
         """
       }.joined(separator: "\n")
 


### PR DESCRIPTION
- **Explanation**: Amazon Linux 2023 tests are failing because it uses `ld.bfd` and errors since these are absolute paths and thus `-l` is not required.
- **Scope**: Test only change
- **Issues**: rdar://165188592
- **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/2269
- **Risk**: None, just fixes tests