### PR TITLE
Improve build system inferrence

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -37,7 +37,6 @@ import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 package import class ToolchainRegistry.Toolchain
 import struct TSCBasic.FileSystemError
-
 private typealias AbsolutePath = Basics.AbsolutePath
 
 /// A build target in SwiftPM
@@ -162,25 +161,34 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       scratchPath = try? AbsolutePath(validating: path.filePath).appending(component: ".build")
     }
     let inferredBuildSystem: SwiftPMBuildSystem?
-    if let scratchPath {
-      let existingScratchContents = try? FileManager.default.contentsOfDirectory(
-        at: scratchPath.asURL,
-        includingPropertiesForKeys: nil
-      )
-      let foundSwiftBuildOutputs = (existingScratchContents ?? []).contains(where: { $0.lastPathComponent == "out" })
-      let foundNativeOutputs = (existingScratchContents ?? []).contains(where: {
-        $0.lastPathComponent == "debug" || $0.lastPathComponent == "release"
-      })
-      if foundNativeOutputs && foundSwiftBuildOutputs {
-        // TODO: update this shortly after SwiftPM's default build system changes.
-        // https://github.com/swiftlang/sourcekit-lsp/issues/2576
-        inferredBuildSystem = .native
-      } else if foundNativeOutputs {
-        inferredBuildSystem = .native
-      } else if foundSwiftBuildOutputs {
-        inferredBuildSystem = .swiftbuild
+    if let scratchPath: AbsolutePath {
+      let config = Self.getSwiftPMBuildConfiguration(options: options)
+      let buildSystemFilePath = scratchPath.appending(".buildSystem_\(config)")
+      if FileManager.default.fileExists(at: buildSystemFilePath.asURL) {
+        do {
+          let buildSystem = try String(contentsOf: buildSystemFilePath.asURL)
+          inferredBuildSystem = SwiftPMBuildSystem(rawValue: buildSystem)
+        } catch {
+          inferredBuildSystem = nil
+        }
       } else {
-        inferredBuildSystem = nil
+        let existingScratchContents = try? FileManager.default.contentsOfDirectory(
+          at: scratchPath.asURL,
+          includingPropertiesForKeys: nil
+        )
+        let foundSwiftBuildOutputs = (existingScratchContents ?? []).contains(where: { $0.lastPathComponent == "out" })
+        let foundNativeOutputs = (existingScratchContents ?? []).contains(where: {
+          $0.lastPathComponent == "debug" || $0.lastPathComponent == "release"
+        })
+        if foundNativeOutputs && foundSwiftBuildOutputs {
+          inferredBuildSystem = .swiftbuild
+        } else if foundNativeOutputs {
+          inferredBuildSystem = .native
+        } else if foundSwiftBuildOutputs {
+          inferredBuildSystem = .swiftbuild
+        } else {
+          inferredBuildSystem = nil
+        }
       }
     } else {
       inferredBuildSystem = nil
@@ -190,6 +198,20 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       projectRoot: path,
       configPath: packagePath
     )
+  }
+
+  /// Converts the SourceKit LSP SwiftPM build configuration value to a SwiftPM API equivalent
+  ///
+  /// -Parameters:
+  ///   - options: The `SourceKitLSPOptions` to use to determine the build configuration.
+  /// - Returns: The `PackageModel.BuildConfiguration` equivalent of the SourceKit `SKOptions.Configuration`.
+  static func getSwiftPMBuildConfiguration(options: SourceKitLSPOptions) -> PackageModel.BuildConfiguration {
+    return switch options.swiftPMOrDefault.configuration {
+    case .debug, nil:
+      .debug
+    case .release:
+      .release
+    }
   }
 
   /// Creates a build server using the Swift Package Manager, if this workspace is a package.
@@ -325,13 +347,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       )
     )
 
-    let buildConfiguration: PackageModel.BuildConfiguration
-    switch options.swiftPMOrDefault.configuration {
-    case .debug, nil:
-      buildConfiguration = .debug
-    case .release:
-      buildConfiguration = .release
-    }
+    let buildConfiguration = Self.getSwiftPMBuildConfiguration(options: options)
 
     let buildFlags = BuildFlags(
       cCompilerFlags: (options.swiftPMOrDefault.cCompilerFlags ?? []).map { BuildFlag(value: $0, source: nil) },

--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -1431,6 +1431,300 @@ struct SwiftPMBuildServerTests {
       #expect(!unexpectedReloadStarted.value)
     }
   }
+
+  /// Verifies that the build system is correctly inferred as 'native' from the `.buildSystem_debug` file.
+  @Test
+  func testBuildSystemInferenceNativeFromFile() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      let buildSystemFile = buildDir.appending(component: ".buildSystem_debug")
+      try "native".write(to: buildSystemFile, atomically: true, encoding: .utf8)
+
+      let spec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: SourceKitLSPOptions())
+      )
+      if case .swiftPM(let inferredBuildSystem) = spec.kind {
+        #expect(inferredBuildSystem == .native, "Expected .native but got \(String(describing: inferredBuildSystem))")
+      } else {
+        Issue.record("Expected swiftPM build server kind")
+      }
+    }
+  }
+
+  /// Verifies that the build system is correctly inferred as 'swiftbuild' from the `.buildSystem_debug` file.
+  @Test
+  func testBuildSystemInferenceSwiftBuildFromFile() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      let buildSystemFile = buildDir.appending(component: ".buildSystem_debug")
+      try "swiftbuild".write(to: buildSystemFile, atomically: true, encoding: .utf8)
+
+      let spec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: SourceKitLSPOptions())
+      )
+      if case .swiftPM(let inferredBuildSystem) = spec.kind {
+        #expect(
+          inferredBuildSystem == .swiftbuild,
+          "Expected .swiftbuild but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind")
+      }
+    }
+  }
+
+  /// Verifies that the build system inference uses the correct file for release configuration.
+  @Test
+  func testBuildSystemInferenceReleaseConfiguration() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      // Create release configuration file
+      let releaseOptions = SourceKitLSPOptions(swiftPM: .init(configuration: .release))
+      let buildSystemFileRelease = buildDir.appending(component: ".buildSystem_release")
+      try "swiftbuild".write(to: buildSystemFileRelease, atomically: true, encoding: .utf8)
+
+      let spec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: releaseOptions)
+      )
+      if case .swiftPM(let inferredBuildSystem) = spec.kind {
+        #expect(
+          inferredBuildSystem == .swiftbuild,
+          "Expected .swiftbuild for release config but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind")
+      }
+    }
+  }
+
+  /// Verifies that the build system inference falls back to heuristics when the file doesn't exist.
+  @Test
+  func testBuildSystemInferenceFallbackToHeuristics() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      // Create 'debug' directory to trigger native heuristic
+      let debugDir = buildDir.appending(component: "debug")
+      try FileManager.default.createDirectory(at: debugDir, withIntermediateDirectories: true)
+
+      let spec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: SourceKitLSPOptions())
+      )
+      if case .swiftPM(let inferredBuildSystem) = spec.kind {
+        #expect(
+          inferredBuildSystem == .native,
+          "Expected .native from heuristic but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind")
+      }
+    }
+  }
+
+  /// Verifies that when both build system outputs exist, swiftbuild is preferred.
+  @Test
+  func testBuildSystemInferencePreferSwiftBuildWhenBothExist() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      // Create both 'debug' and 'out' directories
+      let debugDir = buildDir.appending(component: "debug")
+      let outDir = buildDir.appending(component: "out")
+      try FileManager.default.createDirectory(at: debugDir, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+      let spec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: SourceKitLSPOptions())
+      )
+      if case .swiftPM(let inferredBuildSystem) = spec.kind {
+        #expect(
+          inferredBuildSystem == .swiftbuild,
+          "Expected .swiftbuild when both outputs exist but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind")
+      }
+    }
+  }
+
+  /// Verifies that the correct `.buildSystem_{config}` file is read based on the configuration when both exist.
+  @Test
+  func testBuildSystemInferenceUsesCorrectConfigurationFile() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      // Create both debug and release configuration files with different values
+      let buildSystemFileDebug = buildDir.appending(component: ".buildSystem_debug")
+      let buildSystemFileRelease = buildDir.appending(component: ".buildSystem_release")
+      try "native".write(to: buildSystemFileDebug, atomically: true, encoding: .utf8)
+      try "swiftbuild".write(to: buildSystemFileRelease, atomically: true, encoding: .utf8)
+
+      // Test with debug configuration (default)
+      let debugSpec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: SourceKitLSPOptions())
+      )
+      if case .swiftPM(let inferredBuildSystem) = debugSpec.kind {
+        #expect(
+          inferredBuildSystem == .native,
+          "Expected .native for debug config but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind for debug")
+      }
+
+      // Test with release configuration
+      let releaseOptions = SourceKitLSPOptions(swiftPM: .init(configuration: .release))
+      let releaseSpec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: releaseOptions)
+      )
+      if case .swiftPM(let inferredBuildSystem) = releaseSpec.kind {
+        #expect(
+          inferredBuildSystem == .swiftbuild,
+          "Expected .swiftbuild for release config but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind for release")
+      }
+    }
+  }
+
+  /// Verifies that invalid content in the `.buildSystem_{config}` file results in nil inference.
+  @Test
+  func testBuildSystemInferenceInvalidContent() async throws {
+    try await withTestScratchDir { tempDir in
+      try FileManager.default.createFiles(
+        root: tempDir,
+        files: [
+          "pkg/Sources/lib/a.swift": "",
+          "pkg/Package.swift": """
+          // swift-tools-version:4.2
+          import PackageDescription
+          let package = Package(
+            name: "a",
+            targets: [.target(name: "lib")]
+          )
+          """,
+        ]
+      )
+      let packageRoot = tempDir.appending(component: "pkg")
+      let buildDir = packageRoot.appending(component: ".build")
+      try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+      let buildSystemFile = buildDir.appending(component: ".buildSystem_debug")
+      try "invalid_build_system".write(to: buildSystemFile, atomically: true, encoding: .utf8)
+
+      let spec = try #require(
+        SwiftPMBuildServer.searchForConfig(in: packageRoot, options: SourceKitLSPOptions())
+      )
+      if case .swiftPM(let inferredBuildSystem) = spec.kind {
+        #expect(
+          inferredBuildSystem == nil,
+          "Expected nil for invalid build system but got \(String(describing: inferredBuildSystem))"
+        )
+      } else {
+        Issue.record("Expected swiftPM build server kind")
+      }
+    }
+  }
 }
 
 private func expectArgumentsDoNotContain(


### PR DESCRIPTION
The Swift Build build system is currently the default build system in SwiftPM. Change the default build system.

Also, SwiftPM PR #9985 introduce files in the scratch path whose contents indicate which build system was used to build artifact for a given build configuration.  if this file exist, use it's contents to infer the build system. Otherwise, fallback to the existing behaviour.

Fixes: #2576

Depends on: https://github.com/swiftlang/swift-package-manager/pull/9985