### PR TITLE
Fix encoding error and typo

### DIFF
--- a/Sources/DocumentationLanguageService/BuildSystemIntegrationExtensions.swift
+++ b/Sources/DocumentationLanguageService/BuildSystemIntegrationExtensions.swift
@@ -30,7 +30,7 @@ extension BuildServerManager {
   func moduleName(for target: BuildTargetIdentifier) async -> String? {
     let sourceFiles =
       await orLog(
-        "Failed to retreive source files from target \(target.uri)",
+        "Failed to retrieve source files from target \(target.uri)",
         { try await self.sourceFiles(in: [target]).flatMap(\.sources) }
       ) ?? []
     for sourceFile in sourceFiles {

--- a/Sources/DocumentationLanguageService/DocCReferenceResolutionService.swift
+++ b/Sources/DocumentationLanguageService/DocCReferenceResolutionService.swift
@@ -134,7 +134,7 @@ final class DocCReferenceResolutionService: DocumentationService, Sendable {
     do {
       return try JSONEncoder().encode(value)
     } catch {
-      throw .decodingFailure(error.localizedDescription)
+      throw .encodingFailure(error.localizedDescription)
     }
   }
 


### PR DESCRIPTION
Two small fixes in the DocumentationLanguageService:
Changes:
- Bug fix: encode(_:) was incorrectly throwing .decodingFailure on encoding errors due to a copy-paste mistake from decode(_:from:). This change updates it to throw .encodingFailure, ensuring the correct error is used.
- Typo fix: Corrected "retreive" → "retrieve" in an error log message in BuildSystemIntegrationExtensions.swift for consistency with the identical message below.