### PR TITLE
Fix build failure caused by `BuildTargetPrepareRequest` changing its return type

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -1578,7 +1578,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   }
 
   package func prepare(targets: Set<BuildTargetIdentifier>) async throws {
-    let _: VoidResponse? = try await buildServerAdapterAfterInitialized?.send(
+    let _: BuildTargetPrepareResponse? = try await buildServerAdapterAfterInitialized?.send(
       BuildTargetPrepareRequest(targets: targets.sorted { $0.uri.stringValue < $1.uri.stringValue })
     )
     await orLog("Calling fileDependenciesUpdated") {

--- a/Sources/BuildServerIntegration/BuiltInBuildServer.swift
+++ b/Sources/BuildServerIntegration/BuiltInBuildServer.swift
@@ -51,7 +51,7 @@ package protocol BuiltInBuildServer: AnyObject, Sendable {
 
   /// Prepare the given targets for indexing and semantic functionality. This should build all swift modules of target
   /// dependencies.
-  func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse
+  func prepare(request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse
 
   /// Retrieve build settings for the given document.
   ///

--- a/Sources/BuildServerIntegration/FixedCompilationDatabaseBuildServer.swift
+++ b/Sources/BuildServerIntegration/FixedCompilationDatabaseBuildServer.swift
@@ -111,7 +111,7 @@ package actor FixedCompilationDatabaseBuildServer: BuiltInBuildServer {
     }
   }
 
-  package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+  package func prepare(request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
     throw ResponseError.methodNotFound(BuildTargetPrepareRequest.method)
   }
 

--- a/Sources/BuildServerIntegration/JSONCompilationDatabaseBuildServer.swift
+++ b/Sources/BuildServerIntegration/JSONCompilationDatabaseBuildServer.swift
@@ -176,7 +176,7 @@ package actor JSONCompilationDatabaseBuildServer: BuiltInBuildServer {
     }
   }
 
-  package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+  package func prepare(request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
     throw ResponseError.methodNotFound(BuildTargetPrepareRequest.method)
   }
 

--- a/Sources/BuildServerIntegration/LegacyBuildServer.swift
+++ b/Sources/BuildServerIntegration/LegacyBuildServer.swift
@@ -169,7 +169,7 @@ actor LegacyBuildServer: MessageHandler, BuiltInBuildServer {
 
   package func didChangeWatchedFiles(notification: OnWatchedFilesDidChangeNotification) {}
 
-  package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+  package func prepare(request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
     throw ResponseError.methodNotFound(BuildTargetPrepareRequest.method)
   }
 

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -758,12 +758,12 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     return VoidResponse()
   }
 
-  package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+  package func prepare(request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
     // TODO: Support preparation of multiple targets at once. (https://github.com/swiftlang/sourcekit-lsp/issues/1262)
     for target in request.targets {
       await orLog("Preparing") { try await prepare(singleTarget: target) }
     }
-    return VoidResponse()
+    return BuildTargetPrepareResponse()
   }
 
   private func prepare(singleTarget target: BuildTargetIdentifier) async throws {

--- a/Sources/SKTestSupport/CustomBuildServerTestProject.swift
+++ b/Sources/SKTestSupport/CustomBuildServerTestProject.swift
@@ -92,7 +92,7 @@ package protocol CustomBuildServer: MessageHandler {
   func textDocumentSourceKitOptionsRequest(
     _ request: TextDocumentSourceKitOptionsRequest
   ) async throws -> TextDocumentSourceKitOptionsResponse?
-  func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse
+  func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse
   func waitForBuildSystemUpdates(request: WorkspaceWaitForBuildSystemUpdatesRequest) async -> VoidResponse
   nonisolated func onWatchedFilesDidChange(_ notification: OnWatchedFilesDidChangeNotification) throws
   func workspaceWaitForBuildSystemUpdatesRequest(
@@ -243,8 +243,8 @@ package extension CustomBuildServer {
     ])
   }
 
-  func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse {
-    return VoidResponse()
+  func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
+    return BuildTargetPrepareResponse()
   }
 
   func waitForBuildSystemUpdates(request: WorkspaceWaitForBuildSystemUpdatesRequest) async -> VoidResponse {

--- a/Tests/BuildServerIntegrationTests/ExternalBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/ExternalBuildServerTests.swift
@@ -621,13 +621,13 @@ final class ExternalBuildServerTests: SourceKitLSPTestCase {
         return TextDocumentSourceKitOptionsResponse(compilerArguments: [request.textDocument.uri.pseudoPath])
       }
 
-      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
         preparationStarted.fulfill()
         await assertThrowsError(try await Task.sleep(for: .seconds(defaultTimeout))) { error in
           XCTAssert(error is CancellationError)
         }
         preparationFinished.fulfill()
-        return VoidResponse()
+        return BuildTargetPrepareResponse()
       }
     }
 

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -3020,9 +3020,9 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         return TextDocumentSourceKitOptionsResponse(compilerArguments: [request.textDocument.uri.pseudoPath])
       }
 
-      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
         preparedTargetBatches.append(request.targets.sorted { $0.uri.stringValue < $1.uri.stringValue })
-        return VoidResponse()
+        return BuildTargetPrepareResponse()
       }
 
       fileprivate func getPreparedBatches() async -> [[BuildTargetIdentifier]] {

--- a/Tests/SourceKitLSPTests/CopyDestinationTests.swift
+++ b/Tests/SourceKitLSPTests/CopyDestinationTests.swift
@@ -79,7 +79,7 @@ class CopyDestinationTests: SourceKitLSPTestCase {
       ])
     }
 
-    func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+    func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
       try FileManager.default.createDirectory(
         at: headerCopyDestination.deletingLastPathComponent(),
         withIntermediateDirectories: true
@@ -88,7 +88,7 @@ class CopyDestinationTests: SourceKitLSPTestCase {
         at: projectRoot.appending(component: "Test.h"),
         to: headerCopyDestination
       )
-      return VoidResponse()
+      return BuildTargetPrepareResponse()
     }
   }
 
@@ -275,7 +275,7 @@ class CopyDestinationTests: SourceKitLSPTestCase {
         ])
       }
 
-      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> BuildTargetPrepareResponse {
         try FileManager.default.createDirectory(
           at: headerCopyDestination.deletingLastPathComponent(),
           withIntermediateDirectories: true
@@ -283,7 +283,7 @@ class CopyDestinationTests: SourceKitLSPTestCase {
         try await """
         void hello();
         """.writeWithRetry(to: headerCopyDestination)
-        return VoidResponse()
+        return BuildTargetPrepareResponse()
       }
     }
 


### PR DESCRIPTION
API-break caused by swiftlang/swift-tools-protocols#42.