### PR TITLE
Add parameterLabel modifier for argument labels in semantic tokens

### DIFF
--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -161,7 +161,7 @@ extension SyntaxClassification {
     case .docLineComment, .docBlockComment:
       return (.comment, .documentation)
     case .argumentLabel:
-      return (.function, [])
+      return (.function, .parameterLabel)
     #if RESILIENT_LIBRARIES
     @unknown default:
       fatalError("Unknown case")

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
@@ -172,7 +172,7 @@ struct SyntaxHighlightingTokenParser {
       // therefore we don't use .parameter here (which LSP clients like
       // VSCode seem to interpret as variable identifiers, however
       // causing a 'wrong highlighting' e.g. of `x` in `f(x y: Int) {}`)
-      return (.function, [.declaration])
+      return (.function, [.declaration, .parameterLabel])
     case values.refVarStatic,
       values.refVarClass,
       values.refVarInstance:

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -321,7 +321,7 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
       expected: [
         TokenSpec(marker: "1️⃣", length: 4, kind: .keyword),
         TokenSpec(marker: "2️⃣", length: 1, kind: .identifier),
-        TokenSpec(marker: "3️⃣", length: 1, kind: .function),
+        TokenSpec(marker: "3️⃣", length: 1, kind: .function, modifiers: .parameterLabel),
         TokenSpec(marker: "4️⃣", length: 3, kind: .struct, modifiers: .defaultLibrary),
         TokenSpec(marker: "5️⃣", length: 1, kind: .identifier),
         TokenSpec(marker: "6️⃣", length: 6, kind: .struct, modifiers: .defaultLibrary),
@@ -844,7 +844,7 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
         TokenSpec(marker: "2️⃣", length: 7, kind: .identifier),
         TokenSpec(marker: "3️⃣", length: 4, kind: .keyword),
         TokenSpec(marker: "4️⃣", length: 1, kind: .identifier),
-        TokenSpec(marker: "5️⃣", length: 1, kind: .function),
+        TokenSpec(marker: "5️⃣", length: 1, kind: .function, modifiers: .parameterLabel),
         TokenSpec(marker: "6️⃣", length: 7, kind: .actor),
       ]
     )
@@ -859,10 +859,10 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
       expected: [
         TokenSpec(marker: "1️⃣", length: 4, kind: .keyword),
         TokenSpec(marker: "2️⃣", length: 3, kind: .identifier),
-        TokenSpec(marker: "3️⃣", length: 3, kind: .function),
+        TokenSpec(marker: "3️⃣", length: 3, kind: .function, modifiers: .parameterLabel),
         TokenSpec(marker: "4️⃣", length: 3, kind: .struct, modifiers: .defaultLibrary),
         TokenSpec(marker: "5️⃣", length: 3, kind: .function),
-        TokenSpec(marker: "6️⃣", length: 3, kind: .function),
+        TokenSpec(marker: "6️⃣", length: 3, kind: .function, modifiers: .parameterLabel),
         TokenSpec(marker: "7️⃣", length: 1, kind: .number),
       ]
     )
@@ -876,7 +876,7 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
       expected: [
         TokenSpec(marker: "1️⃣", length: 4, kind: .keyword),
         TokenSpec(marker: "2️⃣", length: 3, kind: .identifier),
-        TokenSpec(marker: "3️⃣", length: 3, kind: .function),
+        TokenSpec(marker: "3️⃣", length: 3, kind: .function, modifiers: .parameterLabel),
         TokenSpec(marker: "4️⃣", length: 12, kind: .identifier),
         TokenSpec(marker: "5️⃣", length: 3, kind: .struct, modifiers: .defaultLibrary),
       ]


### PR DESCRIPTION
**Motivation**: Argument labels are currently tokenized as function without any modifier, making them indistinguishable from function names. This prevents theme authors from styling them differently, particularly important for accessibility (e.g., themes for neurodivergent developers) and personal preference.

**Changes**: 
- Added parameterLabel semantic token modifier to SemanticTokenModifiers extension
- Applied the modifier to argument labels in both the syntactic path (SemanticTokens.swift) and semantic path (SyntaxHighlightingTokenParser.swift) to ensure consistency.
- Updated the token legend to include the new modifier so editors can decode it.
- Updated all(?) relevant test expectations to include .parameterLabel for argument label tokens.


Fixes https://github.com/swiftlang/sourcekit-lsp/issues/1540