### PR TITLE
[6.3] Added forceResolvedVersions option

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -29,6 +29,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `swiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files. Equivalent to SwiftPM's `-Xswiftc` option.
   - `linkerFlags: string[]`: Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.
   - `buildToolsSwiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files or plugins. Equivalent to SwiftPM's `-Xbuild-tools-swiftc` option.
+  - `forceResolvedVersions: boolean`: Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.
   - `disableSandbox: boolean`: Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
   - `buildSystem: "native"|"swiftbuild"`: Which SwiftPM build system should be used when opening a package.
 - `compilationDatabase`: Dictionary with the following keys, defining options for workspaces with a compilation database.

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -422,7 +422,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
 
     let modulesGraph = try await self.swiftPMWorkspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [AbsolutePath(validating: projectRoot.filePath)]),
-      forceResolvedVersions: !isForIndexBuild,
+      forceResolvedVersions: options.swiftPMOrDefault.forceResolvedVersions ?? !isForIndexBuild,
       observabilityScope: observabilitySystem.topScope.makeChildScope(description: "Load package graph")
     )
 

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -66,6 +66,10 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     /// `-Xbuild-tools-swiftc` option.
     public var buildToolsSwiftCompilerFlags: [String]?
 
+    /// Equivalent to SwiftPM's `--force-resolved-versions` option.
+    /// Makes all processes (including background indexing) treat Package.resolved as a lock file.
+    public var forceResolvedVersions: Bool?
+
     /// Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option.
     /// Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
     public var disableSandbox: Bool?
@@ -92,6 +96,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       swiftCompilerFlags: [String]? = nil,
       linkerFlags: [String]? = nil,
       buildToolsSwiftCompilerFlags: [String]? = nil,
+      forceResolvedVersions: Bool? = nil,
       disableSandbox: Bool? = nil,
       skipPlugins: Bool? = nil,
       buildSystem: SwiftPMBuildSystem? = nil
@@ -108,6 +113,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       self.swiftCompilerFlags = swiftCompilerFlags
       self.linkerFlags = linkerFlags
       self.buildToolsSwiftCompilerFlags = buildToolsSwiftCompilerFlags
+      self.forceResolvedVersions = forceResolvedVersions
       self.disableSandbox = disableSandbox
       self.buildSystem = buildSystem
     }
@@ -126,6 +132,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
         swiftCompilerFlags: override?.swiftCompilerFlags ?? base.swiftCompilerFlags,
         linkerFlags: override?.linkerFlags ?? base.linkerFlags,
         buildToolsSwiftCompilerFlags: override?.buildToolsSwiftCompilerFlags ?? base.buildToolsSwiftCompilerFlags,
+        forceResolvedVersions: override?.forceResolvedVersions ?? base.forceResolvedVersions,
         disableSandbox: override?.disableSandbox ?? base.disableSandbox,
         skipPlugins: override?.skipPlugins ?? base.skipPlugins,
         buildSystem: override?.buildSystem ?? base.buildSystem

--- a/config.schema.json
+++ b/config.schema.json
@@ -252,6 +252,11 @@
           "markdownDescription" : "Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.",
           "type" : "boolean"
         },
+        "forceResolvedVersions" : {
+          "description" : "Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.",
+          "markdownDescription" : "Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.",
+          "type" : "boolean"
+        },
         "linkerFlags" : {
           "description" : "Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.",
           "items" : {


### PR DESCRIPTION
- **Explanation**:
In some cases, devs don't want source kit to write to `Package.resolved`. This adds an option that tells source kit to treat the resolved file as a lock file. 
- **Scope**:
This is an optional flag that users have to opt in to by writing to `.sourcekit-lsp/config.json`. Nothing will change for users who do not add this setting to the source kit config. 
- **Issues**:
https://github.com/swiftlang/sourcekit-lsp/issues/2602
- **Original PRs**:
https://github.com/swiftlang/sourcekit-lsp/pull/2611
- **Risk**:
Minimal risk. This change doesn't affect the happy path on any platform. 
- **Testing**: 
Ran [the manual test outlined in the original PR description](https://github.com/swiftlang/sourcekit-lsp/pull/2611).
- **Reviewers**:
@plemarquand and @rintaro 