### PR TITLE
Mention Noctule extension for JetBrains IDEs

### DIFF
--- a/Documentation/Editor Integration.md
+++ b/Documentation/Editor Integration.md
@@ -12,6 +12,12 @@ If `sourcekit-lsp` is in your `$PATH` or is discoverable by using `xcrun --find 
 
 You can read more about BBEdit's LSP support and configuration hints [here](https://www.barebones.com/support/bbedit/lsp-notes.html).
 
+## JetBrains IDEs
+
+[Noctule](https://noctule.dev) is a 3rd-party extension to provide cross-platform support for Swift.
+
+By default, Noctule will try to detect `sourcekit-lsp` on a system. But you can configure the toolchain to use in the settings. Please [refer to Noctule's website](https://noctule.dev/docs/configuration/) to learn how to do that.
+
 ## Nova
 
 You can use SourceKit-LSP with Nova by using the [Icarus](http://panic.com/open-in-nova/extension?id=panic.Icarus) extension.


### PR DESCRIPTION
Added information about Noctule for JetBrains IDEs and its configuration. Noctule is currently the only plugin for JetBrains IDEs, which is supporting cross-platform Swift support and support for Swift PM.

Noctule is a closed-source extension. It's currently offering all features for free, but will become freemium or paid software in the future.

It's okay if you don't want to mention Noctule because it's closed-source or commercial.