### PR TITLE
Use SymbolLink.destination directly in MarkdownTitleFinder

### DIFF
--- a/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
+++ b/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
@@ -249,17 +249,7 @@ struct MarkdownTitleFinder: MarkupVisitor {
       return nil
     }
     if let symbolLink = heading.child(at: 0) as? SymbolLink {
-      // Remove the surrounding backticks to find the symbol name
-      let plainText = symbolLink.plainText
-      var startIndex = plainText.startIndex
-      if plainText.hasPrefix("``") {
-        startIndex = plainText.index(plainText.startIndex, offsetBy: 2)
-      }
-      var endIndex = plainText.endIndex
-      if plainText.hasSuffix("``") {
-        endIndex = plainText.index(plainText.endIndex, offsetBy: -2)
-      }
-      return .symbol(String(plainText[startIndex..<endIndex]))
+      return .symbol(symbolLink.destination ?? "")
     }
     return .plainText(heading.plainText)
   }


### PR DESCRIPTION
While reading through the DocC documentation code, I noticed that
`MarkdownTitleFinder.visitHeading(_:)` was doing unnecessary work to extract
a symbol name from a heading like `# ``MyClass`` `.
The code was calling `symbolLink.plainText` to get the text, and then manually
stripping the surrounding backticks off to recover the actual symbol name.
The problem is that `SymbolLink.plainText` is literally defined as:
    "``\(destination ?? "")``"
So it adds the backticks in the first place. Using `symbolLink.destination` directly gives us the clean symbol name without any string manipulation needed.