### PR TITLE
Don’t implicitly cancel requests when an edit is detected

### DIFF
--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -388,7 +388,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
   public var cancelTextDocumentRequestsOnEditAndClose: Bool? = nil
 
   public var cancelTextDocumentRequestsOnEditAndCloseOrDefault: Bool {
-    return cancelTextDocumentRequestsOnEditAndClose ?? true
+    return cancelTextDocumentRequestsOnEditAndClose ?? false
   }
 
   /// Whether the response for `textDocument/semanticTokens` should include semantic tokens for syntactic and semantic

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -663,10 +663,25 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
   /// - Important: Should be invoked on `textDocumentTrackingQueue` to ensure that new text document requests are
   ///   registered before a notification that triggers cancellation might come in.
   private func cancelTextDocumentRequests(for uri: DocumentURI, reason: ImplicitTextDocumentRequestCancellationReason) {
-    guard self.options.cancelTextDocumentRequestsOnEditAndCloseOrDefault else {
-      return
-    }
+    let staleRequestSupport = self.capabilityRegistry?.clientCapabilities.general?.staleRequestSupport
     for (requestID, requestMethod) in self.inProgressTextDocumentRequests[uri, default: []] {
+      // Implicitly cancel text document requests if:
+      //  - We have enabled implicit text document request cancellation in the SourceKit options
+      //  - The client has indicated that it does not cancel stale requests. Defaults to `true` because this is an
+      //    option introduced in LSP 3.17 and most clients cancel requests diligently without setting
+      //    `staleRequestSupport.cancel = true`
+      //  - `staleRequestSupport.retryOnContentModified` contains this request method. Documentation for this behavior
+      //    is very limited but it appears that if a request is included in that array, the client (VS Code in
+      //    particular) expects to receive a `ContentModified` response when the LSP server detects an edit, in which
+      //    case it will re-run the request with the new file contents.
+      guard
+        self.options.cancelTextDocumentRequestsOnEditAndCloseOrDefault
+          || !(staleRequestSupport?.cancel ?? true)
+          || staleRequestSupport?.retryOnContentModified.contains(requestMethod) ?? false
+      else {
+        continue
+      }
+
       if reason == .documentChanged && requestMethod == CompletionRequest.method {
         // As the user types, we filter the code completion results. Cancelling the completion request on every
         // keystroke means that we will never build the initial list of completion results for this code
@@ -675,7 +690,7 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
         continue
       }
       logger.info("Implicitly cancelling request \(requestID)")
-      self.messageHandlingHelper.cancelRequest(id: requestID, error: .cancelled)
+      self.messageHandlingHelper.cancelRequest(id: requestID, error: .contentModified)
     }
   }
 

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -992,14 +992,22 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
             try? await Task.sleep(for: .seconds(1))
           }
         }
-      })
+      }),
+      capabilities: ClientCapabilities(
+        general: .init(
+          staleRequestSupport: .init(
+            cancel: true,
+            retryOnContentModified: [DocumentSemanticTokensRequest.method]
+          )
+        )
+      )
     )
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument("1️⃣", uri: uri)
 
     let receivedSemanticTokensResponse = self.expectation(description: "Received semantic tokens response")
     testClient.send(DocumentSemanticTokensRequest(textDocument: TextDocumentIdentifier(uri))) { result in
-      XCTAssertEqual(result, .failure(ResponseError.cancelled))
+      XCTAssertEqual(result, .failure(ResponseError(code: .contentModified, message: "content modified")))
       receivedSemanticTokensResponse.fulfill()
     }
     testClient.send(


### PR DESCRIPTION
Instead, use `staleRequestSupport.retryOnContentModified` as an indicator which requests should return a `ContentModified` error when the document is modified. This fixes https://github.com/swiftlang/sourcekit-lsp/issues/2136 by no longer implicitly cancelling inlayHints in Helix while still implicitly cancelling semantic tokens request, which was the motivation for https://github.com/swiftlang/sourcekit-lsp/pull/1629.

Fixes #1650