### PR TITLE
Factor out CopiedFileMap as a Sendable value type

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -346,6 +346,165 @@ private extension BuildServerSpec {
   }
 }
 
+/// Maps build-directory copies of source files back to their original source URIs.
+///
+/// During target preparation the build system may copy source files into the build directory
+/// (recorded as `copyDestinations` in `SourceFileInfo`). Index records and diagnostics can
+/// therefore reference the copy rather than the original. `CopiedFileMap` holds the reverse
+/// mapping — copy URI → original source URI — so that the server can translate those locations
+/// back to the files the user is actually editing before returning them to the client.
+package struct CopiedFileMap: Sendable {
+  private var map: [DocumentURI: DocumentURI]
+
+  init(map: [DocumentURI: DocumentURI]) {
+    self.map = map
+  }
+
+  /// Returns `true` if `uri` is a copy of a source file created during target preparation.
+  package func isCopiedFile(_ uri: DocumentURI) -> Bool {
+    return map[uri] != nil
+  }
+
+  /// Returns the original source URI for the given copied file URI, or `nil` if the URI is not a known copy.
+  package func originalURI(for uri: DocumentURI) -> DocumentURI? {
+    return map[uri]
+  }
+
+  /// Check if the URI referenced by `location` has been copied during the preparation phase. If so, adjust the URI to
+  /// the original source file.
+  package func locationAdjustedForCopiedFiles(_ location: Location) -> Location {
+    guard let originalUri = map[location.uri] else {
+      return location
+    }
+
+    if let fileUrl = originalUri.fileURL, !FileManager.default.fileExists(at: fileUrl) {
+      return location
+    }
+    // If we regularly get issues that the copied file is out-of-sync with its original, we can check that the contents
+    // of the lines touched by the location match and only return the original URI if they do. For now, we avoid this
+    // check due to its performance cost of reading files from disk.
+    return Location(uri: originalUri, range: location.range)
+  }
+
+  /// Check if the URI referenced by `location` has been copied during the preparation phase. If so, adjust the URI to
+  /// the original source file.
+  package func locationsAdjustedForCopiedFiles(_ locations: [Location]) -> [Location] {
+    return locations.map { locationAdjustedForCopiedFiles($0) }
+  }
+
+  private func uriAdjustedForCopiedFiles(_ uri: DocumentURI) -> DocumentURI {
+    guard let originalUri = map[uri] else {
+      return uri
+    }
+    return originalUri
+  }
+
+  package func workspaceEditAdjustedForCopiedFiles(_ workspaceEdit: WorkspaceEdit?) -> WorkspaceEdit? {
+    guard var edit = workspaceEdit else {
+      return nil
+    }
+    if let changes = edit.changes {
+      var newChanges: [DocumentURI: [TextEdit]] = [:]
+      for (uri, edits) in changes {
+        let newUri = self.uriAdjustedForCopiedFiles(uri)
+        newChanges[newUri, default: []] += edits
+      }
+      edit.changes = newChanges
+    }
+    if let documentChanges = edit.documentChanges {
+      edit.documentChanges = documentChanges.map { change in
+        switch change {
+        case .textDocumentEdit(var textEdit):
+          textEdit.textDocument.uri = self.uriAdjustedForCopiedFiles(textEdit.textDocument.uri)
+          return .textDocumentEdit(textEdit)
+        case .createFile(var create):
+          create.uri = self.uriAdjustedForCopiedFiles(create.uri)
+          return .createFile(create)
+        case .renameFile(var rename):
+          rename.oldUri = self.uriAdjustedForCopiedFiles(rename.oldUri)
+          rename.newUri = self.uriAdjustedForCopiedFiles(rename.newUri)
+          return .renameFile(rename)
+        case .deleteFile(var delete):
+          delete.uri = self.uriAdjustedForCopiedFiles(delete.uri)
+          return .deleteFile(delete)
+        }
+      }
+    }
+    return edit
+  }
+
+  package func locationsOrLocationLinksAdjustedForCopiedFiles(
+    _ response: LocationsOrLocationLinksResponse?
+  ) -> LocationsOrLocationLinksResponse? {
+    guard let response = response else {
+      return nil
+    }
+    switch response {
+    case .locations(let locations):
+      let remappedLocations = self.locationsAdjustedForCopiedFiles(locations)
+      return .locations(remappedLocations)
+    case .locationLinks(let locationLinks):
+      let remappedLinks = locationLinks.map { link -> LocationLink in
+        let adjustedTargetLocation = self.locationAdjustedForCopiedFiles(
+          Location(uri: link.targetUri, range: link.targetRange)
+        )
+        let adjustedTargetSelectionLocation = self.locationAdjustedForCopiedFiles(
+          Location(uri: link.targetUri, range: link.targetSelectionRange)
+        )
+        return LocationLink(
+          originSelectionRange: link.originSelectionRange,
+          targetUri: adjustedTargetLocation.uri,
+          targetRange: adjustedTargetLocation.range,
+          targetSelectionRange: adjustedTargetSelectionLocation.range
+        )
+      }
+      return .locationLinks(remappedLinks)
+    }
+  }
+
+  package func typeHierarchyItemAdjustedForCopiedFiles(_ item: TypeHierarchyItem) -> TypeHierarchyItem {
+    let adjustedLocation = self.locationAdjustedForCopiedFiles(Location(uri: item.uri, range: item.range))
+    let adjustedSelectionLocation = self.locationAdjustedForCopiedFiles(
+      Location(uri: item.uri, range: item.selectionRange)
+    )
+    return TypeHierarchyItem(
+      name: item.name,
+      kind: item.kind,
+      tags: item.tags,
+      detail: item.detail,
+      uri: adjustedLocation.uri,
+      range: adjustedLocation.range,
+      selectionRange: adjustedSelectionLocation.range,
+      data: item.data
+    )
+  }
+
+  package func callHierarchyItemAdjustedForCopiedFiles(_ item: CallHierarchyItem) -> CallHierarchyItem {
+    let adjustedLocation = self.locationAdjustedForCopiedFiles(Location(uri: item.uri, range: item.range))
+    let adjustedSelectionLocation = self.locationAdjustedForCopiedFiles(
+      Location(uri: item.uri, range: item.selectionRange)
+    )
+    return CallHierarchyItem(
+      name: item.name,
+      kind: item.kind,
+      tags: item.tags,
+      detail: item.detail,
+      uri: adjustedLocation.uri,
+      range: adjustedLocation.range,
+      selectionRange: adjustedSelectionLocation.range,
+      data: .dictionary([
+        "usr": item.data.flatMap { data in
+          if case let .dictionary(dict) = data {
+            return dict["usr"]
+          }
+          return nil
+        } ?? .null,
+        "uri": .string(adjustedLocation.uri.stringValue),
+      ])
+    )
+  }
+}
+
 /// Entry point for all build server queries.
 package actor BuildServerManager: QueueBasedMessageHandler {
   package let messageHandlingHelper = QueueBasedMessageHandlerHelper(
@@ -504,14 +663,14 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   private let cachedSourceFilesAndDirectories = Cache<SourceFilesAndDirectoriesKey, SourceFilesAndDirectories>()
 
   /// Task that computes the latest map of copied file URIs to their original source locations.
-  private var copiedFileMap: Task<[DocumentURI: DocumentURI], Never>?
+  private var copiedFileMap: Task<CopiedFileMap, Never>?
 
   /// The last computed copied file map, which may be out-of-date.
   ///
   /// Even with out-of-date information for the copied file map, we can provide reasonable functionality - in the worst
   /// case we jump to a file in the build directory instead of the source directory. We don't want to block requests
   /// like definition on receiving up-to-date build target information from the build server.
-  private var cachedCopiedFileMap: [DocumentURI: DocumentURI] = [:]
+  package private(set) var cachedCopiedFileMap: CopiedFileMap = CopiedFileMap(map: [:])
 
   /// The `SourceKitInitializeBuildResponseData` received from the `build/initialize` request, if any.
   package var initializationData: SourceKitInitializeBuildResponseData? {
@@ -980,142 +1139,9 @@ package actor BuildServerManager: QueueBasedMessageHandler {
     }
   }
 
-  /// Check if the URI referenced by `location` has been copied during the preparation phase. If so, adjust the URI to
-  /// the original source file.
-  package func locationAdjustedForCopiedFiles(_ location: Location) -> Location {
-    guard let originalUri = cachedCopiedFileMap[location.uri] else {
-      return location
-    }
-    if let fileUrl = originalUri.fileURL, !FileManager.default.fileExists(at: fileUrl) {
-      return location
-    }
-    // If we regularly get issues that the copied file is out-of-sync with its original, we can check that the contents
-    // of the lines touched by the location match and only return the original URI if they do. For now, we avoid this
-    // check due to its performance cost of reading files from disk.
-    return Location(uri: originalUri, range: location.range)
-  }
-
-  /// Check if the URI referenced by `location` has been copied during the preparation phase. If so, adjust the URI to
-  /// the original source file.
-  package func locationsAdjustedForCopiedFiles(_ locations: [Location]) -> [Location] {
-    return locations.map { locationAdjustedForCopiedFiles($0) }
-  }
-
-  private func uriAdjustedForCopiedFiles(_ uri: DocumentURI) -> DocumentURI {
-    guard let originalUri = cachedCopiedFileMap[uri] else {
-      return uri
-    }
-    return originalUri
-  }
-
-  package func workspaceEditAdjustedForCopiedFiles(_ workspaceEdit: WorkspaceEdit?) -> WorkspaceEdit? {
-    guard var edit = workspaceEdit else {
-      return nil
-    }
-    if let changes = edit.changes {
-      var newChanges: [DocumentURI: [TextEdit]] = [:]
-      for (uri, edits) in changes {
-        let newUri = self.uriAdjustedForCopiedFiles(uri)
-        newChanges[newUri, default: []] += edits
-      }
-      edit.changes = newChanges
-    }
-    if let documentChanges = edit.documentChanges {
-      edit.documentChanges = documentChanges.map { change in
-        switch change {
-        case .textDocumentEdit(var textEdit):
-          textEdit.textDocument.uri = self.uriAdjustedForCopiedFiles(textEdit.textDocument.uri)
-          return .textDocumentEdit(textEdit)
-        case .createFile(var create):
-          create.uri = self.uriAdjustedForCopiedFiles(create.uri)
-          return .createFile(create)
-        case .renameFile(var rename):
-          rename.oldUri = self.uriAdjustedForCopiedFiles(rename.oldUri)
-          rename.newUri = self.uriAdjustedForCopiedFiles(rename.newUri)
-          return .renameFile(rename)
-        case .deleteFile(var delete):
-          delete.uri = self.uriAdjustedForCopiedFiles(delete.uri)
-          return .deleteFile(delete)
-        }
-      }
-    }
-    return edit
-  }
-
-  package func locationsOrLocationLinksAdjustedForCopiedFiles(
-    _ response: LocationsOrLocationLinksResponse?
-  ) -> LocationsOrLocationLinksResponse? {
-    guard let response = response else {
-      return nil
-    }
-    switch response {
-    case .locations(let locations):
-      let remappedLocations = self.locationsAdjustedForCopiedFiles(locations)
-      return .locations(remappedLocations)
-    case .locationLinks(let locationLinks):
-      let remappedLinks = locationLinks.map { link -> LocationLink in
-        let adjustedTargetLocation = self.locationAdjustedForCopiedFiles(
-          Location(uri: link.targetUri, range: link.targetRange)
-        )
-        let adjustedTargetSelectionLocation = self.locationAdjustedForCopiedFiles(
-          Location(uri: link.targetUri, range: link.targetSelectionRange)
-        )
-        return LocationLink(
-          originSelectionRange: link.originSelectionRange,
-          targetUri: adjustedTargetLocation.uri,
-          targetRange: adjustedTargetLocation.range,
-          targetSelectionRange: adjustedTargetSelectionLocation.range
-        )
-      }
-      return .locationLinks(remappedLinks)
-    }
-  }
-
-  package func typeHierarchyItemAdjustedForCopiedFiles(_ item: TypeHierarchyItem) -> TypeHierarchyItem {
-    let adjustedLocation = self.locationAdjustedForCopiedFiles(Location(uri: item.uri, range: item.range))
-    let adjustedSelectionLocation = self.locationAdjustedForCopiedFiles(
-      Location(uri: item.uri, range: item.selectionRange)
-    )
-    return TypeHierarchyItem(
-      name: item.name,
-      kind: item.kind,
-      tags: item.tags,
-      detail: item.detail,
-      uri: adjustedLocation.uri,
-      range: adjustedLocation.range,
-      selectionRange: adjustedSelectionLocation.range,
-      data: item.data
-    )
-  }
-
-  package func callHierarchyItemAdjustedForCopiedFiles(_ item: CallHierarchyItem) -> CallHierarchyItem {
-    let adjustedLocation = self.locationAdjustedForCopiedFiles(Location(uri: item.uri, range: item.range))
-    let adjustedSelectionLocation = self.locationAdjustedForCopiedFiles(
-      Location(uri: item.uri, range: item.selectionRange)
-    )
-    return CallHierarchyItem(
-      name: item.name,
-      kind: item.kind,
-      tags: item.tags,
-      detail: item.detail,
-      uri: adjustedLocation.uri,
-      range: adjustedLocation.range,
-      selectionRange: adjustedSelectionLocation.range,
-      data: .dictionary([
-        "usr": item.data.flatMap { data in
-          if case let .dictionary(dict) = data {
-            return dict["usr"]
-          }
-          return nil
-        } ?? .null,
-        "uri": .string(adjustedLocation.uri.stringValue),
-      ])
-    )
-  }
-
   @discardableResult
-  package func scheduleRecomputeCopyFileMap() -> Task<[DocumentURI: DocumentURI], Never> {
-    let task = Task<[DocumentURI: DocumentURI], Never> { [previousUpdateTask = copiedFileMap] in
+  package func scheduleRecomputeCopyFileMap() -> Task<CopiedFileMap, Never> {
+    let task = Task<CopiedFileMap, Never> { [previousUpdateTask = copiedFileMap] in
       previousUpdateTask?.cancel()
       return await orLog("Re-computing copy file map") {
         let sourceFilesAndDirectories = try await self.sourceFilesAndDirectories()
@@ -1126,9 +1152,9 @@ package actor BuildServerManager: QueueBasedMessageHandler {
             copiedFileMap[copyDestination] = file
           }
         }
-        self.cachedCopiedFileMap = copiedFileMap
-        return copiedFileMap
-      } ?? [:]
+        self.cachedCopiedFileMap = CopiedFileMap(map: copiedFileMap)
+        return self.cachedCopiedFileMap
+      } ?? CopiedFileMap(map: [:])
     }
     copiedFileMap = task
     return task
@@ -1140,7 +1166,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
     if await !targets(for: document).isEmpty {
       return true
     }
-    if await self.copiedFileMap?.value[document] != nil {
+    if await self.copiedFileMap?.value.isCopiedFile(document) == true {
       return true
     }
     return false
@@ -1281,7 +1307,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
     language: Language?,
     fallbackAfterTimeout: Bool
   ) async throws -> FileBuildSettings? {
-    guard let copySource = cachedCopiedFileMap[document] else {
+    guard let copySource = cachedCopiedFileMap.originalURI(for: document) else {
       return nil
     }
     let copySourceSettings = await self.buildSettingsInferredFromMainFile(

--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -487,7 +487,7 @@ extension ClangLanguageService {
     guard let workspace = self.workspace.value else {
       return result
     }
-    return await workspace.buildServerManager.locationsOrLocationLinksAdjustedForCopiedFiles(result)
+    return await workspace.buildServerManager.cachedCopiedFileMap.locationsOrLocationLinksAdjustedForCopiedFiles(result)
   }
 
   package func typeDefinition(_ req: TypeDefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
@@ -636,7 +636,7 @@ extension ClangLanguageService {
     guard let workspace = self.workspace.value else {
       return workspaceEdit
     }
-    return await workspace.buildServerManager.workspaceEditAdjustedForCopiedFiles(workspaceEdit)
+    return await workspace.buildServerManager.cachedCopiedFileMap.workspaceEditAdjustedForCopiedFiles(workspaceEdit)
   }
 
   // MARK: - Other
@@ -656,7 +656,8 @@ extension ClangLanguageService {
     guard let workspace = self.workspace.value else {
       return (workspaceEdit, symbolDetail?.usr)
     }
-    let remappedEdit = await workspace.buildServerManager.workspaceEditAdjustedForCopiedFiles(workspaceEdit)
+    let remappedEdit = await workspace.buildServerManager.cachedCopiedFileMap
+      .workspaceEditAdjustedForCopiedFiles(workspaceEdit)
     return (remappedEdit ?? WorkspaceEdit(), symbolDetail?.usr)
   }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1773,11 +1773,13 @@ extension SourceKitLSPServer {
     guard req.query.count >= minWorkspaceSymbolPatternLength else {
       return []
     }
-    var symbolsIndexAndWorkspaces: [(symbol: SymbolOccurrence, index: CheckedIndex, workspace: Workspace)] = []
+    var items: [WorkspaceSymbolItem] = []
     for workspace in workspaces {
       guard let index = await workspace.index(checkedFor: .deletedFiles) else {
         continue
       }
+      let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+      var symbols: [SymbolOccurrence] = []
       try index.forEachCanonicalSymbolOccurrence(
         containing: req.query,
         anchorStart: false,
@@ -1791,38 +1793,40 @@ extension SourceKitLSPServer {
         guard !symbol.location.isSystem && !symbol.roles.contains(.accessorOf) else {
           return true
         }
-        symbolsIndexAndWorkspaces.append((symbol, index, workspace))
+        symbols.append(symbol)
         return true
       }
       try Task.checkCancellation()
-    }
+      for symbolOccurrence in symbols.sorted(by: <) {
+        try Task.checkCancellation()
+        guard let symbolLocation = symbolOccurrence.location.lspLocation else { continue }
+        let location = copiedFileMap.locationAdjustedForCopiedFiles(symbolLocation)
 
-    return try await symbolsIndexAndWorkspaces.sorted(by: { $0.symbol < $1.symbol }).asyncCompactMap {
-      (symbolOccurrence, index, workspace) in
-      guard let symbolLocation = symbolOccurrence.location.lspLocation else { return nil }
-      let location = await workspace.buildServerManager.locationAdjustedForCopiedFiles(symbolLocation)
-
-      let containerNames = try index.containerNames(of: symbolOccurrence)
-      let containerName: String?
-      if containerNames.isEmpty {
-        containerName = nil
-      } else {
-        switch symbolOccurrence.symbol.language {
-        case .cxx, .c, .objc: containerName = containerNames.joined(separator: "::")
-        case .swift: containerName = containerNames.joined(separator: ".")
+        let containerNames = try index.containerNames(of: symbolOccurrence)
+        let containerName: String?
+        if containerNames.isEmpty {
+          containerName = nil
+        } else {
+          switch symbolOccurrence.symbol.language {
+          case .cxx, .c, .objc: containerName = containerNames.joined(separator: "::")
+          case .swift: containerName = containerNames.joined(separator: ".")
+          }
         }
-      }
 
-      return WorkspaceSymbolItem.symbolInformation(
-        SymbolInformation(
-          name: symbolOccurrence.symbol.name,
-          kind: symbolOccurrence.symbol.kind.asLspSymbolKind(),
-          deprecated: nil,
-          location: location,
-          containerName: containerName
+        items.append(
+          WorkspaceSymbolItem.symbolInformation(
+            SymbolInformation(
+              name: symbolOccurrence.symbol.name,
+              kind: symbolOccurrence.symbol.kind.asLspSymbolKind(),
+              deprecated: nil,
+              location: location,
+              containerName: containerName
+            )
+          )
         )
-      )
+      }
     }
+    return items
   }
 
   /// Forwards a SymbolInfoRequest to the appropriate toolchain service for this document.
@@ -2210,6 +2214,7 @@ extension SourceKitLSPServer {
     languageService: any LanguageService
   ) async throws -> LocationsOrLocationLinksResponse? {
     let indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     // If we're unable to handle the definition request using our index, see if the
     // language service can handle it (e.g. clangd can provide AST based definitions).
     // We are on only calling the language service's `definition` function if your index-based lookup failed.
@@ -2219,10 +2224,10 @@ extension SourceKitLSPServer {
     if indexBasedResponse.isEmpty {
       return await orLog("Fallback definition request", level: .info) {
         let result = try await languageService.definition(req)
-        return await workspace.buildServerManager.locationsOrLocationLinksAdjustedForCopiedFiles(result)
+        return copiedFileMap.locationsOrLocationLinksAdjustedForCopiedFiles(result)
       }
     }
-    let remappedLocations = await workspace.buildServerManager.locationsAdjustedForCopiedFiles(indexBasedResponse)
+    let remappedLocations = copiedFileMap.locationsAdjustedForCopiedFiles(indexBasedResponse)
     return .locations(remappedLocations)
   }
 
@@ -2249,7 +2254,8 @@ extension SourceKitLSPServer {
 
       return occurrences.compactMap { $0.location.lspLocation }
     }
-    let remappedLocations = await workspace.buildServerManager.locationsAdjustedForCopiedFiles(locations)
+    let remappedLocations = await workspace.buildServerManager.cachedCopiedFileMap
+      .locationsAdjustedForCopiedFiles(locations)
     return .locations(remappedLocations.sorted())
   }
 
@@ -2276,7 +2282,8 @@ extension SourceKitLSPServer {
       }
       return try index.occurrences(ofUSR: usr, roles: roles).compactMap { $0.location.lspLocation }
     }
-    let remappedLocations = await workspace.buildServerManager.locationsAdjustedForCopiedFiles(locations)
+    let remappedLocations = await workspace.buildServerManager.cachedCopiedFileMap
+      .locationsAdjustedForCopiedFiles(locations)
     return remappedLocations.unique.sorted()
   }
 
@@ -2333,6 +2340,7 @@ extension SourceKitLSPServer {
     // Only return a single call hierarchy item. Returning multiple doesn't make sense because they will all have the
     // same USR (because we query them by USR) and will thus expand to the exact same call hierarchy.
     var callHierarchyItems: [CallHierarchyItem] = []
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     for usr in usrs {
       guard let definition = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: usr) else {
         continue
@@ -2340,7 +2348,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPCallHierarchyItem2(definition: definition, index: index) else {
         continue
       }
-      callHierarchyItems.append(await workspace.buildServerManager.callHierarchyItemAdjustedForCopiedFiles(item))
+      callHierarchyItems.append(copiedFileMap.callHierarchyItemAdjustedForCopiedFiles(item))
     }
     callHierarchyItems.sort(by: { Location(uri: $0.uri, range: $0.range) < Location(uri: $1.uri, range: $1.range) })
 
@@ -2407,6 +2415,7 @@ extension SourceKitLSPServer {
     }
 
     var calls: [CallHierarchyIncomingCall] = []
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     for (caller, callsList) in callersToCalls {
       // Resolve the caller's definition to find its location
       guard let definition = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: caller.usr) else {
@@ -2414,7 +2423,7 @@ extension SourceKitLSPServer {
       }
 
       let locations = callsList.compactMap { $0.location.lspLocation }.sorted()
-      let remappedLocations = await workspace.buildServerManager.locationsAdjustedForCopiedFiles(locations)
+      let remappedLocations = copiedFileMap.locationsAdjustedForCopiedFiles(locations)
       guard !remappedLocations.isEmpty else {
         continue
       }
@@ -2422,7 +2431,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPCallHierarchyItem2(definition: definition, index: index) else {
         continue
       }
-      let remappedItem = await workspace.buildServerManager.callHierarchyItemAdjustedForCopiedFiles(item)
+      let remappedItem = copiedFileMap.callHierarchyItemAdjustedForCopiedFiles(item)
 
       calls.append(CallHierarchyIncomingCall(from: remappedItem, fromRanges: remappedLocations.map(\.range)))
     }
@@ -2449,6 +2458,7 @@ extension SourceKitLSPServer {
     let callOccurrences = try callableUsrs.flatMap { try index.occurrences(relatedToUSR: $0, roles: .containedBy) }
       .filter(\.shouldShowInCallHierarchy)
     var calls: [CallHierarchyOutgoingCall] = []
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     for occurrence in callOccurrences {
       guard occurrence.symbol.kind.isCallable else {
         continue
@@ -2456,7 +2466,7 @@ extension SourceKitLSPServer {
       guard let location = occurrence.location.lspLocation else {
         continue
       }
-      let remappedLocation = await workspace.buildServerManager.locationAdjustedForCopiedFiles(location)
+      let remappedLocation = copiedFileMap.locationAdjustedForCopiedFiles(location)
 
       // Resolve the callee's definition to find its location
       guard let definition = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: occurrence.symbol.usr) else {
@@ -2466,7 +2476,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPCallHierarchyItem2(definition: definition, index: index) else {
         continue
       }
-      let remappedItem = await workspace.buildServerManager.callHierarchyItemAdjustedForCopiedFiles(item)
+      let remappedItem = copiedFileMap.callHierarchyItemAdjustedForCopiedFiles(item)
 
       calls.append(CallHierarchyOutgoingCall(to: remappedItem, fromRanges: [remappedLocation.range]))
     }
@@ -2568,6 +2578,7 @@ extension SourceKitLSPServer {
     }
 
     var typeHierarchyItems: [TypeHierarchyItem] = []
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     for usr in usrs {
       guard let info = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: usr) else {
         continue
@@ -2592,7 +2603,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPTypeHierarchyItem2(definition: info, moduleName: moduleName, index: index) else {
         continue
       }
-      typeHierarchyItems.append(await workspace.buildServerManager.typeHierarchyItemAdjustedForCopiedFiles(item))
+      typeHierarchyItems.append(copiedFileMap.typeHierarchyItemAdjustedForCopiedFiles(item))
     }
     typeHierarchyItems.sort(by: { $0.name < $1.name })
 
@@ -2665,6 +2676,7 @@ extension SourceKitLSPServer {
     // Convert occurrences to type hierarchy items
     let occurs = baseOccurs + retroactiveConformanceOccurs
     var types: [TypeHierarchyItem] = []
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     for occurrence in occurs {
       // Resolve the supertype's definition to find its location
       guard let definition = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: occurrence.symbol.usr) else {
@@ -2676,7 +2688,7 @@ extension SourceKitLSPServer {
       else {
         continue
       }
-      types.append(await workspace.buildServerManager.typeHierarchyItemAdjustedForCopiedFiles(item))
+      types.append(copiedFileMap.typeHierarchyItemAdjustedForCopiedFiles(item))
     }
     return types.sorted(by: { $0.name < $1.name })
   }
@@ -2707,6 +2719,7 @@ extension SourceKitLSPServer {
 
     // Convert occurrences to type hierarchy items
     var types: [TypeHierarchyItem] = []
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     for occurrence in occurs {
       if occurrence.relations.count > 1 {
         // An occurrence with a `baseOf` or `extendedBy` relation is an occurrence inside an inheritance clause.
@@ -2728,7 +2741,7 @@ extension SourceKitLSPServer {
       else {
         continue
       }
-      types.append(await workspace.buildServerManager.typeHierarchyItemAdjustedForCopiedFiles(item))
+      types.append(copiedFileMap.typeHierarchyItemAdjustedForCopiedFiles(item))
     }
     return types.sorted { $0.name < $1.name }
   }


### PR DESCRIPTION
Extract the copied-file adjustment logic from `BuildServerManager` into a `Sendable` value type `CopiedFileMap`. Call sites snapshot `cachedCopiedFileMap` once per request (hoisted before loops) instead of awaiting the actor on every iteration.