### PR TITLE
[Contributor Docs] Document guidelines for code actions

### DIFF
--- a/Contributor Documentation/Code Action.md
+++ b/Contributor Documentation/Code Action.md
@@ -1,0 +1,22 @@
+# Code Actions
+
+SourceKit-LSP is selective about accepting new code actions.
+
+Code actions appear directly in editor UI, so adding too many can create noise. In general, a proposed code action should ideally satisfy all of the following:
+
+- **Hard to get right** - the change is non-trivial and easy to implement incorrectly by hand.
+- **Common** - the situation occurs frequently enough to justify dedicated tooling.
+- **Tedious** - performing the change manually would require repetitive or mechanical edits.
+- **Not already covered by other tools** - the functionality should not duplicate what is more appropriately provided by other tools such as linters or formatters.
+
+Code actions that do not meet these criteria are unlikely to be accepted.
+
+## Proposing a new code action
+
+Before implementing a new code action, contributors should first file a GitHub issue describing the proposal and wait for guidance from the code owners.
+
+## Implementation location
+
+Code actions should generally be implemented in [**sourcekit-lsp**](https://github.com/swiftlang/sourcekit-lsp/tree/main/Sources/SwiftLanguageService/CodeActions), since they are primarily a language-server feature.
+
+They should only be implemented in [**swift-syntax**](https://github.com/swiftlang/swift-syntax/tree/main/Sources/SwiftRefactor) when there is a clear reason to do so, such as when the functionality needs to be reused outside of the language server.

--- a/Contributor Documentation/README.md
+++ b/Contributor Documentation/README.md
@@ -4,6 +4,7 @@ The following documentation documents are primarily intended for developers of S
 
 - [Background Indexing](Background%20Indexing.md)
 - [BSP Extension](BSP%20Extensions.md)
+- [Code Action](Code%20Action.md)
 - [Debugging Memory Leaks](Debugging%20Memory%20Leaks.md)
 - [Environment Variables](Environment%20Variables.md)
 - [Files To Reindex](Files%20To%20Reindex.md)


### PR DESCRIPTION
First of all, thank you to everyone who has contributed Code Action ideas and PRs to SourceKit-LSP. We really appreciate the interest in improving the developer experience.

Recently, the code owners discussed how we want to approach Code Action contributions and wrote down some guidelines.

Because code actions appear directly in editor UI, adding too many of them can quickly create noise. In general, new code actions should generally be **hard to get right**, **common**, and **tedious to perform manually**, and should not duplicate functionality that is better provided by other tools such as linters or formatters.

As tools that can generate code automatically become more common, we want to make sure we stay thoughtful about which code actions we add and keep the editor experience focused and useful.

This PR documents these guidelines in the contributor documentation.