### PR TITLE
Only adjust location for copied files if the original file exists

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -971,6 +971,9 @@ package actor BuildServerManager: QueueBasedMessageHandler {
     guard let originalUri = cachedCopiedFileMap[location.uri] else {
       return location
     }
+    if let fileUrl = originalUri.fileURL, !FileManager.default.fileExists(at: fileUrl) {
+      return location
+    }
     // If we regularly get issues that the copied file is out-of-sync with its original, we can check that the contents
     // of the lines touched by the location match and only return the original URI if they do. For now, we avoid this
     // check due to its performance cost of reading files from disk.


### PR DESCRIPTION
If the original file does not exist, it is preferable to jump to a file generated by the build system instead of trying to jump to a file that the editor can’t open. This will become important when using the copied file logic to jump to files in `.build/checkouts` instead of `.build/index-build/checkouts` in a follow-up PR.