### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -332,10 +332,10 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     }
 
     let buildFlags = BuildFlags(
-      cCompilerFlags: options.swiftPMOrDefault.cCompilerFlags ?? [],
-      cxxCompilerFlags: options.swiftPMOrDefault.cxxCompilerFlags ?? [],
-      swiftCompilerFlags: options.swiftPMOrDefault.swiftCompilerFlags ?? [],
-      linkerFlags: options.swiftPMOrDefault.linkerFlags ?? []
+      cCompilerFlags: (options.swiftPMOrDefault.cCompilerFlags ?? []).map { BuildFlag(value: $0, source: nil) },
+      cxxCompilerFlags: (options.swiftPMOrDefault.cxxCompilerFlags ?? []).map { BuildFlag(value: $0, source: nil) },
+      swiftCompilerFlags: (options.swiftPMOrDefault.swiftCompilerFlags ?? []).map { BuildFlag(value: $0, source: nil) },
+      linkerFlags: (options.swiftPMOrDefault.linkerFlags ?? []).map { BuildFlag(value: $0, source: nil) },
     )
 
     self.toolsBuildParameters = try BuildParameters(

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1027,7 +1027,7 @@ extension SourceKitLSPServer {
 
     capabilityRegistry = CapabilityRegistry(clientCapabilities: clientCapabilities)
 
-    let initializeOptions = orLog("Parsing options") { try SourceKitLSPOptions(fromLSPAny: req.initializationOptions) }
+    let initializeOptions = SourceKitLSPOptions(fromLSPAny: req.initializationOptions)
     _options.withLock { options in
       options = SourceKitLSPOptions.merging(base: options, override: initializeOptions)
     }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -566,7 +566,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
       //
       // Technically, we might be doing unnecessary work here if the output file map is already up-to-date. But since
       // this option is mostly intended for testing purposes, this is acceptable.
-      await buildServerManager.scheduleRecomputeCopyFileMap().value
+      _ = await buildServerManager.scheduleRecomputeCopyFileMap().value
     }
     if request.index ?? false {
       if let semanticIndexManager = await semanticIndexManager {

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -25,7 +25,7 @@ import SemanticIndex
 package import SourceKitD
 package import SourceKitLSP
 import SwiftExtensions
-@_spi(ExperimentalLanguageFeatures) public import SwiftParser
+@_spi(ExperimentalLanguageFeatures) package import SwiftParser
 import SwiftParserDiagnostics
 package import SwiftSyntax
 package import ToolchainRegistry


### PR DESCRIPTION
- **Explanation**: Fix all build warnings except those caused by using old DocC request/response types, which are a little harder to resolve.
- **Scope**: Buildtime only
- **Issue**: n/a
- **Risk**: Low
- **Testing**: Still builds