### PR TITLE
[Test/PlaygroundsDiscovery] Add "/refresh" style entry point requests

### DIFF
--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -213,7 +213,8 @@ package class MultiFileTestProject {
   @discardableResult
   package func changeFileOnDisk(
     _ fileName: String,
-    newMarkedContents: String?
+    newMarkedContents: String?,
+    synchronize: Bool = true
   ) async throws -> (uri: DocumentURI, positions: DocumentPositions) {
     let uri = try self.uri(for: fileName)
     guard let url = uri.fileURL else {
@@ -244,8 +245,10 @@ package class MultiFileTestProject {
       changeType = .deleted
     }
     testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: changeType)]))
-    // Ensure that we handle the `DidChangeWatchedFilesNotification`.
-    try await testClient.send(SynchronizeRequest())
+    if synchronize {
+      // Ensure that we handle the `DidChangeWatchedFilesNotification`.
+      try await testClient.send(SynchronizeRequest())
+    }
 
     return (uri, positions)
   }

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -391,6 +391,33 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
     requestHandlers.value.append((requestHandler: requestHandler, isOneShot: false))
   }
 
+  /// Executes `operation` and waits until a request of the specified type is received from the server.
+  package func withWaitingFor<R: RequestType, Value>(
+    _: R.Type,
+    timeout: Duration = defaultTimeoutDuration,
+    pollingInterval: Duration = .milliseconds(10),
+    operation: () async throws -> Value,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws -> Value where R.Response == VoidResponse {
+    // Register a one-shot handler that records when the request arrives.
+    let received = AtomicBool(initialValue: false)
+    self.handleSingleRequest { (_: R) in
+      received.value = true
+      return VoidResponse()
+    }
+
+    let result = try await operation()
+    try await repeatUntilExpectedResult(
+      timeout: timeout,
+      sleepInterval: pollingInterval,
+      { received.value },
+      file: file,
+      line: line
+    )
+    return result
+  }
+
   // MARK: - Conformance to MessageHandler
 
   /// - Important: Implementation detail of `TestSourceKitLSPServer`. Do not call from tests.

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(SourceKitLSP STATIC
   DocumentSnapshot+FromFileContents.swift
   DocumentSnapshot+PositionConversions.swift
   DefinitionLocations.swift
+  EntryPointManager.swift
   GeneratedInterfaceDocumentURLData.swift
   Hooks.swift
   IndexProgressManager.swift

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -106,6 +106,14 @@ package final actor CapabilityRegistry {
     return clientHasExperimentalCapability(DidChangeActiveDocumentNotification.method)
   }
 
+  package nonisolated var clientHasWorkspaceTestsRefreshSupport: Bool {
+    return clientHasExperimentalCapability(WorkspaceTestsRefreshRequest.method)
+  }
+
+  package nonisolated var clientHasWorkspacePlaygroundsRefreshSupport: Bool {
+    return clientHasExperimentalCapability(WorkspacePlaygroundsRefreshRequest.method)
+  }
+
   package nonisolated func clientHasExperimentalCapability(_ name: String) -> Bool {
     guard case .dictionary(let experimentalCapabilities) = clientCapabilities.experimental else {
       return false

--- a/Sources/SourceKitLSP/EntryPointManager.swift
+++ b/Sources/SourceKitLSP/EntryPointManager.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SKUtilities
+
+/// Manages discovered tests and playgrounds.
+actor EntryPointManager {
+  weak let sourceKitLSPServer: SourceKitLSPServer?
+
+  // Implicitly-unwrapped because initializing it requires capturing `self`.
+  private nonisolated(unsafe) var refreshDebouncer: Debouncer<Void>!
+  private var currentRefreshTask: Task<Void, any Error>?
+
+  // Collected entry points in the workspaces.
+  private(set) var latestWorkspaceTests: [TestItem] = []
+  private(set) var latestPlaygrounds: [Playground] = []
+
+  // Callback functions when the list has changed. Non-nil means the client wants that entry point kind.
+  var onWorkspaceTestsChanged: (() -> Void)? = nil
+  var onWorkspacePlaygroundsChanged: (() -> Void)? = nil
+
+  init(sourceKitLSPServer: SourceKitLSPServer) {
+    self.sourceKitLSPServer = sourceKitLSPServer
+    self.refreshDebouncer = nil
+    self.refreshDebouncer = Debouncer(debounceDuration: .seconds(2)) { [weak self] in
+      await self?.refreshImpl()
+    }
+  }
+
+  /// Sets up the callbacks for each entry point kind.
+  /// If `nil`, the entry point of the kind will not be monitored.
+  func setCallbacks(
+    onWorkspaceTestsChanged: (() -> Void)?,
+    onWorkspacePlaygroundsChanged: (() -> Void)?,
+  ) {
+    self.onWorkspaceTestsChanged = onWorkspaceTestsChanged
+    self.onWorkspacePlaygroundsChanged = onWorkspacePlaygroundsChanged
+  }
+
+  /// Schedules a new refresh of the cached entry point lists.
+  ///
+  /// - Parameters:
+  ///   - debounce: If `true`, the refresh is debounced to coalesce rapid successive refresh requests,
+  ///     such as when multiple index changes arrive in quick succession. If `false` (default), the
+  ///     refresh starts immediately.
+  func refresh(debounce: Bool = false) {
+    guard onWorkspaceTestsChanged != nil || onWorkspacePlaygroundsChanged != nil else {
+      // If there's no listener, no need to scan things.
+      return
+    }
+
+    Task {
+      await refreshDebouncer.scheduleCall()
+      if !debounce {
+        await refreshDebouncer.flush()
+      }
+    }
+  }
+
+  private func refreshImpl() {
+    self.currentRefreshTask?.cancel()
+
+    self.currentRefreshTask = Task { [weak self] in
+      guard let self else {
+        return
+      }
+      try Task.checkCancellation()
+
+      async let testsTask = self.refreshTestsImpl()
+      async let playgroundsTask = self.refreshPlaygroundsImpl()
+      _ = await (testsTask, playgroundsTask)
+
+      // No need to clear 'self.currentRefreshTask'; the next call to `refresh()` will cancel and replace it.
+    }
+  }
+
+  private func refreshTestsImpl() async {
+    guard let onWorkspaceTestsChanged, let sourceKitLSPServer else {
+      // 'onWorkspaceTestsChanged == nil' means the client is not interested in 'workspace/tests/refresh' request.
+      return
+    }
+    let newTests = await TestDiscovery(sourceKitLSPServer: sourceKitLSPServer).workspaceTests()
+    // Never modify the result here. modify 'workspaceTests()' if needed so other clients can gent the same result.
+    if !Task.isCancelled, newTests != latestWorkspaceTests {
+      self.latestWorkspaceTests = newTests
+      onWorkspaceTestsChanged()
+    }
+  }
+
+  private func refreshPlaygroundsImpl() async {
+    guard let onWorkspacePlaygroundsChanged, let sourceKitLSPServer else {
+      return
+    }
+    let newPlaygrounds = await PlaygroundDiscovery(sourceKitLSPServer: sourceKitLSPServer).workspacePlaygrounds()
+    // Never modify the result here. modify 'workspacePlaygrounds()' if needed so other clients can get the same results.
+    if !Task.isCancelled, newPlaygrounds != latestPlaygrounds {
+      self.latestPlaygrounds = newPlaygrounds
+      onWorkspacePlaygroundsChanged()
+    }
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -96,6 +96,12 @@ package actor SourceKitLSPServer {
   /// the initializer.
   nonisolated(unsafe) package private(set) var sourcekitdCrashedWorkDoneProgress: SharedWorkDoneProgressManager!
 
+  /// Implicitly unwrapped optional so we can create an `EntryPointManager` that has a weak reference to
+  /// `SourceKitLSPServer`.
+  /// `nonisolated(unsafe)` because `entryPointManager` will not be modified after it is assigned from the
+  /// initializer.
+  private(set) nonisolated(unsafe) var entryPointManager: EntryPointManager!
+
   /// Stores which workspace the given URI has been opened in.
   ///
   /// - Important: Must only be modified from `workspaceQueue`. This means that the value of `workspaceForUri`
@@ -185,6 +191,7 @@ package actor SourceKitLSPServer {
       title: "SourceKit-LSP: Restoring functionality",
       message: "Please run 'sourcekit-lsp diagnose' to file an issue"
     )
+    self.entryPointManager = EntryPointManager(sourceKitLSPServer: self)
   }
 
   /// Await until the server has send the reply to the initialize request.
@@ -1060,6 +1067,23 @@ extension SourceKitLSPServer {
 
     assert(!self.workspaces.isEmpty)
 
+    do {  // Setup EntryPointManager.
+      let onWorkspaceTestsChanged =
+        capabilityRegistry!.clientHasWorkspaceTestsRefreshSupport
+        ? { [weak self] in
+          _ = Task { try await self?.client.send(WorkspaceTestsRefreshRequest()) }
+        } : nil
+      let onWorkspacePlaygroundsChanged =
+        capabilityRegistry!.clientHasWorkspacePlaygroundsRefreshSupport
+        ? { [weak self] in
+          _ = Task { try await self?.client.send(WorkspacePlaygroundsRefreshRequest()) }
+        } : nil
+      await entryPointManager.setCallbacks(
+        onWorkspaceTestsChanged: onWorkspaceTestsChanged,
+        onWorkspacePlaygroundsChanged: onWorkspacePlaygroundsChanged
+      )
+    }
+
     let result = InitializeResult(
       capabilities: await self.serverCapabilities(
         for: req.capabilities,
@@ -1124,10 +1148,12 @@ extension SourceKitLSPServer {
 
     var experimentalCapabilities: [String: LSPAny] = [
       WorkspaceTestsRequest.method: .dictionary(["version": .int(2)]),
+      WorkspaceTestsRefreshRequest.method: .dictionary(["version": .int(1)]),
       DocumentTestsRequest.method: .dictionary(["version": .int(2)]),
       TriggerReindexRequest.method: .dictionary(["version": .int(1)]),
       GetReferenceDocumentRequest.method: .dictionary(["version": .int(1)]),
       DidChangeActiveDocumentNotification.method: .dictionary(["version": .int(1)]),
+      WorkspacePlaygroundsRefreshRequest.method: .dictionary(["version": .int(1)]),
     ]
     if let toolchain = await toolchainRegistry.preferredToolchain(containing: [\.swiftc]), toolchain.swiftPlay != nil {
       experimentalCapabilities[WorkspacePlaygroundsRequest.method] = .dictionary(["version": .int(1)])
@@ -1597,6 +1623,9 @@ extension SourceKitLSPServer {
     for languageService in languageServices.values.flatMap(\.self) {
       await languageService.filesDidChange(notification.changes)
     }
+
+    // Schedule updating entry point cache.
+    await entryPointManager.refresh()
   }
 
   func setBackgroundIndexingPaused(_ request: SetOptionsRequest) async throws -> VoidResponse {
@@ -2731,7 +2760,13 @@ extension SourceKitLSPServer {
   }
 
   func workspaceTests(_ req: WorkspaceTestsRequest) async throws -> [TestItem] {
-    return await TestDiscovery(sourceKitLSPServer: self).workspaceTests()
+    if self.capabilityRegistry?.clientHasWorkspaceTestsRefreshSupport ?? false {
+      // If the client supports 'workspace/tests/refresh', return the pre-populated tests.
+      return await self.entryPointManager.latestWorkspaceTests
+    } else {
+      // Otherwise, retrieve tests from the current index.
+      return await TestDiscovery(sourceKitLSPServer: self).workspaceTests()
+    }
   }
 
   func documentTests(
@@ -2744,6 +2779,14 @@ extension SourceKitLSPServer {
       workspace: workspace,
       languageService: languageService
     )
+  }
+
+  func workspacePlaygrounds(_ req: WorkspacePlaygroundsRequest) async throws -> [Playground] {
+    if self.capabilityRegistry?.clientHasWorkspacePlaygroundsRefreshSupport ?? false {
+      return await self.entryPointManager.latestPlaygrounds
+    } else {
+      return await PlaygroundDiscovery(sourceKitLSPServer: self).workspacePlaygrounds()
+    }
   }
 }
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -75,7 +75,7 @@ fileprivate actor SourceFilesWithSameRealpathInferrer {
 /// Create an index instance based on the given options and response from the build server.
 func createIndex(
   initializationData: SourceKitInitializeBuildResponseData?,
-  mainFilesChangedCallback: @escaping @Sendable () async -> Void,
+  indexChangedCallback: @escaping @Sendable () async -> Void,
   rootUri: DocumentURI?,
   toolchainRegistry: ToolchainRegistry,
   options: SourceKitLSPOptions,
@@ -97,9 +97,7 @@ func createIndex(
   let supportsOutputPaths = initializationData?.outputPathsProvider ?? false
   if let indexStorePath, let indexDatabasePath, let libPath = await toolchainRegistry.default?.libIndexStore {
     do {
-      let indexDelegate = SourceKitIndexDelegate {
-        await mainFilesChangedCallback()
-      }
+      let indexDelegate = SourceKitIndexDelegate(callback: indexChangedCallback)
       let prefixMappings =
         (indexOptions.indexPrefixMap ?? [:])
         .map { PathMapping(original: $0.key, replacement: $0.value) }
@@ -389,7 +387,14 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
       createMainFilesProvider: { (initializationData, mainFilesChangedCallback) -> (any MainFilesProvider)? in
         await createIndex(
           initializationData: initializationData,
-          mainFilesChangedCallback: mainFilesChangedCallback,
+          indexChangedCallback: { [weak sourceKitLSPServer] in
+            // Notify that main files may have changed.
+            await mainFilesChangedCallback()
+
+            // Schedule updating entry point cache.
+            // Set the debounce duration so rapid repeated calls won't start/cancel the task often.
+            await sourceKitLSPServer?.entryPointManager.refresh(debounce: true)
+          },
           rootUri: rootUri,
           toolchainRegistry: toolchainRegistry,
           options: options,
@@ -513,6 +518,9 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     }
 
     await scheduleUpdateOfUnitOutputPathsInIndexIfNecessary()
+
+    // Schedule updating entry point cache.
+    await sourceKitLSPServer?.entryPointManager.refresh()
   }
 
   private func scheduleUpdateOfUnitOutputPathsInIndexIfNecessary() async {

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -1160,6 +1160,248 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
     let tests = try await project.testClient.send(WorkspaceTestsRequest())
     XCTAssertEqual(tests, [])
   }
+
+  // MARK: - workspace/tests/refresh opt-in tests
+
+  func testInitialRefreshIsSentOnStartup() async throws {
+    let refreshReceived = self.expectation(description: "Initial workspace/tests/refresh received")
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        1️⃣class MyTests: XCTestCase {
+          2️⃣func testMyLibrary() {}3️⃣
+        }4️⃣
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      capabilities: ClientCapabilities(experimental: [
+        WorkspaceTestsRefreshRequest.method: .bool(true)
+      ]),
+      preInitialization: { testClient in
+        testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
+          refreshReceived.fulfill()
+          return VoidResponse()
+        }
+      }
+    )
+    try await fulfillmentOfOrThrow(refreshReceived)
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyLibraryTests.MyTests",
+          label: "MyTests",
+          location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
+            )
+          ]
+        )
+      ]
+    )
+  }
+
+  func testRefreshIsSentAfterFileChangedOnDisk() async throws {
+    let initialRefresh = self.expectation(description: "Initial workspace/tests/refresh")
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        1️⃣class MyTests: XCTestCase {
+          2️⃣func testMyLibrary() {}3️⃣
+        }4️⃣
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      capabilities: ClientCapabilities(experimental: [
+        WorkspaceTestsRefreshRequest.method: .bool(true)
+      ]),
+      preInitialization: { testClient in
+        testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
+          initialRefresh.fulfill()
+          return VoidResponse()
+        }
+      }
+    )
+
+    // Drain the initial refresh.
+    try await fulfillmentOfOrThrow(initialRefresh)
+
+    // Now change the file and wait for the follow-up refresh.
+    let (uri, newPositions) = try await project.testClient.withWaitingFor(WorkspaceTestsRefreshRequest.self) {
+      try await project.changeFileOnDisk(
+        "MyTests.swift",
+        newMarkedContents: """
+          import XCTest
+
+          5️⃣class MyTests: XCTestCase {
+            6️⃣func testRenamedMethod() {}7️⃣
+          }8️⃣
+          """,
+        synchronize: false
+      )
+    }
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyLibraryTests.MyTests",
+          label: "MyTests",
+          location: Location(uri: uri, range: newPositions["5️⃣"]..<newPositions["8️⃣"]),
+          children: [
+            TestItem(
+              id: "MyLibraryTests.MyTests/testRenamedMethod()",
+              label: "testRenamedMethod()",
+              location: Location(uri: uri, range: newPositions["6️⃣"]..<newPositions["7️⃣"])
+            )
+          ]
+        )
+      ]
+    )
+  }
+
+  func testRefreshIsSentAfterFileDeleted() async throws {
+    let initialRefresh = self.expectation(description: "Initial workspace/tests/refresh")
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class MyTests: XCTestCase {
+          func testMyLibrary() {}
+        }
+        """
+      ],
+      manifest: packageManifestWithTestTarget,
+      capabilities: ClientCapabilities(experimental: [
+        WorkspaceTestsRefreshRequest.method: .bool(true)
+      ]),
+      preInitialization: { testClient in
+        testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
+          initialRefresh.fulfill()
+          return VoidResponse()
+        }
+      }
+    )
+
+    // Drain the initial refresh.
+    try await fulfillmentOfOrThrow(initialRefresh)
+
+    // Delete the file and wait for the follow-up refresh.
+    _ = try await project.testClient.withWaitingFor(WorkspaceTestsRefreshRequest.self) {
+      try await project.changeFileOnDisk("MyTests.swift", newMarkedContents: nil, synchronize: false)
+    }
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(tests, [])
+  }
+
+  func testRefreshIsSentAfterFileAdded() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": ""
+      ],
+      manifest: packageManifestWithTestTarget,
+      capabilities: ClientCapabilities(experimental: [
+        WorkspaceTestsRefreshRequest.method: .bool(true)
+      ])
+    )
+
+    // The initial file is empty so no tests are discovered and no initial refresh is sent.
+    // Add test content to the file and wait for the refresh.
+    let (uri, positions) = try await project.testClient.withWaitingFor(WorkspaceTestsRefreshRequest.self) {
+      try await project.changeFileOnDisk(
+        "MyTests.swift",
+        newMarkedContents: """
+          import XCTest
+
+          1️⃣class MyTests: XCTestCase {
+            2️⃣func testMyLibrary() {}3️⃣
+          }4️⃣
+          """,
+        synchronize: false
+      )
+    }
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyLibraryTests.MyTests",
+          label: "MyTests",
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+          children: [
+            TestItem(
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
+            )
+          ]
+        )
+      ]
+    )
+  }
+
+  func testNoRefreshSentWhenTestsUnchanged() async throws {
+    let initialRefresh = self.expectation(description: "Initial workspace/tests/refresh")
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        class MyTests: XCTestCase {
+          func testMyLibrary() {}
+        }
+        """,
+        "Tests/MyLibraryTests/Helper.swift": """
+        func helperFunction() {}
+        """,
+      ],
+      manifest: packageManifestWithTestTarget,
+      capabilities: ClientCapabilities(experimental: [
+        WorkspaceTestsRefreshRequest.method: .bool(true)
+      ]),
+      preInitialization: { testClient in
+        testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
+          initialRefresh.fulfill()
+          return VoidResponse()
+        }
+      }
+    )
+
+    // Drain the initial refresh.
+    try await fulfillmentOfOrThrow(initialRefresh)
+
+    // Install a persistent handler that fails if any unexpected refresh arrives.
+    project.testClient.handleMultipleRequests { (_: WorkspaceTestsRefreshRequest) in
+      XCTFail("Unexpected workspace/tests/refresh after non-test file change")
+      return VoidResponse()
+    }
+
+    // Modify the non-test helper file.
+    try await project.changeFileOnDisk(
+      "Helper.swift",
+      newMarkedContents: """
+        // A comment was added
+        func helperFunction() {}
+        """
+    )
+
+    // Flush all pending processing.
+    try await project.testClient.send(SynchronizeRequest())
+  }
+
 }
 
 extension TestItem {


### PR DESCRIPTION
(Based on #2500)

When the client opts in to `workspace/tests/refresh` or `workspace/playgrounds/refresh` via experimental client capabilities, SourceKit-LSP now maintains a proactive cache of the current test and
playground lists and sends the corresponding `workspace/.../refresh` notification whenever the cache changes. `workspaceTests()`/`workspacePlaygrounds()` then serve subsequent fetch requests directly from the cache.

Add `EntryPointManager`: runs background scans, stores the results, fires callbacks on changes:
 - Start scanning when build targets are updated including initial updates, any watched files are changed, and index is updated.
 - Send `*/refresh` server initiated requests when the cache has changed.
 - Coalesces rapid invalidations by cancelling any in-flight refresh task.

NOTE: `/refresh` is not sent when the user edits the open documents. But the scanning for the cache takes in-memory documents into account. This is just a design decision. The cache should capture as newest status as possible, but `/refresh` shouldn't be sent for every key stroke.

Also:
- Simplify `SourceKitIndexDelegate` from an `actor` with `AtomicInt32` to a plain `class`, since it is only called from IndexStoreDB's internal serial dispatch queue.