### PR TITLE
[TestSupport] Don't try to GPG-sign commits

### DIFF
--- a/Sources/SKTestSupport/SwiftPMDependencyProject.swift
+++ b/Sources/SKTestSupport/SwiftPMDependencyProject.swift
@@ -99,7 +99,10 @@ package class SwiftPMDependencyProject {
       workingDirectory: packageDirectory
     )
     try await runGitCommand(
-      ["-c", "user.name=Dummy", "-c", "user.email=noreply@swift.org", "commit", "-m", "Version \(version)"],
+      [
+        "-c", "user.name=Dummy", "-c", "user.email=noreply@swift.org",
+        "commit", "--no-gpg-sign", "-m", "Version \(version)",
+      ],
       workingDirectory: packageDirectory
     )
 


### PR DESCRIPTION
When `commit.gpgsign = true` is enabled globally, signing fails because the author `Dummy <noreply@swift.org>`  likey has no configured GPG key, causing test failures.
