### PR TITLE
Use a branch of `swift-tools-protocols` instead of a tag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -784,7 +784,7 @@ var dependencies: [Package.Dependency] {
       .package(url: "https://github.com/swiftlang/swift-docc.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/swiftlang/swift-docc-symbolkit.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/swiftlang/swift-markdown.git", branch: relatedDependenciesBranch),
-      .package(url: "https://github.com/swiftlang/swift-tools-protocols.git", exact: "0.0.10"),
+      .package(url: "https://github.com/swiftlang/swift-tools-protocols.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.1"),
       .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: relatedDependenciesBranch),


### PR DESCRIPTION
Align with other dependencies.

related:
https://github.com/swiftlang/swift-build/pull/1204
https://github.com/swiftlang/swift-package-manager/pull/9817
https://github.com/swiftlang/swift/pull/87886