### PR TITLE
Deduplicate rename locations from multiple compilation units

### DIFF
--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -30,6 +30,23 @@ private extension RenameLocation.Usage {
       self = .reference
     }
   }
+
+  /// Higher rank means more specific usage. Used to pick the best usage when multiple index occurrences exist for the
+  /// same source location — `definition` must win because it triggers parameter renaming in function bodies.
+  var specificityRank: Int {
+    switch self {
+    case .definition: 3
+    case .call: 2
+    case .reference: 1
+    case .unknown: 0
+    }
+  }
+}
+
+/// A position in a source file, used as a key to deduplicate `RenameLocation`s that refer to the same place.
+private struct RenameLocationPosition: Hashable {
+  let line: Int
+  let utf8Column: Int
 }
 
 private extension IndexSymbolKind {
@@ -370,6 +387,30 @@ extension SourceKitLSPServer {
         locationsByFile[uri] = (existingLocations.renameLocations + [renameLocation], occurrence.symbolProvider)
       } else {
         locationsByFile[uri] = ([renameLocation], occurrence.symbolProvider)
+      }
+    }
+
+    // Deduplicate rename locations that appear at the same position within a file. When a file is indexed by multiple
+    // compilation units (e.g. multiple targets in a build system), `index.occurrences` returns one entry per unit,
+    // producing duplicate `RenameLocation`s for the same source position. Without deduplication the resulting
+    // `WorkspaceEdit` contains overlapping `TextEdit`s which editors rightfully reject.
+    // When duplicates exist at the same position, prefer the most specific usage.
+    for (uri, value) in locationsByFile {
+      var bestIndexByPosition: [RenameLocationPosition: Int] = [:]
+      var deduplicatedLocations: [RenameLocation] = []
+      for location in value.renameLocations {
+        let key = RenameLocationPosition(line: location.line, utf8Column: location.utf8Column)
+        if let existingIndex = bestIndexByPosition[key] {
+          if location.usage.specificityRank > deduplicatedLocations[existingIndex].usage.specificityRank {
+            deduplicatedLocations[existingIndex] = location
+          }
+        } else {
+          bestIndexByPosition[key] = deduplicatedLocations.count
+          deduplicatedLocations.append(location)
+        }
+      }
+      if deduplicatedLocations.count != value.renameLocations.count {
+        locationsByFile[uri] = (deduplicatedLocations, value.symbolProvider)
       }
     }
 

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -1303,6 +1303,106 @@ final class RenameTests: SourceKitLSPTestCase {
     )
   }
 
+  func testRenameSymbolUsedByMultipleTargets() async throws {
+    // When a symbol is used across multiple targets, the index may return duplicate occurrences for the same source
+    // location (one per compilation unit that indexed the file). The rename handler must deduplicate them so the
+    // resulting WorkspaceEdit doesn't contain overlapping TextEdits — which editors reject.
+    try await assertMultiFileRename(
+      files: [
+        "LibA/LibA.swift": """
+        public func 1️⃣foo2️⃣() {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func testB() {
+          3️⃣foo4️⃣()
+        }
+        """,
+        "LibC/LibC.swift": """
+        import LibA
+        public func testC() {
+          5️⃣foo6️⃣()
+        }
+        """,
+      ],
+      newName: "bar",
+      expectedPrepareRenamePlaceholder: "foo",
+      expected: [
+        "LibA/LibA.swift": """
+        public func bar() {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func testB() {
+          bar()
+        }
+        """,
+        "LibC/LibC.swift": """
+        import LibA
+        public func testC() {
+          bar()
+        }
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(name: "LibA"),
+            .target(name: "LibB", dependencies: ["LibA"]),
+            .target(name: "LibC", dependencies: ["LibA"]),
+          ]
+        )
+        """
+    )
+  }
+
+  func testRenameAcrossMultipleTargetsProducesNoDuplicateEdits() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "LibA/LibA.swift": """
+        public func 1️⃣foo() {}
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+        public func testB() {
+          foo()
+        }
+        """,
+        "LibC/LibC.swift": """
+        import LibA
+        public func testC() {
+          foo()
+        }
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(name: "LibA"),
+            .target(name: "LibB", dependencies: ["LibA"]),
+            .target(name: "LibC", dependencies: ["LibA"]),
+          ]
+        )
+        """,
+      enableBackgroundIndexing: true
+    )
+    let (uri, positions) = try project.openDocument("LibA.swift")
+    let result = try await project.testClient.send(
+      RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"], newName: "bar")
+    )
+    let changes = try XCTUnwrap(result?.changes)
+    for (uri, edits) in changes {
+      let rangeStrings = edits.map { "\($0.range)" }
+      XCTAssertEqual(
+        rangeStrings.count,
+        Set(rangeStrings).count,
+        "Duplicate edits found in \(uri): \(rangeStrings)"
+      )
+    }
+  }
+
   func testRenameDoesNotReportEditsIfNoActualChangeIsMade() async throws {
     let project = try await SwiftPMTestProject(
       files: [


### PR DESCRIPTION
## Summary

When a file is indexed by multiple compilation units (e.g. multiple targets in a build system reference the same source file), `index.occurrences(ofUSR:roles:)` returns one entry per unit for the same source position. This produces duplicate `RenameLocation`s which generate overlapping `TextEdit`s in the `WorkspaceEdit`. Editors such as VS Code reject overlapping edits, causing **"Rename failed to apply edits"** with no further details.

This was observed in a large GN-based project (Chromium fork) where a widely-used type (`Disposable`) was compiled into many targets. The SourceKit-LSP log showed the `textDocument/rename` response containing 8 identical edits for the same range in a single file, and duplicate edits across many other files.

### Changes

- After collecting `RenameLocation`s from the index into `locationsByFile`, deduplicate entries by `(line, utf8Column)`, keeping the most specific `usage` (`definition` > `call` > `reference` > `unknown`). Definition must win because it triggers `editsToRenameParametersInFunctionBody`.
- Added `RenameLocation.Usage.specificityRank` to rank usage types.
- Added `RenameLocationPosition` as a `Hashable` deduplication key.

### Test plan

- Added `testRenameSymbolUsedByMultipleTargets`: end-to-end multi-file rename across 3 SwiftPM targets (LibA defines symbol, LibB and LibC consume it). Verifies correct rename results.
- Added `testRenameAcrossMultipleTargetsProducesNoDuplicateEdits`: directly inspects the `WorkspaceEdit` and asserts no file contains duplicate edits at the same range.
- All 71 existing rename tests (RenameTests + CrossLanguageRenameTests) continue to pass.

Made with [Cursor](https://cursor.com)