### PR TITLE
Add Generate enum associated value accessors code action

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/GenerateEnumAssociatedValueAccessors.swift
+++ b/Sources/SwiftLanguageService/CodeActions/GenerateEnumAssociatedValueAccessors.swift
@@ -1,0 +1,157 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SourceKitLSP
+import SwiftSyntax
+
+/// A code action that generates computed properties to extract associated
+/// values and check cases for an enum.
+///
+/// For each case with associated values, generates:
+/// - `asX: T?` — extracts the associated value, or `nil` if a different case
+/// - `isX: Bool` — returns `true` if the value matches that case
+///
+/// Example:
+/// ```swift
+/// enum Value {
+///     case text(String)
+///     case number(Int)
+/// }
+/// ```
+/// Generates `asText`, `isText`, `asNumber`, `isNumber` computed properties.
+struct GenerateEnumAssociatedValueAccessors: SyntaxCodeActionProvider {
+  static func codeActions(in scope: SyntaxCodeActionScope) -> [CodeAction] {
+    guard let node = scope.innermostNodeContainingRange else {
+      return []
+    }
+
+    guard let enumDecl = node.findParentOfSelf(
+      ofType: EnumDeclSyntax.self,
+      stoppingIf: { _ in false }
+    ) else {
+      return []
+    }
+
+    // Collect all cases with associated values.
+    let casesWithAssociatedValues = enumDecl.memberBlock.members.compactMap { member -> EnumCaseElementSyntax? in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self),
+            let element = caseDecl.elements.first,
+            caseDecl.elements.count == 1,
+            element.parameterClause != nil
+      else {
+        return nil
+      }
+      return element
+    }
+
+    if casesWithAssociatedValues.isEmpty {
+      return []
+    }
+
+    // Scan existing member names to avoid duplicates.
+    let existingMembers = Set(
+      enumDecl.memberBlock.members.compactMap { member -> String? in
+        guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let pattern = binding.pattern.as(IdentifierPatternSyntax.self)
+        else {
+          return nil
+        }
+        return pattern.identifier.text
+      }
+    )
+
+    var accessors: [String] = []
+
+    for element in casesWithAssociatedValues {
+      let caseName = element.name.text
+      let capitalizedName = caseName.prefix(1).uppercased() + caseName.dropFirst()
+      let asName = "as\(capitalizedName)"
+      let isName = "is\(capitalizedName)"
+
+      guard let paramClause = element.parameterClause else { continue }
+      let params = Array(paramClause.parameters)
+
+      if params.count == 1 {
+        let typeText = params[0].type.trimmedDescription
+
+        if !existingMembers.contains(asName) {
+          accessors.append(
+            """
+                var \(asName): \(typeText)? {
+                    if case let .\(caseName)(v) = self { return v }
+                    return nil
+                }
+            """
+          )
+        }
+      } else {
+        let tupleTypes = params.map { $0.type.trimmedDescription }
+        let returnType = "(\(tupleTypes.joined(separator: ", ")))"
+        let bindingVars = (0..<params.count).map { "v\($0)" }
+        let bindingPattern = bindingVars.joined(separator: ", ")
+
+        if !existingMembers.contains(asName) {
+          accessors.append(
+            """
+                var \(asName): \(returnType)? {
+                    if case let .\(caseName)(\(bindingPattern)) = self { return (\(bindingPattern)) }
+                    return nil
+                }
+            """
+          )
+        }
+      }
+
+      if !existingMembers.contains(isName) {
+        accessors.append(
+          """
+              var \(isName): Bool {
+                  if case .\(caseName) = self { return true }
+                  return false
+              }
+          """
+        )
+      }
+    }
+
+    if accessors.isEmpty {
+      return []
+    }
+
+    // Insert before the closing brace.
+    let closingBrace = enumDecl.memberBlock.rightBrace
+    let insertPosition = scope.snapshot.position(of: closingBrace.positionAfterSkippingLeadingTrivia)
+
+    let insertionText = "\n" + accessors.joined(separator: "\n\n") + "\n"
+
+    return [
+      CodeAction(
+        title: "Generate enum associated value accessors",
+        kind: .refactorInline,
+        edit: WorkspaceEdit(
+          changes: [
+            scope.snapshot.uri: [
+              TextEdit(
+                range: Range(
+                  uncheckedBounds: (lower: insertPosition, upper: insertPosition)
+                ),
+                newText: insertionText
+              )
+            ]
+          ]
+        )
+      )
+    ]
+  }
+}

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActions.swift
@@ -26,6 +26,7 @@ let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
     ConvertStringConcatenationToStringInterpolation.self,
     ConvertZeroParameterFunctionToComputedProperty.self,
     FormatRawStringLiteral.self,
+    GenerateEnumAssociatedValueAccessors.self,
     MigrateToNewIfLetSyntax.self,
     OpaqueParameterToGeneric.self,
     RemoveRedundantParentheses.self,

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -1925,3 +1925,52 @@ private func assertDeMorganTransform(
 
   XCTAssertEqual(result.description, expected, file: file, line: line)
 }
+
+// MARK: - Generate Enum Associated Value Accessors Tests
+
+extension CodeActionTests {
+  func testGenerateEnumAssociatedValueAccessors() async throws {
+    try await assertCodeActions(
+      ##"""
+      1️⃣enum Value {
+          case text(String)
+          case number(Int)
+      2️⃣}
+      """##,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Generate enum associated value accessors",
+          kind: .refactorInline,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(
+                  range: positions["2️⃣"]..<positions["2️⃣"],
+                  newText: "\n    var asText: String? {\n        if case let .text(v) = self { return v }\n        return nil\n    }\n\n    var isText: Bool {\n        if case .text = self { return true }\n        return false\n    }\n\n    var asNumber: Int? {\n        if case let .number(v) = self { return v }\n        return nil\n    }\n\n    var isNumber: Bool {\n        if case .number = self { return true }\n        return false\n    }\n"
+                )
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testGenerateEnumNoAssociatedValues() async throws {
+    try await assertCodeActions(
+      ##"""
+      1️⃣enum Direction {
+          case north
+          case south
+      2️⃣}
+      """##,
+      ranges: [("1️⃣", "2️⃣")],
+      exhaustive: false
+    ) { _, _ in
+      []
+    }
+  }
+}


### PR DESCRIPTION
### Description

Adds a syntax-based code action that generates computed properties for enums with associated values.

For each case with associated values, generates:
- `asX: T?` — extracts the associated value via pattern matching, or `nil` for other cases
- `isX: Bool` — returns `true` if the value matches the case

**Before:**
```swift
enum Value {
    case text(String)
    case number(Int)
}
```

**After:**
```swift
enum Value {
    case text(String)
    case number(Int)

    var asText: String? {
        if case let .text(v) = self { return v }
        return nil
    }

    var isText: Bool {
        if case .text = self { return true }
        return false
    }

    var asNumber: Int? {
        if case let .number(v) = self { return v }
        return nil
    }

    var isNumber: Bool {
        if case .number = self { return true }
        return false
    }
}
```

Handles single and multiple associated values (tuples). Skips generation for accessors that already exist. Inspired by [rust-analyzer's `generate_enum_as_method`](https://rust-analyzer.github.io/book/assists.html#generate_enum_as_method).

### Tests

- Test for enum with two cases having associated values
- Test that no action is offered for enums without associated values

Resolves #2522