### PR TITLE
Add 'Flip operands of binary expression' code action

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/FlipBinaryOperands.swift
+++ b/Sources/SwiftLanguageService/CodeActions/FlipBinaryOperands.swift
@@ -1,0 +1,145 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SourceKitLSP
+import SwiftOperators
+import SwiftSyntax
+
+/// A code action that flips the operands of a binary expression, adjusting
+/// the operator if needed (e.g. `<` becomes `>`).
+///
+/// Examples:
+/// - `5 < count` → `count > 5`
+/// - `1 + value` → `value + 1`
+/// - `a == b` → `b == a`
+struct FlipBinaryOperands: SyntaxCodeActionProvider {
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard let node = scope.innermostNodeContainingRange else {
+      return []
+    }
+
+    // Find the nearest SequenceExprSyntax — this is the unfolded binary expression
+    // in the raw syntax tree. After operator folding, it becomes InfixOperatorExprSyntax.
+    guard let seqExpr = node.findParentOfSelf(
+      ofType: SequenceExprSyntax.self,
+      stoppingIf: { $0.is(CodeBlockItemSyntax.self) || $0.is(MemberBlockItemSyntax.self) }
+    ) else {
+      return []
+    }
+
+    // Fold the sequence expression to get structured InfixOperatorExprSyntax.
+    guard let folded = OperatorTable.standardOperators.foldAll(
+      ExprSyntax(seqExpr),
+      errorHandler: { _ in }
+    ).as(ExprSyntax.self) else {
+      return []
+    }
+
+    // Find the innermost InfixOperatorExprSyntax with a flippable operator.
+    guard let infixExpr = findInnermostFlippableInfix(in: folded) else {
+      return []
+    }
+
+    guard let binOp = infixExpr.operator.as(BinaryOperatorExprSyntax.self) else {
+      return []
+    }
+
+    let opText = binOp.operator.text
+    let flippedOp = operatorFlipMap[opText] ?? opText
+
+    // Swap operands, preserving trivia positions.
+    let newLeft = infixExpr.rightOperand
+      .with(\.leadingTrivia, infixExpr.leftOperand.leadingTrivia)
+      .with(\.trailingTrivia, infixExpr.leftOperand.trailingTrivia)
+    let newRight = infixExpr.leftOperand
+      .with(\.leadingTrivia, infixExpr.rightOperand.leadingTrivia)
+      .with(\.trailingTrivia, infixExpr.rightOperand.trailingTrivia)
+
+    let newBinOp = binOp.with(\.operator.tokenKind, .binaryOperator(flippedOp))
+
+    let newExpr = infixExpr
+      .with(\.leftOperand, newLeft)
+      .with(\.operator, ExprSyntax(newBinOp))
+      .with(\.rightOperand, newRight)
+
+    let originalText = infixExpr.trimmedDescription
+    let newText = newExpr.trimmedDescription
+
+    // Don't offer the action if nothing would change.
+    if originalText == newText {
+      return []
+    }
+
+    return [
+      CodeAction(
+        title: "Flip operands of '\(originalText)' to '\(newText)'",
+        kind: .refactorInline,
+        edit: WorkspaceEdit(
+          changes: [
+            scope.snapshot.uri: [
+              TextEdit(
+                range: Range(
+                  uncheckedBounds: (
+                    lower: scope.snapshot.position(of: seqExpr.positionAfterSkippingLeadingTrivia),
+                    upper: scope.snapshot.position(of: seqExpr.endPositionBeforeTrailingTrivia)
+                  )
+                ),
+                newText: newExpr.trimmedDescription
+              )
+            ]
+          ]
+        )
+      )
+    ]
+  }
+
+  /// Find the innermost InfixOperatorExprSyntax with a flippable operator.
+  private static func findInnermostFlippableInfix(in expr: ExprSyntax) -> InfixOperatorExprSyntax? {
+    if let infix = expr.as(InfixOperatorExprSyntax.self),
+       let binOp = infix.operator.as(BinaryOperatorExprSyntax.self),
+       flippableOperators.contains(binOp.operator.text) {
+      // Try to find a deeper infix in left or right operand first.
+      if let deeper = findInnermostFlippableInfix(in: infix.leftOperand)
+          ?? findInnermostFlippableInfix(in: infix.rightOperand) {
+        return deeper
+      }
+      return infix
+    }
+
+    for child in expr.children(viewMode: .sourceAccurate) {
+      if let childExpr = child.as(ExprSyntax.self),
+         let found = findInnermostFlippableInfix(in: childExpr) {
+        return found
+      }
+    }
+    return nil
+  }
+
+  /// Operators where flipping operands is meaningful.
+  private static let flippableOperators: Set<String> = [
+    "<", ">", "<=", ">=",
+    "==", "!=", "===", "!==",
+    "+", "*",
+    "&", "|", "^",
+    "&&", "||",
+  ]
+
+  /// Maps non-commutative operators to their flipped counterparts.
+  /// Commutative operators are absent — they remain unchanged.
+  private static let operatorFlipMap: [String: String] = [
+    "<": ">",
+    ">": "<",
+    "<=": ">=",
+    ">=": "<=",
+  ]
+}

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
@@ -21,6 +21,7 @@ let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
     ApplyDeMorganLaw.self,
     ConvertComputedPropertyToZeroParameterFunction.self,
     ConvertIfLetToGuard.self,
+    FlipBinaryOperands.self,
     ConvertIntegerLiteral.self,
     ConvertJSONToCodableStruct.self,
     ConvertStringConcatenationToStringInterpolation.self,

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -1564,6 +1564,114 @@ final class CodeActionTests: SourceKitLSPTestCase {
     }
   }
 
+  func testFlipBinaryOperandsComparison() async throws {
+    try await assertCodeActions(
+      """
+      let x = 1️⃣5 < count2️⃣
+      """,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Flip operands of '5 < count' to 'count > 5'",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["2️⃣"],
+                  newText: "count > 5"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testFlipBinaryOperandsCommutative() async throws {
+    try await assertCodeActions(
+      """
+      let sum = 1️⃣1 + value2️⃣
+      """,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Flip operands of '1 + value' to 'value + 1'",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["2️⃣"],
+                  newText: "value + 1"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testFlipBinaryOperandsEquality() async throws {
+    try await assertCodeActions(
+      """
+      let x = 1️⃣a == b2️⃣
+      """,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Flip operands of 'a == b' to 'b == a'",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["2️⃣"],
+                  newText: "b == a"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testFlipBinaryOperandsGreaterOrEqual() async throws {
+    try await assertCodeActions(
+      """
+      if 1️⃣count >= 102️⃣ { }
+      """,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Flip operands of 'count >= 10' to '10 <= count'",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["2️⃣"],
+                  newText: "10 <= count"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
   func testRemoveUnusedImports() async throws {
     let project = try await SwiftPMTestProject(
       files: [


### PR DESCRIPTION
### Description

Implements the code action described in #2520.

This adds a new **Flip operands of binary expression** refactoring code action that swaps the left and right operands of a binary expression, adjusting the operator when needed (e.g. `<` becomes `>`).

### Examples

- `5 < count` → `count > 5`
- `1 + value` → `value + 1`
- `a == b` → `b == a`

### Implementation

- New `FlipBinaryOperands` provider conforming to `SyntaxCodeActionProvider`
- Uses `OperatorTable.standardOperators` to fold `SequenceExprSyntax` into `InfixOperatorExprSyntax`
- Handles operator flipping for comparison operators (`<`↔`>`, `<=`↔`>=`)
- Commutative operators (`+`, `*`, `==`, `&&`, etc.) simply swap operands
- Preserves trivia positions
- Only offers the action when the result differs from the original

### Testing

Added tests for:
- Comparison operators (`5 < count` → `count > 5`)
- Commutative operators (`1 + value` → `value + 1`)
- Equality (`a == b` → `b == a`)

Fixes #2520