### PR TITLE
Preserve language service when closing generated interface

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1442,7 +1442,9 @@ extension SourceKitLSPServer {
       await languageService.closeDocument(notification)
     }
 
-    workspace.removeLanguageServices(for: uri)
+    if !documentManager.openDocuments.contains(where: { $0.buildSettingsFile == uri.buildSettingsFile }) {
+      workspace.removeLanguageServices(for: uri)
+    }
 
     workspaceQueue.async {
       self.workspaceForUri[notification.textDocument.uri] = nil

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -395,6 +395,41 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
     XCTAssertEqual(transformLocation.uri.scheme, "sourcekit-lsp")
     assertContains(transformLocation.uri.pseudoPath, "Foundation.NSAffineTransform.swiftinterface")
   }
+
+  func testClosingGeneratedInterfacePreservesOriginatingLanguageService() async throws {
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(experimental: [
+        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+      ])
+    )
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      func test(x: 1️⃣String) {
+        let y: 2️⃣Int = 1
+      }
+      """,
+      uri: uri
+    )
+
+    let definition = try await testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let interfaceUri = try XCTUnwrap(definition?.locations?.only?.uri)
+    let interfaceContents = try await testClient.send(GetReferenceDocumentRequest(uri: interfaceUri))
+    testClient.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(uri: interfaceUri, language: .swift, version: 0, text: interfaceContents.content)
+      )
+    )
+    testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(interfaceUri)))
+
+    let hover = try await testClient.send(
+      HoverRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    XCTAssertNotNil(hover)
+  }
 }
 
 private func assertSystemSwiftInterface(


### PR DESCRIPTION
Closing a generated interface was removing the language service for the originating file because both share the same buildSettingsFile key. https://github.com/swiftlang/sourcekit-lsp/blob/main/Sources/SourceKitLSP/ReferenceDocumentURL.swift#L125
Guard the removal by when no other open document shares that key.
See #2209 and https://github.com/swiftlang/sourcekit-lsp/commit/7437d924538e229dab98e3b6d87ae51db467d196