### PR TITLE
Fix inverted log check when updating the index store

### DIFF
--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -261,7 +261,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         mainFile: fileInfo.mainFile,
         outputPath: fileInfo.outputPath
       )
-      if !hasUpToDateUnit {
+      if hasUpToDateUnit {
         logger.debug("Not indexing \(fileInfo.file.forLogging) because index has an up-to-date unit")
         // We consider a file's index up-to-date if we have any up-to-date unit. Changing build settings does not
         // invalidate the up-to-date status of the index.


### PR DESCRIPTION
I think this check seems inverted; it says the unit is up-to-date but it checks for the opposite. I bumped into this when investigating a case where the logs would claim something would not be indexed and then follow-up by indexing it.