### PR TITLE
[Test] Fix testCompilerArgumentsForFileThatContainsPlusCharacterURLEcoded

### DIFF
--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -261,7 +261,7 @@ struct SwiftPMBuildServerTests {
     }
   }
 
-  @Test(.disabled("rdar://175272642"))
+  @Test
   func testCompilerArgumentsForFileThatContainsPlusCharacterURLEncoded() async throws {
     try await withTestScratchDir { tempDir in
       try FileManager.default.createFiles(
@@ -295,12 +295,10 @@ struct SwiftPMBuildServerTests {
         .appending(components: "Sources", "lib", "a+something.swift")
 
       _ = try #require(await buildServerManager.initializationData?.indexStorePath)
-      let pathWithPlusEscaped = "\(try aPlusSomething.filePath.replacing("+", with: "%2B"))"
-      #if os(Windows)
-      let urlWithPlusEscaped = try #require(URL(string: "file:///\(pathWithPlusEscaped)"))
-      #else
-      let urlWithPlusEscaped = try #require(URL(string: "file://\(pathWithPlusEscaped)"))
-      #endif
+      // Simulate an LSP client that percent-encodes `+` as `%2B` in file URIs.
+      let urlWithPlusEscaped = try #require(
+        URL(string: aPlusSomething.absoluteString.replacing("+", with: "%2B"))
+      )
       let arguments = try #require(
         await buildServerManager.buildSettingsInferredFromMainFile(
           for: DocumentURI(urlWithPlusEscaped),


### PR DESCRIPTION
The test was constructing the percent-encoded file URL from `filePath`, which uses native OS path separators. On Windows this produced a backslash-separated path inside a `file://` URL, making the URL malformed. Fix by replacing `+` with `%2B` in `absoluteString` instead, which is already a well-formed URL string with forward slashes on all platforms.

rdar://175272642