### PR TITLE
[test] change to expect the updated signature of `filter()`

### DIFF
--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -266,7 +266,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       position: positions["1️⃣"],
       testClient: testClient,
       swiftInterfaceFile: "Swift.Collection.Array.swiftinterface",
-      linePrefix: "@inlinable public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> [Element]"
+      linePrefix: "public consuming func filter<E>(_ isIncluded: (Element) throws(E) -> Bool) throws(E) -> [Element]"
     )
   }
 
@@ -285,7 +285,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       position: project.positions["1️⃣"],
       testClient: project.testClient,
       swiftInterfaceFile: "Swift.Collection.Array.swiftinterface",
-      linePrefix: "@inlinable public func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> [Element]"
+      linePrefix: "public consuming func filter<E>(_ isIncluded: (Element) throws(E) -> Bool) throws(E) -> [Element]"
     )
   }
 


### PR DESCRIPTION
The `filter(_:)` function is getting generalized for typed throws in https://github.com/swiftlang/swift/pull/87020.
These two tests expect to find the signature for the "rethrows" version of the `filter(_:)` function. This PR updates the tests.