### PR TITLE
Add test to verify RemoveImports works inside active #if clauses

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/RemoveUnusedImports.swift
+++ b/Sources/SwiftLanguageService/CodeActions/RemoveUnusedImports.swift
@@ -165,7 +165,7 @@ extension SwiftLanguageService {
           }
 
           activeRegionStack.removeLast()
-          break  // 🚨 CRITICAL — stop after first true clause
+          break  // CRITICAL — stop after first true clause
         }
       }
 


### PR DESCRIPTION
### This PR expands test coverage for the Remove Unused Imports code action.
Fix: https://github.com/swiftlang/sourcekit-lsp/issues/2335
#### Existing tests verify that:
Unused top-level import declarations are removed correctly
The code action is not available when the source file contains compilation errors

This PR begins adding test coverage for import declarations nested inside conditional compilation blocks. In particular, it verifies that unused imports inside active #if clauses are considered by the code action.

This helps guard against regressions when extending RemoveUnusedImports to account for conditional compilation regions in future changes.