### PR TITLE
Mark `Connection.send` as `@_disfavoredOverload`

### DIFF
--- a/Sources/LanguageServerProtocolExtensions/Connection+Send.swift
+++ b/Sources/LanguageServerProtocolExtensions/Connection+Send.swift
@@ -23,6 +23,9 @@ extension Connection {
   /// - Warning: Because this message is `async`, it does not provide any ordering
   ///   guarantees. If you need to guarantee that messages are sent in-order
   ///   use the version with a completion handler.
+  // Disfavor this over Connection.send implemented in swift-tools-protocols by https://github.com/swiftlang/swift-tools-protocols/pull/28
+  // TODO: Remove this file once we have updated the swift-tools-protocols dependency to include #28
+  @_disfavoredOverload
   package func send<R: RequestType>(_ request: R) async throws -> R.Response {
     return try await withCancellableCheckedThrowingContinuation { continuation in
       return self.send(request) { result in


### PR DESCRIPTION
Otherwise `Connection.send` is ambiguous once we pick up https://github.com/swiftlang/swift-tools-protocols/pull/28