### PR TITLE
[6.3] Allow opting in to using the new SwiftPM BSP when opening a package

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -30,6 +30,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `linkerFlags: string[]`: Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.
   - `buildToolsSwiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files or plugins. Equivalent to SwiftPM's `-Xbuild-tools-swiftc` option.
   - `disableSandbox: boolean`: Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
+  - `buildSystem: "native"|"swiftbuild"`: Which SwiftPM build system should be used when opening a package.
 - `compilationDatabase`: Dictionary with the following keys, defining options for workspaces with a compilation database.
   - `searchPaths: string[]`: Additional paths to search for a compilation database, relative to a workspace root.
 - `fallbackBuildSystem`: Dictionary with the following keys, defining options for files that aren't managed by any build server.

--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -277,22 +277,43 @@ private extension BuildServerSpec {
         )
       }
     case .swiftPM:
-      #if !NO_SWIFTPM_DEPENDENCY
-      return await createBuiltInBuildServerAdapter(
-        messagesToSourceKitLSPHandler: messagesToSourceKitLSPHandler,
-        buildServerHooks: buildServerHooks
-      ) { connectionToSourceKitLSP in
-        try await SwiftPMBuildServer(
-          projectRoot: projectRoot,
-          toolchainRegistry: toolchainRegistry,
-          options: options,
-          connectionToSourceKitLSP: connectionToSourceKitLSP,
-          testHooks: buildServerHooks.swiftPMTestHooks
-        )
+      switch options.swiftPMOrDefault.buildSystem {
+      case .swiftbuild:
+        let buildServer = await orLog("Creating external SwiftPM build server") {
+          try await ExternalBuildServerAdapter(
+            projectRoot: projectRoot,
+            config: BuildServerConfig.forSwiftPMBuildServer(
+              projectRoot: projectRoot,
+              swiftPMOptions: options.swiftPMOrDefault,
+              toolchainRegistry: toolchainRegistry
+            ),
+            messagesToSourceKitLSPHandler: messagesToSourceKitLSPHandler
+          )
+        }
+        guard let buildServer else {
+          logger.log("Failed to create external SwiftPM build server at \(projectRoot)")
+          return nil
+        }
+        logger.log("Created external SwiftPM build server at \(projectRoot)")
+        return .external(buildServer)
+      case .native, nil:
+        #if !NO_SWIFTPM_DEPENDENCY
+        return await createBuiltInBuildServerAdapter(
+          messagesToSourceKitLSPHandler: messagesToSourceKitLSPHandler,
+          buildServerHooks: buildServerHooks
+        ) { connectionToSourceKitLSP in
+          try await SwiftPMBuildServer(
+            projectRoot: projectRoot,
+            toolchainRegistry: toolchainRegistry,
+            options: options,
+            connectionToSourceKitLSP: connectionToSourceKitLSP,
+            testHooks: buildServerHooks.swiftPMTestHooks
+          )
+        }
+        #else
+        return nil
+        #endif
       }
-      #else
-      return nil
-      #endif
     case .injected(let injector):
       let connectionToSourceKitLSP = LocalConnection(
         receiverName: "BuildServerManager for \(projectRoot.lastPathComponent)",

--- a/Sources/SKOptions/CMakeLists.txt
+++ b/Sources/SKOptions/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(SKOptions STATIC
   BuildConfiguration.swift
   ExperimentalFeatures.swift
   SourceKitLSPOptions.swift
+  SwiftPMBuildSystem.swift
   WorkspaceType.swift)
 set_target_properties(SKOptions PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -76,6 +76,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     ///   background indexing.
     public var skipPlugins: Bool?
 
+    /// Which SwiftPM build system should be used when opening a package.
+    public var buildSystem: SwiftPMBuildSystem?
+
     public init(
       configuration: BuildConfiguration? = nil,
       scratchPath: String? = nil,
@@ -90,7 +93,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       linkerFlags: [String]? = nil,
       buildToolsSwiftCompilerFlags: [String]? = nil,
       disableSandbox: Bool? = nil,
-      skipPlugins: Bool? = nil
+      skipPlugins: Bool? = nil,
+      buildSystem: SwiftPMBuildSystem? = nil
     ) {
       self.configuration = configuration
       self.scratchPath = scratchPath
@@ -105,6 +109,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       self.linkerFlags = linkerFlags
       self.buildToolsSwiftCompilerFlags = buildToolsSwiftCompilerFlags
       self.disableSandbox = disableSandbox
+      self.buildSystem = buildSystem
     }
 
     static func merging(base: SwiftPMOptions, override: SwiftPMOptions?) -> SwiftPMOptions {
@@ -122,7 +127,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
         linkerFlags: override?.linkerFlags ?? base.linkerFlags,
         buildToolsSwiftCompilerFlags: override?.buildToolsSwiftCompilerFlags ?? base.buildToolsSwiftCompilerFlags,
         disableSandbox: override?.disableSandbox ?? base.disableSandbox,
-        skipPlugins: override?.skipPlugins ?? base.skipPlugins
+        skipPlugins: override?.skipPlugins ?? base.skipPlugins,
+        buildSystem: override?.buildSystem ?? base.buildSystem
       )
     }
   }

--- a/Sources/SKOptions/SwiftPMBuildSystem.swift
+++ b/Sources/SKOptions/SwiftPMBuildSystem.swift
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum SwiftPMBuildSystem: String, Codable, Sendable {
+  case native
+  case swiftbuild
+}

--- a/config.schema.json
+++ b/config.schema.json
@@ -205,6 +205,15 @@
       "description" : "Options for SwiftPM workspaces.",
       "markdownDescription" : "Options for SwiftPM workspaces.",
       "properties" : {
+        "buildSystem" : {
+          "description" : "Which SwiftPM build system should be used when opening a package.",
+          "enum" : [
+            "native",
+            "swiftbuild"
+          ],
+          "markdownDescription" : "Which SwiftPM build system should be used when opening a package.",
+          "type" : "string"
+        },
         "buildToolsSwiftCompilerFlags" : {
           "description" : "Extra arguments passed to the compiler for Swift files or plugins. Equivalent to SwiftPM's `-Xbuild-tools-swiftc` option.",
           "items" : {


### PR DESCRIPTION
Explanation:
Add an opt-in flag to configure SourceKit-LSP to use the SwiftPM build server for package functionality

Scope:
Cherrypicks an opt in flag for integrating the new build server using the existing external BSP functionality


Original PR:
https://github.com/swiftlang/sourcekit-lsp/pull/2378

Risk:
Low. This is a small change to the build system backend selection which is entirely opt-in.

Testing:
Existing CI tests

Reviewers:
@ahoppen