### PR TITLE
[6.3][ToolchainRegistry] Prefer .dylib SourceKit plugins over .framework

### DIFF
--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -361,13 +361,13 @@ public final class Toolchain: Sendable {
       }
 
       func findDylib(named name: String, searchFramework: Bool = false) -> URL? {
-        let frameworkPath = libPath.appending(components: "\(name).framework", name)
-        if FileManager.default.isFile(at: frameworkPath) {
-          return frameworkPath
-        }
         let libSearchPath = libPath.appending(component: "lib\(name)\(dylibExtension)")
         if FileManager.default.isFile(at: libSearchPath) {
           return libSearchPath
+        }
+        let frameworkPath = libPath.appending(components: "\(name).framework", name)
+        if FileManager.default.isFile(at: frameworkPath) {
+          return frameworkPath
         }
         #if os(Windows)
         let binSearchPath = binPath.appending(component: "\(name)\(dylibExtension)")


### PR DESCRIPTION
Cherry-pick #2480  into `release/6.3`


* **Explanation**: Some environment may have `SwiftSourceKitPlugin.framework` which might not be compatible with `SourceKitLSP`. Since `.dylib` version is generated from this project and is guaranteed to be synced with sourcekit-lsp itself, we should prefer `SwiftSourceKitPlugin..dylib` over `SwiftSourceKitPlugin.framework`.
* **Scope**: SourceKit plugins
* **Risk**: Low. This only changes the search order for `SwiftSourceKitPlugin`, `SwiftSourceKitClientPlugin`, and `sourcekitd` libraries. But practically `sourcekitd` search will not be affected because there's no known environment that has `sourcekitd.dylib`
* **Testing**: Passes current test cases, locally tested the behavior
* **Issues**: rdar://170177167
* **Reviewer**: Alex Hoppen (@ahoppen)