### PR TITLE
Handles unused imports 

### DIFF
--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -1610,15 +1610,24 @@ final class CodeActionTests: SourceKitLSPTestCase {
       // Verify we have 3 edits (Darwin, LibA, LibB)
       XCTAssertEqual(changes.count, 3, "Expected 3 import removals")
 
-      // Verify Glibc import range is NOT in the edits
-      // Glibc should be between positions 2️⃣ and 3️⃣
-      let glibcRange = positions["2️⃣"]..<positions["3️⃣"]
-      for edit in changes {
-        XCTAssertFalse(
-          edit.range.contains(glibcRange.lowerBound),
-          "Glibc import should not be removed (it's in an inactive clause)"
+      let expectedPositions = [
+        positions["1️⃣"],
+        positions["4️⃣"],
+        positions["5️⃣"],
+      ]
+
+      for expected in expectedPositions {
+        XCTAssertTrue(
+          changes.contains(where: { $0.range.contains(expected) }),
+          "Expected an edit containing \(expected)"
         )
       }
+
+      // Verify Glibc import range is NOT in the edits
+      XCTAssertFalse(
+        changes.contains(where: { $0.range.contains(positions["2️⃣"]) }),
+        "Glibc import should not be removed (it's in an inactive clause)"
+      )
 
       return ApplyEditResponse(applied: true, failureReason: nil)
     }


### PR DESCRIPTION
Fixes #2335 
1-**Integrated** `SwiftIfConfig`: Added and linked the library in `Package.swift` and `CMakeLists.txt` to enable conditional compilation evaluation.
2-New Build Configuration: Implemented `SourceKitLSPBuildConfiguration` to provide the necessary compiler arguments and target triple for `#if` evaluation.
3-Platform-Aware Visitor: Refactored `ImportCollectorVisitor` to use `activeClause(in:)`, ensuring only active code blocks are scanned for unused imports.
4-**Verified Logic**: Added unit tests confirming correct behavior for both active and inactive branches, passing all 71 tests in the suite.