### PR TITLE
Always wait for real build settings in `testExperimentalFeaturesPassedToSyntaxTreeManager`

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -29,10 +29,20 @@ import XCTest
 extension SourceKitLSPOptions {
   package static func testDefault(
     backgroundIndexing: Bool = true,
+    buildSettingsTimeout: Duration? = nil,
     experimentalFeatures: Set<ExperimentalFeature> = [.synchronizeCopyFileMap]
   ) async throws -> SourceKitLSPOptions {
     let pluginPaths = try await sourceKitPluginPaths
+
+    let buildSettingsTimeoutMilliseconds: Int? =
+      if let buildSettingsTimeout {
+        Int(buildSettingsTimeout.seconds * 1000)
+      } else {
+        nil
+      }
+
     return SourceKitLSPOptions(
+      buildSettingsTimeout: buildSettingsTimeoutMilliseconds,
       sourcekitd: SourceKitDOptions(
         clientPlugin: try pluginPaths.clientPlugin.filePath,
         servicePlugin: try pluginPaths.servicePlugin.filePath

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -723,7 +723,9 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
           a.1️⃣
         }
         """,
-      ]
+      ],
+      // We don't want to test behavior based on fallback settings. Increase the buildSettingsTimeout to ensure we always get proper build settings.
+      options: .testDefault(buildSettingsTimeout: defaultTimeoutDuration)
     )
     let (uri, positions) = try project.openDocument("b.swift")
 
@@ -1412,12 +1414,16 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
   }
 
   func testSuggestInMemoryFunctionsFromFilesWithinSameModule() async throws {
-    let project = try await SwiftPMTestProject(files: [
-      "First.swift": """
-      myFancyFunc1️⃣
-      """,
-      "Second.swift": "2️⃣",
-    ])
+    let project = try await SwiftPMTestProject(
+      files: [
+        "First.swift": """
+        myFancyFunc1️⃣
+        """,
+        "Second.swift": "2️⃣",
+      ],
+      // We don't want to test behavior based on fallback settings. Increase the buildSettingsTimeout to ensure we always get proper build settings.
+      options: .testDefault(buildSettingsTimeout: defaultTimeoutDuration)
+    )
 
     let (secondUri, secondPositions) = try project.openDocument("Second.swift")
     project.testClient.send(

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -14,6 +14,7 @@ import BuildServerIntegration
 import Foundation
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKLogging
+import SKOptions
 import SKTestSupport
 import SourceKitLSP
 import SwiftExtensions
@@ -782,7 +783,9 @@ final class SwiftPMIntegrationTests: SourceKitLSPTestCase {
             )
           ]
         )
-        """
+        """,
+      // We don't want to test behavior based on fallback settings. Increase the buildSettingsTimeout to ensure we always get proper build settings.
+      options: .testDefault(buildSettingsTimeout: defaultTimeoutDuration)
     )
 
     let (uri, _) = try project.openDocument("Test.swift")

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -669,7 +669,9 @@ final class WorkspaceTests: SourceKitLSPTestCase {
         return [
           WorkspaceFolder(uri: DocumentURI(scratchDir.appending(component: "fake")))
         ]
-      }
+      },
+      // We don't want to test behavior based on fallback settings. Increase the buildSettingsTimeout to ensure we always get proper build settings.
+      options: .testDefault(buildSettingsTimeout: defaultTimeoutDuration)
     )
 
     let packageDir = try project.uri(for: "Package.swift").fileURL!.deletingLastPathComponent()


### PR DESCRIPTION
If the SwiftPM build server is slow to respond, we may get document symbols based on a `SyntaxTreeManager` with fallback build settings, which would not contain the `_test_EverythingUnexpected` experimental feature and which would thus fail.