### PR TITLE
[6.3]Ensure the string passed to `PathIsRelativeW` is null terminated

### DIFF
--- a/Sources/BuildServerIntegration/CompilationDatabase.swift
+++ b/Sources/BuildServerIntegration/CompilationDatabase.swift
@@ -206,8 +206,9 @@ enum CompilationDatabaseDecodingError: Error {
 fileprivate extension String {
   var isAbsolutePath: Bool {
     #if os(Windows)
-    Array(self.utf16).withUnsafeBufferPointer { buffer in
-      return !PathIsRelativeW(buffer.baseAddress)
+    // PathIsRelativeW requires a null-terminated UTF16 encoded string
+    return withCString(encodedAs: UTF16.self) { ptr in
+      return !PathIsRelativeW(ptr)
     }
     #else
     return self.hasPrefix("/")


### PR DESCRIPTION
Cherry-pick #2361 into release/6.3

* **Explanation**: `PathIsRelativeW` in Windows requires a null terminated string. Ensure to pass null terminated C string encoded with UTF16. This prevents crashes and fixes flaky tests
* **Scope**: compilation database project for Windows
* **Risk**: Low. Small obvious changes, only in Windows
* **Issue**: rdar://165006835
* **Testing**: Passes current test suite.
* **Reviewer**: @bnbarham as the original author, @compnerd, and @ahoppen 
