### PR TITLE
Implement support for textDocument/selectionRange

### DIFF
--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -245,6 +245,7 @@ package protocol LanguageService: AnyObject, Sendable {
   func typeDefinition(_ request: TypeDefinitionRequest) async throws -> LocationsOrLocationLinksResponse?
   func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]?
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]?
+  func selectionRange(_ req: SelectionRangeRequest) async throws -> [SelectionRange]
   func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse?
   func documentColor(_ req: DocumentColorRequest) async throws -> [ColorInformation]
   func documentSemanticTokens(_ req: DocumentSemanticTokensRequest) async throws -> DocumentSemanticTokensResponse?
@@ -449,6 +450,10 @@ package extension LanguageService {
 
   func foldingRange(_ req: FoldingRangeRequest) async throws -> [FoldingRange]? {
     throw ResponseError.requestNotImplemented(FoldingRangeRequest.self)
+  }
+
+  func selectionRange(_ req: SelectionRangeRequest) async throws -> [SelectionRange] {
+    throw ResponseError.requestNotImplemented(SelectionRangeRequest.self)
   }
 
   func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse? {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -820,6 +820,8 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
       await request.reply { try await executeCommand(request.params) }
     case let request as RequestAndReply<FoldingRangeRequest>:
       await self.handleRequest(for: request, requestHandler: self.foldingRange)
+    case let request as RequestAndReply<SelectionRangeRequest>:
+      await self.handleRequest(for: request, requestHandler: self.selectionRange)
     case let request as RequestAndReply<GetReferenceDocumentRequest>:
       await request.reply { try await getReferenceDocument(request.params) }
     case let request as RequestAndReply<HoverRequest>:
@@ -1180,6 +1182,7 @@ extension SourceKitLSPServer {
       typeHierarchyProvider: .bool(true),
       semanticTokensProvider: semanticTokensOptions,
       inlayHintProvider: inlayHintOptions,
+      selectionRangeProvider: .bool(true),
       experimental: .dictionary(experimentalCapabilities)
     )
   }
@@ -1804,6 +1807,14 @@ extension SourceKitLSPServer {
     languageService: any LanguageService
   ) async throws -> [FoldingRange]? {
     return try await languageService.foldingRange(req)
+  }
+
+  func selectionRange(
+    _ req: SelectionRangeRequest,
+    workspace: Workspace,
+    languageService: any LanguageService
+  ) async throws -> [SelectionRange] {
+    return try await languageService.selectionRange(req)
   }
 
   func documentSymbol(

--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(SwiftLanguageService STATIC
   RelatedIdentifiers.swift
   Rename.swift
   RewriteSourceKitPlaceholders.swift
+  SelectionRange.swift
   SemanticRefactorCommand.swift
   SemanticRefactoring.swift
   SemanticTokens.swift

--- a/Sources/SwiftLanguageService/SelectionRange.swift
+++ b/Sources/SwiftLanguageService/SelectionRange.swift
@@ -1,0 +1,605 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) package import LanguageServerProtocol
+@_spi(SourceKitLSP) import SKLogging
+import SourceKitLSP
+import SwiftOperators
+import SwiftSyntax
+
+extension SwiftLanguageService {
+  package func selectionRange(_ req: SelectionRangeRequest) async throws -> [SelectionRange] {
+    let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
+    let sourceFile = await syntaxTreeManager.syntaxTree(for: snapshot)
+
+    try Task.checkCancellation()
+
+    return req.positions.map { position in
+      let absolutePosition = snapshot.absolutePosition(of: position)
+
+      guard let (token, newPosition) = findIntuitiveToken(in: sourceFile, at: absolutePosition) else {
+        return SelectionRange(range: position..<position)
+      }
+
+      guard
+        let selectionRange = computeSelectionRangeFor(
+          position: newPosition,
+          snapshot: snapshot,
+          node: Syntax(token)
+        )
+      else {
+        return SelectionRange(range: position..<position)
+      }
+
+      return selectionRange
+    }
+  }
+}
+
+private func findIntuitiveToken(
+  in sourceFile: SourceFileSyntax,
+  at position: AbsolutePosition
+) -> (TokenSyntax, AbsolutePosition)? {
+  guard let currentToken = sourceFile.token(at: position) else {
+    if (sourceFile.endPositionBeforeTrailingTrivia...sourceFile.endPosition).contains(position),
+      // The last token is EOF, so we use the token just before EOF
+      let newToken = sourceFile.lastToken(viewMode: .sourceAccurate)?.previousToken(viewMode: .sourceAccurate)
+    {
+      return (newToken, newToken.endPosition.advanced(by: -1))
+    }
+    return nil
+  }
+
+  let boundaryTokens: [TokenKind] = [
+    .leftParen, .rightParen,
+    .leftBrace, .rightBrace,
+    .leftSquare, .rightSquare,
+    .leftAngle, .rightAngle,
+    .comma, .period,
+    .semicolon, .colon,
+  ]
+
+  if position == currentToken.position && boundaryTokens.contains(currentToken.tokenKind) {
+    // The cursor is at the start of a boundary token (e.g. `test(a: 3, b: 2|)`)
+    // here the user most likely wants to select the `2` and then `b: 2` instead of
+    // selecting the entire function call, so we use the previous token
+
+    let newToken = currentToken.previousToken(viewMode: .sourceAccurate) ?? currentToken
+
+    if newToken.endPositionBeforeTrailingTrivia == position {
+      return (newToken, newToken.endPosition.advanced(by: -1))
+    }
+  }
+
+  return (currentToken, position)
+}
+
+private func computeSelectionRangeFor(
+  position: AbsolutePosition,
+  snapshot: DocumentSnapshot,
+  node: Syntax
+) -> SelectionRange? {
+  var ranges: [Range<AbsolutePosition>] = []
+
+  var current = node
+  while true {
+    let rangesForNode = calculateRangesFor(node: current, snapshot: snapshot, position: position)
+
+    for range in rangesForNode {
+      if ranges.last == range {
+        // Some AST nodes have the exact same range, we just skip creating ranges for them
+        continue
+      }
+
+      ranges.append(range)
+    }
+
+    guard let parent = current.parent else {
+      break
+    }
+
+    current = parent
+  }
+
+  var selectionRange: SelectionRange? = nil
+  for range in ranges.reversed() {
+    let start = snapshot.position(of: range.lowerBound)
+    let end = snapshot.position(of: range.upperBound)
+    selectionRange = SelectionRange(range: start..<end, parent: selectionRange)
+  }
+
+  return selectionRange
+}
+
+private func calculateRangesFor(
+  node: Syntax,
+  snapshot: DocumentSnapshot,
+  position: AbsolutePosition
+) -> [Range<AbsolutePosition>] {
+  if let stringSegment = node.as(StringSegmentSyntax.self) {
+    return calculateSelectionRangesForStringSegment(stringSegment: stringSegment, position: position)
+  }
+
+  if node.isProtocol((any DeclGroupSyntax).self)
+    || node.is(TypeAliasDeclSyntax.self)
+    || node.is(FunctionDeclSyntax.self)
+  {
+    let name = Syntax(node.asProtocol((any NamedDeclSyntax).self)?.name)
+    let type = Syntax(node.as(ExtensionDeclSyntax.self)?.extendedType)
+    let genericParameterClause = node.asProtocol((any WithGenericParametersSyntax).self)?.genericParameterClause
+
+    if let nameOrType = name ?? type {
+      return calculateRangesForTypeOrFunctionDeclaration(
+        declaration: node,
+        position: position,
+        nameOrType: nameOrType,
+        genericParameters: genericParameterClause
+      )
+    }
+  }
+
+  if let provider = node.asProtocol((any SyntaxProtocol).self) as? (any SelectionRangeProvider) {
+    return provider.calculateSelectionRanges(position: position)
+  }
+
+  return []
+}
+
+private func calculateSelectionRangesForStringSegment(
+  stringSegment: StringSegmentSyntax,
+  position: AbsolutePosition
+) -> [Range<AbsolutePosition>] {
+  // For string segments we first want to select just the word under the cursor.
+  // To determine words we use a simple heuristic: expand the selection until we hit any non-letter character.
+  let offsetInString = position.utf8Offset - stringSegment.positionAfterSkippingLeadingTrivia.utf8Offset
+
+  let text = stringSegment.content.text
+  let index = text.utf8.index(text.startIndex, offsetBy: offsetInString)
+
+  if !text[index].isLetter {
+    return []
+  }
+
+  let start = text[..<index].lastIndex(where: { !$0.isLetter }).flatMap { text.index(after: $0) } ?? text.startIndex
+  let end = text[index...].firstIndex(where: { !$0.isLetter }) ?? text.endIndex
+
+  let startOffsetInString = text.utf8.distance(from: text.startIndex, to: start)
+  let endOffsetInString = text.utf8.distance(from: text.startIndex, to: end)
+
+  let startPosition = stringSegment.positionAfterSkippingLeadingTrivia.advanced(by: startOffsetInString)
+  let endPosition = stringSegment.positionAfterSkippingLeadingTrivia.advanced(by: endOffsetInString)
+
+  return [startPosition..<endPosition]
+}
+
+private func calculateRangesForTypeOrFunctionDeclaration(
+  declaration: some SyntaxProtocol,
+  position: AbsolutePosition,
+  nameOrType: some SyntaxProtocol,
+  genericParameters: GenericParameterClauseSyntax?,
+) -> [Range<AbsolutePosition>] {
+  // If we started the selection in either the name (or type in the case of extensions)
+  // or the generic parameter clause of a declaration we want to have a selection range
+  // for just the name (type) and generic parameter clause.
+  //
+  // Example: given `struct Test<|T> {}` we want to have a selection range for `Test<T>`
+  //
+  // As the name (type) and generic parameter clause are siblings in the declaration nodes
+  // we have to special-case them.
+
+  var ranges: [Range<AbsolutePosition>] = []
+
+  if let genericParameters = genericParameters,
+    nameOrType.range.contains(position) || genericParameters.range.contains(position)
+  {
+    let start = nameOrType.positionAfterSkippingLeadingTrivia
+    let end = genericParameters.endPositionBeforeTrailingTrivia
+    ranges.append(start..<end)
+  }
+
+  ranges.append(declaration.trimmedRange)
+
+  return ranges
+}
+
+private protocol SelectionRangeProvider: SyntaxProtocol {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>]
+}
+
+extension FunctionCallExprSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    if let memberAccess = self.calledExpression.as(MemberAccessExprSyntax.self),
+      !(self.parent?.is(ExpressionPatternSyntax.self) ?? false),
+      (memberAccess.declName.position..<self.additionalTrailingClosures.endPosition).contains(position)
+    {
+      // Special case for adding an extra range including the function name and parameters/trailing closures
+      // this is needed for chained method calls
+      // Example:
+      // numbers
+      //  .filter { $0 > 0 }
+      //  .map { $0 * 2 }
+      //  .reduce(0,| +)
+      //
+      // When starting a selection from | we want to have a selection for `reduce(0, +)` in addition to selecting
+      // the entire function call (starting from `numbers`)
+      return [
+        memberAccess.declName.positionAfterSkippingLeadingTrivia..<self.endPositionBeforeTrailingTrivia,
+        self.trimmedRange,
+      ]
+    }
+
+    // the default case: just create a range for the function call node
+    return [self.trimmedRange]
+  }
+}
+
+extension SubscriptCallExprSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // For subscript calls we want to have a selection range for the entire subscript operator
+    // including the `[]`
+    // Example: given `matrix[2, |3]` we want to be able to select `[2, 3]`
+
+    if self.arguments.range.contains(position) {
+      let start = self.leftSquare.positionAfterSkippingLeadingTrivia
+      let end = self.rightSquare.endPositionBeforeTrailingTrivia
+      return [start..<end, self.trimmedRange]
+    }
+
+    return [self.trimmedRange]
+  }
+}
+
+extension LabeledExprSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // For labeled expressions we want to be able to select just the label and expression without the comma
+    let start = self.positionAfterSkippingLeadingTrivia
+    let end = self.expression.endPositionBeforeTrailingTrivia
+
+    return [start..<end]
+  }
+}
+
+extension GenericParameterSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // Don't include the trailing comma in the selection, except if the parameter is the only one
+    if let parameterList = self.parent?.as(GenericParameterListSyntax.self),
+      parameterList.count == 1
+    {
+      return [self.trimmedRange]
+    }
+
+    let end = self.trailingComma?.position ?? self.endPositionBeforeTrailingTrivia
+    return [self.positionAfterSkippingLeadingTrivia..<end]
+  }
+}
+
+extension FunctionParameterSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // Function parameters have two special cases:
+    // - If the cursor is in the type and the type includes an ellipsis we want to have a range for the type and ellipsis
+    // - If the parameter has two names we want to have a range for selecting both names
+    let start = self.positionAfterSkippingLeadingTrivia
+    let end = self.trailingComma?.position ?? self.endPositionBeforeTrailingTrivia
+    let rangeWithoutComma = start..<end
+
+    if type.range.contains(position) {
+      if let ellipsis = self.ellipsis {
+        // Add an additional range for selecting the ellipsis of variadic parameters.
+        let range = self.type.positionAfterSkippingLeadingTrivia..<ellipsis.endPositionBeforeTrailingTrivia
+        return [range, rangeWithoutComma]
+      }
+      return [rangeWithoutComma]
+    }
+
+    if let defaultValue = self.defaultValue, defaultValue.range.contains(position) {
+      return [rangeWithoutComma]
+    }
+
+    var ranges: [Range<AbsolutePosition>] = []
+
+    if let secondName = self.secondName {
+      // If the parameter has two names, add an additional range for selecting both names
+      let range = self.firstName.positionAfterSkippingLeadingTrivia..<secondName.endPositionBeforeTrailingTrivia
+      if range.contains(position) {
+        ranges.append(range)
+      }
+    }
+
+    ranges.append(rangeWithoutComma)
+    return ranges
+  }
+}
+
+extension ClosureExprSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    var ranges: [Range<AbsolutePosition>] = []
+
+    if let signature = self.signature, signature.range.contains(position) {
+      let start = signature.positionAfterSkippingLeadingTrivia
+      let end = self.statements.endPositionBeforeTrailingTrivia
+      ranges.append(start..<end)
+    }
+
+    ranges.append(self.trimmedRange)
+    return ranges
+  }
+}
+
+extension EnumCaseParameterSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // For enum case parameters we also add a range for selecting the names of the parameter, similar to function parameters
+
+    // This implementation is really similar to the one for FunctionParameterSyntax,
+    // except that we don't have to deal with ellipses and have to deal with unlabeled parameters
+    let start = self.positionAfterSkippingLeadingTrivia
+    let end = self.trailingComma?.position ?? self.endPositionBeforeTrailingTrivia
+    let rangeWithoutComma = start..<end
+
+    if self.type.range.contains(position) {
+      return [rangeWithoutComma]
+    }
+
+    if let defaultValue = self.defaultValue, defaultValue.range.contains(position) {
+      return [rangeWithoutComma]
+    }
+
+    var ranges: [Range<AbsolutePosition>] = []
+
+    if let firstName = self.firstName,
+      let secondName = self.secondName
+    {
+      // The parameter has two names, add a selection range for selecting both names
+      let range = firstName.positionAfterSkippingLeadingTrivia..<secondName.endPositionBeforeTrailingTrivia
+      if range.contains(position) {
+        ranges.append(range)
+      }
+    }
+
+    ranges.append(rangeWithoutComma)
+
+    return ranges
+  }
+}
+
+extension ExprListSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // Expression lists are more complex to deal with as we first have to convert the expression list into the
+    // corresponding tree. We can then find the node the cursor is on in the tree and walk the tree up to its root
+    guard let sequenceExpression = self.parent?.as(SequenceExprSyntax.self) else {
+      return [self.trimmedRange]
+    }
+
+    let table = OperatorTable.standardOperators
+    let foldedTree = orLog("Folding ExprListSyntax") {
+      try table.foldSingle(sequenceExpression)
+    }
+
+    guard let foldedTree = foldedTree else { return [] }
+
+    let foldedTreeOffset = SourceLength(utf8Length: sequenceExpression.position.utf8Offset)
+    let offsetInTree = position - foldedTreeOffset
+
+    guard var operandNode = foldedTree.token(at: offsetInTree)?.parent else {
+      return []
+    }
+
+    // Walk up from the token to the operand node
+    // This is needed to avoid processing everything below the operand node two times, as everything below has already
+    // been processed by the normal logic before hitting the ExprListSyntax
+    while let parent = operandNode.parent {
+      if parent.is(InfixOperatorExprSyntax.self) {
+        break
+      }
+
+      operandNode = parent
+    }
+
+    var ranges: [Range<AbsolutePosition>] = []
+
+    for node in sequence(first: operandNode, next: \.parent) {
+      let startPosition = node.positionAfterSkippingLeadingTrivia + foldedTreeOffset
+      let endPosition = node.endPositionBeforeTrailingTrivia + foldedTreeOffset
+      ranges.append(startPosition..<endPosition)
+    }
+
+    return ranges
+  }
+}
+
+extension PatternBindingSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // For pattern bindings we special-case depending on whether we have a single pattern binding or multiple
+    guard let patternBindingList = self.parent?.as(PatternBindingListSyntax.self) else {
+      return []
+    }
+
+    if patternBindingList.children(viewMode: .sourceAccurate).count > 1 {
+      // Special case for pattern bindings like this: `let x = 1, y = 2, z = 3`
+      // Here we want to be able to select only `y = 2`
+      let start = self.positionAfterSkippingLeadingTrivia
+      let end = self.trailingComma?.position ?? self.endPositionBeforeTrailingTrivia
+      return [start..<end]
+    }
+
+    // By default we don't want to create ranges for pattern bindings to avoid selecting `x = 0` in `let x = 0`
+    return []
+  }
+}
+
+extension IfExprSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    var ranges: [Range<AbsolutePosition>] = []
+
+    if let elseKeyword = self.elseKeyword, let elseBody = self.elseBody {
+      // When inside the else block add a range for selecting `else {...}`
+      let range = elseKeyword.positionAfterSkippingLeadingTrivia..<elseBody.endPositionBeforeTrailingTrivia
+      if range.contains(position) {
+        ranges.append(range)
+      }
+    }
+
+    ranges.append(self.trimmedRange)
+    return ranges
+  }
+}
+
+extension ForStmtSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    // For statements get an extra range for selecting from the pattern until the sequence,
+    // i.e. selecting `i in 1...3` in `for i in 1...3 {}`
+    // As the for statement can have a lot of immediate children, more special cases can be added here in the future,
+    // for example for the keywords before the pattern
+    var ranges: [Range<AbsolutePosition>] = []
+
+    if (self.pattern.position..<self.sequence.endPosition).contains(position) {
+      let range = self.pattern.positionAfterSkippingLeadingTrivia..<self.sequence.endPositionBeforeTrailingTrivia
+      ranges.append(range)
+    }
+
+    ranges.append(self.trimmedRange)
+
+    return ranges
+  }
+}
+
+extension DictionaryElementSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    let start = self.positionAfterSkippingLeadingTrivia
+    let end = self.trailingComma?.position ?? self.endPositionBeforeTrailingTrivia
+    return [start..<end]
+  }
+}
+
+extension MemberAccessExprSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    if self.parent?.is(FunctionCallExprSyntax.self) ?? false {
+      // If the member access is part of a function call, we don't return any range as this case is handled in the
+      // FunctionCallExprSyntax extension
+      return []
+    }
+
+    return [self.trimmedRange]
+  }
+}
+
+extension AvailabilityArgumentSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    if let trailingComma = self.trailingComma {
+      let start = self.positionAfterSkippingLeadingTrivia
+      let end = trailingComma.positionAfterSkippingLeadingTrivia
+      return [start..<end]
+    }
+
+    return [self.trimmedRange]
+  }
+}
+
+extension TokenSyntax: SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    switch self.tokenKind {
+    case .identifier where self.parent?.keyPathInParent == \AttributeSyntax.attributeName:
+      // For attributes we don't want to create a range for just the attribute name but rather always include the `@`
+      return []
+
+    case .identifier where self.keyPathInParent == \MacroExpansionExprSyntax.macroName:
+      // For macro expansions we don't want to create a range for just the macro name but rather always include the `#`
+      return []
+
+    case .identifier where self.keyPathInParent == \GenericParameterSyntax.name:
+      // For generic parameters we want to handle the identifier in the `GenericParameter` node as we may have to
+      // include or exclude the trailing comma
+      return []
+
+    case .keyword(let keyword) where keyword == .as:
+      // The `as` keyword should always be handled by the `UnresolvedAsExpr` node as it also includes the `!` or `?`
+      return []
+
+    case .binaryOperator, .dollarIdentifier, .floatLiteral, .identifier, .integerLiteral, .keyword:
+      return [self.trimmedRange]
+
+    default:
+      return []
+    }
+  }
+}
+
+// Default implementation used by all the nodes declared below
+private extension SelectionRangeProvider {
+  func calculateSelectionRanges(position: AbsolutePosition) -> [Range<AbsolutePosition>] {
+    return [self.trimmedRange]
+  }
+}
+
+extension AccessorBlockSyntax: SelectionRangeProvider {}
+extension AccessorDeclSyntax: SelectionRangeProvider {}
+extension ArrayElementListSyntax: SelectionRangeProvider {}
+extension ArrayExprSyntax: SelectionRangeProvider {}
+extension AsExprSyntax: SelectionRangeProvider {}
+extension AssociatedTypeDeclSyntax: SelectionRangeProvider {}
+extension AttributedTypeSyntax: SelectionRangeProvider {}
+extension AttributeListSyntax: SelectionRangeProvider {}
+extension AttributeSyntax: SelectionRangeProvider {}
+extension AvailabilityArgumentListSyntax: SelectionRangeProvider {}
+extension AwaitExprSyntax: SelectionRangeProvider {}
+extension ClassDeclSyntax: SelectionRangeProvider {}
+extension ClosureShorthandParameterListSyntax: SelectionRangeProvider {}
+extension ClosureShorthandParameterSyntax: SelectionRangeProvider {}
+extension ClosureSignatureSyntax: SelectionRangeProvider {}
+extension CompositionTypeElementListSyntax: SelectionRangeProvider {}
+extension ConditionElementListSyntax: SelectionRangeProvider {}
+extension ConditionElementSyntax: SelectionRangeProvider {}
+extension ConformanceRequirementSyntax: SelectionRangeProvider {}
+extension DeclReferenceExprSyntax: SelectionRangeProvider {}
+extension DeinitializerDeclSyntax: SelectionRangeProvider {}
+extension DictionaryElementListSyntax: SelectionRangeProvider {}
+extension DictionaryExprSyntax: SelectionRangeProvider {}
+extension DoStmtSyntax: SelectionRangeProvider {}
+extension EnumCaseDeclSyntax: SelectionRangeProvider {}
+extension EnumCaseElementListSyntax: SelectionRangeProvider {}
+extension ExpressionSegmentSyntax: SelectionRangeProvider {}
+extension FunctionEffectSpecifiersSyntax: SelectionRangeProvider {}
+extension FunctionParameterListSyntax: SelectionRangeProvider {}
+extension GenericParameterClauseSyntax: SelectionRangeProvider {}
+extension GenericParameterListSyntax: SelectionRangeProvider {}
+extension GenericRequirementSyntax: SelectionRangeProvider {}
+extension GenericWhereClauseSyntax: SelectionRangeProvider {}
+extension GuardStmtSyntax: SelectionRangeProvider {}
+extension ImplicitlyUnwrappedOptionalTypeSyntax: SelectionRangeProvider {}
+extension InheritanceClauseSyntax: SelectionRangeProvider {}
+extension InheritedTypeListSyntax: SelectionRangeProvider {}
+extension InitializerDeclSyntax: SelectionRangeProvider {}
+extension KeyPathExprSyntax: SelectionRangeProvider {}
+extension LabeledExprListSyntax: SelectionRangeProvider {}
+extension MacroExpansionExprSyntax: SelectionRangeProvider {}
+extension OperatorDeclSyntax: SelectionRangeProvider {}
+extension PlatformVersionSyntax: SelectionRangeProvider {}
+extension PrefixOperatorExprSyntax: SelectionRangeProvider {}
+extension RepeatStmtSyntax: SelectionRangeProvider {}
+extension ReturnClauseSyntax: SelectionRangeProvider {}
+extension ReturnStmtSyntax: SelectionRangeProvider {}
+extension StringLiteralExprSyntax: SelectionRangeProvider {}
+extension StringLiteralSegmentListSyntax: SelectionRangeProvider {}
+extension SubscriptDeclSyntax: SelectionRangeProvider {}
+extension SwitchCaseItemListSyntax: SelectionRangeProvider {}
+extension SwitchCaseItemSyntax: SelectionRangeProvider {}
+extension SwitchCaseSyntax: SelectionRangeProvider {}
+extension SwitchExprSyntax: SelectionRangeProvider {}
+extension ThrowStmtSyntax: SelectionRangeProvider {}
+extension TryExprSyntax: SelectionRangeProvider {}
+extension TupleExprSyntax: SelectionRangeProvider {}
+extension TuplePatternElementListSyntax: SelectionRangeProvider {}
+extension TuplePatternSyntax: SelectionRangeProvider {}
+extension TypeAnnotationSyntax: SelectionRangeProvider {}
+extension UnresolvedAsExprSyntax: SelectionRangeProvider {}
+extension VariableDeclSyntax: SelectionRangeProvider {}
+extension VersionTupleSyntax: SelectionRangeProvider {}
+extension WhileStmtSyntax: SelectionRangeProvider {}

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -418,7 +418,8 @@ extension SwiftLanguageService {
         diagnosticProvider: DiagnosticOptions(
           interFileDependencies: true,
           workspaceDiagnostics: false
-        )
+        ),
+        selectionRangeProvider: .bool(true)
       )
     )
   }

--- a/Tests/SourceKitLSPTests/SelectionRangeTests.swift
+++ b/Tests/SourceKitLSPTests/SelectionRangeTests.swift
@@ -1,0 +1,2162 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SKTestSupport
+import SKUtilities
+import XCTest
+
+class SelectionRangeTests: XCTestCase {
+
+  // MARK: - Strings And Expressions
+
+  func testStringLiteralWithCursorInWord() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let a = "Hel1️⃣lo, World!"
+        """,
+      expectedSelections: [
+        "Hello",
+        "Hello, World!",
+        #""Hello, World!""#,
+      ]
+    )
+  }
+
+  func testStringLiteralWithCursorInWord2() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let a = "Hello, Wor1️⃣ld!"
+        """,
+      expectedSelections: [
+        "World",
+        "Hello, World!",
+        #""Hello, World!""#,
+      ]
+    )
+  }
+
+  func testStringLiteralWithCursorInWord3() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let a = "Hello, 1️⃣World!"
+        """,
+      expectedSelections: [
+        "World",
+        "Hello, World!",
+        #""Hello, World!""#,
+      ]
+    )
+  }
+
+  func testStringLiteralWithCursorInWhitespace() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let a = "Hello,1️⃣ World!"
+        """,
+      expectedSelections: [
+        "Hello, World!",
+        #""Hello, World!""#,
+        #"let a = "Hello, World!""#,
+      ]
+    )
+  }
+
+  func testStringLiteralWithUnicodeChars() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let a = "test 🚀 tes1️⃣t"
+        """,
+      expectedSelections: ["test", "test 🚀 test", #""test 🚀 test""#]
+    )
+  }
+
+  func testStringLiteralWithStringInterpolation() async throws {
+    try await assertSelectionRanges(
+      markedSource: #"""
+        func a() {
+          let a = "Hello \(w1️⃣o)rld"
+        }
+        """#,
+      expectedSelections: [
+        "wo",
+        #"\(wo)"#,
+        #"Hello \(wo)rld"#,
+      ]
+    )
+  }
+
+  func testStringConcatenation() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+          let x = "abc" + "def" + "ghi" + "jk1️⃣l" + "mno" + "pqr" + "stu" + "vwx" + "yz"
+        """,
+      expectedSelections: [
+        "jkl",
+        #""jkl""#,
+        #""abc" + "def" + "ghi" + "jkl""#,
+        #""abc" + "def" + "ghi" + "jkl" + "mno""#,
+        #""abc" + "def" + "ghi" + "jkl" + "mno" + "pqr""#,
+        #""abc" + "def" + "ghi" + "jkl" + "mno" + "pqr" + "stu""#,
+        #""abc" + "def" + "ghi" + "jkl" + "mno" + "pqr" + "stu" + "vwx""#,
+        #""abc" + "def" + "ghi" + "jkl" + "mno" + "pqr" + "stu" + "vwx" + "yz""#,
+      ]
+    )
+  }
+
+  func testNegativeIntegerLiteral() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let x = -101️⃣0
+        """,
+      expectedSelections: [
+        "100",
+        "-100",
+        "let x = -100",
+      ]
+    )
+  }
+
+  func testFloatLiteral() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let x = 3.1️⃣5
+        """,
+      expectedSelections: ["3.5", "let x = 3.5"]
+    )
+  }
+
+  func testBinaryExpression() async throws {
+    try await assertSelectionRanges(
+      markedSource: "let a = 3 + 51️⃣",
+      expectedSelections: ["5", "3 + 5", "let a = 3 + 5"]
+    )
+  }
+
+  func testComplexConditionalExpression() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let valid = (x > 0 && y <1️⃣ 100) || (x == 0 && y == 0)
+        """,
+      expectedSelections: [
+        "<",
+        "y < 100",
+        "x > 0 && y < 100",
+        "(x > 0 && y < 100)",
+        "(x > 0 && y < 100) || (x == 0 && y == 0)",
+        "let valid = (x > 0 && y < 100) || (x == 0 && y == 0)",
+      ]
+    )
+  }
+
+  // MARK: - Variable And Constant Declaration
+
+  func testSimpleVariableDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        var sim1️⃣ple = 42
+        """,
+      expectedSelections: [
+        "simple",
+        "var simple = 42",
+      ]
+    )
+  }
+
+  func testMultipleBindingsInSingleDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let x = 1, 1️⃣y = 2, z = 3
+        """,
+      expectedSelections: [
+        "y",
+        "y = 2",
+        "let x = 1, y = 2, z = 3",
+      ]
+    )
+  }
+
+  func testVariableWithExplicitType() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let name: Str1️⃣ing = "Swift"
+        """,
+      expectedSelections: [
+        "String",
+        ": String",
+        #"let name: String = "Swift""#,
+      ]
+    )
+  }
+
+  func testLazyVariable() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        lazy var data = exp1️⃣ensive()
+        """,
+      expectedSelections: [
+        "expensive",
+        "expensive()",
+        "lazy var data = expensive()",
+      ]
+    )
+  }
+
+  func testComputedProperty() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        var fullName: String {
+          return first1️⃣Name + " " + lastName
+        }
+        """,
+      expectedSelections: [
+        "firstName",
+        #"firstName + " ""#,
+        #"firstName + " " + lastName"#,
+        #"return firstName + " " + lastName"#,
+        """
+        {
+          return firstName + " " + lastName
+        }
+        """,
+        """
+        var fullName: String {
+          return firstName + " " + lastName
+        }
+        """,
+      ]
+    )
+  }
+
+  func testPropertyWithGetterAndSetter() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        var temperature: Double {
+          get {
+            return _temp1️⃣erature
+          }
+          set {
+            _temperature = newValue
+          }
+        }
+        """,
+      expectedSelections: [
+        "_temperature",
+        "return _temperature",
+        """
+        get {
+            return _temperature
+          }
+        """,
+      ]
+    )
+  }
+
+  func testPropertyWithGetterAndSetterWithCursorInName() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        var temp1️⃣erature: Double {
+          get {
+            return _temperature
+          }
+        }
+        """,
+      expectedSelections: [
+        "temperature",
+        """
+        var temperature: Double {
+          get {
+            return _temperature
+          }
+        }
+        """,
+      ]
+    )
+  }
+
+  func testPropertyWithWillSetDidSet() async throws {
+    try await assertSelectionRanges(
+      markedSource: #"""
+        var count: Int = 0 {
+          willSet {
+            print("About to set count to \(new1️⃣Value)")
+          }
+          didSet {
+            print("Changed from \(oldValue)")
+          }
+        }
+        """#,
+      expectedSelections: [
+        "newValue",
+        #"\(newValue)"#,
+        #"About to set count to \(newValue)"#,
+        #""About to set count to \(newValue)""#,
+        #"print("About to set count to \(newValue)")"#,
+        #"""
+        willSet {
+            print("About to set count to \(newValue)")
+          }
+        """#,
+        #"""
+        {
+          willSet {
+            print("About to set count to \(newValue)")
+          }
+          didSet {
+            print("Changed from \(oldValue)")
+          }
+        }
+        """#,
+        #"""
+        var count: Int = 0 {
+          willSet {
+            print("About to set count to \(newValue)")
+          }
+          didSet {
+            print("Changed from \(oldValue)")
+          }
+        }
+        """#,
+      ]
+    )
+  }
+
+  // MARK: - Functions And Methods
+
+  func testChainedMethodCalls() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let result = numbers
+          .filter { $0 > 1️⃣0 }
+          .map { $0 * 2️⃣2 }
+          .red3️⃣uce(0, 4️⃣+)
+        """,
+      expectedSelections: [
+        "1️⃣": [
+          "0",
+          "$0 > 0",
+          "{ $0 > 0 }",
+          "filter { $0 > 0 }",
+          """
+          numbers
+            .filter { $0 > 0 }
+          """,
+          """
+          numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+          """,
+          """
+          numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+            .reduce(0, +)
+          """,
+          """
+          let result = numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+            .reduce(0, +)
+          """,
+        ],
+        "2️⃣": [
+          "2",
+          "$0 * 2",
+          "{ $0 * 2 }",
+          "map { $0 * 2 }",
+          """
+          numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+          """,
+          """
+          numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+            .reduce(0, +)
+          """,
+        ],
+        "3️⃣": [
+          "reduce",
+          "reduce(0, +)",
+          """
+          numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+            .reduce(0, +)
+          """,
+        ],
+        "4️⃣": [
+          "+",
+          "0, +",
+          "reduce(0, +)",
+          """
+          numbers
+            .filter { $0 > 0 }
+            .map { $0 * 2 }
+            .reduce(0, +)
+          """,
+        ],
+      ]
+    )
+  }
+
+  func testNestedFunctionCalls() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let result = max(min(va1️⃣lue, 100), 0)
+        """,
+      expectedSelections: [
+        "value",
+        "value, 100",
+        "min(value, 100)",
+        "min(value, 100), 0",
+        "max(min(value, 100), 0)",
+        "let result = max(min(value, 100), 0)",
+      ]
+    )
+  }
+
+  func testFunctionCallParameterExplicit() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func a() {
+          b(c, d: 1️⃣320)
+        }
+        """,
+      expectedSelections: [
+        "320",
+        "d: 320",
+        "c, d: 320",
+        "b(c, d: 320)",
+      ]
+    )
+  }
+
+  func testFunctionCallCursorAfterLastParameter() async throws {
+    try await assertSelectionRanges(
+      markedSource: "test(a: 12, b: 31️⃣)",
+      expectedSelections: [
+        "3",
+        "b: 3",
+        "a: 12, b: 3",
+        "test(a: 12, b: 3)",
+      ]
+    )
+  }
+
+  func testFunctionCallWithNoArguments() async throws {
+    try await assertSelectionRanges(
+      markedSource: "test(1️⃣)",
+      expectedSelections: [
+        "test()"
+      ]
+    )
+  }
+
+  func testSimpleFunctionDeclarationParameter() async throws {
+    try await assertSelectionRanges(
+      markedSource: #"""
+        func greet(nam1️⃣e: String) -> String {
+          return "Hello, \(name)"
+        }
+        """#,
+      expectedSelections: [
+        "name",
+        "name: String",
+        #"""
+        func greet(name: String) -> String {
+          return "Hello, \(name)"
+        }
+        """#,
+      ]
+    )
+  }
+
+  func testSimpleFunctionDeclarationWithCursorAfterLastParameter() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func test(a: Int, b: Int1️⃣) {}",
+      expectedSelections: [
+        "Int",
+        "b: Int",
+        "a: Int, b: Int",
+      ]
+    )
+  }
+
+  func testSimpleFunctionDeclarationName() async throws {
+    try await assertSelectionRanges(
+      markedSource: #"""
+        func gre1️⃣et(name: String) -> String {
+          return "Hello, \(name)"
+        }
+        """#,
+      expectedSelections: [
+        "greet",
+        #"""
+        func greet(name: String) -> String {
+          return "Hello, \(name)"
+        }
+        """#,
+      ]
+    )
+  }
+
+  func testFunctionDeclarationWithCursorImmediatelyBeforeParenthesis() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func foo1️⃣(a: Int) {}",
+      expectedSelections: ["foo", "func foo(a: Int) {}"]
+    )
+  }
+
+  func testFunctionDeclarationWithTwoNameParameter() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func test(abc de1️⃣f: String) {}",
+      expectedSelections: [
+        "def",
+        "abc def",
+        "abc def: String",
+      ]
+    )
+  }
+
+  func testFunctionWithMultipleParameters() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func calculate(a: Int, b: I1️⃣nt, operation: (Int, Int) -> Int) -> Int {
+          return operation(a, b)
+        }
+        """,
+      expectedSelections: [
+        "Int",
+        "b: Int",
+        "a: Int, b: Int, operation: (Int, Int) -> Int",
+        """
+        func calculate(a: Int, b: Int, operation: (Int, Int) -> Int) -> Int {
+          return operation(a, b)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testFunctionWithDefaultParameters() async throws {
+    try await assertSelectionRanges(
+      markedSource: #"""
+        func greet(name: String, greeting: String = "Hel1️⃣lo") {
+          print("\(greeting), \(name)")
+        }
+        """#,
+      expectedSelections: [
+        "Hello",
+        #""Hello""#,
+        #"greeting: String = "Hello""#,
+        #"name: String, greeting: String = "Hello""#,
+      ]
+    )
+  }
+
+  func testFunctionWithVariadicParameters() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func sum(numbers: I1️⃣nt...) -> Int {
+          return numbers.reduce(0, +)
+        }
+        """,
+      expectedSelections: [
+        "Int",
+        "Int...",
+        "numbers: Int...",
+      ]
+    )
+  }
+
+  func testFunctionWithInoutParameter() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func swap(a: inout In1️⃣t, b: inout Int) {
+          let temp = a
+          a = b
+          b = temp
+        }
+        """,
+      expectedSelections: [
+        "Int",
+        "inout Int",
+        "a: inout Int",
+        "a: inout Int, b: inout Int",
+      ]
+    )
+  }
+
+  func testReturnType() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func test() -> Str1️⃣ing {
+          return "test"
+        }
+        """,
+      expectedSelections: [
+        "String",
+        "-> String",
+        """
+        func test() -> String {
+          return "test"
+        }
+        """,
+      ]
+    )
+  }
+
+  func testReturnTypeWithEffects() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func test() async throws -> Str1️⃣ing {
+          return "test"
+        }
+        """,
+      expectedSelections: [
+        "String",
+        "-> String",
+        """
+        func test() async throws -> String {
+          return "test"
+        }
+        """,
+      ]
+    )
+  }
+
+  func testFunctionWithThrows() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func processFile() thr1️⃣ows -> String {
+          return try readFile()
+        }
+        """,
+      expectedSelections: [
+        "throws",
+        """
+        func processFile() throws -> String {
+          return try readFile()
+        }
+        """,
+      ]
+    )
+  }
+
+  func testAsyncFunction() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func fetchData() as1️⃣ync throws -> Data {
+          return try await URLSession.shared.data(from: url)
+        }
+        """,
+      expectedSelections: [
+        "async",
+        "async throws",
+      ]
+    )
+  }
+
+  func testFunctionWithGenericParameter() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func identity<1️⃣T>(value: T) -> T {
+          return value
+        }
+        """,
+      expectedSelections: [
+        "T",
+        "<T>",
+        "identity<T>",
+      ]
+    )
+  }
+
+  func testFunctionWithGenericParameterCursorAfterGenericVariable() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func test<T1️⃣>() {}",
+      expectedSelections: [
+        "T",
+        "<T>",
+        "test<T>",
+      ]
+    )
+  }
+
+  func testFunctionWithMultipleGenericParameters() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func test<T1️⃣, S>(value: T) {}
+        """,
+      expectedSelections: [
+        "T",
+        "T, S",
+        "<T, S>",
+        "test<T, S>",
+      ]
+    )
+  }
+
+  func testGenericParametersWithTrailingComma() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func test<T,1️⃣>() {}",
+      expectedSelections: [
+        "T,",
+        "<T,>",
+        "test<T,>",
+      ]
+    )
+  }
+
+  func testGenericParametersWithTrailingComma2() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func test<T1️⃣,>() {}",
+      expectedSelections: [
+        "T,",
+        "<T,>",
+        "test<T,>",
+      ]
+    )
+  }
+
+  func testFunctionWithWhereClause() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func compare<T>(a: T, b: T) -> Bool where T: Co1️⃣mparable {
+          return a < b
+        }
+        """,
+      expectedSelections: [
+        "Comparable",
+        "T: Comparable",
+        "where T: Comparable",
+        """
+        func compare<T>(a: T, b: T) -> Bool where T: Comparable {
+          return a < b
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Closures And Function Types
+
+  func testSimpleClosure() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let closure = { (x: Int) -> Int in
+          return x * 1️⃣2
+        }
+        """,
+      expectedSelections: [
+        "2",
+        "x * 2",
+        "return x * 2",
+        """
+        { (x: Int) -> Int in
+          return x * 2
+        }
+        """,
+        """
+        let closure = { (x: Int) -> Int in
+          return x * 2
+        }
+        """,
+      ]
+    )
+  }
+
+  func testClosureCursorImmediatelyBeforeBrace() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+          let x = "abc".map 1️⃣{ $0 }
+        """,
+      expectedSelections: [
+        "{ $0 }",
+        "map { $0 }",
+        #""abc".map { $0 }"#,
+        #"let x = "abc".map { $0 }"#,
+      ]
+    )
+  }
+
+  func testTrailingClosure() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        numbers.map { nu1️⃣m in
+          return num * 2
+        }
+        """,
+      expectedSelections: [
+        "num",
+        "num in",
+        """
+        num in
+          return num * 2
+        """,
+        """
+        { num in
+          return num * 2
+        }
+        """,
+        """
+        map { num in
+          return num * 2
+        }
+        """,
+      ]
+    )
+  }
+
+  func testShorthandClosureArgument() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let doubled = numbers.map { $0 1️⃣* 2 }
+        """,
+      expectedSelections: [
+        "*",
+        "$0 * 2",
+        "{ $0 * 2 }",
+        "map { $0 * 2 }",
+        "numbers.map { $0 * 2 }",
+        "let doubled = numbers.map { $0 * 2 }",
+      ]
+    )
+  }
+
+  func testMultipleTrailingClosures() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        loadData { data in
+          process(da1️⃣ta)
+        } onError: { error in
+          print(error)
+        }
+        """,
+      expectedSelections: [
+        "data",
+        "process(data)",
+        """
+        { data in
+          process(data)
+        }
+        """,
+        """
+        loadData { data in
+          process(data)
+        } onError: { error in
+          print(error)
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Control Flow
+
+  func testIfStatement() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        if x >1️⃣ 0 {
+          print("positive")
+        }
+        """,
+      expectedSelections: [
+        ">",
+        "x > 0",
+        """
+        if x > 0 {
+          print("positive")
+        }
+        """,
+      ]
+    )
+  }
+
+  func testIfElseStatement() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        if x > 0 {
+          print("positive")
+        } else {
+          print("neg1️⃣ative")
+        }
+        """,
+      expectedSelections: [
+        "negative",
+        #""negative""#,
+        #"print("negative")"#,
+        """
+        else {
+          print("negative")
+        }
+        """,
+        """
+        if x > 0 {
+          print("positive")
+        } else {
+          print("negative")
+        }
+        """,
+      ]
+    )
+  }
+
+  func testGuardStatement() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        guard let va1️⃣lue = optional else {
+          return
+        }
+        """,
+      expectedSelections: [
+        "value",
+        "let value = optional",
+        """
+        guard let value = optional else {
+          return
+        }
+        """,
+      ]
+    )
+  }
+
+  func testSwitchStatement() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        switch value {
+        case .option1️⃣1:
+          print("one")
+        case .option2:
+          print("two")
+        default:
+          break
+        }
+        """,
+      expectedSelections: [
+        "option1",
+        ".option1",
+        """
+        case .option1:
+          print("one")
+        """,
+        """
+        switch value {
+        case .option1:
+          print("one")
+        case .option2:
+          print("two")
+        default:
+          break
+        }
+        """,
+      ]
+    )
+  }
+
+  func testSwitchWithMultipleCases() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        switch value {
+        case 1...5, 10.1️⃣..15:
+          print("in range")
+        default:
+          break
+        }
+        """,
+      expectedSelections: [
+        "...",
+        "10...15",
+        "1...5, 10...15",
+        """
+        case 1...5, 10...15:
+          print("in range")
+        """,
+      ]
+    )
+  }
+
+  func testForLoop() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        for i in 1..<1️⃣10 {
+          print(i)
+        }
+        """,
+      expectedSelections: [
+        "10",
+        "1..<10",
+        "i in 1..<10",
+        """
+        for i in 1..<10 {
+          print(i)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testForLoopCursorInForKeyword() async throws {
+    try await assertSelectionRanges(
+      markedSource: "f1️⃣or i in 1...3 {}",
+      expectedSelections: ["for", "for i in 1...3 {}"]
+    )
+  }
+
+  func testWhileLoop() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        while counter <1️⃣ 10 {
+          counter += 1
+        }
+        """,
+      expectedSelections: [
+        "<",
+        "counter < 10",
+        """
+        while counter < 10 {
+          counter += 1
+        }
+        """,
+      ]
+    )
+  }
+
+  func testRepeatWhileLoop() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        repeat {
+          counter +1️⃣= 1
+        } while counter < 10
+        """,
+      expectedSelections: [
+        "+=",
+        "counter += 1",
+        """
+        repeat {
+          counter += 1
+        } while counter < 10
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Classes And Structs
+
+  func testClassDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        class MyC1️⃣lass: SuperClass, Protocol1 {
+          var property: Int = 0
+        }
+        """,
+      expectedSelections: [
+        "MyClass",
+        """
+        class MyClass: SuperClass, Protocol1 {
+          var property: Int = 0
+        }
+        """,
+      ]
+    )
+  }
+
+  func testClassDeclarationInheritance() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        class MyClass: SuperC1️⃣lass, Protocol1, Protocol2 {
+          var property: Int = 0
+        }
+        """,
+      expectedSelections: [
+        "SuperClass",
+        "SuperClass, Protocol1, Protocol2",
+        ": SuperClass, Protocol1, Protocol2",
+        """
+        class MyClass: SuperClass, Protocol1, Protocol2 {
+          var property: Int = 0
+        }
+        """,
+      ]
+    )
+  }
+
+  func testStructDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        struct Po1️⃣int {
+          var x: Double
+          var y: Double
+        }
+        """,
+      expectedSelections: [
+        "Point",
+        """
+        struct Point {
+          var x: Double
+          var y: Double
+        }
+        """,
+      ]
+    )
+  }
+
+  func testClassWithInitializer() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        class Person {
+          let name: String
+          init(na1️⃣me: String) {
+            self.name = name
+          }
+        }
+        """,
+      expectedSelections: [
+        "name",
+        "name: String",
+        """
+        init(name: String) {
+            self.name = name
+          }
+        """,
+      ]
+    )
+  }
+
+  func testDeinitializer() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        class Resource {
+          deinit {
+            print("Clean1️⃣ing up")
+          }
+        }
+        """,
+      expectedSelections: [
+        "Cleaning",
+        "Cleaning up",
+        #""Cleaning up""#,
+        #"print("Cleaning up")"#,
+        """
+        deinit {
+            print("Cleaning up")
+          }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Enums
+
+  func testSimpleEnum() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        enum Direction {
+          case no1️⃣rth
+          case south
+          case east
+          case west
+        }
+        """,
+      expectedSelections: [
+        "north",
+        "case north",
+        """
+        enum Direction {
+          case north
+          case south
+          case east
+          case west
+        }
+        """,
+      ]
+    )
+  }
+
+  func testEnumWithAssociatedValues() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        enum Result {
+          case success(val1️⃣ue: String)
+          case failure(Error)
+        }
+        """,
+      expectedSelections: [
+        "value",
+        "value: String",
+        "success(value: String)",
+        "case success(value: String)",
+        """
+        enum Result {
+          case success(value: String)
+          case failure(Error)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testEnumCaseWithTwoNames() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+          enum Test {
+            case caseA(foo b1️⃣ar: String)
+            case caseB()
+          }
+        """,
+      expectedSelections: [
+        "bar",
+        "foo bar",
+        "foo bar: String",
+        "caseA(foo bar: String)",
+      ]
+    )
+  }
+
+  func testEnumWithRawValues() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        enum Planet: Int {
+          case mercury = 1️⃣1
+          case venus = 2
+          case earth = 3
+        }
+        """,
+      expectedSelections: [
+        "1",
+        "mercury = 1",
+        "case mercury = 1",
+        """
+        enum Planet: Int {
+          case mercury = 1
+          case venus = 2
+          case earth = 3
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Protocols
+
+  func testProtocolDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        protocol Drawable {
+          func dra1️⃣w()
+        }
+        """,
+      expectedSelections: [
+        "draw",
+        "func draw()",
+        """
+        protocol Drawable {
+          func draw()
+        }
+        """,
+      ]
+    )
+  }
+
+  func testProtocolWithAssociatedType() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        protocol Container {
+          associatedtype Ite1️⃣m
+          func add(item: Item)
+        }
+        """,
+      expectedSelections: [
+        "Item",
+        "associatedtype Item",
+        """
+        protocol Container {
+          associatedtype Item
+          func add(item: Item)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testProtocolInheritance() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        protocol TextRepresentable: CustomStringConve1️⃣rtible, Protocol2, Protocol3 {
+          var text: String { get }
+        }
+        """,
+      expectedSelections: [
+        "CustomStringConvertible",
+        "CustomStringConvertible, Protocol2, Protocol3",
+        ": CustomStringConvertible, Protocol2, Protocol3",
+        """
+        protocol TextRepresentable: CustomStringConvertible, Protocol2, Protocol3 {
+          var text: String { get }
+        }
+        """,
+      ]
+    )
+  }
+
+  func testProtocolInheritance2() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        protocol TextRepr1️⃣esentable: CustomStringConvertible, Protocol2 {
+          var text: String { get }
+        }
+        """,
+      expectedSelections: [
+        "TextRepresentable",
+        """
+        protocol TextRepresentable: CustomStringConvertible, Protocol2 {
+          var text: String { get }
+        }
+        """,
+      ]
+    )
+  }
+
+  func testProtocolComposition() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func process(item: Codable & Hashab1️⃣le) {
+          print(item)
+        }
+        """,
+      expectedSelections: [
+        "Hashable",
+        "Codable & Hashable",
+        "item: Codable & Hashable",
+        """
+        func process(item: Codable & Hashable) {
+          print(item)
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Extensions
+
+  func testExtensionDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        extension St1️⃣ring {
+          func reversed() -> String {
+            return String(self.reversed())
+          }
+        }
+        """,
+      expectedSelections: [
+        "String",
+        """
+        extension String {
+          func reversed() -> String {
+            return String(self.reversed())
+          }
+        }
+        """,
+      ]
+    )
+  }
+
+  func testExtensionWithWhereClause() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        extension Array where Ele1️⃣ment == String {
+          var description: String { return "" }
+        }
+        """,
+      expectedSelections: [
+        "Element",
+        "Element == String",
+        "where Element == String",
+        """
+        extension Array where Element == String {
+          var description: String { return "" }
+        }
+        """,
+      ]
+    )
+  }
+
+  func testExtensionWithConformance() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        extension Array: CustomStr1️⃣ingConvertible where Element: CustomStringConvertible {
+          var description: String { return "" }
+        }
+        """,
+      expectedSelections: [
+        "CustomStringConvertible",
+        ": CustomStringConvertible",
+        """
+        extension Array: CustomStringConvertible where Element: CustomStringConvertible {
+          var description: String { return "" }
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Generics
+
+  func testGenericStruct() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        struct Stack<Ele1️⃣ment> {
+          var items: [Element] = []
+        }
+        """,
+      expectedSelections: [
+        "Element",
+        "<Element>",
+        "Stack<Element>",
+        """
+        struct Stack<Element> {
+          var items: [Element] = []
+        }
+        """,
+      ]
+    )
+  }
+
+  func testGenericStructWithCursorImmediatelyBeforeAngleBracket() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        struct Stack1️⃣<Element> {
+          var items: [Element] = []
+        }
+        """,
+      expectedSelections: [
+        "Stack",
+        "Stack<Element>",
+        """
+        struct Stack<Element> {
+          var items: [Element] = []
+        }
+        """,
+      ]
+    )
+  }
+
+  func testGenericFunction() async throws {
+    try await assertSelectionRanges(
+      markedSource: "func te1️⃣st<T>() {}",
+      expectedSelections: [
+        "test",
+        "test<T>",
+        "func test<T>() {}",
+      ]
+    )
+  }
+
+  func testGenericConstraints() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func findIndex<T>(of value: T, in array: [T]) -> Int? where T: Equat1️⃣able {
+          return array.firstIndex(of: value)
+        }
+        """,
+      expectedSelections: [
+        "Equatable",
+        "T: Equatable",
+        "where T: Equatable",
+      ]
+    )
+  }
+
+  // MARK: - Operators
+
+  func testCustomOperator() async throws {
+    try await assertSelectionRanges(
+      markedSource: "infix operator *1️⃣*: MultiplicationPrecedence",
+      expectedSelections: [
+        "**",
+        "infix operator **: MultiplicationPrecedence",
+      ]
+    )
+  }
+
+  // MARK: - Error Handling
+
+  func testThrowStatement() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func validate() throws {
+          throw ValidationErr1️⃣or.invalid
+        }
+        """,
+      expectedSelections: [
+        "ValidationError",
+        "ValidationError.invalid",
+        "throw ValidationError.invalid",
+        """
+        func validate() throws {
+          throw ValidationError.invalid
+        }
+        """,
+      ]
+    )
+  }
+
+  func testDoCatchBlock() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        do {
+          try riskyOper1️⃣ation()
+        } catch {
+          print(error)
+        }
+        """,
+      expectedSelections: [
+        "riskyOperation",
+        "riskyOperation()",
+        "try riskyOperation()",
+        """
+        do {
+          try riskyOperation()
+        } catch {
+          print(error)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testTryOptional() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let result = try? load1️⃣Data()
+        """,
+      expectedSelections: [
+        "loadData",
+        "loadData()",
+        "try? loadData()",
+        "let result = try? loadData()",
+      ]
+    )
+  }
+
+  // MARK: - Type Casting And Checking
+
+  func testTypeCheck() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        if item is Str1️⃣ing {
+          print("It's a string")
+        }
+        """,
+      expectedSelections: [
+        "String",
+        "item is String",
+        """
+        if item is String {
+          print("It's a string")
+        }
+        """,
+      ]
+    )
+  }
+
+  func testTypeDowncast() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        if let text = item as1️⃣? String {
+          print(text)
+        }
+        """,
+      expectedSelections: [
+        "as?",
+        "item as? String",
+        "let text = item as? String",
+        """
+        if let text = item as? String {
+          print(text)
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Optional Handling
+
+  func testOptionalBinding() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        if let na1️⃣me = optionalName {
+          print(name)
+        }
+        """,
+      expectedSelections: [
+        "name",
+        "let name = optionalName",
+        """
+        if let name = optionalName {
+          print(name)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testOptionalChaining() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let count = person?.address?.str1️⃣eet?.count
+        """,
+      expectedSelections: [
+        "street",
+        "person?.address?.street",
+        "person?.address?.street?.count",
+        "let count = person?.address?.street?.count",
+      ]
+    )
+  }
+
+  func testNilCoalescing() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let name = optionalName ??1️⃣ "Default"
+        """,
+      expectedSelections: [
+        "??",
+        #"optionalName ?? "Default""#,
+        #"let name = optionalName ?? "Default""#,
+      ]
+    )
+  }
+
+  func testImplicitlyUnwrappedOptional() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        var assumedString: Str1️⃣ing! = "An implicit string"
+        """,
+      expectedSelections: [
+        "String",
+        "String!",
+        ": String!",
+        #"var assumedString: String! = "An implicit string""#,
+      ]
+    )
+  }
+
+  // MARK: - Attributes
+
+  func testAvailableAttribute() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        @available(iOS 1️⃣15, *)
+        func modernFeature() {
+          print("Modern")
+        }
+        """,
+      expectedSelections: [
+        "15",
+        "iOS 15",
+        "iOS 15, *",
+        "@available(iOS 15, *)",
+        """
+        @available(iOS 15, *)
+        func modernFeature() {
+          print("Modern")
+        }
+        """,
+      ]
+    )
+  }
+
+  func testDiscardableResultAttribute() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        @discardableRes1️⃣ult
+        func compute() -> Int {
+          return 42
+        }
+        """,
+      expectedSelections: [
+        "@discardableResult",
+        """
+        @discardableResult
+        func compute() -> Int {
+          return 42
+        }
+        """,
+      ]
+    )
+  }
+
+  func testEscapingAttribute() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        func perform(completion: @esc1️⃣aping () -> Void) {
+          completion()
+        }
+        """,
+      expectedSelections: [
+        "@escaping",
+        "@escaping () -> Void",
+        "completion: @escaping () -> Void",
+        """
+        func perform(completion: @escaping () -> Void) {
+          completion()
+        }
+        """,
+      ],
+    )
+  }
+
+  // MARK: - Pattern Matching
+
+  func testEnumCasePattern() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        if case .success(let val1️⃣ue) = result {
+          print(value)
+        }
+        """,
+      expectedSelections: [
+        "value",
+        "let value",
+        ".success(let value)",
+        "case .success(let value) = result",
+        """
+        if case .success(let value) = result {
+          print(value)
+        }
+        """,
+      ]
+    )
+  }
+
+  func testTuplePattern() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let (x, 1️⃣y, z) = point
+        """,
+      expectedSelections: [
+        "y",
+        "x, y, z",
+        "(x, y, z)",
+        "let (x, y, z) = point",
+      ]
+    )
+  }
+
+  // MARK: - Access Control
+
+  func testPrivateModifier() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        private var secr1️⃣et: String = "hidden"
+        """,
+      expectedSelections: [
+        "secret",
+        #"private var secret: String = "hidden""#,
+      ]
+    )
+  }
+
+  // MARK: - Subscripts
+
+  func testSubscriptDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        subscript(ind1️⃣ex: Int) -> Int {
+          get { return array[index] }
+          set { array[index] = newValue }
+        }
+        """,
+      expectedSelections: [
+        "index",
+        "index: Int",
+        """
+        subscript(index: Int) -> Int {
+          get { return array[index] }
+          set { array[index] = newValue }
+        }
+        """,
+      ]
+    )
+  }
+
+  func testSubscriptUsage() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let value = matrix[1️⃣2, 3]
+        """,
+      expectedSelections: [
+        "2",
+        "2, 3",
+        "[2, 3]",
+        "matrix[2, 3]",
+        "let value = matrix[2, 3]",
+      ]
+    )
+  }
+
+  func testSubScriptUsageWithCursorImmediatelyBeforeSquare() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let value = matrix1️⃣[2, 3]
+        """,
+      expectedSelections: [
+        "matrix",
+        "matrix[2, 3]",
+        "let value = matrix[2, 3]",
+      ]
+    )
+  }
+
+  // MARK: - Tuple And Array Operations
+
+  func testTupleCreation() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let person = (name: "John", ag1️⃣e: 30)
+        """,
+      expectedSelections: [
+        "age",
+        "age: 30",
+        #"name: "John", age: 30"#,
+        #"(name: "John", age: 30)"#,
+        #"let person = (name: "John", age: 30)"#,
+      ]
+    )
+  }
+
+  func testArrayLiteral() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let numbers = [1, 2, 1️⃣3, 4, 5]
+        """,
+      expectedSelections: [
+        "3",
+        "1, 2, 3, 4, 5",
+        "[1, 2, 3, 4, 5]",
+        "let numbers = [1, 2, 3, 4, 5]",
+      ]
+    )
+  }
+
+  func testDictionaryLiteral() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let dict = ["key": "val1️⃣ue", "another": "item"]
+        """,
+      expectedSelections: [
+        "value",
+        #""value""#,
+        #""key": "value""#,
+        #""key": "value", "another": "item""#,
+        #"["key": "value", "another": "item"]"#,
+        #"let dict = ["key": "value", "another": "item"]"#,
+      ]
+    )
+  }
+
+  // MARK: - Macros
+
+  func testMacroUsage() async throws {
+    try await assertSelectionRanges(
+      markedSource: #"#warnin1️⃣g("This is deprecated")"#,
+      expectedSelections: [
+        #"#warning("This is deprecated")"#
+      ]
+    )
+  }
+
+  // MARK: - Async Await
+
+  func testAwaitExpression() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let data = await fetchDa1️⃣ta()
+        """,
+      expectedSelections: [
+        "fetchData",
+        "fetchData()",
+        "await fetchData()",
+        "let data = await fetchData()",
+      ]
+    )
+  }
+
+  func testAsyncLet() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        async let image1️⃣ = loadImage()
+        """,
+      expectedSelections: [
+        "image",
+        "async let image = loadImage()",
+      ]
+    )
+  }
+
+  func testTaskGroup() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        await withTaskGroup(of: Int.self) { gro1️⃣up in
+          for i in 1...10 {
+            group.addTask { i * 2 }
+          }
+        }
+        """,
+      expectedSelections: [
+        "group",
+        "group in",
+        """
+        group in
+          for i in 1...10 {
+            group.addTask { i * 2 }
+          }
+        """,
+        """
+        { group in
+          for i in 1...10 {
+            group.addTask { i * 2 }
+          }
+        }
+        """,
+        """
+        withTaskGroup(of: Int.self) { group in
+          for i in 1...10 {
+            group.addTask { i * 2 }
+          }
+        }
+        """,
+        """
+        await withTaskGroup(of: Int.self) { group in
+          for i in 1...10 {
+            group.addTask { i * 2 }
+          }
+        }
+        """,
+      ]
+    )
+  }
+
+  // MARK: - Property Wrappers
+
+  func testPropertyWrapperUsage() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        @Published var cou1️⃣nt: Int = 0
+        """,
+      expectedSelections: [
+        "count",
+        "@Published var count: Int = 0",
+      ]
+    )
+  }
+
+  // MARK: - Key Paths
+
+  func testKeyPathExpression() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        let keyPath = \\Person.na1️⃣me
+        """,
+      expectedSelections: [
+        "name",
+        "\\Person.name",
+        "let keyPath = \\Person.name",
+      ]
+    )
+  }
+
+  // MARK: - Type Aliases
+
+  func testTypeAlias() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        typealias StringDict1️⃣ionary = [String: String]
+        """,
+      expectedSelections: [
+        "StringDictionary",
+        "typealias StringDictionary = [String: String]",
+      ]
+    )
+  }
+
+  func testGenericTypeAlias() async throws {
+    try await assertSelectionRanges(
+      markedSource: """
+        typealias Handler<T1️⃣> = (T) -> Void
+        """,
+      expectedSelections: [
+        "T",
+        "<T>",
+        "Handler<T>",
+        "typealias Handler<T> = (T) -> Void",
+      ]
+    )
+  }
+
+  // MARK: - Actors
+
+  func testActorDeclaration() async throws {
+    try await assertSelectionRanges(
+      markedSource: "actor Te1️⃣st {}",
+      expectedSelections: ["Test", "actor Test {}"]
+    )
+  }
+
+  func testActorDeclarationWithGenerics() async throws {
+    try await assertSelectionRanges(
+      markedSource: "actor Test<T1️⃣> {}",
+      expectedSelections: ["T", "<T>", "Test<T>", "actor Test<T> {}"]
+    )
+  }
+}
+
+/// Helper to test selection ranges for a single marker ("1️⃣") in the source.
+///
+/// - Parameters:
+///   - markedSource: The source code string containing a single marker ("1️⃣") indicating the cursor position.
+///   - expectedSelections: The expected selection ranges, from innermost to outermost, as strings.
+///   - file: The file from which the test is called (default: current file).
+///   - line: The line from which the test is called (default: current line).
+///
+/// This function wraps the multi-marker version for convenience when only one marker is present.
+private func assertSelectionRanges(
+  markedSource: String,
+  expectedSelections: [String],
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async throws {
+  try await assertSelectionRanges(
+    markedSource: markedSource,
+    expectedSelections: ["1️⃣": expectedSelections],
+    file: file,
+    line: line
+  )
+}
+
+/// Helper to test selection ranges for multiple markers in the source.
+/// This function extracts marker positions from the source, sends selection range requests, and checks that the returned ranges match the expected selections for each marker.
+/// The test does not fail if `expectedSelections` contains less selection ranges than the request returned.
+/// This is done to avoid having to always list all selections for all tests.
+///
+/// - Parameters:
+///   - markedSource: The source code string containing one or more markers (e.g., "1️⃣", "2️⃣") indicating cursor positions.
+///   - expectedSelections: A dictionary mapping marker strings to arrays of expected selection ranges (from innermost to outermost) as strings.
+///   - file: The file from which the test is called (default: current file).
+///   - line: The line from which the test is called (default: current line).
+private func assertSelectionRanges(
+  markedSource: String,
+  expectedSelections: [String: [String]],
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async throws {
+  let (documentPositions, text) = DocumentPositions.extract(from: markedSource)
+
+  // check that all expectedSelections are valid
+  XCTAssertEqual(
+    Set(expectedSelections.keys),
+    Set(documentPositions.allMarkers),
+    "The markers used in the source differ from those in the expected selections. Source: \(documentPositions.allMarkers) Expected: \(expectedSelections.keys)",
+    file: file,
+    line: line
+  )
+  let flatMappedSelections = expectedSelections.values.flatMap { $0 }
+  XCTAssert(
+    flatMappedSelections.allSatisfy { text.contains($0) },
+    """
+    The following expected selections are not contained in the source:
+    \(flatMappedSelections.filter { !text.contains($0) }.joined(separator: "\n"))
+    """,
+    file: file,
+    line: line
+  )
+
+  // check the actual returned ranges
+  let testClient = try await TestSourceKitLSPClient()
+  let uri = DocumentURI(for: .swift)
+  testClient.openDocument(text, uri: uri)
+
+  for marker in documentPositions.allMarkers {
+    let position = documentPositions[marker]
+    let response = try await testClient.send(
+      SelectionRangeRequest(textDocument: TextDocumentIdentifier(uri), positions: [position])
+    )
+
+    let lineTable = LineTable(text)
+
+    let range = response.first ?? nil
+    let expected = expectedSelections[marker] ?? []
+
+    var rangeIndex = 0
+    var currentRange: SelectionRange? = range
+    while rangeIndex < expected.count {
+      let selectString = getStringOfSelectionRange(lineTable: lineTable, selectionRange: currentRange)
+      XCTAssertEqual(
+        selectString,
+        expected[rangeIndex],
+        selectionRangeMismatchMessage(
+          marker: marker,
+          expected: expected[rangeIndex],
+          actual: String(selectString)
+        ),
+        file: file,
+        line: line
+      )
+
+      currentRange = currentRange?.parent
+      rangeIndex += 1
+    }
+  }
+}
+
+private func selectionRangeMismatchMessage(marker: String, expected: String, actual: String) -> String {
+  let isMultiline = expected.contains("\n") || actual.contains("\n")
+
+  if isMultiline {
+    return """
+      Selection range mismatch for marker \(marker):
+
+      Expected:
+      \(expected)
+
+      Actual:
+      \(actual)
+      """
+  } else {
+    return """
+      Selection range mismatch for marker \(marker):
+        Expected: \(expected)
+        Actual:   \(actual)
+      """
+  }
+}
+
+private func getStringOfSelectionRange(lineTable: LineTable, selectionRange: SelectionRange?) -> String {
+  guard let selectionRange = selectionRange else {
+    return "<no selection range>"
+  }
+
+  let lowerBoundIndex = lineTable.stringIndexOf(
+    line: selectionRange.range.lowerBound.line,
+    utf16Column: selectionRange.range.lowerBound.utf16index
+  )
+  let upperBoundIndex = lineTable.stringIndexOf(
+    line: selectionRange.range.upperBound.line,
+    utf16Column: selectionRange.range.upperBound.utf16index
+  )
+
+  return String(lineTable.content[lowerBoundIndex..<upperBoundIndex])
+}


### PR DESCRIPTION
This PR implement the [textDocument/selectionRange](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange) capability providing better support for the [Shrink/expand selection](https://code.visualstudio.com/docs/editing/codebasics#_shrinkexpand-selection) shortcuts and addresses #2463.

# Comparison
Before:

https://github.com/user-attachments/assets/743a51e0-afbe-483e-8dcf-8d6bec132c76

After:

https://github.com/user-attachments/assets/a42c99f8-a0fa-4418-8168-e5e283917b1a

Before:

https://github.com/user-attachments/assets/d188bfe2-509e-4fc5-9ee5-0f4284326969

After:

https://github.com/user-attachments/assets/00b3630f-04c3-44c7-b2a2-195cb3ecbfa4

# Implementation

The feature works by getting the AST node under the cursor and then creating selection ranges for nodes by walking up the AST to the root. A range that is the same as the last one that was added is automatically filtered out. Additionally, there are special cases for a lot of AST nodes, depending on whether they should never create a selection range or need special handling in that they may create more than one selection range.

I also added handling for when the cursor is directly at a boundary token, e.g. `test(a: 1, b: 2|)`, in this case the user most likely wants to select the `2` even tough the cursor is technically at the `)` token. For this we check if we are at a boundary token and if we are, we use the previous token as the start of our AST traversal.

Most of the unit tests where initially generated by Claude Sonnet 4.5. I have, however, looked over all of them to ensure that they are correct and match the behavior I intended.

# Additional Notes

I am aware that this is a big PR, note however that ~2300 of the added lines are for tests.

I intend to squash a lot of the commits, however I'm unsure if everything should be squashed into one big commit or if multiple commits would be helpful. One approach could be to modify the first commit to only contain the bare-bones logic for walking up the AST nodes and creating selection ranges for all nodes and the basic setup for the unit tests. A second commit could then contain all the unit tests while the third commit introduces all the special cases for the different AST nodes. Commits two and three could also be swapped to avoid having a commit (the commit with the tests) in the history with a bunch of failing unit tests.  

As I was not familiar with the swift-syntax API before working on this I may not have used the API in the most ideal way in some cases. I'm open to feedback on that.