### PR TITLE
Don’t show sourcekitd refactoring actions that have been superseded by swift-syntax refactoring actions

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
@@ -33,3 +33,7 @@ let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
   #endif
   return result
 }()
+
+let supersededSourcekitdRefactoringActions: Set<String> = [
+  "source.refactoring.kind.simplify.long.number.literal"  // Superseded by AddSeparatorsToIntegerLiteral
+]

--- a/Sources/SwiftLanguageService/SemanticRefactorCommand.swift
+++ b/Sources/SwiftLanguageService/SemanticRefactorCommand.swift
@@ -113,6 +113,9 @@ extension Array where Element == SemanticRefactorCommand {
         guard !actionName.hasPrefix("source.refactoring.kind.rename.") else {
           return true
         }
+        guard !supersededSourcekitdRefactoringActions.contains(actionName) else {
+          return true
+        }
         commands.append(
           SemanticRefactorCommand(
             title: name,

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -668,8 +668,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
           diagnostics: nil,
           edit: WorkspaceEdit(
             changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: "0b10000")]]
-          ),
-          command: nil
+          )
         ),
         CodeAction(
           title: "Convert 16 to 0o20",
@@ -677,8 +676,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
           diagnostics: nil,
           edit: WorkspaceEdit(
             changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: "0o20")]]
-          ),
-          command: nil
+          )
         ),
         CodeAction(
           title: "Convert 16 to 0x10",
@@ -686,8 +684,51 @@ final class CodeActionTests: SourceKitLSPTestCase {
           diagnostics: nil,
           edit: WorkspaceEdit(
             changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: "0x10")]]
-          ),
-          command: nil
+          )
+        ),
+      ]
+    }
+  }
+
+  func testAddSeparatorsToIntegerLiteral() async throws {
+    try await assertCodeActions(
+      """
+      let x = 1️⃣10002️⃣
+      """,
+      markers: ["1️⃣"]
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add digit separators",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "1_000")]]
+          )
+        ),
+        CodeAction(
+          title: "Convert 1000 to 0b1111101000",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "0b1111101000")]]
+          )
+        ),
+        CodeAction(
+          title: "Convert 1000 to 0o1750",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "0o1750")]]
+          )
+        ),
+        CodeAction(
+          title: "Convert 1000 to 0x3e8",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "0x3e8")]]
+          )
         ),
       ]
     }
@@ -708,8 +749,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
           diagnostics: nil,
           edit: WorkspaceEdit(
             changes: [uri: [TextEdit(range: positions["1️⃣"]..<positions["3️⃣"], newText: #""Hello world""#)]]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -739,8 +779,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
                 )
               ]
             ]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -778,8 +817,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
                 )
               ]
             ]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -820,8 +858,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
                 )
               ]
             ]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -871,8 +908,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
                 )
               ]
             ]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -906,8 +942,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
                 )
               ]
             ]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -939,8 +974,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
                 )
               ]
             ]
-          ),
-          command: nil
+          )
         )
       ]
     }
@@ -1218,8 +1252,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
             )
           ]
         ]
-      ),
-      command: nil
+      )
     )
 
     XCTAssertTrue(codeActions.contains(expectedCodeAction))
@@ -1276,8 +1309,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
             )
           ]
         ]
-      ),
-      command: nil
+      )
     )
 
     XCTAssertTrue(codeActions.contains(expectedCodeAction))


### PR DESCRIPTION
For now, this is only the action to add thousands separators to integer literals but hopefully this list will grow as we translate more refactoring actions to swift-syntax.