### PR TITLE
Add code action to convert .forEach to for-in

### DIFF
--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(SwiftLanguageService STATIC
   ClosureCompletionFormat.swift
   CodeActions/AddDocumentation.swift
   CodeActions/ApplyDeMorganLaw.swift
+  CodeActions/ConvertForEachToForIn.swift
   CodeActions/ConvertIfLetToGuard.swift
   CodeActions/ConvertIntegerLiteral.swift
   CodeActions/ConvertJSONToCodableStruct.swift
@@ -92,4 +93,3 @@ target_link_libraries(SwiftLanguageService PRIVATE
   SwiftSyntax::SwiftSyntaxBuilder
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>
 )
-

--- a/Sources/SwiftLanguageService/CodeActions/ConvertForEachToForIn.swift
+++ b/Sources/SwiftLanguageService/CodeActions/ConvertForEachToForIn.swift
@@ -1,0 +1,246 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SourceKitLSP
+import SwiftSyntax
+
+@_spi(Testing) public struct ConvertForEachToForIn {
+  struct Candidate {
+    let calleePosition: Position
+    let codeAction: CodeAction
+  }
+
+  static func candidate(in scope: SyntaxCodeActionScope) -> Candidate? {
+    guard let match = findForEachCall(in: scope) else {
+      return nil
+    }
+
+    let callExpr = match.callExpr
+    let collection = match.collection
+    let closure = match.closure
+
+    // Only offer the refactoring when the call is a standalone statement.
+    // `for-in` is a statement, so it can't replace an expression in a larger context
+    // like `let _ = array.forEach { ... }`.
+    var current = Syntax(callExpr)
+    if let parent = current.parent, parent.is(ExpressionStmtSyntax.self) {
+      current = parent
+    }
+    guard current.parent?.is(CodeBlockItemSyntax.self) ?? false else {
+      return nil
+    }
+
+    guard let itemName = extractParameterName(from: closure) else {
+      return nil
+    }
+
+    let leadingTrivia = current.firstToken(viewMode: .sourceAccurate)?.leadingTrivia ?? []
+
+    let body = ReturnToContinueRewriter().rewrite(closure.statements).cast(CodeBlockItemListSyntax.self)
+
+    let forLoop = ForStmtSyntax(
+      forKeyword: .keyword(.for, leadingTrivia: leadingTrivia, trailingTrivia: .space),
+      pattern: IdentifierPatternSyntax(identifier: .identifier(itemName)),
+      inKeyword: .keyword(.in, leadingTrivia: .space, trailingTrivia: .space),
+      sequence: collection.trimmed,
+      body: CodeBlockSyntax(
+        leftBrace: .leftBraceToken(leadingTrivia: .space),
+        statements: body,
+        rightBrace: closure.rightBrace
+      )
+    )
+
+    let edit = TextEdit(
+      range: scope.snapshot.absolutePositionRange(of: current.position..<current.endPosition),
+      newText: forLoop.description
+    )
+
+    let calleeToken = match.memberAccess.declName.baseName
+    let calleePosition = scope.snapshot.position(
+      of: calleeToken.positionAfterSkippingLeadingTrivia
+    )
+
+    return Candidate(
+      calleePosition: calleePosition,
+      codeAction: CodeAction(
+        title: "Convert to 'for-in' loop",
+        kind: .refactorInline,
+        edit: WorkspaceEdit(changes: [scope.snapshot.uri: [edit]])
+      )
+    )
+  }
+
+  private struct Match {
+    let callExpr: FunctionCallExprSyntax
+    let memberAccess: MemberAccessExprSyntax
+    let collection: ExprSyntax
+    let closure: ClosureExprSyntax
+  }
+
+  private static func findForEachCall(in scope: SyntaxCodeActionScope) -> Match? {
+    guard let innermostNode = scope.innermostNodeContainingRange else {
+      return nil
+    }
+
+    if let callExpr = innermostNode.findParentOfSelf(
+      ofType: FunctionCallExprSyntax.self,
+      stoppingIf: isFunctionBoundary,
+      matching: {
+        guard let memberAccess = $0.calledExpression.as(MemberAccessExprSyntax.self) else {
+          return false
+        }
+        return memberAccess.declName.baseName.text == "forEach"
+      }
+    ),
+      let match = matchForEach(callExpr)
+    {
+      return match
+    }
+
+    guard let boundary = nearestFunctionBoundary(from: innermostNode),
+      let closure = boundary.as(ClosureExprSyntax.self),
+      let callExpr = enclosingCall(of: closure),
+      let match = matchForEach(callExpr),
+      Syntax(match.closure).id == Syntax(closure).id
+    else {
+      return nil
+    }
+
+    return match
+  }
+
+  private static func nearestFunctionBoundary(from node: Syntax) -> Syntax? {
+    var current: Syntax? = node
+    while let unwrappedCurrent = current {
+      if isFunctionBoundary(unwrappedCurrent) {
+        return unwrappedCurrent
+      }
+      current = unwrappedCurrent.parent
+    }
+    return nil
+  }
+
+  private static func enclosingCall(of closure: ClosureExprSyntax) -> FunctionCallExprSyntax? {
+    var current = Syntax(closure).parent
+    while let unwrappedCurrent = current {
+      if let callExpr = unwrappedCurrent.as(FunctionCallExprSyntax.self) {
+        return callExpr
+      }
+      if isFunctionBoundary(unwrappedCurrent) || unwrappedCurrent.is(CodeBlockSyntax.self)
+        || unwrappedCurrent.is(MemberBlockSyntax.self)
+      {
+        return nil
+      }
+      current = unwrappedCurrent.parent
+    }
+    return nil
+  }
+
+  private static func matchForEach(_ callExpr: FunctionCallExprSyntax) -> Match? {
+    guard let memberAccess = callExpr.calledExpression.as(MemberAccessExprSyntax.self),
+      memberAccess.declName.baseName.text == "forEach",
+      let collection = memberAccess.base
+    else {
+      return nil
+    }
+
+    let closure: ClosureExprSyntax
+    if let trailingClosure = callExpr.trailingClosure {
+      guard callExpr.arguments.isEmpty,
+        callExpr.additionalTrailingClosures.isEmpty
+      else {
+        return nil
+      }
+      closure = trailingClosure
+    } else if callExpr.arguments.count == 1,
+      let closureArg = callExpr.arguments.first?.expression.as(ClosureExprSyntax.self)
+    {
+      closure = closureArg
+    } else {
+      return nil
+    }
+
+    guard hasSingleExplicitParameter(closure) else {
+      return nil
+    }
+
+    return Match(
+      callExpr: callExpr,
+      memberAccess: memberAccess,
+      collection: collection,
+      closure: closure
+    )
+  }
+
+  private static func hasSingleExplicitParameter(_ closure: ClosureExprSyntax) -> Bool {
+    guard let signature = closure.signature,
+      let parameterClause = signature.parameterClause
+    else {
+      return false
+    }
+
+    switch parameterClause {
+    case .simpleInput(let params):
+      return params.count == 1
+    case .parameterClause(let clause):
+      return clause.parameters.count == 1
+    }
+  }
+
+  /// Returns the named parameter from the closure signature.
+  private static func extractParameterName(from closure: ClosureExprSyntax) -> String? {
+    guard let signature = closure.signature,
+      let paramClause = signature.parameterClause
+    else {
+      return nil
+    }
+
+    switch paramClause {
+    case .simpleInput(let params):
+      guard let param = params.first else { return nil }
+      return param.name.text
+    case .parameterClause(let clause):
+      guard let param = clause.parameters.first else { return nil }
+      return (param.secondName ?? param.firstName).text
+    }
+  }
+}
+
+/// Rewrites bare `return` statements to `continue`, without descending into nested
+/// closures or other function-like declarations.
+private class ReturnToContinueRewriter: SyntaxRewriter {
+  override func visit(_ node: ReturnStmtSyntax) -> StmtSyntax {
+    guard node.expression == nil else {
+      return StmtSyntax(node)
+    }
+    return StmtSyntax(
+      ContinueStmtSyntax(
+        continueKeyword: .keyword(
+          .continue,
+          leadingTrivia: node.returnKeyword.leadingTrivia,
+          trailingTrivia: node.returnKeyword.trailingTrivia
+        )
+      )
+    )
+  }
+
+  override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax { DeclSyntax(node) }
+  override func visit(_ node: AccessorDeclSyntax) -> DeclSyntax { DeclSyntax(node) }
+  override func visit(_ node: SubscriptDeclSyntax) -> DeclSyntax { DeclSyntax(node) }
+  override func visit(_ node: ClosureExprSyntax) -> ExprSyntax { ExprSyntax(node) }
+  override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax { DeclSyntax(node) }
+}
+
+private func isFunctionBoundary(_ syntax: Syntax) -> Bool {
+  [.functionDecl, .initializerDecl, .accessorDecl, .subscriptDecl, .closureExpr].contains(syntax.kind)
+}

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -929,6 +929,7 @@ extension SwiftLanguageService {
     }
     let providersAndKinds: [(provider: CodeActionProvider, kind: CodeActionKind?)] = [
       (retrieveSyntaxCodeActions, nil),
+      (retrieveConvertForEachToForInCodeActions, .refactorInline),
       (retrieveRefactorCodeActions, .refactor),
       (retrieveQuickFixCodeActions, .quickFix),
       (retrieveRemoveUnusedImportsCodeAction, .sourceOrganizeImports),
@@ -985,6 +986,31 @@ extension SwiftLanguageService {
     return req.codeAction
   }
 
+  func retrieveConvertForEachToForInCodeActions(_ request: CodeActionRequest) async throws -> [CodeAction] {
+    let uri = request.textDocument.uri
+    let snapshot = try documentManager.latestSnapshot(uri)
+
+    let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    guard let scope = SyntaxCodeActionScope(snapshot: snapshot, syntaxTree: syntaxTree, request: request),
+      let candidate = ConvertForEachToForIn.candidate(in: scope)
+    else {
+      return []
+    }
+
+    let compileCommand = await compileCommand(for: uri, fallbackAfterTimeout: true)
+    let cursorInfoResponse = try await cursorInfo(
+      snapshot,
+      compileCommand: compileCommand,
+      candidate.calleePosition..<candidate.calleePosition
+    )
+
+    guard cursorInfoResponse.cursorInfo.contains(where: { self.isStandardLibraryForEach($0.symbolInfo) }) else {
+      return []
+    }
+
+    return [candidate.codeAction]
+  }
+
   func retrieveRefactorCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {
     let additionalCursorInfoParameters: ((SKDRequestDictionary) -> Void) = { skreq in
       skreq.set(self.keys.retrieveRefactorActions, to: 1)
@@ -1016,6 +1042,16 @@ extension SwiftLanguageService {
     }
 
     return refactorActions
+  }
+
+  private func isStandardLibraryForEach(_ symbol: SymbolDetails) -> Bool {
+    guard symbol.isSystem == true,
+      let usr = symbol.usr
+    else {
+      return false
+    }
+
+    return usr.contains("s:STsE7forEach")
   }
 
   func retrieveQuickFixCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {

--- a/Tests/SourceKitLSPTests/ForEachToForInTests.swift
+++ b/Tests/SourceKitLSPTests/ForEachToForInTests.swift
@@ -1,0 +1,363 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SKTestSupport
+import SourceKitLSP
+@_spi(Testing) import SwiftLanguageService
+import XCTest
+
+private typealias CodeActionCapabilities = TextDocumentClientCapabilities.CodeAction
+private typealias CodeActionLiteralSupport = CodeActionCapabilities.CodeActionLiteralSupport
+private typealias CodeActionKindCapabilities = CodeActionLiteralSupport.CodeActionKindValueSet
+
+private let clientCapabilitiesWithCodeActionSupport: ClientCapabilities = {
+  var documentCapabilities = TextDocumentClientCapabilities()
+  var codeActionCapabilities = CodeActionCapabilities()
+  codeActionCapabilities.codeActionLiteralSupport = .init(
+    codeActionKind: .init(valueSet: [.refactorInline])
+  )
+  documentCapabilities.codeAction = codeActionCapabilities
+  documentCapabilities.completion = .init(completionItem: .init(snippetSupport: true))
+  return ClientCapabilities(workspace: nil, textDocument: documentCapabilities)
+}()
+
+final class ForEachToForInTests: SourceKitLSPTestCase {
+  private func validateCodeAction(
+    input: String,
+    expectedOutput: String?,
+    title: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(input, uri: uri)
+
+    let range: Range<Position>
+    if input.contains("1️⃣") && input.contains("2️⃣") {
+      range = positions["1️⃣"]..<positions["2️⃣"]
+    } else if input.contains("1️⃣") {
+      let pos = positions["1️⃣"]
+      range = pos..<pos
+    } else {
+      XCTFail("Missing marker 1️⃣ in input", file: file, line: line)
+      return
+    }
+
+    let request = CodeActionRequest(
+      range: range,
+      context: .init(),
+      textDocument: TextDocumentIdentifier(uri)
+    )
+    let result = try await testClient.send(request)
+
+    guard case .codeActions(let codeActions) = result else {
+      XCTFail("Expected code actions response")
+      return
+    }
+
+    let matchingActions = codeActions.filter { $0.title == title }
+    XCTAssertLessThanOrEqual(
+      matchingActions.count,
+      1,
+      "Expected at most one action named '\(title)', found \(matchingActions.count)",
+      file: file,
+      line: line
+    )
+
+    let action = matchingActions.first
+    if let expectedOutput {
+      guard let action else {
+        let available = codeActions.map(\.title)
+        XCTFail("Action '\(title)' not found. Available: \(available)", file: file, line: line)
+        return
+      }
+
+      guard let edit = action.edit else {
+        XCTFail("Action '\(title)' has no edit", file: file, line: line)
+        return
+      }
+
+      let changes = edit.changes?[uri] ?? []
+      let cleanInput = extractMarkers(input).textWithoutMarkers
+      let resultingText = apply(edits: changes, to: cleanInput)
+
+      XCTAssertEqual(resultingText, expectedOutput, file: file, line: line)
+    } else {
+      XCTAssertNil(action, "Expected action '\(title)' to be not offered", file: file, line: line)
+    }
+  }
+
+  func testConvertForEachToForIn() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          1️⃣array.forEach { item in
+            print(item)
+          }
+        }
+        """,
+      expectedOutput: """
+        func test(array: [String]) {
+          for item in array {
+            print(item)
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInInsideClosureBody() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          array.forEach { item in
+            1️⃣print(item)
+          }
+        }
+        """,
+      expectedOutput: """
+        func test(array: [String]) {
+          for item in array {
+            print(item)
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInReturnToContinue() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          1️⃣array.forEach { item in
+            if item.isEmpty { return }
+            print(item)
+          }
+        }
+        """,
+      expectedOutput: """
+        func test(array: [String]) {
+          for item in array {
+            if item.isEmpty { continue }
+            print(item)
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNestedClosureReturnNotConverted() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [[Int]]) {
+          1️⃣array.forEach { item in
+            let mapped = item.map { return $0 + 1 }
+            print(mapped)
+          }
+        }
+        """,
+      expectedOutput: """
+        func test(array: [[Int]]) {
+          for item in array {
+            let mapped = item.map { return $0 + 1 }
+            print(mapped)
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInLocalTypeReturnsNotConverted() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [Int]) {
+          1️⃣array.forEach { item in
+            struct Local {
+              var value: Int {
+                return 1
+              }
+
+              init() {
+                return
+              }
+            }
+
+            if item == 0 { return }
+            _ = Local().value
+          }
+        }
+        """,
+      expectedOutput: """
+        func test(array: [Int]) {
+          for item in array {
+            struct Local {
+              var value: Int {
+                return 1
+              }
+
+              init() {
+                return
+              }
+            }
+
+            if item == 0 { continue }
+            _ = Local().value
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInChainedCall() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [Int]) {
+          1️⃣array.filter { value in value > 0 }.forEach { item in
+            print(item)
+          }
+        }
+        """,
+      expectedOutput: """
+        func test(array: [Int]) {
+          for item in array.filter { value in value > 0 } {
+            print(item)
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachParenthesizedClosure() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          1️⃣array.forEach({ item in
+            print(item)
+          })
+        }
+        """,
+      expectedOutput: """
+        func test(array: [String]) {
+          for item in array {
+            print(item)
+          }
+        }
+        """,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNotShownForAdditionalTrailingClosures() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          1️⃣array.forEach { item in
+            print(item)
+          } extra: {
+            print("extra")
+          }
+        }
+        """,
+      expectedOutput: nil,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNotShownForShorthandParameter() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          1️⃣array.forEach {
+            print($0)
+          }
+        }
+        """,
+      expectedOutput: nil,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNotShownForNestedClosureCursor() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [[Int]]) {
+          array.forEach { item in
+            let mapped = item.map { value in
+              1️⃣print(value)
+            }
+            print(mapped)
+          }
+        }
+        """,
+      expectedOutput: nil,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNotShownForNonStatementPosition() async throws {
+    try await validateCodeAction(
+      input: """
+        func test(array: [String]) {
+          let _ = 1️⃣array.forEach { item in
+            print(item)
+          }
+        }
+        """,
+      expectedOutput: nil,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNotShownWithoutBase() async throws {
+    try await validateCodeAction(
+      input: """
+        func forEach(_ body: (Int) -> Void) {}
+
+        func test() {
+          1️⃣forEach { value in
+            print(value)
+          }
+        }
+        """,
+      expectedOutput: nil,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+
+  func testConvertForEachToForInNotShownForCustomForEach() async throws {
+    try await validateCodeAction(
+      input: """
+        struct Numbers {
+          func forEach(_ body: (Int) -> Void) {
+            body(1)
+          }
+        }
+
+        func test(numbers: Numbers) {
+          1️⃣numbers.forEach { value in
+            print(value)
+          }
+        }
+        """,
+      expectedOutput: nil,
+      title: "Convert to 'for-in' loop"
+    )
+  }
+}


### PR DESCRIPTION
Closes #2509

Add a code action that converts `.forEach` closure calls to `for-in` loops.

Before:

```swift
let names = ["Alice", "Bob", "Charlie"]
names.forEach { name in
  print(name)
}
```

After:

```swift
let names = ["Alice", "Bob", "Charlie"]
for name in names {
  print(name)
}
```

Currently only handles closures with explicit named parameters (`$0` shorthand is not supported).