### PR TITLE
Add Collapse Nested If refactoring

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/CollapseNestedIf.swift
+++ b/Sources/SwiftLanguageService/CodeActions/CollapseNestedIf.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftRefactor
+import SourceKitLSP
+import LanguageServerProtocol
+
+struct CollapseNestedIf: EditRefactoringProvider {
+  // MARK: - Required by EditRefactoringProvider
+
+  typealias Input = IfExprSyntax
+  typealias Context = Void
+
+  static func textRefactor(
+    syntax: IfExprSyntax,
+    in context: Void
+  ) throws -> [SourceEdit] {
+    let statements = syntax.body.statements
+    guard
+      statements.count == 1,
+      let innerIf = statements.first?.item.as(IfExprSyntax.self),
+      syntax.elseBody == nil,
+      innerIf.elseBody == nil
+    else {
+      return []
+    }
+
+    let combinedConditions = ConditionElementListSyntax(
+      Array(syntax.conditions) + Array(innerIf.conditions)
+    )
+
+    let newIf = syntax
+      .with(\.conditions, combinedConditions)
+      .with(\.body, innerIf.body)
+
+    return [
+      SourceEdit(
+        range: syntax.positionAfterSkippingLeadingTrivia..<syntax.endPosition,
+        replacement: newIf.description
+      )
+    ]
+  }
+}
+
+// MARK: - Code Action plumbing
+
+extension CollapseNestedIf: SyntaxRefactoringCodeActionProvider {
+  static var title: String {
+    "Collapse Nested If Statements"
+  }
+
+static func nodeToRefactor(
+  in scope: SyntaxCodeActionScope
+) -> IfExprSyntax? {
+
+  var node: Syntax? = scope.innermostNodeContainingRange
+
+  while let current = node {
+
+    if let ifExpr = current.as(IfExprSyntax.self) {
+
+      // Outer if must not have else
+      guard ifExpr.elseBody == nil else { return nil }
+
+      let statements = ifExpr.body.statements
+      guard
+        statements.count == 1,
+        let innerIf = statements.first?.item.as(IfExprSyntax.self),
+        innerIf.elseBody == nil
+      else {
+        return nil
+      }
+
+      return ifExpr
+    }
+
+    // 🚨 Stop climbing at function / closure boundaries
+    if current.is(FunctionDeclSyntax.self)
+        || current.is(InitializerDeclSyntax.self)
+        || current.is(ClosureExprSyntax.self) {
+      break
+    }
+
+    node = current.parent
+  }
+
+  return nil
+}
+}
+
+// MARK: - Helpers
+
+private func isTopLevelInCodeBlock(_ ifExpr: IfExprSyntax) -> Bool {
+  var current = Syntax(ifExpr)
+  if let parent = current.parent,
+     parent.is(ExpressionStmtSyntax.self) {
+    current = parent
+  }
+  return current.parent?.is(CodeBlockItemSyntax.self) ?? false
+}

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
@@ -19,6 +19,7 @@ let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
     AddDocumentation.self,
     AddSeparatorsToIntegerLiteral.self,
     ApplyDeMorganLaw.self,
+    CollapseNestedIf.self,
     ConvertComputedPropertyToZeroParameterFunction.self,
     ConvertIfLetToGuard.self,
     ConvertIntegerLiteral.self,


### PR DESCRIPTION
### Description

This PR adds a new syntactic refactoring code action “Collapse Nested If Statements” to SwiftLanguageService.

The refactoring detects cases where an if statement contains exactly one statement in its body and that statement is another if (with no else on either), and collapses them into a single if with combined conditions.

Example

Before:

if a {
  if b {
    doSomething()
  }
}

After:

if a && b {
  doSomething()
}

**Implementation notes**

Implemented as a SyntaxRefactoringCodeActionProvider

The refactoring:

Requires both outer and inner if to have no else

Requires the outer if body to contain exactly one statement

Reuses the inner if body and combines condition lists

The action is registered alongside other syntactic refactorings in SyntaxCodeActions.swift

**Known limitation / feedback request**

At the moment, the code action reliably appears when the cursor is on the if keyword itself, but does not always appear when the cursor is inside the condition, on identifiers, operators, or whitespace within the same if expression.

The current implementation walks upward from innermostNodeContainingRange, but there may be a more idiomatic or preferred approach in SourceKit-LSP to make refactorings robust to cursor position within the full if expression.

I’d appreciate feedback on:

Whether this cursor-position behavior is acceptable for an initial implementation

Or if there is a recommended pattern to broaden applicability across the entire if expression range

**Status**

Builds successfully

Refactoring behavior works as expected when triggered

Happy to iterate based on maintainer feedback

**Fixes**

Addresses one part of https://github.com/swiftlang/sourcekit-lsp/issues/2424 (CollapseNestedIfStmt).