### PR TITLE
Perf: Index only reachable products of package dependencies (#2427)

### DIFF
--- a/Sources/BuildServerIntegration/PackageGraph+Reachability.swift
+++ b/Sources/BuildServerIntegration/PackageGraph+Reachability.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !NO_SWIFTPM_DEPENDENCY
+@preconcurrency import PackageGraph
+@preconcurrency import SourceKitLSPAPI
+
+extension ModulesGraph {
+  /// Computes the set of module (target) names that are reachable from root package modules.
+  ///
+  /// A module is considered reachable if it is part of the dependency graph starting
+  /// from the root package's modules. This is used to filter out unreachable modules
+  /// from dependencies during background indexing to improve performance.
+  ///
+  /// - Returns: A set of module names that are reachable from root packages.
+  func reachableModuleNames() -> Set<String> {
+    Set(reachableModules.map(\.name))
+  }
+}
+
+extension SourceKitLSPAPI.BuildDescription {
+  /// Traverses modules while filtering out unreachable modules from dependencies.
+  ///
+  /// This method wraps the standard `traverseModules` call but filters out modules
+  /// that are not reachable from the root package. Modules from the root package
+  /// itself are always included, even if they are not technically reachable,
+  /// to ensure complete indexing of the user's own code.
+  ///
+  /// - Parameters:
+  ///   - modulesGraph: The package graph containing reachability information.
+  ///   - callback: Closure called for each reachable build target with its parent.
+  func traverseReachableModules(
+    in modulesGraph: ModulesGraph,
+    callback: (any BuildTarget, _ parent: (any BuildTarget)?) -> Void
+  ) {
+    let reachableModuleNames = modulesGraph.reachableModuleNames()
+
+    self.traverseModules { buildTarget, parent in
+      // Always include modules from the root package
+      guard !buildTarget.isPartOfRootPackage else {
+        callback(buildTarget, parent)
+        return
+      }
+
+      // For dependency modules, only include them if they are reachable
+      guard reachableModuleNames.contains(buildTarget.name) else {
+        return
+      }
+
+      callback(buildTarget, parent)
+    }
+  }
+}
+
+#endif

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -484,7 +484,9 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     self.swiftPMTargets = [:]
     self.targetDependencies = [:]
 
-    buildDescription.traverseModules { buildTarget, parent in
+    // Use the filtered traversal to only index reachable modules from dependencies.
+    // All modules from the root package are included regardless of reachability.
+    buildDescription.traverseReachableModules(in: modulesGraph) { buildTarget, parent in
       let targetIdentifier = orLog("Getting build target identifier") { try BuildTargetIdentifier(buildTarget) }
       guard let targetIdentifier else {
         return


### PR DESCRIPTION
Fixes #2427
Summary
This PR optimizes background indexing by filtering out unreachable dependency products.

1-**Logic**: Uses `ModulesGraph.reachableProducts` to identify only the dependency modules required by the root package.
2-**Safety**: Always indexes all modules in the root package, regardless of reachability.
3-**Implementation**: Replaces the generic `traverseModules` in `SwiftPMBuildServer.swift` with a filtered `traverseReachableModules` wrapper.
4-**Clean Code**: Moves filtering logic to a new `PackageGraph+Reachability.swift` .