### PR TITLE
[LSPAny] Replace manual LSPAnyCodable impl with Codable-backed default

### DIFF
--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -20,7 +20,7 @@ import struct TSCBasic.AbsolutePath
 /// Options that can be used to modify SourceKit-LSP's behavior.
 ///
 /// See `ConfigurationFile.md` for a description of the configuration file's behavior.
-public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
+public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
   public struct SwiftPMOptions: Sendable, Codable, Equatable {
     /// The configuration to build the project for during background indexing
     /// and the configuration whose build folder should be used for Swift
@@ -513,21 +513,6 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     self.sourcekitdRequestTimeout = sourcekitdRequestTimeout
     self.semanticServiceRestartTimeout = semanticServiceRestartTimeout
     self.buildServerWorkspaceRequestsTimeout = buildServerWorkspaceRequestsTimeout
-  }
-
-  public init?(fromLSPAny lspAny: LSPAny?) throws {
-    guard let lspAny else {
-      return nil
-    }
-    let jsonEncoded = try JSONEncoder().encode(lspAny)
-    self = try JSONDecoder().decode(Self.self, from: jsonEncoded)
-  }
-
-  public var asLSPAny: LSPAny {
-    get throws {
-      let jsonEncoded = try JSONEncoder().encode(self)
-      return try JSONDecoder().decode(LSPAny.self, from: jsonEncoded)
-    }
   }
 
   public init?(path: URL?) {

--- a/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
@@ -18,64 +18,23 @@ import Foundation
 /// Represents metadata that SourceKit-LSP injects at every command returned by code actions.
 /// The ExecuteCommand is not a TextDocumentRequest, so metadata is injected to allow SourceKit-LSP
 /// to determine where a command should be executed.
-package struct SourceKitLSPCommandMetadata: Codable, Hashable {
+package struct SourceKitLSPCommandMetadata: Codable, Hashable, LSPAnyCodable {
 
   package var sourcekitlsp_textDocument: TextDocumentIdentifier
-
-  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    let textDocumentKey = CodingKeys.sourcekitlsp_textDocument.stringValue
-    guard case .dictionary(let textDocumentDict)? = dictionary[textDocumentKey],
-      let textDocument = TextDocumentIdentifier(fromLSPDictionary: textDocumentDict)
-    else {
-      return nil
-    }
-    self.init(textDocument: textDocument)
-  }
 
   package init(textDocument: TextDocumentIdentifier) {
     self.sourcekitlsp_textDocument = textDocument
   }
-
-  package func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      CodingKeys.sourcekitlsp_textDocument.stringValue: sourcekitlsp_textDocument.encodeToLSPAny()
-    ])
-  }
 }
 
 /// Metadata injected into CodeAction.data to support routing codeAction/resolve requests.
-package struct CodeActionResolveMetadata: Codable, Hashable {
+package struct CodeActionResolveMetadata: Codable, Hashable, LSPAnyCodable {
   package var textDocument: TextDocumentIdentifier
   package var underlyingData: LSPAny?
 
   package init(textDocument: TextDocumentIdentifier, underlyingData: LSPAny? = nil) {
     self.textDocument = textDocument
     self.underlyingData = underlyingData
-  }
-}
-
-extension CodeActionResolveMetadata {
-  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard
-      case .dictionary(let textDocumentDict)? = dictionary[CodingKeys.textDocument.stringValue],
-      let textDocument = TextDocumentIdentifier(fromLSPDictionary: textDocumentDict)
-    else {
-      return nil
-    }
-    self.init(
-      textDocument: textDocument,
-      underlyingData: dictionary[CodingKeys.underlyingData.stringValue]
-    )
-  }
-
-  package func encodeToLSPAny() -> LSPAny {
-    var dict: [String: LSPAny] = [
-      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny()
-    ]
-    if let underlyingData {
-      dict[CodingKeys.underlyingData.stringValue] = underlyingData
-    }
-    return .dictionary(dict)
   }
 }
 

--- a/Sources/SwiftLanguageService/CodeActions/RemoveUnusedImports.swift
+++ b/Sources/SwiftLanguageService/CodeActions/RemoveUnusedImports.swift
@@ -64,25 +64,6 @@ package struct RemoveUnusedImportsCommand: SwiftCommand {
   internal init(textDocument: TextDocumentIdentifier) {
     self.textDocument = textDocument
   }
-
-  package init?(fromLSPDictionary dictionary: [String: LanguageServerProtocol.LSPAny]) {
-    guard case .dictionary(let documentDict)? = dictionary[CodingKeys.textDocument.stringValue] else {
-      return nil
-    }
-    guard let textDocument = TextDocumentIdentifier(fromLSPDictionary: documentDict) else {
-      return nil
-    }
-
-    self.init(
-      textDocument: textDocument
-    )
-  }
-
-  package func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny()
-    ])
-  }
 }
 
 extension SwiftLanguageService {

--- a/Sources/SwiftLanguageService/CodeCompletionSession.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionSession.swift
@@ -28,7 +28,7 @@ import SwiftSyntax
 
 /// Uniquely identifies a code completion session. We need this so that when resolving a code completion item, we can
 /// verify that the item to resolve belongs to the code completion session that is currently open.
-struct CompletionSessionID: Equatable {
+struct CompletionSessionID: Equatable, Codable {
   private static let nextSessionID = AtomicUInt32(initialValue: 0)
 
   let value: UInt32
@@ -40,10 +40,20 @@ struct CompletionSessionID: Equatable {
   static func next() -> CompletionSessionID {
     return CompletionSessionID(value: nextSessionID.fetchAndIncrement())
   }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    value = try container.decode(UInt32.self)
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(value)
+  }
 }
 
 /// Data that is attached to a `CompletionItem`.
-struct CompletionItemData: LSPAnyCodable {
+struct CompletionItemData: Codable, LSPAnyCodable {
   let uri: DocumentURI
   let sessionId: CompletionSessionID
   let itemId: Int
@@ -52,27 +62,6 @@ struct CompletionItemData: LSPAnyCodable {
     self.uri = uri
     self.sessionId = sessionId
     self.itemId = itemId
-  }
-
-  init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard case .string(let uriString) = dictionary["uri"],
-      case .int(let sessionId) = dictionary["sessionId"],
-      case .int(let itemId) = dictionary["itemId"],
-      let uri = try? DocumentURI(string: uriString)
-    else {
-      return nil
-    }
-    self.uri = uri
-    self.sessionId = CompletionSessionID(value: UInt32(sessionId))
-    self.itemId = itemId
-  }
-
-  func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      "uri": .string(uri.stringValue),
-      "sessionId": .int(Int(sessionId.value)),
-      "itemId": .int(itemId),
-    ])
   }
 }
 

--- a/Sources/SwiftLanguageService/ExpandMacroCommand.swift
+++ b/Sources/SwiftLanguageService/ExpandMacroCommand.swift
@@ -23,6 +23,7 @@ package struct ExpandMacroCommand: SwiftCommand {
   package var actionString = "source.refactoring.kind.expand.macro"
 
   /// The range to expand.
+  @CustomCodable<PositionRange>
   package var positionRange: Range<Position>
 
   /// The text document related to the refactoring action.
@@ -31,48 +32,5 @@ package struct ExpandMacroCommand: SwiftCommand {
   package init(positionRange: Range<Position>, textDocument: TextDocumentIdentifier) {
     self.positionRange = positionRange
     self.textDocument = textDocument
-  }
-
-  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard case .dictionary(let documentDict)? = dictionary[CodingKeys.textDocument.stringValue],
-      case .string(let title)? = dictionary[CodingKeys.title.stringValue],
-      case .string(let actionString)? = dictionary[CodingKeys.actionString.stringValue],
-      case .dictionary(let rangeDict)? = dictionary[CodingKeys.positionRange.stringValue]
-    else {
-      return nil
-    }
-    guard let positionRange = Range<Position>(fromLSPDictionary: rangeDict),
-      let textDocument = TextDocumentIdentifier(fromLSPDictionary: documentDict)
-    else {
-      return nil
-    }
-
-    self.init(
-      title: title,
-      actionString: actionString,
-      positionRange: positionRange,
-      textDocument: textDocument
-    )
-  }
-
-  package init(
-    title: String,
-    actionString: String,
-    positionRange: Range<Position>,
-    textDocument: TextDocumentIdentifier
-  ) {
-    self.title = title
-    self.actionString = actionString
-    self.positionRange = positionRange
-    self.textDocument = textDocument
-  }
-
-  package func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      CodingKeys.title.stringValue: .string(title),
-      CodingKeys.actionString.stringValue: .string(actionString),
-      CodingKeys.positionRange.stringValue: positionRange.encodeToLSPAny(),
-      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny(),
-    ])
   }
 }

--- a/Sources/SwiftLanguageService/InlayHints.swift
+++ b/Sources/SwiftLanguageService/InlayHints.swift
@@ -16,7 +16,7 @@ import SourceKitLSP
 import SwiftExtensions
 import SwiftSyntax
 
-package struct InlayHintResolveData: LSPAnyCodable {
+package struct InlayHintResolveData: Codable, LSPAnyCodable {
   package let uri: DocumentURI
   package let position: Position
   package let version: Int
@@ -25,27 +25,6 @@ package struct InlayHintResolveData: LSPAnyCodable {
     self.uri = uri
     self.position = position
     self.version = version
-  }
-
-  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard case .string(let uriString) = dictionary["uri"],
-      let uri = try? DocumentURI(string: uriString),
-      case .int(let version) = dictionary["version"],
-      let position = Position(fromLSPAny: dictionary["position"])
-    else {
-      return nil
-    }
-    self.uri = uri
-    self.position = position
-    self.version = version
-  }
-
-  package func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      "uri": .string(uri.stringValue),
-      "position": position.encodeToLSPAny(),
-      "version": .int(version),
-    ])
   }
 }
 

--- a/Sources/SwiftLanguageService/RefactoringEdit.swift
+++ b/Sources/SwiftLanguageService/RefactoringEdit.swift
@@ -29,46 +29,10 @@ package struct RefactoringEdit: Hashable, Sendable, Codable {
   package var bufferName: String?
 
   package init(range: Range<Position>, newText: String, bufferName: String?) {
-    self._range = CustomCodable<PositionRange>(wrappedValue: range)
+    self.range = range
     self.newText = newText
     self.bufferName = bufferName
   }
 }
 
-extension RefactoringEdit: LSPAnyCodable {
-  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard case .dictionary(let rangeDict) = dictionary[CodingKeys.range.stringValue],
-      case .string(let newText) = dictionary[CodingKeys.newText.stringValue]
-    else {
-      return nil
-    }
-
-    guard let range = Range<Position>(fromLSPDictionary: rangeDict) else {
-      return nil
-    }
-
-    self._range = CustomCodable<PositionRange>(wrappedValue: range)
-    self.newText = newText
-
-    if case .string(let bufferName) = dictionary[CodingKeys.bufferName.stringValue] {
-      self.bufferName = bufferName
-    } else {
-      self.bufferName = nil
-    }
-  }
-
-  package func encodeToLSPAny() -> LSPAny {
-    guard let bufferName = bufferName else {
-      return .dictionary([
-        CodingKeys.range.stringValue: range.encodeToLSPAny(),
-        CodingKeys.newText.stringValue: .string(newText),
-      ])
-    }
-
-    return .dictionary([
-      CodingKeys.range.stringValue: range.encodeToLSPAny(),
-      CodingKeys.newText.stringValue: .string(newText),
-      CodingKeys.bufferName.stringValue: .string(bufferName),
-    ])
-  }
-}
+extension RefactoringEdit: LSPAnyCodable {}

--- a/Sources/SwiftLanguageService/SemanticRefactorCommand.swift
+++ b/Sources/SwiftLanguageService/SemanticRefactorCommand.swift
@@ -26,31 +26,11 @@ package struct SemanticRefactorCommand: SwiftCommand {
   package var actionString: String
 
   /// The range to refactor.
+  @CustomCodable<PositionRange>
   package var positionRange: Range<Position>
 
   /// The text document related to the refactoring action.
   package var textDocument: TextDocumentIdentifier
-
-  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
-    guard case .dictionary(let documentDict)? = dictionary[CodingKeys.textDocument.stringValue],
-      case .string(let title)? = dictionary[CodingKeys.title.stringValue],
-      case .string(let actionString)? = dictionary[CodingKeys.actionString.stringValue],
-      case .dictionary(let rangeDict)? = dictionary[CodingKeys.positionRange.stringValue]
-    else {
-      return nil
-    }
-    guard let positionRange = Range<Position>(fromLSPDictionary: rangeDict),
-      let textDocument = TextDocumentIdentifier(fromLSPDictionary: documentDict)
-    else {
-      return nil
-    }
-    self.init(
-      title: title,
-      actionString: actionString,
-      positionRange: positionRange,
-      textDocument: textDocument
-    )
-  }
 
   package init(
     title: String,
@@ -62,15 +42,6 @@ package struct SemanticRefactorCommand: SwiftCommand {
     self.actionString = actionString
     self.positionRange = positionRange
     self.textDocument = textDocument
-  }
-
-  package func encodeToLSPAny() -> LSPAny {
-    return .dictionary([
-      CodingKeys.title.stringValue: .string(title),
-      CodingKeys.actionString.stringValue: .string(actionString),
-      CodingKeys.positionRange.stringValue: positionRange.encodeToLSPAny(),
-      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny(),
-    ])
   }
 
   /// Maps the SourceKit action string to an appropriate LSP CodeActionKind.

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -902,7 +902,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
       ],
       initializationOptions: SourceKitLSPOptions(
         swiftPM: SourceKitLSPOptions.SwiftPMOptions(swiftCompilerFlags: ["-D", "TEST"])
-      ).asLSPAny
+      ).encodeToLSPAny()
     )
 
     let (uri, _) = try project.openDocument("Test.swift")
@@ -938,7 +938,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
       ],
       initializationOptions: SourceKitLSPOptions(
         swiftPM: SourceKitLSPOptions.SwiftPMOptions(swiftCompilerFlags: ["-D", "OTHER"])
-      ).asLSPAny
+      ).encodeToLSPAny()
     )
 
     let (uri, _) = try project.openDocument("Test.swift")


### PR DESCRIPTION
Requires https://github.com/swiftlang/swift-tools-protocols/pull/41

Remove hand-written `init?(fromLSPDictionary:)` / `encodeToLSPAny()` from LSPAnyCodable types, relying instead on the default implementations backed by `LSPAnyEncoder`/`LSPAnyDecoder`