### PR TITLE
Cache inlay hints to avoid flickering

### DIFF
--- a/Sources/SourceKitLSP/DocumentSnapshot+PositionConversions.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+PositionConversions.swift
@@ -179,7 +179,7 @@ extension DocumentSnapshot {
   /// If the bounds of the range do not refer to a valid positions with in the snapshot, this function adjusts them to
   /// the closest valid positions and logs a fault containing the file and line of the caller (from `callerFile` and
   /// `callerLine`).
-  package func absolutePositionRange(
+  package func positionRange(
     of range: Range<AbsolutePosition>,
     callerFile: StaticString = #fileID,
     callerLine: UInt = #line

--- a/Sources/SourceKitLSP/DocumentSnapshot+PositionConversions.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+PositionConversions.swift
@@ -189,6 +189,16 @@ extension DocumentSnapshot {
     return lowerBound..<upperBound
   }
 
+  package func absolutePositionRange(
+    of range: Range<Position>,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> Range<AbsolutePosition> {
+    let lowerBound = self.absolutePosition(of: range.lowerBound, callerFile: callerFile, callerLine: callerLine)
+    let upperBound = self.absolutePosition(of: range.upperBound, callerFile: callerFile, callerLine: callerLine)
+    return lowerBound..<upperBound
+  }
+
   /// Extracts the range of the given syntax node in terms of positions within
   /// this source file.
   package func range(

--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(SwiftLanguageService STATIC
   GeneratedInterfaceManager.swift
   IndentationRemover.swift
   InlayHints.swift
+  InlayHintManager.swift
   InlayHintResolve.swift
   MacroExpansion.swift
   OpenInterface.swift

--- a/Sources/SwiftLanguageService/CodeActions/ConvertIfLetToGuard.swift
+++ b/Sources/SwiftLanguageService/CodeActions/ConvertIfLetToGuard.swift
@@ -100,7 +100,7 @@ import SwiftSyntaxBuilder
     }
 
     let edit = TextEdit(
-      range: scope.snapshot.absolutePositionRange(
+      range: scope.snapshot.positionRange(
         of: ifExpr.positionAfterSkippingLeadingTrivia..<lastStatement.endPosition
       ),
       newText: replacementText

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxRefactoringCodeActionProvider.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxRefactoringCodeActionProvider.swift
@@ -86,7 +86,7 @@ extension [SourceEdit] {
   func asWorkspaceEdit(snapshot: DocumentSnapshot) -> WorkspaceEdit? {
     let textEdits = compactMap { edit -> TextEdit? in
       let edit = TextEdit(
-        range: snapshot.absolutePositionRange(of: edit.range),
+        range: snapshot.positionRange(of: edit.range),
         newText: edit.replacement
       )
 

--- a/Sources/SwiftLanguageService/Diagnostic.swift
+++ b/Sources/SwiftLanguageService/Diagnostic.swift
@@ -69,7 +69,7 @@ extension CodeAction {
   init?(_ fixIt: FixIt, in snapshot: DocumentSnapshot) {
     var textEdits = [TextEdit]()
     for edit in fixIt.edits {
-      textEdits.append(TextEdit(range: snapshot.absolutePositionRange(of: edit.range), newText: edit.replacement))
+      textEdits.append(TextEdit(range: snapshot.positionRange(of: edit.range), newText: edit.replacement))
     }
 
     self.init(
@@ -333,7 +333,7 @@ extension Diagnostic {
     var range = Range(snapshot.position(of: diag.position))
     for highlight in diag.highlights {
       let swiftSyntaxRange = highlight.positionAfterSkippingLeadingTrivia..<highlight.endPositionBeforeTrailingTrivia
-      let highlightRange = snapshot.absolutePositionRange(of: swiftSyntaxRange)
+      let highlightRange = snapshot.positionRange(of: swiftSyntaxRange)
       if range.upperBound == highlightRange.lowerBound {
         range = range.lowerBound..<highlightRange.upperBound
       } else {
@@ -414,7 +414,7 @@ extension DiagnosticRelatedInformation {
   init(_ note: Note, in snapshot: DocumentSnapshot) {
     let nodeRange = note.node.positionAfterSkippingLeadingTrivia..<note.node.endPositionBeforeTrailingTrivia
     self.init(
-      location: Location(uri: snapshot.uri, range: snapshot.absolutePositionRange(of: nodeRange)),
+      location: Location(uri: snapshot.uri, range: snapshot.positionRange(of: nodeRange)),
       message: note.message
     )
   }

--- a/Sources/SwiftLanguageService/DocumentFormatting.swift
+++ b/Sources/SwiftLanguageService/DocumentFormatting.swift
@@ -127,7 +127,7 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
   // Map the offset-based edits to line-column based edits to be consumed by LSP
 
   return concurrentEdits.edits.compactMap {
-    TextEdit(range: original.absolutePositionRange(of: $0.range), newText: $0.replacement)
+    TextEdit(range: original.positionRange(of: $0.range), newText: $0.replacement)
   }
 }
 

--- a/Sources/SwiftLanguageService/DocumentSymbols.swift
+++ b/Sources/SwiftLanguageService/DocumentSymbols.swift
@@ -75,8 +75,8 @@ private final class DocumentSymbolsFinder: SyntaxAnyVisitor {
     if !self.range.overlaps(range) {
       return .skipChildren
     }
-    let positionRange = snapshot.absolutePositionRange(of: range)
-    let selectionPositionRange = snapshot.absolutePositionRange(of: selection)
+    let positionRange = snapshot.positionRange(of: range)
+    let selectionPositionRange = snapshot.positionRange(of: selection)
 
     // Record MARK comments on the node's leading and trailing trivia in `result` not as a child of `node`.
     visit(node.leadingTrivia, position: node.position)
@@ -142,7 +142,7 @@ private final class DocumentSymbolsFinder: SyntaxAnyVisitor {
         let trimmedComment = commentText.trimmingCharacters(in: CharacterSet(["/", "*"]).union(.whitespaces))
         if trimmedComment.starts(with: markPrefix) {
           let markText = trimmedComment.dropFirst(markPrefix.count)
-          let range = snapshot.absolutePositionRange(
+          let range = snapshot.positionRange(
             of: position..<position.advanced(by: piece.sourceLength.utf8Length)
           )
           result.append(

--- a/Sources/SwiftLanguageService/InlayHintManager.swift
+++ b/Sources/SwiftLanguageService/InlayHintManager.swift
@@ -1,0 +1,316 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(SourceKitLSP) package import LanguageServerProtocol
+@_spi(SourceKitLSP) import SKLogging
+import SKUtilities
+import SourceKitLSP
+import SwiftExtensions
+import SwiftSyntax
+
+package struct InlayHintResolveData: Codable, LSPAnyCodable {
+  package let uri: DocumentURI
+  package let position: Position
+  package let version: Int
+
+  package init(uri: DocumentURI, position: Position, version: Int) {
+    self.uri = uri
+    self.position = position
+    self.version = version
+  }
+}
+
+private struct InlayHintCacheEntry {
+  let version: Int
+  /// Marks hints as position-shifted but semantically stale; trigger a background recompute before treating cache as fully fresh.
+  let needsSemanticRefresh: Bool
+  /// The cached hints, sorted ascending by their position in the document.
+  let hints: [InlayHint]
+}
+
+private struct InFlightInlayHintRefreshTask {
+  let id: UUID
+  let expectedVersion: Int
+  let task: Task<(), any Error>
+  var sendRefreshRequest: Bool
+}
+
+actor InlayHintManager {
+  /// Cached inlay hints for each document.
+  ///
+  /// Each entry stores hints for the full document and the document version they were computed for.
+  /// - Note: The capacity has been chosen without scientific measurements. 20 seems like a resonable number of open documents a client may have.
+  private var cache = LRUCache<DocumentURI, InlayHintCacheEntry>(capacity: 20)
+
+  /// Documents that currently have a background inlay-hint recomputation in progress.
+  ///
+  /// Used to avoid scheduling multiple concurrent recomputations for the same document.
+  private var inFlightRefreshTasks: [DocumentURI: InFlightInlayHintRefreshTask] = [:]
+
+  func getCachedInlayHints(
+    swiftLanguageService service: SwiftLanguageService,
+    for snapshot: DocumentSnapshot,
+    range: Range<Position>?
+  ) -> [InlayHint]? {
+    guard let entry = cache[snapshot.uri] else {
+      scheduleInlayHintRefresh(swiftLanguageService: service, for: snapshot)
+      return nil
+    }
+
+    if entry.version != snapshot.version || entry.needsSemanticRefresh {
+      // The cached hints are stale. Schedule a refresh and return the stale hints for now. The stale hints are still in the correct position they may just contain outdated type information.
+      scheduleInlayHintRefresh(swiftLanguageService: service, for: snapshot)
+    }
+
+    return filterInlayHints(entry.hints, in: range)
+  }
+
+  private func filterInlayHints(_ hints: [InlayHint], in range: Range<Position>?) -> [InlayHint] {
+    guard let range else {
+      return hints
+    }
+
+    let lowerBoundIndex = hints.binarySearchFirst(where: { $0.position >= range.lowerBound })
+    let upperBoundIndex = hints.binarySearchFirst(where: { $0.position >= range.upperBound })
+    return Array(hints[lowerBoundIndex..<upperBoundIndex])
+  }
+
+  func processEdits(
+    for uri: DocumentURI,
+    contentChanges: [TextDocumentContentChangeEvent],
+    swiftLanguageService service: SwiftLanguageService,
+    preEditSnapshot: DocumentSnapshot,
+    postEditSnapshot: DocumentSnapshot
+  ) {
+    // Immediately schedule a refresh of the inlay hints using SourceKit, but don't send a `workspace/inlayHint/refresh`
+    // request to the client.
+    // If the time between the client sending `textDocument/didChange` and `textDocument/inlayHint` is longer than the
+    // time taken to recompute the inlay hints, we have them available immediately when the client requests inlay hints.
+    scheduleInlayHintRefresh(swiftLanguageService: service, for: postEditSnapshot, sendRefreshRequest: false)
+
+    guard let cachedEntry = cache[uri] else {
+      return
+    }
+
+    var currentHints = cachedEntry.hints
+    for change in contentChanges {
+      guard let range = change.range else {
+        // Full document replacement. Invalidate all cached hints for the document, since we don't know how to shift them.
+        cache[uri] = nil
+        return
+      }
+
+      let lineDelta = change.text.count(where: \.isNewline) - (range.upperBound.line - range.lowerBound.line)
+      let columnDelta =
+        if let lastNewlineIndex = change.text.lastIndex(where: \.isNewline) {
+          change.text.utf16.distance(from: change.text.index(after: lastNewlineIndex), to: change.text.endIndex)
+        } else {
+          change.text.utf16.count
+        }
+
+      func shiftedPosition(_ position: Position) -> Position {
+        let newUtf16Index =
+          if position.line == range.upperBound.line {
+            if lineDelta > 0 {
+              // The line does change, we thus have to calculate the offset of the hint in the new line
+              // This offset has the length of all characters added by the edit after the newline (columnDelta)
+              // + the length of the text between the end of the edit and the start of the hint
+              columnDelta + position.utf16index - range.upperBound.utf16index
+            } else {
+              // The line does not change, just add the column delta
+              position.utf16index + columnDelta
+            }
+          } else {
+            // The hint is on a different line than the edit, the column doesn't change
+            position.utf16index
+          }
+        return Position(line: position.line + lineDelta, utf16index: newUtf16Index)
+      }
+
+      let previousHints = currentHints
+      currentHints = []
+      let lowerBoundIndex = previousHints.binarySearchFirst(where: { $0.position >= range.lowerBound })
+      let upperBoundIndex = previousHints.binarySearchFirst(where: { $0.position >= range.upperBound })
+
+      // Hints before the edit range are unaffected.
+      currentHints.append(contentsOf: previousHints[..<lowerBoundIndex])
+      // Hints that overlap with the edit range are dropped and will be recomputed in the background.
+      // Hints after the edit range need to be shifted by the edit delta.
+      let shiftedHints: [InlayHint] = previousHints[upperBoundIndex...].compactMap { hint in
+        if hint.position == range.lowerBound,
+          hint.position == range.upperBound,
+          hint.labelAsString == change.text
+        {
+          // This change inserts this inlay hint, so we remove the inlay hint
+          return nil
+        }
+
+        let newPosition = shiftedPosition(hint.position)
+
+        let newTextEdits = hint.textEdits?.map { textEdit in
+          return TextEdit(
+            range: shiftedPosition(textEdit.range.lowerBound)..<shiftedPosition(textEdit.range.upperBound),
+            newText: textEdit.newText
+          )
+        }
+
+        return InlayHint(
+          position: newPosition,
+          label: hint.label,
+          kind: hint.kind,
+          textEdits: newTextEdits,
+          tooltip: hint.tooltip,
+          paddingLeft: hint.paddingLeft,
+          paddingRight: hint.paddingRight,
+          data: hint.data
+        )
+      }
+      currentHints.append(contentsOf: shiftedHints)
+    }
+
+    cache[uri] = InlayHintCacheEntry(version: postEditSnapshot.version, needsSemanticRefresh: true, hints: currentHints)
+  }
+
+  func scheduleInlayHintRefresh(
+    swiftLanguageService service: SwiftLanguageService,
+    for snapshot: DocumentSnapshot,
+    sendRefreshRequest: Bool = true
+  ) {
+    let uri = snapshot.uri
+    if var inFlightTask = inFlightRefreshTasks[uri] {
+      if inFlightTask.expectedVersion >= snapshot.version {
+        // We already have a task running for a newer version of the document, so we don't need to schedule another one.
+        // But we may have to update the `sendRefreshRequest` property, if the already running task did not need a refresh but the new one does
+        inFlightTask.sendRefreshRequest = inFlightTask.sendRefreshRequest || sendRefreshRequest
+        inFlightRefreshTasks[uri] = inFlightTask
+        return
+      }
+      // Cancel the currently running task for the older version of the document, since we will schedule a new one for the newer version below.
+      inFlightTask.task.cancel()
+    }
+
+    let taskID = UUID()
+    let task = Task(priority: .medium) { [self, service] in
+      try await run {
+        do {
+          try Task.checkCancellation()
+
+          // We recompute inlay hints for the whole document, even if only a range was requested. This is because edits
+          // can affect the validity of inlay hints outside of their edit range (e.g., an edit that changes a variable's
+          // type can make type hints for all other variables that use the edited variable stale). Caching and returning
+          // inlay hints for only a subrange of the document would add a lot of complexity, because we would need to track
+          // which hints are valid for which ranges and versions.
+          let updatedHints = try await computeTypeInlayHints(swiftLanguageService: service, for: snapshot, range: nil)
+
+          try Task.checkCancellation()
+
+          let updatedEntry = InlayHintCacheEntry(
+            version: snapshot.version,
+            needsSemanticRefresh: false,
+            hints: updatedHints
+          )
+          cache[uri] = updatedEntry
+
+          guard let inFlightTask = inFlightRefreshTasks[uri], inFlightTask.id == taskID else {
+            return
+          }
+
+          if inFlightTask.sendRefreshRequest {
+            let _ = try await service.sourceKitLSPServer?.sendRequestToClient(InlayHintRefreshRequest())
+          }
+        } catch is CancellationError {
+          return
+        } catch {
+          logger.error("Inlay hint refresh failed for \(uri.forLogging): \(error.forLogging)")
+        }
+      } cleanup: {
+        guard let inFlightTask = inFlightRefreshTasks[uri], inFlightTask.id == taskID else {
+          // This task was already replaced by another one so we should not remove the entry
+          return
+        }
+        inFlightRefreshTasks[uri] = nil
+      }
+    }
+
+    inFlightRefreshTasks[uri] = InFlightInlayHintRefreshTask(
+      id: taskID,
+      expectedVersion: snapshot.version,
+      task: task,
+      sendRefreshRequest: sendRefreshRequest
+    )
+  }
+
+  func computeTypeInlayHints(
+    swiftLanguageService service: SwiftLanguageService,
+    for snapshot: DocumentSnapshot,
+    range: Range<Position>?
+  ) async throws -> [InlayHint] {
+    let infos = try await service.variableTypeInfos(snapshot.uri, nil)
+    return infos
+      .lazy
+      .filter { !$0.hasExplicitType }
+      .map { info -> InlayHint in
+        let position = info.range.upperBound
+        let variableStart = info.range.lowerBound
+        let label = ": \(info.printedType)"
+        let textEdits: [TextEdit]?
+        if info.canBeFollowedByTypeAnnotation {
+          textEdits = [TextEdit(range: position..<position, newText: label)]
+        } else {
+          textEdits = nil
+        }
+        let resolveData = InlayHintResolveData(uri: snapshot.uri, position: variableStart, version: snapshot.version)
+        return InlayHint(
+          position: position,
+          label: .string(label),
+          kind: .type,
+          textEdits: textEdits,
+          data: resolveData.encodeToLSPAny()
+        )
+      }
+      .sorted { $0.position < $1.position }
+  }
+
+  func removeCachedInlayHints(for uri: DocumentURI) {
+    inFlightRefreshTasks.removeValue(forKey: uri)?.task.cancel()
+    cache[uri] = nil
+  }
+}
+
+private extension InlayHint {
+  var labelAsString: String {
+    switch self.label {
+    case .string(let label):
+      return label
+
+    case .parts(let parts):
+      return parts.map { $0.value }.joined()
+    }
+  }
+}
+
+private extension Array {
+  func binarySearchFirst(where predicate: (Element) -> Bool) -> Int {
+    var low = 0
+    var high = self.count
+    while low < high {
+      let mid = (low + high) / 2
+      if predicate(self[mid]) {
+        high = mid
+      } else {
+        low = mid + 1
+      }
+    }
+    return low
+  }
+}

--- a/Sources/SwiftLanguageService/InlayHints.swift
+++ b/Sources/SwiftLanguageService/InlayHints.swift
@@ -12,71 +12,53 @@
 
 import Foundation
 @_spi(SourceKitLSP) package import LanguageServerProtocol
+import SKUtilities
 import SourceKitLSP
 import SwiftExtensions
 import SwiftSyntax
 
-package struct InlayHintResolveData: Codable, LSPAnyCodable {
-  package let uri: DocumentURI
-  package let position: Position
-  package let version: Int
-
-  package init(uri: DocumentURI, position: Position, version: Int) {
-    self.uri = uri
-    self.position = position
-    self.version = version
-  }
-}
-
-private class IfConfigCollector: SyntaxVisitor {
-  private var ifConfigDecls: [IfConfigDeclSyntax] = []
-
-  override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
-    ifConfigDecls.append(node)
-
-    return .visitChildren
-  }
-
-  static func collectIfConfigDecls(in tree: some SyntaxProtocol) -> [IfConfigDeclSyntax] {
-    let visitor = IfConfigCollector(viewMode: .sourceAccurate)
-    visitor.walk(tree)
-    return visitor.ifConfigDecls
-  }
-}
-
 extension SwiftLanguageService {
   package func inlayHint(_ req: InlayHintRequest) async throws -> [InlayHint] {
     let uri = req.textDocument.uri
-    let snapshot = try await self.latestSnapshot(for: uri)
-    let version = snapshot.version
+    let snapshot = try await latestSnapshot(for: uri)
 
-    let infos = try await variableTypeInfos(uri, req.range)
-    let typeHints = infos
-      .lazy
-      .filter { !$0.hasExplicitType }
-      .map { info -> InlayHint in
-        let position = info.range.upperBound
-        let variableStart = info.range.lowerBound
-        let label = ": \(info.printedType)"
-        let textEdits: [TextEdit]?
-        if info.canBeFollowedByTypeAnnotation {
-          textEdits = [TextEdit(range: position..<position, newText: label)]
-        } else {
-          textEdits = nil
-        }
-        let resolveData = InlayHintResolveData(uri: uri, position: variableStart, version: version)
-        return InlayHint(
-          position: position,
-          label: .string(label),
-          kind: .type,
-          textEdits: textEdits,
-          data: resolveData.encodeToLSPAny()
-        )
-      }
+    if let sourceKitLSPServer = self.sourceKitLSPServer,
+      let clientCapabilities = await sourceKitLSPServer.capabilityRegistry?.clientCapabilities,
+      !(clientCapabilities.workspace?.inlayHint?.refreshSupport ?? false)
+    {
+      // The client does not support workspace/inlayHint/refresh.
+      // We have to compute inlay hints on every request, because we cannot trigger a refresh when the inlay hints have been recomputed in the background.
+      let snapshot = try await latestSnapshot(for: uri)
+      async let typeInlayHints = inlayHintManager.computeTypeInlayHints(
+        swiftLanguageService: self,
+        for: snapshot,
+        range: req.range
+      )
+      return try await typeInlayHints + computeIfConfigInlayHints(snapshot: snapshot, range: req.range)
+    }
 
+    if let hints = await inlayHintManager.getCachedInlayHints(
+      swiftLanguageService: self,
+      for: snapshot,
+      range: req.range
+    ) {
+      return try await hints + computeIfConfigInlayHints(snapshot: snapshot, range: req.range)
+    }
+
+    // No cached hints are available. The inlay hint manager has scheduled a refresh task if needed, so we can just
+    // return an empty response here. The client will trigger another request after the refresh completes, because of
+    // the InlayHintRefreshRequest sent in the refresh task.
+    return []
+  }
+
+  private func computeIfConfigInlayHints(
+    snapshot: DocumentSnapshot,
+    range: Range<Position>?
+  ) async throws -> [InlayHint] {
     let syntaxTree = await syntaxTreeManager.syntaxTree(for: snapshot)
-    let ifConfigDecls = IfConfigCollector.collectIfConfigDecls(in: syntaxTree)
-    let ifConfigHints = ifConfigDecls.compactMap { (ifConfigDecl) -> InlayHint? in
+    let absoluteRange = range.map { snapshot.absolutePositionRange(of: $0) }
+    let ifConfigDecls = IfConfigCollector.collectIfConfigDecls(in: syntaxTree, range: absoluteRange)
+    return ifConfigDecls.compactMap { (ifConfigDecl) -> InlayHint? in
       // Do not show inlay hints for if config clauses that have a `#elseif` of `#else` clause since it is unclear which
       // `#if`, `#elseif`, or `#else` clause the `#endif` now refers to.
       guard let condition = ifConfigDecl.clauses.only?.condition else {
@@ -96,7 +78,33 @@ extension SwiftLanguageService {
         tooltip: .string("Condition of this conditional compilation clause")
       )
     }
+  }
+}
 
-    return Array(typeHints + ifConfigHints)
+private class IfConfigCollector: SyntaxVisitor {
+  private var ifConfigDecls: [IfConfigDeclSyntax] = []
+  private let range: Range<AbsolutePosition>?
+
+  init(viewMode: SyntaxTreeViewMode, range: Range<AbsolutePosition>?) {
+    self.range = range
+    super.init(viewMode: viewMode)
+  }
+
+  override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+    if let range, !range.overlaps(node.range) {
+      return .skipChildren
+    }
+    ifConfigDecls.append(node)
+
+    return .visitChildren
+  }
+
+  static func collectIfConfigDecls(
+    in tree: some SyntaxProtocol,
+    range: Range<AbsolutePosition>?
+  ) -> [IfConfigDeclSyntax] {
+    let visitor = IfConfigCollector(viewMode: .sourceAccurate, range: range)
+    visitor.walk(tree)
+    return visitor.ifConfigDecls
   }
 }

--- a/Sources/SwiftLanguageService/Rename.swift
+++ b/Sources/SwiftLanguageService/Rename.swift
@@ -569,7 +569,7 @@ extension SwiftLanguageService {
     }
 
     if let startToken, let endToken {
-      return snapshot.absolutePositionRange(
+      return snapshot.positionRange(
         of: startToken.positionAfterSkippingLeadingTrivia..<endToken.endPositionBeforeTrailingTrivia
       )
     }

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -129,7 +129,7 @@ extension SyntaxClassifiedRange {
       return SyntaxHighlightingTokens(tokens: [])
     }
 
-    let multiLineRange = snapshot.absolutePositionRange(of: self.range)
+    let multiLineRange = snapshot.positionRange(of: self.range)
     let ranges = multiLineRange.splitToSingleLineRanges(in: snapshot)
 
     let tokens = ranges.map {

--- a/Sources/SwiftLanguageService/SwiftCodeLensScanner.swift
+++ b/Sources/SwiftLanguageService/SwiftCodeLensScanner.swift
@@ -111,7 +111,7 @@ final class SwiftCodeLensScanner: SyntaxVisitor {
 
   private func captureLensFromAttribute(attribute: AttributeListSyntax.Element) {
     if attribute.trimmedDescription == "@main" {
-      let range = self.snapshot.absolutePositionRange(of: attribute.trimmedRange)
+      let range = self.snapshot.positionRange(of: attribute.trimmedRange)
       var targetNameToAppend: String = ""
       var arguments: [LSPAny] = []
       if let targetName {

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -830,7 +830,7 @@ extension SwiftLanguageService {
     if let snapshot = try? await latestSnapshot(for: uri) {
       let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
       if let token = tree.token(at: snapshot.absolutePosition(of: position)) {
-        tokenRange = snapshot.absolutePositionRange(of: token.trimmedRange)
+        tokenRange = snapshot.positionRange(of: token.trimmedRange)
       }
     }
 
@@ -880,7 +880,7 @@ extension SwiftLanguageService {
 
         result.append(
           ColorInformation(
-            range: snapshot.absolutePositionRange(of: node.position..<node.endPosition),
+            range: snapshot.positionRange(of: node.position..<node.endPosition),
             color: Color(red: red, green: green, blue: blue, alpha: alpha)
           )
         )

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -158,6 +158,8 @@ package actor SwiftLanguageService: LanguageService, Sendable {
   ///   might have finished. This isn't an issue since the tasks do not retain `self`.
   private var inFlightPublishDiagnosticsTasks: [DocumentURI: Task<Void, Never>] = [:]
 
+  let inlayHintManager = InlayHintManager()
+
   let syntaxTreeManager = SyntaxTreeManager()
 
   /// The `semanticIndexManager` of the workspace this language service was created for.
@@ -582,6 +584,7 @@ extension SwiftLanguageService {
       }
     case nil:
       cancelInFlightPublishDiagnosticsTask(for: notification.textDocument.uri)
+      await inlayHintManager.removeCachedInlayHints(for: notification.textDocument.uri)
       await diagnosticReportManager.removeItemsFromCache(with: notification.textDocument.uri)
 
       let buildSettings = await self.compileCommand(for: snapshot.uri, fallbackAfterTimeout: true)
@@ -606,6 +609,7 @@ extension SwiftLanguageService {
     buildSettingsForOpenFiles[notification.textDocument.uri] = nil
     await syntaxTreeManager.clearSyntaxTrees(for: notification.textDocument.uri)
     await syntaxTreeManager.clearExperimentalFeatures(for: notification.textDocument.uri)
+    await inlayHintManager.removeCachedInlayHints(for: notification.textDocument.uri)
     switch try? ReferenceDocumentURL(from: notification.textDocument.uri) {
     case .macroExpansion:
       break
@@ -758,6 +762,19 @@ extension SwiftLanguageService {
       postEditSnapshot: postEditSnapshot,
       edits: concurrentEdits
     )
+
+    if await sourceKitLSPServer?.capabilityRegistry?.clientCapabilities.workspace?.inlayHint?.refreshSupport ?? false {
+      // Only process the edits if the client supports inlay hint refreshing
+      // If the client does not support refreshing, we have to calculate the inlay hints using SourceKit each time and
+      // cannot cache them. Thus, we also do not have to update any cached inlay hints.
+      await inlayHintManager.processEdits(
+        for: notification.textDocument.uri,
+        contentChanges: notification.contentChanges,
+        swiftLanguageService: self,
+        preEditSnapshot: preEditSnapshot,
+        postEditSnapshot: postEditSnapshot
+      )
+    }
 
     await publishDiagnosticsIfNeeded(for: notification.textDocument.uri)
   }

--- a/Sources/SwiftLanguageService/SwiftPlaygroundsScanner.swift
+++ b/Sources/SwiftLanguageService/SwiftPlaygroundsScanner.swift
@@ -69,7 +69,7 @@ final class SwiftPlaygroundsScanner: SyntaxVisitor {
     label: String?,
     range: Range<AbsolutePosition>
   ) {
-    let positionRange = snapshot.absolutePositionRange(of: range)
+    let positionRange = snapshot.positionRange(of: range)
 
     result.append(
       TextDocumentPlayground(

--- a/Sources/SwiftLanguageService/SwiftTestingScanner.swift
+++ b/Sources/SwiftLanguageService/SwiftTestingScanner.swift
@@ -258,7 +258,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
       return .skipChildren
     }
 
-    let range = snapshot.absolutePositionRange(
+    let range = snapshot.positionRange(
       of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia
     )
     // Members won't be extensions since extensions will only be at the top level.
@@ -368,7 +368,7 @@ final class SyntacticSwiftTestingTestScanner: SyntaxVisitor {
     // name then we use the full name as the display name.
     let displayName = attributeData.displayName ?? (hasBackticks ? identifier.name : fullName)
 
-    let range = snapshot.absolutePositionRange(
+    let range = snapshot.positionRange(
       of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia
     )
     let testItem = AnnotatedTestItem(

--- a/Sources/SwiftLanguageService/SyntacticSwiftXCTestScanner.swift
+++ b/Sources/SwiftLanguageService/SyntacticSwiftXCTestScanner.swift
@@ -65,7 +65,7 @@ final class SyntacticSwiftXCTestScanner: SyntaxVisitor {
         // declarations are probably less common than helper functions that start with `test` and have a return type.
         return nil
       }
-      let range = snapshot.absolutePositionRange(
+      let range = snapshot.positionRange(
         of: function.positionAfterSkippingLeadingTrivia..<function.endPositionBeforeTrailingTrivia
       )
 
@@ -93,7 +93,7 @@ final class SyntacticSwiftXCTestScanner: SyntaxVisitor {
       return .visitChildren
     }
 
-    let range = snapshot.absolutePositionRange(
+    let range = snapshot.positionRange(
       of: node.positionAfterSkippingLeadingTrivia..<node.endPositionBeforeTrailingTrivia
     )
     let testItem = AnnotatedTestItem(

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -19,25 +19,127 @@ import XCTest
 
 final class InlayHintTests: SourceKitLSPTestCase {
   // MARK: - Helpers
+  class InlayHintTestCaseContext {
+    let positions: DocumentPositions
+    let testClient: TestSourceKitLSPClient
+    let uri: DocumentURI
+    private let range: Range<Position>?
+    private let testCase: InlayHintTests
+    private var version: Int = 1
 
-  func performInlayHintRequest(
-    markedText: String,
-    range: (fromMarker: String, toMarker: String)? = nil
-  ) async throws -> (DocumentPositions, [InlayHint]) {
-    let testClient = try await TestSourceKitLSPClient()
+    init(
+      positions: DocumentPositions,
+      testClient: TestSourceKitLSPClient,
+      uri: DocumentURI,
+      range: Range<Position>?,
+      testCase: InlayHintTests
+    ) {
+      self.positions = positions
+      self.testClient = testClient
+      self.uri = uri
+      self.range = range
+      self.testCase = testCase
+    }
+
+    /// Verifies that inlay hints for the current snapshot eventually match `expectedHints`.
+    ///
+    /// This method first sends an inlay-hint request and returns immediately if the response already matches the
+    /// expected hints (eg. when background computation finished before this helper was called). Otherwise it waits for
+    /// a single `InlayHintRefreshRequest`, then requests hints again and asserts they now match.
+    ///
+    /// Returns the matching hint array to allow additional assertions in the caller.
+    @discardableResult
+    func checkInlayHintsComputedInTheBackgroundMatch(expected expectedHints: [InlayHint]) async throws -> [InlayHint] {
+      let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: range)
+      let firstResult = try await testClient.send(request)
+
+      if hintsAreEqual(actual: firstResult, expected: expectedHints) {
+        // Hints were already computed by the time we send the first request
+        return firstResult
+      }
+
+      let refreshRequestReceived = testCase.expectation(description: "Receive first inlay hint refresh request")
+      testClient.handleSingleRequest { (_: InlayHintRefreshRequest) in
+        refreshRequestReceived.fulfill()
+        return VoidResponse()
+      }
+
+      try await fulfillmentOfOrThrow(refreshRequestReceived)
+
+      let secondResult = try await testClient.send(request)
+      testCase.assertHintsEqual(secondResult, expectedHints)
+      return secondResult
+    }
+
+    func getCachedInlayHints() async throws -> [InlayHint] {
+      let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: range)
+      return try await testClient.send(request)
+    }
+
+    func sendChange(range: Range<Position>, text: String) {
+      sendChanges(changes: [(range: range, text: text)])
+    }
+
+    func sendChanges(changes: [(range: Range<Position>, text: String)]) {
+      testClient.send(
+        DidChangeTextDocumentNotification(
+          textDocument: VersionedTextDocumentIdentifier(uri, version: version),
+          contentChanges: changes.map { change in
+            TextDocumentContentChangeEvent(
+              range: change.range,
+              text: change.text
+            )
+          }
+        )
+      )
+      version += 1
+    }
+
+    private func hintsAreEqual(
+      actual: [InlayHint],
+      expected: [InlayHint]
+    ) -> Bool {
+      if actual.count != expected.count {
+        return false
+      }
+
+      for (actualHint, expectedHint) in zip(actual, expected) {
+        if actualHint.position != expectedHint.position { return false }
+        if actualHint.label != expectedHint.label { return false }
+        if actualHint.kind != expectedHint.kind { return false }
+        if actualHint.textEdits != expectedHint.textEdits { return false }
+        if actualHint.tooltip != expectedHint.tooltip { return false }
+      }
+      return true
+    }
+  }
+
+  private func runInlayHintTestCase(
+    initialText: String,
+    range: (start: String, end: String)? = nil,
+    testBody: (InlayHintTestCaseContext) async throws -> Void
+  ) async throws {
+    let capabilities = ClientCapabilities(
+      workspace: WorkspaceClientCapabilities(inlayHint: RefreshRegistrationCapability(refreshSupport: true))
+    )
+    let testClient = try await TestSourceKitLSPClient(capabilities: capabilities)
     let uri = DocumentURI(for: .swift)
 
-    let (positions, text) = DocumentPositions.extract(from: markedText)
-    testClient.openDocument(text, uri: uri)
+    let positions = testClient.openDocument(initialText, uri: uri)
 
-    let range: Range<Position>? =
-      if let range {
-        positions[range.fromMarker]..<positions[range.toMarker]
-      } else {
-        nil
-      }
-    let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: range)
-    return (positions, try await testClient.send(request))
+    let transformedRange = range.map { (start, end) in
+      let startPos = positions[start]
+      let endPos = positions[end]
+      return startPos..<endPos
+    }
+    let context = InlayHintTestCaseContext(
+      positions: positions,
+      testClient: testClient,
+      uri: uri,
+      range: transformedRange,
+      testCase: self
+    )
+    try await testBody(context)
   }
 
   private func makeInlayHint(
@@ -80,37 +182,30 @@ final class InlayHintTests: SourceKitLSPTestCase {
   // MARK: - Tests
 
   func testEmpty() async throws {
-    let (_, hints) = try await performInlayHintRequest(markedText: "")
-    XCTAssertEqual(hints, [])
+    try await runInlayHintTestCase(initialText: "") { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [])
+    }
   }
 
   func testBindings() async throws {
-    let (positions, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         let x1️⃣ = 4
         var y2️⃣ = "test" + "123"
         """
-    )
-    assertHintsEqual(
-      hints,
-      [
-        makeInlayHint(
-          position: positions["1️⃣"],
-          kind: .type,
-          label: ": Int"
-        ),
-        makeInlayHint(
-          position: positions["2️⃣"],
-          kind: .type,
-          label: ": String"
-        ),
-      ]
-    )
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
+          makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": String"),
+        ]
+      )
+    }
   }
 
-  func testRanged() async throws {
-    let (positions, hints) = try await performInlayHintRequest(
-      markedText: """
+  func testRangedRangeOverlapsUntilAfterLastHint() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
         func square(_ x: Double) -> Double {
           let result = x * x
           return result
@@ -123,27 +218,64 @@ final class InlayHintTests: SourceKitLSPTestCase {
         } 4️⃣
         """,
       range: ("1️⃣", "4️⃣")
-    )
-    assertHintsEqual(
-      hints,
-      [
-        makeInlayHint(
-          position: positions["2️⃣"],
-          kind: .type,
-          label: ": Bool"
-        ),
-        makeInlayHint(
-          position: positions["3️⃣"],
-          kind: .type,
-          label: ": Int"
-        ),
-      ]
-    )
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Bool"),
+          makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Int"),
+        ]
+      )
+    }
+  }
+
+  func testRangedRangeOverlapsUntilBeforeFirstHint() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        1️⃣let x2️⃣ = 43️⃣
+        var y = "test" + "123"
+        """,
+      range: ("1️⃣", "3️⃣")
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Int")
+        ]
+      )
+    }
+  }
+
+  func testRangedRangeOverlapsAllHints() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        let1️⃣ x2️⃣ = 4
+        var y3️⃣ = "test" + "123"4️⃣
+        """,
+      range: ("1️⃣", "4️⃣")
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Int"),
+          makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": String"),
+        ]
+      )
+    }
+  }
+
+  func testRangedRangeDoesNotOverlapAnyHints() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        let x = 4
+        var y = 1️⃣"test" + "123"2️⃣
+        """,
+      range: ("1️⃣", "2️⃣")
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [])
+    }
   }
 
   func testFields() async throws {
-    let (positions, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         class X {
           let instanceMember1️⃣ = 3
           static let staticMember2️⃣ = "abc"
@@ -158,55 +290,35 @@ final class InlayHintTests: SourceKitLSPTestCase {
           static let staticMember5️⃣ = 3.0
         }
         """
-    )
-    assertHintsEqual(
-      hints,
-      [
-        makeInlayHint(
-          position: positions["1️⃣"],
-          kind: .type,
-          label: ": Int"
-        ),
-        makeInlayHint(
-          position: positions["2️⃣"],
-          kind: .type,
-          label: ": String"
-        ),
-        makeInlayHint(
-          position: positions["3️⃣"],
-          kind: .type,
-          label: ": String"
-        ),
-        makeInlayHint(
-          position: positions["4️⃣"],
-          kind: .type,
-          label: ": Int"
-        ),
-        makeInlayHint(
-          position: positions["5️⃣"],
-          kind: .type,
-          label: ": Double"
-        ),
-      ]
-    )
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
+          makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": String"),
+          makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": String"),
+          makeInlayHint(position: context.positions["4️⃣"], kind: .type, label: ": Int"),
+          makeInlayHint(position: context.positions["5️⃣"], kind: .type, label: ": Double"),
+        ])
+    }
   }
 
   func testExplicitTypeAnnotation() async throws {
-    let (_, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         let x: String = "abc"
 
         struct X {
           var y: Int = 34
         }
         """
-    )
-    XCTAssertEqual(hints, [])
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [])
+    }
   }
 
   func testClosureParams() async throws {
-    let (positions, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         func f(x: Int) {}
 
         let g1️⃣ = { (x: Int) in }
@@ -215,116 +327,101 @@ final class InlayHintTests: SourceKitLSPTestCase {
           x + y
         }
         """
-    )
-    assertHintsEqual(
-      hints,
-      [
-        makeInlayHint(
-          position: positions["1️⃣"],
-          kind: .type,
-          label: ": (Int) -> ()"
-        ),
-        makeInlayHint(
-          position: positions["2️⃣"],
-          kind: .type,
-          label: ": String",
-          hasEdit: false
-        ),
-        makeInlayHint(
-          position: positions["3️⃣"],
-          kind: .type,
-          label: ": Double"
-        ),
-        makeInlayHint(
-          position: positions["4️⃣"],
-          kind: .type,
-          label: ": Double"
-        ),
-      ]
-    )
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": (Int) -> ()"),
+        makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": String", hasEdit: false),
+        makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Double"),
+        makeInlayHint(position: context.positions["4️⃣"], kind: .type, label: ": Double"),
+      ])
+    }
   }
 
   func testIfConfigHints() async throws {
-    let (positions, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         #if DEBUG
         #endif1️⃣
         """
-    )
-    XCTAssertEqual(
-      hints,
-      [
-        InlayHint(
-          position: positions["1️⃣"],
-          label: " // DEBUG",
-          kind: .type,
-          textEdits: [TextEdit(range: Range(positions["1️⃣"]), newText: " // DEBUG")],
-          tooltip: .string("Condition of this conditional compilation clause")
-        )
-      ]
-    )
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          InlayHint(
+            position: context.positions["1️⃣"],
+            label: " // DEBUG",
+            kind: .type,
+            textEdits: [TextEdit(range: Range(context.positions["1️⃣"]), newText: " // DEBUG")],
+            tooltip: .string("Condition of this conditional compilation clause")
+          )
+        ])
+    }
   }
 
   func testIfConfigHintDoesNotShowIfCommentExits() async throws {
-    let (_, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         #if DEBUG
         #endif // DEBUG
         """
-    )
-    XCTAssertEqual(hints, [])
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [])
+    }
   }
 
   func testIfConfigHintDoesNotShowIfElseClauseExists() async throws {
-    let (_, hints) = try await performInlayHintRequest(
-      markedText: """
+    try await runInlayHintTestCase(
+      initialText: """
         #if DEBUG
         #else
         #endif
         """
-    )
-    XCTAssertEqual(hints, [])
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [])
+    }
   }
 
   func testInlayHintResolve() async throws {
-    let testClient = try await TestSourceKitLSPClient()
-    let uri = DocumentURI(for: .swift)
+    try await runInlayHintTestCase(
+      initialText: """
+        struct 1️⃣MyType {}
+        let x2️⃣ = MyType()
+        """,
+    ) { context in
+      let hints = try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": MyType")
+      ])
 
-    let positions = testClient.openDocument(
-      """
-      struct 1️⃣MyType {}
-      let x2️⃣ = MyType()
-      """,
-      uri: uri
-    )
+      guard let typeHint = hints.first(where: { $0.kind == .type }) else {
+        XCTFail("Expected type hint")
+        return
+      }
 
-    let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: nil)
-    let hints = try await testClient.send(request)
+      XCTAssertNotNil(typeHint.data, "Expected type hint to have data for resolution")
 
-    guard let typeHint = hints.first(where: { $0.kind == .type }) else {
-      XCTFail("Expected type hint")
-      return
+      let resolvedHint = try await context.testClient.send(InlayHintResolveRequest(inlayHint: typeHint))
+
+      guard case .parts(let parts) = resolvedHint.label else {
+        XCTFail("Expected resolved hint to have label parts, got: \(resolvedHint.label)")
+        return
+      }
+
+      guard let location = parts.only?.location else {
+        XCTFail("Expected label part to have location for go-to-definition")
+        return
+      }
+
+      XCTAssertEqual(location.uri, context.uri)
+      XCTAssertEqual(location.range, Range(context.positions["1️⃣"]))
     }
-
-    XCTAssertNotNil(typeHint.data, "Expected type hint to have data for resolution")
-
-    let resolvedHint = try await testClient.send(InlayHintResolveRequest(inlayHint: typeHint))
-
-    guard case .parts(let parts) = resolvedHint.label else {
-      XCTFail("Expected resolved hint to have label parts, got: \(resolvedHint.label)")
-      return
-    }
-
-    guard let location = parts.only?.location else {
-      XCTFail("Expected label part to have location for go-to-definition")
-      return
-    }
-
-    XCTAssertEqual(location.uri, uri)
-    XCTAssertEqual(location.range, Range(positions["1️⃣"]))
   }
 
   func testInlayHintResolveCrossModule() async throws {
+    let inlayHintRefreshRequestReceived = expectation(description: "Receive inlay hint refresh request")
+    let capabilities = ClientCapabilities(
+      workspace: WorkspaceClientCapabilities(
+        inlayHint: RefreshRegistrationCapability(refreshSupport: true)
+      )
+    )
     let project = try await SwiftPMTestProject(
       files: [
         "LibA/MyType.swift": """
@@ -346,12 +443,20 @@ final class InlayHintTests: SourceKitLSPTestCase {
           ]
         )
         """,
-      enableBackgroundIndexing: true
+      capabilities: capabilities,
+      enableBackgroundIndexing: true,
     )
+
+    project.testClient.handleSingleRequest { (_: InlayHintRefreshRequest) in
+      inlayHintRefreshRequestReceived.fulfill()
+      return VoidResponse()
+    }
 
     let (uri, _) = try project.openDocument("UseType.swift")
 
     let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri), range: nil)
+    let _ = try await project.testClient.send(request)
+    try await fulfillmentOfOrThrow(inlayHintRefreshRequestReceived)
     let hints = try await project.testClient.send(request)
 
     guard let typeHint = hints.first(where: { $0.kind == .type }) else {
@@ -374,14 +479,28 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintResolveSDKType() async throws {
+    let inlayHintRefreshRequestReceived = expectation(description: "Receive inlay hint refresh request")
+    let capabilities = ClientCapabilities(
+      workspace: WorkspaceClientCapabilities(
+        inlayHint: RefreshRegistrationCapability(refreshSupport: true)
+      )
+    )
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       let 1️⃣x = "hello"
       """,
+      capabilities: capabilities,
       indexSystemModules: true
     )
 
+    project.testClient.handleSingleRequest { (_: InlayHintRefreshRequest) in
+      inlayHintRefreshRequestReceived.fulfill()
+      return VoidResponse()
+    }
+
     let request = InlayHintRequest(textDocument: TextDocumentIdentifier(project.fileURI), range: nil)
+    let _ = try await project.testClient.send(request)
+    try await fulfillmentOfOrThrow(inlayHintRefreshRequestReceived)
     let hints = try await project.testClient.send(request)
 
     guard let typeHint = hints.first(where: { $0.kind == .type }) else {
@@ -403,5 +522,274 @@ final class InlayHintTests: SourceKitLSPTestCase {
       location.uri.pseudoPath.hasSuffix(".swiftinterface"),
       "Expected .swiftinterface file, got: \(location.uri.pseudoPath)"
     )
+  }
+
+  func testInlayHintWithoutRefreshSupport() async throws {
+    let capabilities = ClientCapabilities(workspace: WorkspaceClientCapabilities(inlayHint: nil))
+    let testClient = try await TestSourceKitLSPClient(capabilities: capabilities)
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      let x1️⃣ = 4
+      """,
+      uri: uri
+    )
+
+    let request = InlayHintRequest(textDocument: TextDocumentIdentifier(uri))
+    let hints = try await testClient.send(request)
+    assertHintsEqual(
+      hints,
+      [
+        makeInlayHint(position: positions["1️⃣"], kind: .type, label: ": Int")
+      ]
+    )
+  }
+
+  func testInlayHintCacheUpdatesAfterParameterTypeChange() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        func test(x: 1️⃣Int2️⃣) {
+          let y3️⃣ = x
+        }
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Int")
+        ]
+      )
+
+      context.sendChange(
+        range: context.positions["1️⃣"]..<context.positions["2️⃣"],
+        text: "String"
+      )
+
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": String")
+        ]
+      )
+    }
+  }
+
+  func testInlayHintShiftingWorks() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        let y1️⃣ = 2
+        2️⃣
+        let x3️⃣ = 4
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
+        makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Int"),
+      ])
+
+      context.sendChange(
+        range: context.positions["2️⃣"]..<context.positions["2️⃣"],
+        text: """
+          let a: Int = 5
+          let b: Int = 10
+          """
+      )
+
+      let shiftedPositions = DocumentPositions.extract(
+        from: """
+          let y1️⃣ = 2
+          let a: Int = 5
+          let b: Int = 10
+          let x3️⃣ = 4
+          """
+      ).positions
+
+      let shiftedHints = try await context.getCachedInlayHints()
+      assertHintsEqual(
+        shiftedHints,
+        [
+          makeInlayHint(position: shiftedPositions["1️⃣"], kind: .type, label: ": Int"),
+          makeInlayHint(position: shiftedPositions["3️⃣"], kind: .type, label: ": Int"),
+        ]
+      )
+    }
+  }
+
+  func testInlayHintShiftingRemovesHintsInsideDeletedRegion() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        let x1️⃣ = 1
+        2️⃣let y3️⃣ = 24️⃣
+        let z5️⃣ = ""
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
+        makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Int"),
+        makeInlayHint(position: context.positions["5️⃣"], kind: .type, label: ": String"),
+      ])
+
+      context.sendChange(
+        range: context.positions["2️⃣"]..<context.positions["4️⃣"],
+        text: ""
+      )
+
+      let shiftedPositions = DocumentPositions.extract(
+        from: """
+          let x1️⃣ = 1
+
+          let z5️⃣ = ""
+          """
+      ).positions
+
+      let shiftedHints = try await context.getCachedInlayHints()
+      assertHintsEqual(
+        shiftedHints,
+        [
+          makeInlayHint(position: shiftedPositions["1️⃣"], kind: .type, label: ": Int"),
+          makeInlayHint(position: shiftedPositions["5️⃣"], kind: .type, label: ": String"),
+        ]
+      )
+    }
+  }
+
+  func testInlayHintShiftingWithInsertionDirectlyBeforeAHint() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        let x1️⃣ = 1
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int")
+      ])
+
+      context.sendChange(
+        range: context.positions["1️⃣"]..<context.positions["1️⃣"],
+        text: "yz"
+      )
+
+      let shiftedPositions = DocumentPositions.extract(
+        from: """
+          let xyz1️⃣ = 1
+          """
+      ).positions
+
+      let shiftedHints = try await context.getCachedInlayHints()
+      assertHintsEqual(
+        shiftedHints,
+        [
+          makeInlayHint(position: shiftedPositions["1️⃣"], kind: .type, label: ": Int")
+        ]
+      )
+    }
+  }
+
+  func testInlayHintShiftingWithMultiCodePointInsertion() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        1️⃣let x2️⃣ = 1
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Int")
+      ]
+      )
+
+      let inserted = "👨‍💻"
+      context.sendChange(
+        range: context.positions["1️⃣"]..<context.positions["1️⃣"],
+        text: inserted
+      )
+
+      let shiftedPositions = DocumentPositions.extract(
+        from: """
+          👨‍💻let x2️⃣ = 1
+          """
+      ).positions
+
+      let shiftedHints = try await context.getCachedInlayHints()
+      assertHintsEqual(
+        shiftedHints,
+        [
+          makeInlayHint(position: shiftedPositions["2️⃣"], kind: .type, label: ": Int")
+        ]
+      )
+    }
+  }
+
+  func testInlayHintShiftingWithMultiCodePointAndNewlineInsertionDirectlyBeforeAHint() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        let x1️⃣ = 1
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int")
+      ])
+
+      context.sendChange(
+        range: context.positions["1️⃣"]..<context.positions["1️⃣"],
+        text: "abc\n👨‍💻"
+      )
+
+      let shiftedPositions = DocumentPositions.extract(
+        from: """
+          let xabc
+          👨‍💻1️⃣ = 1
+          """
+      ).positions
+
+      let shiftedHints = try await context.getCachedInlayHints()
+      assertHintsEqual(
+        shiftedHints,
+        [
+          makeInlayHint(position: shiftedPositions["1️⃣"], kind: .type, label: ": Int")
+        ]
+      )
+    }
+  }
+
+  func testInlayHintShiftingWithMultipleChanges() async throws {
+    try await runInlayHintTestCase(
+      initialText: """
+        4️⃣let x1️⃣ = 1
+        let y2️⃣ = 2
+
+        let z3️⃣ = ""
+        """,
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
+        makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
+        makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Int"),
+        makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": String"),
+      ])
+
+      context.sendChanges(changes: [
+        (range: context.positions["4️⃣"]..<context.positions["4️⃣"], text: "let abc = 5\n"),
+        (range: Position(line: 2, utf16index: 0)..<Position(line: 3, utf16index: 0), text: ""),
+        (range: Position(line: 3, utf16index: 0)..<Position(line: 3, utf16index: 0), text: "let str = \"test\"\n"),
+      ])
+
+      let shiftedPositions = DocumentPositions.extract(
+        from: """
+          let abc = 5
+          let x1️⃣ = 1
+
+          let str = "test"
+          let z2️⃣ = ""
+          """
+      ).positions
+
+      let shiftedHints = try await context.getCachedInlayHints()
+      assertHintsEqual(
+        shiftedHints,
+        [
+          // hint for let x = 1
+          makeInlayHint(position: shiftedPositions["1️⃣"], kind: .type, label: ": Int"),
+          // hint for let z = ""
+          makeInlayHint(position: shiftedPositions["2️⃣"], kind: .type, label: ": String"),
+          // no other hints are present as they were either removed or haven't been computed by the background task yet
+        ]
+      )
+    }
   }
 }


### PR DESCRIPTION
Fixes #2468.

## Comparison
Before:

https://github.com/user-attachments/assets/abd4570b-2083-410e-809e-155adfe466f4

https://github.com/user-attachments/assets/13157ee3-d992-4a2e-9aa7-8efae977983a

After:

https://github.com/user-attachments/assets/b8e37145-927f-4447-a620-bc9ff1487956

https://github.com/user-attachments/assets/e9e510aa-7a2b-4abb-a4ac-85943bb1d774

## Description

Currently, we always recomputed the inlay hints by calling into SourceKit. If the document that we compute inlay hints for has recently changed, SourceKit may need a bit of time to perform parsing and semantic analysis. The inlay hints may thus need roughly 200-700ms to be computed. This causes flickering in VSCode as it removes the old inlay hints immediately and only displays them again when SourceKit-LSP returned them.

With this PR the inlay hints are cached and recomputed in the background. On each `textDocument/didChange` request the cached inlay hints are shifted according to the text edits to ensure their positions are still correct. This avoids the flickering as we always have inlay hints which we can return immediately. The returned hints may however temporarily show outdated type information until the background recompute is finished. This can be seen in the first example where the inlay hints need a short time to be updated.

## Open Questions / ToDo

There are still a few open questions which I need to think about, but I also wanted to get input on them as early as possible:

In the current version of this PR whenever the file changes, the inlay hints for the entire file are recomputed. I think this is not strictly necessary, but I'm also unsure how much of an impact it has compared to only computing inlay hints for a part of the document. The main thing that takes time for computing inlay hints is the parsing and semantic analysis of the file in SourceKit. I haven't looked into if it can do this incrementally or if it always does the semantic analysis for the entire file.

~~The inlay hints for `#if` directives are currently also cached, but I'm not sure that's necessary, they can maybe be recomputed each time.~~

~~It may currently also be possible to have a memory leak with the cache if the client disconnects/loses connection without sending a `didClose` request. This can maybe be handled by using a LRU cache or a timeout after which the cached inlay hints for a document are dropped if they were not accessed.~~

~~I also don't like the constant conversions between `Position`s and `AbsolutePosition`s in the code, but they probably can't be avoided.~~

## `DocumentSnapshot` changes 

I can also move the two commits for the `DocumentSnapshot` methods to a separate PR.