### PR TITLE
add support for multi-line string literals when converting string concatenation to string interpolation

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/ConvertStringConcatenationToStringInterpolation.swift
+++ b/Sources/SwiftLanguageService/CodeActions/ConvertStringConcatenationToStringInterpolation.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(SourceKitLSP) import LanguageServerProtocol
+import SwiftBasicFormat
 import SwiftRefactor
 import SwiftSyntax
 
@@ -86,6 +87,10 @@ struct ConvertStringConcatenationToStringInterpolation: SyntaxRefactoringProvide
         lastSegment.trailingTrivia = .newline
         segments = StringLiteralSegmentListSyntax(segments.dropLast() + [lastSegment])
       }
+
+      // Re-introduce the indentation of the last multi-line string literal's
+      // closing quote to the entire string literal.
+      segments = segments.indented(by: closingQuoteTrivia, indentFirstLine: true)
     }
 
     let quoteToken: TokenSyntax =
@@ -98,10 +103,7 @@ struct ConvertStringConcatenationToStringInterpolation: SyntaxRefactoringProvide
       ? quoteToken.with(\.trailingTrivia, .newline)
       : quoteToken
 
-    let closingQuote: TokenSyntax =
-      hasMultilineString
-      ? quoteToken.with(\.leadingTrivia, closingQuoteTrivia)
-      : quoteToken
+    let closingQuote: TokenSyntax = quoteToken
 
     return syntax.with(
       \.elements,

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -1150,9 +1150,9 @@ final class CodeActionTests: SourceKitLSPTestCase {
                   range: positions["1️⃣"]..<positions["2️⃣"],
                   newText: #"""
                     """
-                    a
-                    bc
-                    d
+                      a
+                      bc
+                      d
                       """
                     """#
                 )


### PR DESCRIPTION
fixes #1568
Thiis PR adds support for multi-line string literals in the "Convert String Concatenation to String Interpolation" code action.

Changes:

modified preflight to track hasMultilineString instead of rejecting multi-line strings
used multilineStringQuoteToken() when any input string is multi-line
updated test to verify multi-line string support works correctly
