### PR TITLE
[SKUtilities] Fix Debouncer deadline reset on subsequent scheduleCalls

### DIFF
--- a/Sources/SKUtilities/Debouncer.swift
+++ b/Sources/SKUtilities/Debouncer.swift
@@ -53,11 +53,13 @@ package actor Debouncer<Parameter: Sendable> {
   /// `debounceDuration` after the second `scheduleCall` call.
   package func scheduleCall(_ parameter: Parameter) {
     var parameter = parameter
-    var targetDate = ContinuousClock.now + debounceDuration
+    let targetDate: ContinuousClock.Instant
     if let (inProgressParameter, inProgressTargetDate, inProgressTask) = inProgressData {
       inProgressTask.cancel()
       parameter = combineParameters(inProgressParameter, parameter)
       targetDate = inProgressTargetDate
+    } else {
+      targetDate = ContinuousClock.now + debounceDuration
     }
     let task = Task {
       do {
@@ -68,7 +70,7 @@ package actor Debouncer<Parameter: Sendable> {
       }
       await self.flush()
     }
-    inProgressData = (parameter, ContinuousClock.now + debounceDuration, task)
+    inProgressData = (parameter, targetDate, task)
   }
 
   /// If any debounced calls are in progress, make them now, even if the debounce duration hasn't expired yet.

--- a/Tests/SKUtilitiesTests/DebouncerTests.swift
+++ b/Tests/SKUtilitiesTests/DebouncerTests.swift
@@ -43,4 +43,48 @@ final class DebouncerTests: XCTestCase {
     await debouncer.scheduleCall(2)
     try await fulfillmentOfOrThrow(expectation)
   }
+
+  /// Tests that the debounce deadline is fixed at the time of the first `scheduleCall` and not reset by subsequent
+  /// calls. Subsequent calls within the debounce window should preserve the original deadline.
+  func testDebouncerDeadlineIsNotResetBySubsequentCalls() async throws {
+    let expectation = self.expectation(description: "makeCallCalled")
+    expectation.assertForOverFulfill = true
+    let debouncer = Debouncer<Void>(debounceDuration: .milliseconds(500)) {
+      expectation.fulfill()
+    }
+    await debouncer.scheduleCall()  // deadline: now + 500ms
+    try await Task.sleep(for: .milliseconds(100))
+    await debouncer.scheduleCall()  // should keep the original deadline, not reset to now + 500ms
+    try await Task.sleep(for: .milliseconds(100))
+    await debouncer.scheduleCall()  // same
+
+    // Fires -300ms from now (500ms from first call, 200ms already elapsed).
+    try await fulfillmentOfOrThrow(expectation, timeout: 0.4)
+  }
+
+  /// Tests that a `makeCall` in progress is not cancelled when a new `scheduleCall` arrives.
+  func testMakeCallIsNotCancelledBySubsequentScheduleCall() async throws {
+    nonisolated(unsafe) var makeCallContinuation: CheckedContinuation<Void, Never>? = nil
+    let makeCallStarted = self.expectation(description: "makeCallStarted")
+    let makeCallCompleted = self.expectation(description: "makeCallCompleted")
+
+    let debouncer = Debouncer<Void>(debounceDuration: .milliseconds(50)) {
+      // Pause makeCall and signal the test that it has started.
+      await withCheckedContinuation { continuation in
+        makeCallContinuation = continuation
+        makeCallStarted.fulfill()
+      }
+      XCTAssertFalse(Task.isCancelled, "makeCall should run in a fresh, non-cancelled task")
+      makeCallCompleted.fulfill()
+    }
+
+    await debouncer.scheduleCall()
+    // Wait until makeCall has started executing.
+    try await fulfillmentOfOrThrow(makeCallStarted)
+    // Schedule another call while the first makeCall is suspended.
+    await debouncer.scheduleCall()
+    // Resume makeCall and verify it completes without being cancelled.
+    makeCallContinuation!.resume()
+    try await fulfillmentOfOrThrow(makeCallCompleted)
+  }
 }


### PR DESCRIPTION
`inProgressData` was always storing `ContinuousClock.now + debounceDuration` instead of the computed `targetDate`, causing the debounce deadline to reset on every call rather than being fixed at the time of the first `scheduleCall`.