### PR TITLE
Allow `QueueBasedMessageHandler.handle` to return `any Error` instead of `ResponseError`

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -706,7 +706,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   package func handle<Request: RequestType>(
     request: Request,
     id: RequestID,
-    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+    reply: @Sendable @escaping (Result<Request.Response, any Error>) -> Void
   ) async {
     let request = RequestAndReply(request, reply: reply)
     switch request {

--- a/Sources/BuildServerIntegration/BuiltInBuildServerAdapter.swift
+++ b/Sources/BuildServerIntegration/BuiltInBuildServerAdapter.swift
@@ -120,7 +120,7 @@ actor BuiltInBuildServerAdapter: QueueBasedMessageHandler {
   func handle<Request: RequestType>(
     request: Request,
     id: RequestID,
-    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+    reply: @Sendable @escaping (Result<Request.Response, any Error>) -> Void
   ) async {
     let request = RequestAndReply(request, reply: reply)
     await buildServerHooks.preHandleRequest?(request.params)

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -668,7 +668,7 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
         continue
       }
       logger.info("Implicitly cancelling request \(requestID)")
-      self.messageHandlingHelper.cancelRequest(id: requestID)
+      self.messageHandlingHelper.cancelRequest(id: requestID, error: .cancelled)
     }
   }
 
@@ -722,7 +722,7 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
   package func handle<Request: RequestType>(
     request params: Request,
     id: RequestID,
-    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+    reply: @Sendable @escaping (Result<Request.Response, any Error>) -> Void
   ) async {
     defer {
       if let request = params as? any TextDocumentRequest {


### PR DESCRIPTION
Update for the API changed in https://github.com/swiftlang/swift-tools-protocols/pull/33.