### PR TITLE
FreeBSD: Include freebsd runtimes in rpath

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -141,7 +141,9 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace, suppress_verb
         # pkg installs packages to /usr/local/include on FreeBSD
         # Required for SwiftPM to find sqlite
         swiftpm_args += ['-Xcxx', '-I', '-Xcxx', '/usr/local/include',
-                         '-Xswiftc', '-I', '-Xswiftc', '/usr/local/include']
+                         '-Xswiftc', '-I', '-Xswiftc', '/usr/local/include',
+                         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/freebsd',
+                         ]
     elif not build_os.startswith('macosx'):
         # Library rpath for swift, dispatch, Foundation, etc. when installing
         swiftpm_args += [


### PR DESCRIPTION
Running sourcekit-lsp built by Swift CI on FreeBSD results in the following error:

```
ld-elf.so.1: Shared object "libswiftCore.so" not found, required by "sourcekit-lsp"
```

The runpath is pointing at a location in CI rather than the binary-relative location where we can find the runtime libraries.