### PR TITLE
new feature to move methods and fields between types

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/MoveMember.swift
+++ b/Sources/SwiftLanguageService/CodeActions/MoveMember.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SourceKitLSP
+import SwiftSyntax
+
+extension CodeActionKind {
+  static let refactorMove = CodeActionKind(rawValue: "refactor.move")
+}
+
+struct MoveMember: SyntaxCodeActionProvider {
+
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+
+    guard
+      let member =
+        scope.innermostNodeContainingRange?
+        .findParentOfSelf(
+          ofType: MemberBlockItemSyntax.self,
+          stoppingIf: { $0.is(SourceFileSyntax.self) }
+        )
+    else {
+      return []
+    }
+
+    return [
+      CodeAction(
+        title: "Move to another type",
+        kind: .refactorMove,
+        command: Command(
+          title: "Move to another type",
+          command: "swift.moveMember",
+          arguments: [
+            .string(scope.snapshot.uri.stringValue),
+            .int(member.position.utf8Offset),
+            .int(member.endPosition.utf8Offset),
+          ]
+        )
+      )
+    ]
+  }
+}

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
@@ -29,6 +29,7 @@ let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
     MigrateToNewIfLetSyntax.self,
     OpaqueParameterToGeneric.self,
     RemoveSeparatorsFromIntegerLiteral.self,
+    MoveMember.self,
   ]
   #if !NO_SWIFTPM_DEPENDENCY
   result.append(PackageManifestEdits.self)


### PR DESCRIPTION
## Add Move Member Refactoring Code Action (`refactor.move`)

This PR introduces a new **Move Member** Code Action to Swift LSP that allows users to move a member declaration (e.g. property, method, enum case) from one type to another.

The action is surfaced under the **Refactor…** menu when the cursor is placed inside a member of a nominal type (`struct`, `class`, or `enum`). It is not offered for top-level declarations.

The implementation adds a new provider in:

Sources/SwiftLanguageService/CodeActions/MoveMember.swift

which detects `MemberBlockItemSyntax` at the cursor position and returns a command-based Code Action (`swift.moveMember`) of kind `"refactor.move"`.

### Tests Added

Added test coverage in:

Tests/SourceKitLSPTests/CodeActionTests.swift

- `testMoveMemberCodeAction`
- `testMoveMemberCodeActionNotOfferedForTopLevelCode`

feature: https://github.com/swiftlang/sourcekit-lsp/issues/2384