### PR TITLE
Update based on SwiftPM API change

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -339,6 +339,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     )
 
     self.toolsBuildParameters = try BuildParameters(
+      scratchPath: location.scratchDirectory,
       destination: .host,
       dataPath: location.scratchDirectory.appending(
         component: hostSwiftPMToolchain.targetTriple.platformBuildPathComponent
@@ -350,6 +351,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     )
 
     self.destinationBuildParameters = try BuildParameters(
+      scratchPath: location.scratchDirectory,
       destination: .target,
       dataPath: location.scratchDirectory.appending(
         component: destinationSwiftPMToolchain.targetTriple.platformBuildPathComponent


### PR DESCRIPTION
The `BuildParameters` struct in SwiftPM introduced a new property.

Update all call sites to set this property.

Relates to: https://github.com/swiftlang/swift-package-manager/pull/9972
Linked PR: https://github.com/swiftlang/swift-package-manager/pull/9972