### PR TITLE
Add codeAction/resolve support

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -608,6 +608,10 @@ extension ClangLanguageService {
     return try await forwardRequestToClangd(req)
   }
 
+  package func codeActionResolve(_ req: CodeActionResolveRequest) async throws -> CodeAction {
+    return try await forwardRequestToClangd(req)
+  }
+
   package func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint] {
     return try await forwardRequestToClangd(req)
   }

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -256,6 +256,7 @@ package protocol LanguageService: AnyObject, Sendable {
   ) async throws -> DocumentSemanticTokensResponse?
   func colorPresentation(_ req: ColorPresentationRequest) async throws -> [ColorPresentation]
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse?
+  func codeActionResolve(_ req: CodeActionResolveRequest) async throws -> CodeAction
   func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint]
   func inlayHintResolve(_ req: InlayHintResolveRequest) async throws -> InlayHint
   func codeLens(_ req: CodeLensRequest) async throws -> [CodeLens]
@@ -481,6 +482,10 @@ package extension LanguageService {
 
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse? {
     throw ResponseError.requestNotImplemented(CodeActionRequest.self)
+  }
+
+  func codeActionResolve(_ req: CodeActionResolveRequest) async throws -> CodeAction {
+    return req.codeAction
   }
 
   func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint] {

--- a/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
@@ -43,19 +43,62 @@ package struct SourceKitLSPCommandMetadata: Codable, Hashable {
   }
 }
 
+/// Metadata injected into CodeAction.data to support routing codeAction/resolve requests.
+package struct CodeActionResolveMetadata: Codable, Hashable {
+  package var textDocument: TextDocumentIdentifier
+  package var underlyingData: LSPAny?
+
+  package init(textDocument: TextDocumentIdentifier, underlyingData: LSPAny? = nil) {
+    self.textDocument = textDocument
+    self.underlyingData = underlyingData
+  }
+}
+
+extension CodeActionResolveMetadata {
+  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
+    guard
+      case .dictionary(let textDocumentDict)? = dictionary[CodingKeys.textDocument.stringValue],
+      let textDocument = TextDocumentIdentifier(fromLSPDictionary: textDocumentDict)
+    else {
+      return nil
+    }
+    self.init(
+      textDocument: textDocument,
+      underlyingData: dictionary[CodingKeys.underlyingData.stringValue]
+    )
+  }
+
+  package func encodeToLSPAny() -> LSPAny {
+    var dict: [String: LSPAny] = [
+      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny()
+    ]
+    if let underlyingData {
+      dict[CodingKeys.underlyingData.stringValue] = underlyingData
+    }
+    return .dictionary(dict)
+  }
+}
+
 extension CodeActionRequest {
   package func injectMetadata(toResponse response: CodeActionRequestResponse?) -> CodeActionRequestResponse? {
-    let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
-    let metadataArgument = metadata.encodeToLSPAny()
+    let commandMetadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
+    let commandMetadataArgument = commandMetadata.encodeToLSPAny()
     switch response {
     case .codeActions(var codeActions)?:
       for i in 0..<codeActions.count {
-        codeActions[i].command?.arguments?.append(metadataArgument)
+        codeActions[i].command?.arguments?.append(commandMetadataArgument)
+
+        if codeActions[i].edit == nil && codeActions[i].command == nil {
+          codeActions[i].data = CodeActionResolveMetadata(
+            textDocument: textDocument,
+            underlyingData: codeActions[i].data
+          ).encodeToLSPAny()
+        }
       }
       return .codeActions(codeActions)
     case .commands(var commands)?:
       for i in 0..<commands.count {
-        commands[i].arguments?.append(metadataArgument)
+        commands[i].arguments?.append(commandMetadataArgument)
       }
       return .commands(commands)
     case nil:

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -776,6 +776,8 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
       await self.handleRequest(for: request, requestHandler: self.prepareCallHierarchy)
     case let request as RequestAndReply<CodeActionRequest>:
       await self.handleRequest(for: request, requestHandler: self.codeAction)
+    case let request as RequestAndReply<CodeActionResolveRequest>:
+      await request.reply { try await codeActionResolve(request.params) }
     case let request as RequestAndReply<CodeLensRequest>:
       await self.handleRequest(for: request, requestHandler: self.codeLens)
     case let request as RequestAndReply<ColorPresentationRequest>:
@@ -1157,7 +1159,7 @@ extension SourceKitLSPServer {
       codeActionProvider: .value(
         CodeActionServerCapabilities(
           clientCapabilities: client.textDocument?.codeAction,
-          codeActionOptions: CodeActionOptions(codeActionKinds: nil),
+          codeActionOptions: CodeActionOptions(codeActionKinds: nil, resolveProvider: true),
           supportsCodeActions: true
         )
       ),
@@ -1935,6 +1937,27 @@ extension SourceKitLSPServer {
   ) async throws -> CodeActionRequestResponse? {
     let response = try await languageService.codeAction(req)
     return req.injectMetadata(toResponse: response)
+  }
+
+  func codeActionResolve(_ req: CodeActionResolveRequest) async throws -> CodeAction {
+    guard case .dictionary(let dict) = req.codeAction.data,
+      let resolveMetadata = CodeActionResolveMetadata(fromLSPDictionary: dict)
+    else {
+      return req.codeAction
+    }
+
+    let uri = resolveMetadata.textDocument.uri
+
+    guard let workspace = await self.workspaceForDocument(uri: uri) else {
+      return req.codeAction
+    }
+
+    var forwardedReq = req
+    forwardedReq.codeAction.data = resolveMetadata.underlyingData
+
+    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
+    return try await primaryLanguageService(for: uri, language, in: workspace)
+      .codeActionResolve(forwardedReq)
   }
 
   func codeLens(

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -949,6 +949,10 @@ extension SwiftLanguageService {
     }.flatMap { $0 }
   }
 
+  package func codeActionResolve(_ req: CodeActionResolveRequest) async throws -> CodeAction {
+    return req.codeAction
+  }
+
   func retrieveRefactorCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {
     let additionalCursorInfoParameters: ((SKDRequestDictionary) -> Void) = { skreq in
       skreq.set(self.keys.retrieveRefactorActions, to: 1)

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -141,12 +141,20 @@ final class CodeActionTests: SourceKitLSPTestCase {
   func testCodeActionResponseCommandMetadataInjection() throws {
     let url = URL(fileURLWithPath: "/a.swift")
     let textDocument = TextDocumentIdentifier(url)
-    let expectedMetadata: LSPAny = try {
+    let expectedCommandMetadata: LSPAny = try {
       let metadata = SourceKitLSPCommandMetadata(textDocument: textDocument)
       let data = try JSONEncoder().encode(metadata)
       return try JSONDecoder().decode(LSPAny.self, from: data)
     }()
-    XCTAssertEqual(expectedMetadata, .dictionary(["sourcekitlsp_textDocument": ["uri": "file:///a.swift"]]))
+    XCTAssertEqual(expectedCommandMetadata, .dictionary(["sourcekitlsp_textDocument": ["uri": "file:///a.swift"]]))
+
+    let expectedResolveMetadata: LSPAny = try {
+      let metadata = CodeActionResolveMetadata(textDocument: textDocument)
+      let data = try JSONEncoder().encode(metadata)
+      return try JSONDecoder().decode(LSPAny.self, from: data)
+    }()
+    XCTAssertEqual(expectedResolveMetadata, .dictionary(["textDocument": ["uri": "file:///a.swift"]]))
+
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
     let codeAction = CodeAction(title: "1")
     let codeAction2 = CodeAction(title: "2", command: command)
@@ -162,27 +170,55 @@ final class CodeActionTests: SourceKitLSPTestCase {
         Command(
           title: command.title,
           command: command.command,
-          arguments: command.arguments! + [expectedMetadata]
+          arguments: command.arguments! + [expectedCommandMetadata]
         )
       ])
     )
     response = request.injectMetadata(toResponse: .codeActions([codeAction, codeAction2]))
+    var expectedCodeAction = codeAction
+    expectedCodeAction.data = expectedResolveMetadata
     XCTAssertEqual(
       response,
       .codeActions([
-        codeAction,
+        expectedCodeAction,
         CodeAction(
           title: codeAction2.title,
           command: Command(
             title: command.title,
             command: command.command,
-            arguments: command.arguments! + [expectedMetadata]
+            arguments: command.arguments! + [expectedCommandMetadata]
           )
         ),
       ])
     )
     response = request.injectMetadata(toResponse: nil)
     XCTAssertNil(response)
+  }
+
+  func testCodeActionResolveMetadataPreservesUnderlyingData() throws {
+    let url = URL(fileURLWithPath: "/a.swift")
+    let textDocument = TextDocumentIdentifier(url)
+
+    let originalData: LSPAny = .dictionary(["custom": "value"])
+    var codeAction = CodeAction(title: "With data")
+    codeAction.data = originalData
+
+    let request = CodeActionRequest(
+      range: Position(line: 0, utf16index: 0)..<Position(line: 1, utf16index: 1),
+      context: .init(diagnostics: [], only: nil),
+      textDocument: textDocument
+    )
+    let response = request.injectMetadata(toResponse: .codeActions([codeAction]))
+
+    guard case .codeActions(let actions) = response, let injected = actions.first,
+      case .dictionary(let dict) = injected.data,
+      let metadata = CodeActionResolveMetadata(fromLSPDictionary: dict)
+    else {
+      return XCTFail("Expected resolve metadata in data")
+    }
+
+    XCTAssertEqual(metadata.textDocument, textDocument)
+    XCTAssertEqual(metadata.underlyingData, originalData)
   }
 
   func testCommandEncoding() throws {


### PR DESCRIPTION
Mentioned in #1539, `codeAction/resolve` support is missing in sourcekit-lsp. This aims to add that support.