### PR TITLE
Require Swift 6.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 
 import Foundation
 import PackageDescription

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -574,19 +574,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
 
       throw NonFileURIError(uri: file)
     }
-    #if compiler(>=6.4)
-    #warning(
-      "Once we can guarantee that the toolchain can index multiple Swift files in a single invocation, we no longer need to set -index-unit-output-path since it's always set using an -output-file-map"
-    )
-    #endif
-    var compilerArguments = try buildTarget.compileArguments(for: fileURL)
-    if buildTarget.compiler == .swift {
-      compilerArguments += [
-        // Fake an output path so that we get a different unit file for every Swift file we background index
-        "-index-unit-output-path", indexUnitOutputPath(forSwiftFile: file),
-      ]
-    }
-    return compilerArguments
+    return try buildTarget.compileArguments(for: fileURL)
   }
 
   package func buildTargets(request: WorkspaceBuildTargetsRequest) async throws -> WorkspaceBuildTargetsResponse {

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -459,15 +459,6 @@ package actor SkipUnless {
     }
   }
 
-  package static func canIndexMultipleSwiftFilesInSingleInvocation(
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) async throws {
-    return try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(6, 3), file: file, line: line) {
-      return await ToolchainRegistry.forTesting.default?.canIndexMultipleSwiftFilesInSingleInvocation ?? false
-    }
-  }
-
   package static func swiftPMBuildServerSupportedWithoutBackgroundIndexing(
     file: StaticString = #filePath,
     line: UInt = #line

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -321,14 +321,6 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         continue
       }
 
-      guard
-        await buildServerManager.toolchain(for: target, language: language)?
-          .canIndexMultipleSwiftFilesInSingleInvocation ?? false
-      else {
-        partitions.append(.singleFile(file: fileInfo, buildSettings: buildSettings))
-        continue
-      }
-
       // If the build settings contain `-index-unit-output-path`, remove it. We add the index unit output path back in
       // using an `-output-file-map`. Removing it from the build settings allows us to index multiple Swift files in a
       // single compiler invocation if they share all build settings and only differ in their `-index-unit-output-path`.
@@ -478,12 +470,6 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
 
     switch partition {
     case .multipleFiles(let filesAndOutputPaths, let buildSettings):
-      if await !toolchain.canIndexMultipleSwiftFilesInSingleInvocation {
-        // We should never get here because we shouldn't create `multipleFiles` batches if the toolchain doesn't support
-        // indexing multiple files in a single compiler invocation.
-        logger.fault("Cannot index multiple files in a single compiler invocation.")
-      }
-
       struct OutputFileMapEntry: Encodable {
         let indexUnitOutputPath: String
 
@@ -687,10 +673,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
     var partitions: [(target: BuildTargetIdentifier, language: Language, files: [FileIndexInfo])] = []
     var fileIndexInfosToBatch: [TargetAndLanguage: [FileIndexInfo]] = [:]
     for fileIndexInfo in fileIndexInfos {
-      guard fileIndexInfo.language == .swift,
-        await buildServerManager.toolchain(for: fileIndexInfo.target, language: fileIndexInfo.language)?
-          .canIndexMultipleSwiftFilesInSingleInvocation ?? false
-      else {
+      guard fileIndexInfo.language == .swift else {
         // Only Swift supports indexing multiple files in a single compiler invocation, so don't batch files of other
         // languages.
         partitions.append((fileIndexInfo.target, fileIndexInfo.language, [fileIndexInfo]))

--- a/Sources/SwiftExtensions/RunWithCleanup.swift
+++ b/Sources/SwiftExtensions/RunWithCleanup.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=6.4)
+#if compiler(>=6.5)
 #warning("Remove this in favor of SE-0493 (Support async calls in defer bodies) when possible")
 #endif
 /// Run `body` and always ensure that `cleanup` gets run, independently of whether `body` threw an error or returned a

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -148,56 +148,6 @@ public final class Toolchain: Sendable {
     }
   }
 
-  private let canIndexMultipleSwiftFilesInSingleInvocationTask = ThreadSafeBox<Task<Bool, Never>?>(
-    initialValue: nil
-  )
-
-  /// Checks if the Swift compiler in this toolchain can index multiple Swift files in a single compiler invocation, i.e
-  /// if the Swift compiler contains https://github.com/swiftlang/swift-driver/pull/1979.
-  package var canIndexMultipleSwiftFilesInSingleInvocation: Bool {
-    get async {
-      let task = canIndexMultipleSwiftFilesInSingleInvocationTask.withLock { task in
-        if let task {
-          return task
-        }
-        let newTask = Task<Bool, Never> { () -> Bool in
-          #if compiler(>=6.4)
-          #warning(
-            "Once we no longer Swift 6.2 toolchains, we can assume that the compiler has https://github.com/swiftlang/swift-driver/pull/1979"
-          )
-          #endif
-          let result = await orLog("Getting frontend invocation to check if multi-file indexing is supported") {
-            guard let swiftc else {
-              throw SwiftVersionParsingError.failedToFindSwiftc
-            }
-            return try await Process.run(
-              arguments: [
-                swiftc.filePath,
-                "-index-file", "a.swift", "b.swift",
-                "-index-file-path", "a.swift",
-                "-index-file-path", "b.swift",
-                "-###",
-              ],
-              workingDirectory: nil
-            ).utf8Output()
-          }
-          guard let result else {
-            return false
-          }
-
-          // Before https://github.com/swiftlang/swift-driver/pull/1979, only the last `-index-file-path` was declared
-          // as `-primary-file`. With https://github.com/swiftlang/swift-driver/pull/1979, all `-index-file-path`s are
-          // passed as primary files to the frontend.
-          return result.contains("-primary-file a.swift") && result.contains("-primary-file b.swift")
-        }
-        task = newTask
-        return newTask
-      }
-
-      return await task.value
-    }
-  }
-
   package init(
     identifier: String,
     displayName: String,

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -2767,7 +2767,6 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
   }
 
   func testIndexMultipleSwiftFilesInSameCompilerInvocation() async throws {
-    try await SkipUnless.canIndexMultipleSwiftFilesInSingleInvocation()
     let hooks = Hooks(
       indexHooks: IndexHooks(
         updateIndexStoreTaskDidStart: { taskDescription in

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -105,7 +105,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       uri: project.fileURI,
       position: project.positions["3️⃣"],
       testClient: project.testClient,
-      swiftInterfaceFiles: ["Swift.swiftinterface", "_Concurrency.swiftinterface", "TaskGroup.swift"],
+      swiftInterfaceFiles: ["Swift.swiftinterface", "TaskGroup.swift"],
       lineContains: "public func withTaskGroup"
     )
   }
@@ -270,7 +270,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       uri: uri,
       position: positions["1️⃣"],
       testClient: testClient,
-      swiftInterfaceFile: "Swift.Collection.Array.swiftinterface",
+      swiftInterfaceFiles: ["Swift.Collection.Array.swiftinterface"],
       lineContains: "func filter<E>(_ isIncluded: (Element) throws(E) -> Bool) throws(E) -> [Element]"
     )
   }
@@ -289,7 +289,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       uri: project.fileURI,
       position: project.positions["1️⃣"],
       testClient: project.testClient,
-      swiftInterfaceFile: "Swift.Collection.Array.swiftinterface",
+      swiftInterfaceFiles: ["Swift.Collection.Array.swiftinterface"],
       lineContains: "func filter<E>(_ isIncluded: (Element) throws(E) -> Bool) throws(E) -> [Element]"
     )
   }
@@ -397,33 +397,6 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
   }
 }
 
-private func assertSystemSwiftInterface(
-  uri: DocumentURI,
-  position: Position,
-  testClient: TestSourceKitLSPClient,
-  swiftInterfaceFile: String,
-  linePrefix: String? = nil,
-  lineContains: String? = nil,
-  line: UInt = #line
-) async throws {
-  try await assertSystemSwiftInterface(
-    uri: uri,
-    position: position,
-    testClient: testClient,
-    swiftInterfaceFiles: [swiftInterfaceFile],
-    linePrefix: linePrefix,
-    lineContains: lineContains,
-    line: line
-  )
-}
-
-#if compiler(>=6.4)
-@available(
-  *,
-  deprecated,
-  message: "temporary workaround for '_Concurrency.swiftinterface' should no longer be necessary"
-)
-#endif
 private func assertSystemSwiftInterface(
   uri: DocumentURI,
   position: Position,


### PR DESCRIPTION
Swift 6.3 has been released and we no longer need to support building or testing SourceKit-LSP with Swift 6.2.