### PR TITLE
[6.3][cherrypick]Fix rpath handling on OpenBSD.

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -142,6 +142,11 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace, suppress_verb
         # Required for SwiftPM to find sqlite
         swiftpm_args += ['-Xcxx', '-I', '-Xcxx', '/usr/local/include',
                          '-Xswiftc', '-I', '-Xswiftc', '/usr/local/include']
+    elif build_os.startswith('openbsd'):
+        swiftpm_args += [
+            '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/openbsd',
+            '-Xlinker', '-z', '-Xlinker', 'origin',
+        ]
     elif not build_os.startswith('macosx'):
         # Library rpath for swift, dispatch, Foundation, etc. when installing
         swiftpm_args += [


### PR DESCRIPTION
- **Explanation**:

Set rpath and required `-z origin` flags for this platform.

- **Scope**:

Minor, scoped to the platform only.

- **Issues**:

Of relevance to the OpenBSD port at swiftlang/swift#78437

- **Original PRs**:

#2570 

- **Risk**:

Minimal, since it affects only this platform.

- **Testing**:

Passed CI and local testing.

- **Reviewers**:

@ahoppen 
also cc @hamishknight