### PR TITLE
Log an error when ignoring an unknown notification sent by the client

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -700,7 +700,7 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
       await self.withLanguageServiceAndWorkspace(for: notification, notificationHandler: self.willSaveDocument)
     // IMPORTANT: When adding a new entry to this switch, also add it to the `MessageHandlingDependencyTracker` initializer.
     default:
-      break
+      logger.error("Ignoring unknown notification \(type(of: notification).method)")
     }
   }
 


### PR DESCRIPTION
Just noticed that we don’t emit a log message here while reviewing the new SwiftPM BSP server.