### PR TITLE
Fix build-script-helper.py to silence directory exists error

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -257,7 +257,7 @@ def copy_file(source: str, destination_dir: str, verbose: bool) -> None:
     """
     Copies the file at `source` into `destination_dir`.
     """
-    os.makedirs(destination_dir)
+    os.makedirs(destination_dir, exist_ok=True)
     check_call(['rsync', '-a', source, destination_dir], verbose=verbose)
 
 


### PR DESCRIPTION
ca9ef8c129db4c95c90403a6521186fedb41cd7e introduced the `os.makedirs(destination_dir)` call without `exist_ok=True`, which causes a `FileExistsError` for `usr/bin` which already created by the main toolchain packaging step.
```
Traceback (most recent call last):
  File "/home/build-user/sourcekit-lsp/Utilities/build-script-helper.py", line 391, in <module>
    main()
  File "/home/build-user/sourcekit-lsp/Utilities/build-script-helper.py", line 367, in main
    handle_invocation(swift_exec, args)
  File "/home/build-user/sourcekit-lsp/Utilities/build-script-helper.py", line 300, in handle_invocation
    install(swift_exec, args)
  File "/home/build-user/sourcekit-lsp/Utilities/build-script-helper.py", line 279, in install
    copy_file(os.path.join(bin_path, 'sourcekit-lsp'), os.path.join(prefix, 'bin'), verbose=args.verbose)
  File "/home/build-user/sourcekit-lsp/Utilities/build-script-helper.py", line 260, in copy_file
    os.makedirs(destination_dir)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/home/build-user/swift-nightly-install/usr/bin'
```

https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/3982/console