### PR TITLE
[6.3] Fix issue that caused the target preparation status to not be cleared when workspace root did not have trailing slash

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -844,7 +844,9 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     else {
       return false
     }
-    return url.deletingLastPathComponent() == self.projectRoot
+    // Compare the URLs as `DocumentURI`, which is a little more lenient to declare equality, eg. it considers paths
+    // equivalent even `url.deletingLastPathComponent()` has a trailing slash while `self.projectRoot` does not.
+    return DocumentURI(url.deletingLastPathComponent()) == DocumentURI(self.projectRoot)
   }
 
   /// An event is relevant if it modifies a file that matches one of the file rules used by the SwiftPM workspace.


### PR DESCRIPTION
- **Explanation**: If a workspace was opened as `/path/to/workspace` instead of `/path/to/workspace/` (notice the trailing slash), the check for `url.deletingLastPathComponent() == self.projectRoot` failed because deleting the last path component always produces a URL with a trailing slash and URL considers two path different if they mismatch in their trailing slash usage.
Use `DocumentURI` for equality checking, which is a little more lenient with declaring equality, including with regard to trailing slashes, and whose equality definition aligns better with what we want in SourceKit-LSP.
- **Scope**: Files did change events for Package manifest files
- **Issue**: rdar://171744166
- **Original PR**: https://github.com/swiftlang/sourcekit-lsp/pull/2363
- **Risk**: Low, makes the URL equality comparison for package manifest changes a little more relaxed
- **Testing**: Added test case
- **Reviewer**: @rintaro 

