### PR TITLE
Automatically set the issue type for issues created through templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something isn't working as expected
-labels: [bug]
+type: Bug
 body:
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: A suggestion for a new feature
-labels: [enhancement]
+type: Feature
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
I recently cleaned up our issues to use the GitHub issue types *Bug*, *Feature*, and *Task* instead of the *bug* and *enhancement* labels. Reflect this in the issue forms.