### PR TITLE
Make RenameLocation unique

### DIFF
--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -46,12 +46,12 @@ package struct AnnotatedTestItem: Sendable {
   }
 }
 
-package struct RenameLocation: Sendable {
+package struct RenameLocation: Sendable, Hashable {
   /// How the identifier at a given location is being used.
   ///
   /// This is primarily used to influence how argument labels should be renamed in Swift and if a location should be
   /// rejected if argument labels don't match.
-  package enum Usage {
+  package enum Usage: Hashable {
     /// The definition of a function/subscript/variable/...
     case definition
 

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -324,7 +324,7 @@ extension SourceKitLSPServer {
 
     // If we have a USR + old name, perform an index lookup to find workspace-wide symbols to rename.
     // First, group all occurrences of that USR by the files they occur in.
-    var locationsByFile: [DocumentURI: (renameLocations: [RenameLocation], symbolProvider: SymbolProviderKind)] = [:]
+    var locationsByFile: [DocumentURI: (renameLocations: Set<RenameLocation>, symbolProvider: SymbolProviderKind)] = [:]
 
     let usrsToRename = try overridingAndOverriddenUsrs(of: usr, index: index)
     let occurrencesToRename = try usrsToRename.flatMap { try index.occurrences(ofUSR: $0, roles: renameRoles) }
@@ -367,7 +367,7 @@ extension SourceKitLSPServer {
             """
           )
         }
-        locationsByFile[uri] = (existingLocations.renameLocations + [renameLocation], occurrence.symbolProvider)
+        locationsByFile[uri] = (existingLocations.renameLocations.union([renameLocation]), occurrence.symbolProvider)
       } else {
         locationsByFile[uri] = ([renameLocation], occurrence.symbolProvider)
       }
@@ -380,7 +380,7 @@ extension SourceKitLSPServer {
       .concurrentMap {
         (
           uri: DocumentURI,
-          value: (renameLocations: [RenameLocation], symbolProvider: SymbolProviderKind)
+          value: (renameLocations: Set<RenameLocation>, symbolProvider: SymbolProviderKind)
         ) -> (DocumentURI, [TextEdit])? in
         let language: Language
         switch value.symbolProvider {
@@ -405,16 +405,19 @@ extension SourceKitLSPServer {
           return nil
         }
 
+        let renameLocations = value.renameLocations.sorted {
+          ($0.line, $0.utf8Column) < ($1.line, $1.utf8Column)
+        }
         var edits: [TextEdit] =
           await orLog("Getting edits for rename location") {
             return try await languageService.editsToRename(
-              locations: value.renameLocations,
+              locations: renameLocations,
               in: snapshot,
               oldName: oldName,
               newName: newName
             )
           } ?? []
-        for location in value.renameLocations where location.usage == .definition {
+        for location in renameLocations where location.usage == .definition {
           edits += await languageService.editsToRenameParametersInFunctionBody(
             snapshot: snapshot,
             renameLocation: location,

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -10,9 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SourceKitLSP) import BuildServerProtocol
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKLogging
 import SKTestSupport
+import SwiftExtensions
+import ToolchainRegistry
 import XCTest
 
 final class RenameTests: SourceKitLSPTestCase {
@@ -1322,5 +1325,125 @@ final class RenameTests: SourceKitLSPTestCase {
       RenameRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"], newName: "foo(x:)")
     )
     XCTAssertEqual(result?.changes, [:])
+  }
+
+  func testRenameDedupesMultiUnitIndexEntries() async throws {
+    final class BuildServer: CustomBuildServer {
+      let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
+
+      private let projectRoot: URL
+
+      private let libATarget = BuildTargetIdentifier(uri: try! URI(string: "build://targetA"))
+      private let libBTarget = BuildTargetIdentifier(uri: try! URI(string: "build://targetB"))
+
+      private var sources: [SourcesItem] {
+        return [
+          SourcesItem(
+            target: libATarget,
+            sources: [
+              sourceItem(
+                for: projectRoot.appending(component: "Shared.swift"),
+                outputPath: fakeOutputPath(for: "Shared.swift", in: "LibA")
+              ),
+              sourceItem(
+                for: projectRoot.appending(component: "LibA.swift"),
+                outputPath: fakeOutputPath(for: "LibA.swift", in: "LibA")
+              ),
+            ]
+          ),
+          SourcesItem(
+            target: libBTarget,
+            sources: [
+              sourceItem(
+                for: projectRoot.appending(component: "Shared.swift"),
+                outputPath: fakeOutputPath(for: "Shared.swift", in: "LibB")
+              )
+            ]
+          ),
+        ]
+      }
+
+      init(projectRoot: URL, connectionToSourceKitLSP: any LanguageServerProtocol.Connection) {
+        self.projectRoot = projectRoot
+      }
+
+      func initializeBuildRequest(_ request: InitializeBuildRequest) async throws -> InitializeBuildResponse {
+        return try initializationResponseSupportingBackgroundIndexing(
+          projectRoot: projectRoot,
+          outputPathsProvider: true
+        )
+      }
+
+      func workspaceBuildTargetsRequest(
+        _ request: WorkspaceBuildTargetsRequest
+      ) async throws -> WorkspaceBuildTargetsResponse {
+        WorkspaceBuildTargetsResponse(targets: [
+          BuildTarget(id: libATarget, languageIds: [.swift], dependencies: []),
+          BuildTarget(id: libBTarget, languageIds: [.swift], dependencies: []),
+        ])
+      }
+
+      func buildTargetSourcesRequest(_ request: BuildTargetSourcesRequest) async throws -> BuildTargetSourcesResponse {
+        return BuildTargetSourcesResponse(items: sources.filter { request.targets.contains($0.target) })
+      }
+
+      func textDocumentSourceKitOptionsRequest(
+        _ request: TextDocumentSourceKitOptionsRequest
+      ) async throws -> TextDocumentSourceKitOptionsResponse? {
+        let targetSources = try XCTUnwrap(sources.first(where: { $0.target == request.target })?.sources)
+        let sourceInfo = try XCTUnwrap(targetSources.first(where: { $0.uri == request.textDocument.uri }))
+        var arguments = targetSources.map(\.uri.pseudoPath)
+        arguments += [
+          "-module-name", "Shared",
+          "-index-unit-output-path", try XCTUnwrap(sourceInfo.sourceKitData?.outputPath),
+        ]
+        if request.target == libBTarget {
+          arguments.append("-DLIB_B")
+        }
+        if let defaultSDKPath {
+          arguments += ["-sdk", defaultSDKPath]
+        }
+        return TextDocumentSourceKitOptionsResponse(compilerArguments: arguments)
+      }
+    }
+
+    let project = try await CustomBuildServerTestProject(
+      files: [
+        "Shared.swift": """
+        func 1️⃣foo2️⃣() {}
+        #if LIB_B
+        func extra() {}
+        #endif
+        """,
+        "LibA.swift": """
+        func bar() {
+          3️⃣foo4️⃣()
+        }
+        """,
+      ],
+      buildServer: BuildServer.self,
+      enableBackgroundIndexing: true
+    )
+
+    let newName = "baz"
+    let (libAUri, libAPositions) = try project.openDocument("LibA.swift")
+    let result = try await project.testClient.send(
+      RenameRequest(
+        textDocument: TextDocumentIdentifier(libAUri),
+        position: libAPositions["3️⃣"],
+        newName: newName
+      )
+    )
+    XCTAssertEqual(
+      result,
+      WorkspaceEdit(changes: [
+        try project.uri(for: "Shared.swift"): [
+          TextEdit(range: try project.range(from: "1️⃣", to: "2️⃣", in: "Shared.swift"), newText: newName)
+        ],
+        libAUri: [
+          TextEdit(range: libAPositions["3️⃣"]..<libAPositions["4️⃣"], newText: newName)
+        ],
+      ])
+    )
   }
 }


### PR DESCRIPTION
## Summary

When a file is indexed by multiple compilation units (e.g. multiple targets in a build system compile or import the same source file), `index.occurrences(ofUSR:roles:)` returns one entry per unit for the same source position. These duplicate `RenameLocation`s produce overlapping `TextEdit`s in the `WorkspaceEdit`, which editors reject — VS Code shows "Rename failed to apply edits" with no further detail.

## Changes

- Changed `locationsByFile` to collect rename locations in a `Set<RenameLocation>` instead of `[RenameLocation]`, effectively making duplicates impossible.
- Made `RenameLocation` and `RenameLocation.Usage` conform to `Hashable` so they can be stored in a `Set`.
- Sort the set into an array before passing to `editsToRename`, since the downstream API expects `[RenameLocation]` and some callers depend on ordering.

## Test

- I've added a test case that simulates the issue: it compiles single source file twice with different compilation conditions and then checks that rename doesn't produce duplicate edits. I've verified that this test fails if I rollback the fix.