### PR TITLE
change default build system inherrence

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -174,7 +174,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       if foundNativeOutputs && foundSwiftBuildOutputs {
         // TODO: update this shortly after SwiftPM's default build system changes.
         // https://github.com/swiftlang/sourcekit-lsp/issues/2576
-        inferredBuildSystem = .native
+        inferredBuildSystem = .swiftbuild
       } else if foundNativeOutputs {
         inferredBuildSystem = .native
       } else if foundSwiftBuildOutputs {


### PR DESCRIPTION
The Swift Build build system is current the default.  Change the default build system.

Relates to: #2576

Merge with: https://github.com/swiftlang/swift-package-manager/pull/9972