### PR TITLE
Add '@Sendable' annotation code action

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/AddSendableAnnotation.swift
+++ b/Sources/SwiftLanguageService/CodeActions/AddSendableAnnotation.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SourceKitLSP
+import SwiftSyntax
+
+/// A code action that adds `@Sendable` to function types for concurrency safety.
+///
+/// Examples:
+/// - `() -> Void` → `@Sendable () -> Void`
+/// - `@escaping () -> Void` → `@Sendable @escaping () -> Void`
+struct AddSendableAnnotation: SyntaxCodeActionProvider {
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard let node = scope.innermostNodeContainingRange else {
+      return []
+    }
+
+    // Try to find a FunctionTypeSyntax either as a parent or within an
+    // AttributedTypeSyntax that contains a function type.
+    let functionType: FunctionTypeSyntax
+    let attributedType: AttributedTypeSyntax?
+
+    if let ft = node.findParentOfSelf(
+      ofType: FunctionTypeSyntax.self,
+      stoppingIf: { $0.is(CodeBlockItemSyntax.self) || $0.is(MemberBlockItemSyntax.self) }
+    ) {
+      functionType = ft
+      attributedType = ft.parent?.as(AttributedTypeSyntax.self)
+    } else if let at = node.findParentOfSelf(
+      ofType: AttributedTypeSyntax.self,
+      stoppingIf: { $0.is(CodeBlockItemSyntax.self) || $0.is(MemberBlockItemSyntax.self) }
+    ), let ft = at.baseType.as(FunctionTypeSyntax.self) {
+      functionType = ft
+      attributedType = at
+    } else {
+      return []
+    }
+
+    // Check if @Sendable is already present.
+    if let at = attributedType {
+      for attribute in at.attributes {
+        if case .attribute(let attr) = attribute,
+           attr.attributeName.trimmedDescription == "Sendable" {
+          return []
+        }
+      }
+    }
+
+    let sendableAttribute = AttributeSyntax(
+      atSign: .atSignToken(),
+      attributeName: IdentifierTypeSyntax(name: .identifier("Sendable")),
+      trailingTrivia: .space
+    )
+
+    let newText: String
+    let editRange: Range<Position>
+
+    if let at = attributedType {
+      // Already has attributes (e.g., @escaping) — prepend @Sendable before them.
+      let newAttributes = AttributeListSyntax(
+        [.attribute(sendableAttribute)] + at.attributes.map { $0 }
+      )
+      let newAttributedType = at.with(\.attributes, newAttributes)
+      newText = newAttributedType.trimmedDescription
+      editRange = Range(
+        uncheckedBounds: (
+          lower: scope.snapshot.position(of: at.positionAfterSkippingLeadingTrivia),
+          upper: scope.snapshot.position(of: at.endPositionBeforeTrailingTrivia)
+        )
+      )
+    } else {
+      // No existing attributes — just prepend @Sendable.
+      newText = "@Sendable \(functionType.trimmedDescription)"
+      editRange = Range(
+        uncheckedBounds: (
+          lower: scope.snapshot.position(of: functionType.positionAfterSkippingLeadingTrivia),
+          upper: scope.snapshot.position(of: functionType.endPositionBeforeTrailingTrivia)
+        )
+      )
+    }
+
+    return [
+      CodeAction(
+        title: "Add @Sendable",
+        kind: .refactorInline,
+        edit: WorkspaceEdit(
+          changes: [
+            scope.snapshot.uri: [
+              TextEdit(
+                range: editRange,
+                newText: newText
+              )
+            ]
+          ]
+        )
+      )
+    ]
+  }
+}

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
@@ -17,6 +17,7 @@ import SwiftRefactor
 let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
   var result: [any SyntaxCodeActionProvider.Type] = [
     AddDocumentation.self,
+    AddSendableAnnotation.self,
     AddSeparatorsToIntegerLiteral.self,
     ApplyDeMorganLaw.self,
     ConvertComputedPropertyToZeroParameterFunction.self,

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -487,6 +487,60 @@ final class CodeActionTests: SourceKitLSPTestCase {
     try await fulfillmentOfOrThrow(editReceived)
   }
 
+  func testAddSendableAnnotationToFunctionType() async throws {
+    try await assertCodeActions(
+      """
+      func perform(callback: 1️⃣() -> Void2️⃣) {}
+      """,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add @Sendable",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["2️⃣"],
+                  newText: "@Sendable () -> Void"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddSendableAnnotationWithEscaping() async throws {
+    try await assertCodeActions(
+      """
+      func perform(callback: 1️⃣@escaping () -> Void2️⃣) {}
+      """,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add @Sendable",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["1️⃣"]..<positions["2️⃣"],
+                  newText: "@Sendable @escaping () -> Void"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
   func testAddDocumentationCodeActionResult() async throws {
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI(for: .swift)


### PR DESCRIPTION
### Description

Implements the code action described in #2525.

Adds a new **Add @Sendable** refactoring code action that adds `@Sendable` to function types for concurrency safety.

### Examples

**Bare function type:**
- `() -> Void` → `@Sendable () -> Void`

**With existing attributes:**
- `@escaping () -> Void` → `@Sendable @escaping () -> Void`

### Implementation

- New `AddSendableAnnotation` provider conforming to `SyntaxCodeActionProvider`
- Finds `FunctionTypeSyntax` nodes, either directly or within an `AttributedTypeSyntax`
- Checks if `@Sendable` is already present (skips if so)
- Prepends `@Sendable` before any existing attributes, or wraps bare function types

### Testing

Added tests for:
- Bare function type parameter (`() -> Void` → `@Sendable () -> Void`)
- Function type with `@escaping` (`@escaping () -> Void` → `@Sendable @escaping () -> Void`)

Fixes #2525