### PR TITLE
Explicitly close the index when shutting down SourceKit-LSP

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -504,7 +504,11 @@ package final actor SemanticIndexManager {
             logger.info("Not indexing \(uri.forLogging) because its output file could not be determined")
             continue
           }
-          if !indexFilesWithUpToDateUnits, modifiedFilesIndex.hasUpToDateUnit(for: uri, outputPath: outputPath) {
+          let hasUpToDateUnit =
+            orLog("Checking if modified file has up-to-date unit") {
+              try modifiedFilesIndex.hasUpToDateUnit(for: uri, outputPath: outputPath)
+            } ?? true
+          if !indexFilesWithUpToDateUnits, hasUpToDateUnit {
             continue
           }
           // If this is a source file, just index it.
@@ -549,9 +553,11 @@ package final actor SemanticIndexManager {
         )
         continue
       }
-      if !indexFilesWithUpToDateUnits,
-        modifiedFilesIndex.hasUpToDateUnit(for: uri, mainFile: mainFile, outputPath: outputPath)
-      {
+      let hasUpToDateUnit =
+        orLog("Checking if modified file has up-to-date unit") {
+          try modifiedFilesIndex.hasUpToDateUnit(for: uri, mainFile: mainFile, outputPath: outputPath)
+        } ?? true
+      if !indexFilesWithUpToDateUnits, hasUpToDateUnit {
         continue
       }
       guard let language = await buildServerManager.defaultLanguage(for: uri, in: targetAndOutputPath.key) else {

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -256,11 +256,14 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       if indexFilesWithUpToDateUnit {
         return true
       }
-      let hasUpToDateUnit = index.checked(for: .modifiedFiles).hasUpToDateUnit(
-        for: fileInfo.sourceFile,
-        mainFile: fileInfo.mainFile,
-        outputPath: fileInfo.outputPath
-      )
+      let hasUpToDateUnit =
+        orLog("Checking if file has up-to-date unit") {
+          try index.checked(for: .modifiedFiles).hasUpToDateUnit(
+            for: fileInfo.sourceFile,
+            mainFile: fileInfo.mainFile,
+            outputPath: fileInfo.outputPath
+          )
+        } ?? true
       if hasUpToDateUnit {
         logger.debug("Not indexing \(fileInfo.file.forLogging) because index has an up-to-date unit")
         // We consider a file's index up-to-date if we have any up-to-date unit. Changing build settings does not

--- a/Sources/SourceKitLSP/DefinitionLocations.swift
+++ b/Sources/SourceKitLSP/DefinitionLocations.swift
@@ -104,7 +104,7 @@ package func definitionLocations(
   guard let usr = symbol.usr else { return DefinitionLocationsResult(locations: []) }
   logger.info("Performing indexed jump-to-definition with USR \(usr)")
 
-  let occurrences = index.definitionOrDeclarationOccurrences(ofUSR: usr)
+  let occurrences = try index.definitionOrDeclarationOccurrences(ofUSR: usr)
 
   if occurrences.isEmpty {
     if let bestLocalDeclaration = symbol.bestLocalDeclaration {

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -24,7 +24,11 @@ extension UncheckedIndex: BuildServerIntegration.MainFilesProvider {
   package func mainFiles(containing uri: DocumentURI, crossLanguage: Bool) -> Set<DocumentURI> {
     let mainFiles: Set<DocumentURI>
     if let filePath = orLog("File path to get main files", { try uri.fileURL?.filePath }) {
-      let mainFilePaths = self.underlyingIndexStoreDB.mainFilesContainingFile(
+      guard let underlyingIndexStoreDB = self.underlyingIndexStoreDB else {
+        logger.error("Not checking main files for URI because index has been closed")
+        return []
+      }
+      let mainFilePaths = underlyingIndexStoreDB.mainFilesContainingFile(
         path: filePath,
         crossLanguage: crossLanguage
       )

--- a/Sources/SwiftLanguageService/TestDiscovery.swift
+++ b/Sources/SwiftLanguageService/TestDiscovery.swift
@@ -33,7 +33,9 @@ extension SwiftLanguageService {
       return nil
     }
     let snapshot = try documentManager.latestSnapshot(uri)
-    let semanticSymbols = await workspace.index(checkedFor: .deletedFiles)?.symbols(inFilePath: snapshot.uri.pseudoPath)
+    let semanticSymbols = try await workspace.index(checkedFor: .deletedFiles)?.symbols(
+      inFilePath: snapshot.uri.pseudoPath
+    )
     let xctestSymbols = await SyntacticSwiftXCTestScanner.findTestSymbols(
       in: snapshot,
       syntaxTreeManager: syntaxTreeManager


### PR DESCRIPTION
`IndexStoreDB` moves its index to the `saved` directory when it is deallocated. Because `IndexStoreDB` is primarily owned by `UncheckedIndex`, we rely on deallocating this object to save the index store. This is fairly brittle because various parts of the codebase may hold transient references to that object as reported in https://github.com/swiftlang/sourcekit-lsp/issues/2455#issuecomment-3873561003.

Explicitly remove the reference from `UncheckedIndex` to `IndexStoreDB`. While this still isn’t perfect because other parts of the code base may hold references to `IndexStoreDB` but those should be a lot rarer, resulting in a more consistent closing of the index.