### PR TITLE
[6.3][cherrypick]Add option to install without building.

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -263,9 +263,10 @@ def install(swift_exec: str, args: argparse.Namespace) -> None:
     additional_env = get_swiftpm_environment_variables(swift_exec, args)
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args=swiftpm_args, additional_env=additional_env)
 
-    build_single_product('sourcekit-lsp', swift_exec, args)
-    build_single_product('SwiftSourceKitPlugin', swift_exec, args)
-    build_single_product('SwiftSourceKitClientPlugin', swift_exec, args)
+    if not args.install_only:
+        build_single_product('sourcekit-lsp', swift_exec, args)
+        build_single_product('SwiftSourceKitPlugin', swift_exec, args)
+        build_single_product('SwiftSourceKitClientPlugin', swift_exec, args)
 
     if platform.system() == 'Darwin':
         dynamic_library_extension = "dylib"
@@ -334,6 +335,7 @@ def parse_args() -> argparse.Namespace:
     install_parser = subparsers.add_parser('install', help='build the package')
     add_common_args(install_parser)
     install_parser.add_argument('--prefix', dest='install_prefixes', nargs='*', metavar='PATHS', help="paths to install sourcekit-lsp, default: 'toolchain/bin'")
+    install_parser.add_argument('--install-only', action='store_true', default=False)
 
     args = parser.parse_args(sys.argv[1:])
 


### PR DESCRIPTION
- **Explanation**:

Allows the install action to be run without rebuilding.

- **Scope**:

Minor. Option is not wired up to anything.

- **Issues**:

Of relevance to the OpenBSD port in swiftlang/swift#78437

- **Original PRs**:

#2579 

- **Risk**:

Minor. Option is off by default.

- **Testing**:

Local testing, passed CI.

- **Reviewers**:

@rintaro 
also cc @hamishknight 