### PR TITLE
[ToolchainRegistry] Prefer .dylib SourceKit plugins over .framework

### DIFF
--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -366,7 +366,7 @@ public final class Toolchain: Sendable {
           return libSearchPath
         }
         let frameworkPath = libPath.appending(components: "\(name).framework", name)
-        if FileManager.default.isFile(at: frameworkPath) {
+        if searchFramework, FileManager.default.isFile(at: frameworkPath) {
           return frameworkPath
         }
         #if os(Windows)


### PR DESCRIPTION
`sourcekit-lsp` project generates `SwiftSourceKitPlugin.{.dylib|.so}`. No reason to check `.framework` first.

rdar://170177167