### PR TITLE
Added forceResolvedVersions option

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -30,6 +30,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `swiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files. Equivalent to SwiftPM's `-Xswiftc` option.
   - `linkerFlags: string[]`: Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.
   - `buildToolsSwiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files or plugins. Equivalent to SwiftPM's `-Xbuild-tools-swiftc` option.
+  - `forceResolvedVersions: boolean`: Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.
   - `disableSandbox: boolean`: Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
   - `buildSystem: "native"|"swiftbuild"`: Which SwiftPM build system should be used when opening a package.
 - `compilationDatabase`: Dictionary with the following keys, defining options for workspaces with a compilation database.

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -481,7 +481,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
 
     let modulesGraph = try await self.swiftPMWorkspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [AbsolutePath(validating: projectRoot.filePath)]),
-      forceResolvedVersions: !isForIndexBuild,
+      forceResolvedVersions: options.swiftPMOrDefault.forceResolvedVersions ?? !isForIndexBuild,
       observabilityScope: observabilitySystem.topScope.makeChildScope(description: "Load package graph")
     )
 

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -69,6 +69,10 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
     /// `-Xbuild-tools-swiftc` option.
     public var buildToolsSwiftCompilerFlags: [String]?
 
+    /// Equivalent to SwiftPM's `--force-resolved-versions` option.
+    /// Makes all processes (including background indexing) treat Package.resolved as a lock file.
+    public var forceResolvedVersions: Bool?
+
     /// Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option.
     /// Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
     public var disableSandbox: Bool?
@@ -96,6 +100,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
       swiftCompilerFlags: [String]? = nil,
       linkerFlags: [String]? = nil,
       buildToolsSwiftCompilerFlags: [String]? = nil,
+      forceResolvedVersions: Bool? = nil,
       disableSandbox: Bool? = nil,
       skipPlugins: Bool? = nil,
       buildSystem: SwiftPMBuildSystem? = nil
@@ -113,6 +118,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
       self.swiftCompilerFlags = swiftCompilerFlags
       self.linkerFlags = linkerFlags
       self.buildToolsSwiftCompilerFlags = buildToolsSwiftCompilerFlags
+      self.forceResolvedVersions = forceResolvedVersions
       self.disableSandbox = disableSandbox
       self.buildSystem = buildSystem
     }
@@ -132,6 +138,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
         swiftCompilerFlags: override?.swiftCompilerFlags ?? base.swiftCompilerFlags,
         linkerFlags: override?.linkerFlags ?? base.linkerFlags,
         buildToolsSwiftCompilerFlags: override?.buildToolsSwiftCompilerFlags ?? base.buildToolsSwiftCompilerFlags,
+        forceResolvedVersions: override?.forceResolvedVersions ?? base.forceResolvedVersions,
         disableSandbox: override?.disableSandbox ?? base.disableSandbox,
         skipPlugins: override?.skipPlugins ?? base.skipPlugins,
         buildSystem: override?.buildSystem ?? base.buildSystem

--- a/config.schema.json
+++ b/config.schema.json
@@ -282,6 +282,11 @@
           "markdownDescription" : "Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.",
           "type" : "boolean"
         },
+        "forceResolvedVersions" : {
+          "description" : "Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.",
+          "markdownDescription" : "Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.",
+          "type" : "boolean"
+        },
         "linkerFlags" : {
           "description" : "Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.",
           "items" : {


### PR DESCRIPTION
Acts as a work around for https://github.com/swiftlang/sourcekit-lsp/issues/2602

## Motivation
In some cases, devs don't want source kit to write to `Package.resolved`. Consider this example from https://github.com/swiftlang/sourcekit-lsp/issues/2602: the VS Code Swift extension is passed in the `--replace-scm-with-registry` flag via project-scoped VS Code settings. This means that when the extension does a package resolve, it replaces every GitHub package defined in the `Package.swift` with the same package from the project's registry. 

Source kit doesn't have an option that maps to `--replace-scm-with-registry`, so on every change, it writes to `Package.resolve`, ignoring `--replace-scm-with-registry`. Developers have to turn off background indexing to stop source kit from stomping on the resolved file. 

## Modifications
This PR adds an option to tell source kit to always treat `Package.resolved` as a lock file, and never write to it.

I followed the pattern of adding an option to `SourceKitLSPOptions.swift`, and auto-generating the docs for this new option.

## Manual Test
Here's the manual test I ran to ensure this new option is picked up by source kit: 

Before my change, when you deleted `Package.resolved`, source kit would automatically run a resolve, and add it back. 

After you build and run my version of source kit, and pass in `forceResolvedVersions`, this will stop happening. Deleted resolved files will stay deleted. 

1. Build a release binary:

`swift build -c release --product sourcekit-lsp`
That produces "/path/to/sourcekit-lsp/.build/out/Products/Release/sourcekit-lsp"

2. Tell VS Code to use the release binary

In the VS Code settings for any Swift package (`.vscode/settings.json`):

```json
{
  "swift.sourcekit-lsp.serverPath": "/path/to/sourcekit-lsp/.build/out/Products/Release/sourcekit-lsp"
}
```

3. Restart LSP

Press `Shift + Cmd + P` and run "Swift: Restart LSP Server". 

4. Pass in the flag

Add `.sourcekit-lsp/config.json`, and add this setting: 

```json
{ "swiftPM": { "forceResolvedVersions": true } }
```

5. Delete `Package.resolved`

Now when you delete `Package.resolved`, it won't re-create itself until you manually resolve.