### PR TITLE
[6.3][cherrypick] OpenBSD requires casting id_t for setpriority.

### DIFF
--- a/Sources/TSCExtensions/Process+Run.swift
+++ b/Sources/TSCExtensions/Process+Run.swift
@@ -182,7 +182,7 @@ private func setProcessPriority(pid: Process.ProcessID, newPriority: TaskPriorit
   if !SetPriorityClass(handle, UInt32(newPriority.windowsProcessPriority)) {
     logger.fault("Failed to set process priority of \(pid) to \(newPriority.rawValue): \(GetLastError())")
   }
-  #elseif canImport(Darwin) || canImport(Android)
+  #elseif canImport(Darwin) || canImport(Android) || os(OpenBSD)
   // `setpriority` is only able to decrease a process's priority and cannot elevate it. Since Swift task’s priorities
   // can only be elevated, this means that we can effectively only change a process's priority once, when it is created.
   // All subsequent calls to `setpriority` will fail. Because of this, don't log an error.


### PR DESCRIPTION
- **Explanation**: 

Ensure sourcekit-lsp builds on OpenBSD.

- **Scope**:

Only one minor change to conditionals required for OpenBSD only.

- **Issues**:

Relevance to the OpenBSD port issue in swiftlang/swift#78437

- **Original PRs**:

#2390 

- **Risk**:

Minimal, since only a small conditional change was required.

- **Testing**:

Passes CI and builds locally.

- **Reviewers**:

@ahoppen