### PR TITLE
Fix testEmptyActor using class instead of actor declaration

### DIFF
--- a/Tests/SourceKitLSPTests/DoccDocumentationTests.swift
+++ b/Tests/SourceKitLSPTests/DoccDocumentationTests.swift
@@ -236,7 +236,7 @@ final class DoccDocumentationTests: SourceKitLSPTestCase {
   func testEmptyActor() async throws {
     try await renderDocumentation(
       markedText: """
-        pub1️⃣lic class Act2️⃣or {
+        pub1️⃣lic actor Act2️⃣or {
           3️⃣
         }4️⃣
         """,


### PR DESCRIPTION
Fixes an incorrect declaration in testEmptyActor so it actually tests an actor.

Changes
Bug fix: testEmptyActor was declaring public class Actor instead of public actor Actor.
The test still passed because the symbol name was "Actor" in both cases, but it was effectively testing an empty class instead of an empty actor.
This updates the declaration to use the actor keyword, consistent with testActor above it.