### PR TITLE
Handle /usr/bin compiler shims in ToolchainRegistry

### DIFF
--- a/Sources/BuildServerIntegration/JSONCompilationDatabaseBuildServer.swift
+++ b/Sources/BuildServerIntegration/JSONCompilationDatabaseBuildServer.swift
@@ -172,6 +172,7 @@ package actor JSONCompilationDatabaseBuildServer: BuiltInBuildServer {
     }
     if notification.changes.contains(where: { $0.uri.fileURL?.lastPathComponent == ".swift-version" }) {
       await toolchainResolver.clearCache()
+      await toolchainRegistry.clearXcrunCache()
       connectionToSourceKitLSP.send(OnBuildTargetDidChangeNotification(changes: nil))
     }
   }


### PR DESCRIPTION
## Summary

On macOS, `/usr/bin/swiftc` and `/usr/bin/clang` are shim executables (not symlinks) that delegate to the active Xcode toolchain. When `compile_commands.json` references these paths, `ToolchainRegistry.toolchain(withCompiler:)` couldn't map them to a toolchain because `realpath` doesn't resolve shims.

This causes language services to fail for projects that use CMake or other build systems that generate `compile_commands.json` with `/usr/bin/swiftc` as the compiler path.

## Changes

- Add `XcrunResolverCache` helper class to cache xcrun resolutions for `/usr/bin` shims
- Enhance `toolchain(withCompiler:)` to detect `/usr/bin` shims on Darwin and:
  1. Check cache for previously resolved xcrun results
  2. Trigger background xcrun resolution for future lookups  
  3. Immediately fall back to `preferredToolchain` based on compiler type
- Add `clearXcrunCache()` method called when `.swift-version` changes

## Behavior

- First file open uses fallback toolchain (immediate, no blocking)
- Background xcrun resolution populates cache asynchronously
- Subsequent opens use cached xcrun result for accurate compiler matching
- Works even if xcrun is slow or blocked - falls back gracefully
- Zero behavior change for non-`/usr/bin` compilers

## Test plan

- [x] Tested with CMake project using `/usr/bin/swiftc` in compile_commands.json
- [x] Verified hover and go-to-definition work for Swift files
- [x] Verified no regression for projects with explicit toolchain paths