### PR TITLE
Pass toolsets through to preparation for the SwiftPM build server

### DIFF
--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -632,7 +632,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       // Indexing will frequently fail if the source code is in an invalid state. Thus, log the failure at a low level.
       logger.debug(
         """
-        Updating index store for terminated with non-zero exit code \(code) for \(indexFiles)
+        Updating index store terminated with non-zero exit code \(code) for \(indexFiles)
         Stderr:
         \(stderr)
         Stdout:
@@ -645,7 +645,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         // The indexing job finished with a signal. Could be because the compiler crashed.
         // Ignore signal exit codes if this task has been cancelled because the compiler exits with SIGINT if it gets
         // interrupted.
-        logger.error("Updating index store for signaled \(signal) for \(indexFiles)")
+        logger.error("Updating index store signaled \(signal) for \(indexFiles)")
         BuildSettingsLogger.log(level: .error, settings: buildSettings, for: indexFiles)
       }
     case .abnormal(let exception):

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -524,8 +524,14 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
       await buildServerManager.scheduleRecomputeCopyFileMap().value
     }
     if request.index ?? false {
-      await semanticIndexManager?.waitForUpToDateIndex()
-      await uncheckedIndex?.pollForUnitChangesAndWait()
+      if let semanticIndexManager = await semanticIndexManager {
+        await semanticIndexManager.waitForUpToDateIndex()
+      } else {
+        logger.debug("Skipping wait for background index in synchronize as it's disabled")
+
+        // Might have index while building, so still need to poll for any changes
+        await uncheckedIndex?.pollForUnitChangesAndWait()
+      }
     }
   }
 }


### PR DESCRIPTION
Also adds some logging to the synchronize request so that it's obvious when background indexing is being skipped.

Fixes #2373
Resolves rdar://165519940