### PR TITLE
Explicitly pass --build-system native when preparing using the builtin SwiftPMBuildServer

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -743,6 +743,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     logger.debug("Preparing '\(target.forLogging)' using \(self.toolchain.identifier)")
     var arguments = [
       try swift.filePath, "build",
+      "--build-system", "native",
       "--package-path", try projectRoot.filePath,
       "--scratch-path", self.swiftPMWorkspace.location.scratchDirectory.pathString,
       "--disable-index-store",


### PR DESCRIPTION
In practice, the builtin preparation functionality in source kit-lsp only supports "--build-system native" as "--build-system swiftbuild" clients are expected to use the out of process BSP instead. Specify this explicitly to avoid issues as we stage in the new default build system backend