### PR TITLE
Fix compile warnings in Sources and Tests

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -279,10 +279,10 @@ struct SourceKitLSP: AsyncParsableCommand {
     let clientConnection = JSONRPCConnection(
       name: "client",
       protocol: MessageRegistry.lspProtocol,
-      inFD: FileHandle.standardInput,
-      outFD: realStdoutHandle,
-      inputMirrorFile: inputMirror,
-      outputMirrorFile: outputMirror
+      receiveFD: FileHandle.standardInput,
+      sendFD: realStdoutHandle,
+      receiveMirrorFile: inputMirror,
+      sendMirrorFile: outputMirror
     )
 
     // For reasons that are completely oblivious to me, `DispatchIO.write`, which is used to write LSP responses to

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -349,7 +349,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       enableBackgroundIndexing: true
     )
 
-    let (uri, positions) = try project.openDocument("UseType.swift")
+    let (uri, _) = try project.openDocument("UseType.swift")
 
     let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: nil)
     let hints = try await project.testClient.send(request)


### PR DESCRIPTION
This PR addresses all compiler warnings that are reported while compiling `Sources` and `Tests`. 

The changes in `SourceKitLSP.swift` and `InlayHintTests.swift` are straightforward. I would like to get feedback on the changes in `DocCReferenceResolutionService.swift` as the changes are more substantial and as I'm not familiar with the code.