### PR TITLE
Add Show Objective-C Selector code action

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -478,7 +478,7 @@ package actor SkipUnless {
         )
 
         let testURL = scratchDirectory.appending(component: "test.swift")
-        try source.write(to: testURL, atomically: false, encoding: .utf8)
+        try await source.writeWithRetry(to: testURL)
 
         let sourceFile = try testURL.filePath
 

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -459,6 +459,47 @@ package actor SkipUnless {
     }
   }
 
+  package static func sourcekitdSupportsObjCSelector(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    return try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(6, 5), file: file, line: line) {
+      let sourcekitd = try await getSourceKitD()
+
+      return try await withTestScratchDir { scratchDirectory in
+        let (positions, source) = extractMarkers(
+          """
+          import Foundation
+
+          class Foo: NSObject {
+            @objc func 1️⃣bar() {}
+          }
+          """
+        )
+
+        let testURL = scratchDirectory.appending(component: "test.swift")
+        try source.write(to: testURL, atomically: false, encoding: .utf8)
+
+        let sourceFile = try testURL.filePath
+
+        let skreq = sourcekitd.dictionary([
+          sourcekitd.keys.offset: positions["1️⃣"]!.utf8Offset,
+          sourcekitd.keys.sourceFile: sourceFile,
+          sourcekitd.keys.compilerArgs: [sourceFile],
+        ])
+
+        do {
+          let response = try await sourcekitd.send(\.objcSelector, skreq)
+
+          let selector: String? = response[sourcekitd.keys.text]
+          return selector != nil
+        } catch {
+          return false
+        }
+      }
+    }
+  }
+
   package static func swiftPMBuildServerSupportedWithoutBackgroundIndexing(
     file: StaticString = #filePath,
     line: UInt = #line

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -878,6 +878,8 @@ package struct sourcekitd_api_requests {
   package let findLocalRenameRanges: sourcekitd_api_uid_t
   /// `source.request.semantic.refactoring`
   package let semanticRefactoring: sourcekitd_api_uid_t
+  /// `source.request.objc.selector`
+  package let objcSelector: sourcekitd_api_uid_t
   /// `source.request.enable-compile-notifications`
   package let enableCompileNotifications: sourcekitd_api_uid_t
   /// `source.request.test_notification`
@@ -951,6 +953,7 @@ package struct sourcekitd_api_requests {
     findRenameRanges = api.uid_get_from_cstr("source.request.find-syntactic-rename-ranges")!
     findLocalRenameRanges = api.uid_get_from_cstr("source.request.find-local-rename-ranges")!
     semanticRefactoring = api.uid_get_from_cstr("source.request.semantic.refactoring")!
+    objcSelector = api.uid_get_from_cstr("source.request.objc.selector")!
     enableCompileNotifications = api.uid_get_from_cstr("source.request.enable-compile-notifications")!
     testNotification = api.uid_get_from_cstr("source.request.test_notification")!
     collectExpressionType = api.uid_get_from_cstr("source.request.expression.type")!

--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(SwiftLanguageService STATIC
   SemanticRefactorCommand.swift
   SemanticRefactoring.swift
   SemanticTokens.swift
+  ShowObjCSelector.swift
+  ShowObjCSelectorCommand.swift
   SignatureHelp.swift
   SwiftCodeLensScanner.swift
   SwiftCommand.swift

--- a/Sources/SwiftLanguageService/ShowObjCSelector.swift
+++ b/Sources/SwiftLanguageService/ShowObjCSelector.swift
@@ -19,7 +19,7 @@ extension SwiftLanguageService {
   /// The Objective-C selector of the declaration at `position`, or `nil` if it isn't exposed to Objective-C or the
   /// toolchain doesn't know the request.
   func objcSelector(_ uri: DocumentURI, at position: Position) async -> String? {
-    return await orLog("Getting Objective-C selector", level: .debug) {
+    return await orLog("Getting Objective-C selector") {
       let snapshot = try await self.latestSnapshot(for: uri)
       let skreq = sourcekitd.dictionary([
         keys.offset: snapshot.utf8Offset(of: position),

--- a/Sources/SwiftLanguageService/ShowObjCSelector.swift
+++ b/Sources/SwiftLanguageService/ShowObjCSelector.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+@_spi(SourceKitLSP) import SKLogging
+import SourceKitD
+import SourceKitLSP
+
+extension SwiftLanguageService {
+  /// The Objective-C selector of the declaration at `position`, or `nil` if it isn't exposed to Objective-C or the
+  /// toolchain doesn't know the request.
+  func objcSelector(_ uri: DocumentURI, at position: Position) async -> String? {
+    return await orLog("Getting Objective-C selector", level: .debug) {
+      let snapshot = try await self.latestSnapshot(for: uri)
+      let skreq = sourcekitd.dictionary([
+        keys.offset: snapshot.utf8Offset(of: position),
+        keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
+        keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
+        keys.compilerArgs: await self.compileCommand(for: uri, fallbackAfterTimeout: true)?.compilerArgs
+          as [any SKDRequestValue]?,
+      ])
+      let dict = try await self.send(sourcekitdRequest: \.objcSelector, skreq, snapshot: snapshot)
+      return dict[keys.text] as String?
+    }
+  }
+
+  func showObjCSelector(_ command: ShowObjCSelectorCommand) -> LSPAny {
+    sourceKitLSPServer?.sendNotificationToClient(ShowMessageNotification(type: .info, message: command.selector))
+    return .string(command.selector)
+  }
+}

--- a/Sources/SwiftLanguageService/ShowObjCSelectorCommand.swift
+++ b/Sources/SwiftLanguageService/ShowObjCSelectorCommand.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+
+/// Command to show the Objective-C selector of a method that is exposed to Objective-C.
+package struct ShowObjCSelectorCommand: SwiftCommand {
+  package static let identifier: String = "show.objc.selector.command"
+
+  package var title = "Show Objective-C Selector"
+
+  /// The selector to show, computed when the code action is created.
+  package var selector: String
+
+  init(selector: String) {
+    self.selector = selector
+  }
+}

--- a/Sources/SwiftLanguageService/SwiftCommand.swift
+++ b/Sources/SwiftLanguageService/SwiftCommand.swift
@@ -52,6 +52,7 @@ extension SwiftLanguageService {
       SemanticRefactorCommand.self,
       ExpandMacroCommand.self,
       RemoveUnusedImportsCommand.self,
+      ShowObjCSelectorCommand.self,
     ].map { (command: any SwiftCommand.Type) in
       command.identifier
     }

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -959,7 +959,7 @@ extension SwiftLanguageService {
     }
     let providersAndKinds: [(provider: CodeActionProvider, kind: CodeActionKind?)] = [
       (retrieveSyntaxCodeActions, nil),
-      (retrieveRefactorCodeActions, .refactor),
+      (retrieveCursorInfoBasedCodeActions, nil),
       (retrieveQuickFixCodeActions, .quickFix),
       (retrieveRemoveUnusedImportsCodeAction, .sourceOrganizeImports),
     ]
@@ -1054,7 +1054,19 @@ extension SwiftLanguageService {
     )
   }
 
-  func retrieveRefactorCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {
+  private func codeActionKind(_ kind: CodeActionKind, matches requested: CodeActionKind) -> Bool {
+    return kind == requested || kind.rawValue.hasPrefix("\(requested.rawValue).")
+  }
+
+  func retrieveCursorInfoBasedCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {
+    if let requestedKinds = params.context.only,
+      !requestedKinds.contains(where: {
+        codeActionKind($0, matches: .refactor) || codeActionKind(.refactor, matches: $0)
+      })
+    {
+      return []
+    }
+
     let additionalCursorInfoParameters: ((SKDRequestDictionary) -> Void) = { skreq in
       skreq.set(self.keys.retrieveRefactorActions, to: 1)
     }
@@ -1097,11 +1109,19 @@ extension SwiftLanguageService {
     if isOnObjCFunction, let selector = await objcSelector(params.textDocument.uri, at: params.range.lowerBound) {
       let showObjCSelectorCommand = ShowObjCSelectorCommand(selector: selector).asCommand()
       refactorActions.append(
-        CodeAction(title: showObjCSelectorCommand.title, kind: .refactor, command: showObjCSelectorCommand)
+        CodeAction(title: showObjCSelectorCommand.title, kind: .empty, command: showObjCSelectorCommand)
       )
     }
 
-    return refactorActions
+    guard let requestedKinds = params.context.only else {
+      return refactorActions
+    }
+    return refactorActions.filter { codeAction in
+      guard let kind = codeAction.kind else {
+        return false
+      }
+      return requestedKinds.contains { codeActionKind(kind, matches: $0) }
+    }
   }
 
   func retrieveQuickFixCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -1084,6 +1084,23 @@ extension SwiftLanguageService {
       refactorActions.append(CodeAction(title: expandMacroCommand.title, kind: .refactor, command: expandMacroCommand))
     }
 
+    // Declarations exposed to Objective-C have an Objective-C USR (`c:`), everything else has a Swift USR (`s:`).
+    // Checking it avoids a semantic request per code action on Swift-only declarations.
+    let isOnObjCFunction = cursorInfoResponse.cursorInfo.contains { cursorInfo in
+      switch cursorInfo.symbolInfo.kind {
+      case .method, .function, .constructor:
+        return cursorInfo.symbolInfo.usr?.hasPrefix("c:") ?? false
+      default:
+        return false
+      }
+    }
+    if isOnObjCFunction, let selector = await objcSelector(params.textDocument.uri, at: params.range.lowerBound) {
+      let showObjCSelectorCommand = ShowObjCSelectorCommand(selector: selector).asCommand()
+      refactorActions.append(
+        CodeAction(title: showObjCSelectorCommand.title, kind: .refactor, command: showObjCSelectorCommand)
+      )
+    }
+
     return refactorActions
   }
 
@@ -1201,6 +1218,8 @@ extension SwiftLanguageService {
       try await semanticRefactoring(command)
     } else if let command = req.swiftCommand(ofType: ExpandMacroCommand.self) {
       try await expandMacro(command)
+    } else if let command = req.swiftCommand(ofType: ShowObjCSelectorCommand.self) {
+      return showObjCSelector(command)
     } else if let command = req.swiftCommand(ofType: RemoveUnusedImportsCommand.self) {
       try await removeUnusedImports(command)
     } else {

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -528,6 +528,58 @@ final class CodeActionTests: SourceKitLSPTestCase {
     try await fulfillmentOfOrThrow(editReceived)
   }
 
+  func testShowObjCSelectorCodeActionResult() async throws {
+    try SkipUnless.platformIsDarwin("Non-Darwin platforms don't support Objective-C")
+    try await SkipUnless.sourcekitdSupportsObjCSelector()
+
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      import Foundation
+
+      class Foo: NSObject {
+        @objc func b1️⃣ar(baz: Int) {}
+        func no2️⃣tExposedToObjC() {}
+      }
+      """,
+      uri: uri
+    )
+
+    let objcActions = try await testClient.send(
+      CodeActionRequest(
+        range: Range(positions["1️⃣"]),
+        context: .init(),
+        textDocument: TextDocumentIdentifier(uri)
+      )
+    )
+    guard
+      let command = objcActions?.codeActions?
+        .first(where: { $0.title == "Show Objective-C Selector" })?
+        .command
+    else {
+      XCTFail("Expected a 'Show Objective-C Selector' action, got \(objcActions?.codeActions ?? [])")
+      return
+    }
+
+    let response = try await testClient.send(
+      ExecuteCommandRequest(command: command.command, arguments: command.arguments)
+    )
+    XCTAssertEqual(response, .string("barWithBaz:"))
+
+    let notification = try await testClient.nextNotification(ofType: ShowMessageNotification.self)
+    XCTAssertEqual(notification.message, "barWithBaz:")
+
+    let nonObjCActions = try await testClient.send(
+      CodeActionRequest(
+        range: Range(positions["2️⃣"]),
+        context: .init(),
+        textDocument: TextDocumentIdentifier(uri)
+      )
+    )
+    XCTAssertFalse(nonObjCActions?.codeActions?.contains { $0.title == "Show Objective-C Selector" } ?? false)
+  }
+
   func testAddDocumentationCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI(for: .swift)


### PR DESCRIPTION
Resolves https://github.com/swiftlang/sourcekit-lsp/issues/2145

Adds a *Show Objective-C Selector* code action for declarations exposed to Objective-C.

The action is only offered when the declaration under the cursor actually has a selector, and the selector is fetched while computing the code action, so invoking it needs no second request.

Requires https://github.com/swiftlang/swift/pull/86173.

https://github.com/user-attachments/assets/467cec3f-d0cb-4e64-91f1-adfc7879d33f
