### PR TITLE
[#2118] Implement keyword snippets for control-flow keywords (if/for/while/etc.)

### DIFF
--- a/Sources/SwiftLanguageService/CodeCompletionSession.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionSession.swift
@@ -720,40 +720,48 @@ class CodeCompletionSession {
   private func keywordSnippet(for keyword: String) -> String? {
     guard clientSupportsSnippets else { return nil }
 
-    func indentationUnitString() -> String {
-      // Convert the inferred Trivia (spaces/tabs) to a string we can embed into snippets.
-      if let trivia = indentationWidth {
-        for piece in trivia {
-          switch piece {
-          case .spaces(let n):
-            return String(repeating: " ", count: n)
-          case .tabs(let n):
-            return String(repeating: "\t", count: n)
-          default:
-            continue
-          }
-        }
-      }
-      // Fallback to a single tab to preserve previous behaviour when indentation cannot be inferred.
-      return "\t"
-    }
-
-    let indent = indentationUnitString()
-    let doubleIndent = indent + indent
+    // Use the `description` of inferred `Trivia` (e.g. "    " or "\t").
+    // Fall back to four spaces to match `BasicFormat`.
+    let indent = indentationWidth?.description ?? "    "
 
     switch keyword {
     case "if":
-      return "if ${1:condition} {\n\(indent)${0:}\n}"
+      return """
+        if ${1:condition} {
+        \(indent)${0:body}
+        }
+        """
     case "for":
-      return "for ${1:item} in ${2:sequence} {\n\(indent)${0:}\n}"
+      return """
+        for ${1:item} in ${2:sequence} {
+        \(indent)${0:body}
+        }
+        """
     case "while":
-      return "while ${1:condition} {\n\(indent)${0:}\n}"
+      return """
+        while ${1:condition} {
+        \(indent)${0:body}
+        }
+        """
     case "guard":
-      return "guard ${1:condition} else {\n\(indent)${0:}\n}"
+      return """
+        guard ${1:condition} else {
+        \(indent)${0:body}
+        }
+        """
     case "switch":
-      return "switch ${1:value} {\n\(indent)case ${2:pattern}:\n\(doubleIndent)${0:}\n}"
+      return """
+        switch ${1:value} {
+        case ${2:pattern}:
+        \(indent)${0:body}
+        }
+        """
     case "repeat":
-      return "repeat {\n\(indent)${0:}\n} while ${1:condition}"
+      return """
+        repeat {
+        \(indent)${0:body}
+        } while ${1:condition}
+        """
     default:
       return nil
     }

--- a/Tests/SourceKitLSPTests/SwiftCompletetionSnippetTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletetionSnippetTests.swift
@@ -51,7 +51,7 @@ final class SwiftCompletionSnippetTests: SourceKitLSPTestCase {
 
     let insertText = try XCTUnwrap(ifItem.insertText)
     XCTAssertTrue(insertText.contains("${1:condition}"))
-    XCTAssertTrue(insertText.contains("${0:}"))
+    XCTAssertTrue(insertText.contains("${0:body}"))
   }
 
   func testKeywordForProvidesSnippet() async throws {
@@ -163,6 +163,9 @@ final class SwiftCompletionSnippetTests: SourceKitLSPTestCase {
     let insertText = try XCTUnwrap(switchItem.insertText)
     XCTAssertTrue(insertText.contains("${1:value}"))
     XCTAssertTrue(insertText.contains("case"))
+    // Expect `case` to be not indented and the body placeholder to exist (indentation tested elsewhere).
+    XCTAssertTrue(insertText.contains("case ${2:pattern}:"))
+    XCTAssertTrue(insertText.contains("${0:body}"))
   }
 
   func testKeywordRepeatProvidesSnippet() async throws {
@@ -271,7 +274,10 @@ final class SwiftCompletionSnippetTests: SourceKitLSPTestCase {
     let insertText = try XCTUnwrap(ifItem.insertText)
 
     // Expect newline + two spaces before the final placeholder
-    XCTAssertTrue(insertText.contains("\n  ${0:}"), "expected two-space indentation in snippet, got: '\(insertText)'")
+    XCTAssertTrue(
+      insertText.contains("\n  ${0:body}"),
+      "expected two-space indentation in snippet, got: '\(insertText)'"
+    )
   }
 
   func testKeywordSnippetUsesInferredTabsIndentation() async throws {
@@ -297,6 +303,7 @@ final class SwiftCompletionSnippetTests: SourceKitLSPTestCase {
 
     let ifItem = try XCTUnwrap(completions.items.first(where: { $0.label == "if" }))
     let insertText = try XCTUnwrap(ifItem.insertText)
-    XCTAssertTrue(insertText.contains("\n\t"), "expected tab indentation in snippet, got: '\(insertText)'")
+    // Expect newline + tab then the body placeholder
+    XCTAssertTrue(insertText.contains("\n\t${0:body}"), "expected tab indentation in snippet, got: '\(insertText)'")
   }
 }


### PR DESCRIPTION
This PR implements snippet completions for control-flow keywords (if, for, while, guard, switch, repeat) when they are used in code completion.

The solution involved updating "CodeCompletionSession.swift" to identify keyword completions (.keyword) and overwrite their "insertText" and "textEdit" with the correct LSP snippet strings, setting the insertTextFormat to .snippet.

This ensures that keywords now contain placeholders (e.g., `${1:condition}` and `$0`) required by LSP clients.

Verification
New unit tests were added to "SwiftCompletionSnippetTests.swift" to explicitly verify:
1. The "insertTextFormat" is correctly set to ".snippet".
2. The presence of the required snippet placeholders (e.g., `$1`, `$0`).

All local tests, including the focused test (`swift test --filter SwiftCompletionSnippetTests/testKeywordIfProvidesSnippet`), passed successfully.

Checklist (Based on Contributing Guide)
1-Code has been formatted using `swift format -ipr 
2-New tests were added to cover the feature.

Fixes #2118