### PR TITLE
Allow injection of a pre-initialized sourcekitd connection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -430,6 +430,7 @@ var targets: [Target] = [
       "SKUtilities",
       "SourceKitD",
       "SourceKitLSP",
+      "SwiftExtensions",
       "SwiftLanguageService",
       "ToolchainRegistry",
       .product(name: "BuildServerProtocol", package: "swift-tools-protocols"),

--- a/Sources/SourceKitD/CMakeLists.txt
+++ b/Sources/SourceKitD/CMakeLists.txt
@@ -6,6 +6,7 @@ set(sources
   SKDResponseArray.swift
   SKDResponseDictionary.swift
   SourceKitD.swift
+  SourceKitDCore.swift
   SourceKitDRegistry.swift
   sourcekitd_functions.swift
   sourcekitd_uids.swift)

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -94,19 +94,20 @@ package enum SKDError: Error, Equatable {
   case missingRequiredSymbol(String)
 }
 
-/// Wrapper for sourcekitd, taking care of initialization, shutdown, and notification handler
-/// multiplexing.
+/// Wrapper for sourcekitd that provides the high-level `send` API, notification handler
+/// multiplexing, and convenience UID accessors.
 ///
-/// Users of this class should not call the api functions `initialize`, `shutdown`, or
-/// `set_notification_handler`, which are global state managed internally by this class.
+/// Dylib lifecycle (`initialize`, `shutdown`, `set_notification_handler`) is managed by the
+/// underlying `SourceKitDCore` implementation, not by this type directly.
 package actor SourceKitD {
-  /// The path to the sourcekitd dylib.
-  nonisolated package let path: URL
+  /// The underlying dylib connection (owns the handle, initialize/shutdown, and raw notification
+  /// callback registration).
+  nonisolated package let core: any SourceKitDCore
 
-  /// The handle to the dylib.
-  private let dylib: DLHandle
+  /// Path to the sourcekitd dylib.
+  nonisolated package var path: URL { core.path }
 
-  /// The sourcekitd API functions.
+  /// The sourcekitd API functions loaded from `core.dlHandle`.
   nonisolated package let api: sourcekitd_api_functions_t
 
   /// General API for the SourceKit service and client framework, eg. for plugin initialization and to set up custom
@@ -182,72 +183,42 @@ package actor SourceKitD {
     }
   }
 
-  package init(dylib path: URL, pluginPaths: PluginPaths?, initialize: Bool = true) throws {
-    #if os(Windows)
-    let dlopenModes: DLOpenFlags = []
-    #else
-    let dlopenModes: DLOpenFlags = [.lazy, .local, .first]
-    #endif
-    let dlhandle = try dlopen(path.filePath, mode: dlopenModes)
-    try self.init(
-      dlhandle: dlhandle,
-      path: path,
-      pluginPaths: pluginPaths,
-      initialize: initialize
-    )
+  package static func getOrCreate(core: any SourceKitDCore) async throws -> SourceKitD {
+    try await SourceKitDRegistry.shared.getOrAdd(core.path, pluginPaths: nil) {
+      return try SourceKitD(core: core)
+    }
   }
 
-  /// Create a `SourceKitD` instance from an existing `DLHandle`. `SourceKitD` takes over ownership of the `DLHandler`
-  /// and will close it when the `SourceKitD` instance gets deinitialized or if the initializer throws.
-  package init(dlhandle: DLHandle, path: URL, pluginPaths: PluginPaths?, initialize: Bool) throws {
-    do {
-      self.path = path
-      self.dylib = dlhandle
-      let api = try sourcekitd_api_functions_t(dlhandle)
-      self.api = api
+  /// Create a `SourceKitD` wrapping an existing `SourceKitDCore` connection.
+  package init(core: any SourceKitDCore) throws {
+    self.core = core
+    let api = try sourcekitd_api_functions_t(core.dlHandle)
+    self.api = api
+    // We load the plugin-related functions eagerly so the members are initialized and we don't have data races on first
+    // access to eg. `pluginApi`. But if one of the functions is missing, we will only emit that error when that family
+    // of functions is being used. For example, it is expected that the plugin functions are not available in
+    // SourceKit-LSP.
+    self.ideApiResult = Result(catching: { try sourcekitd_ide_api_functions_t(core.dlHandle) })
+    self.pluginApiResult = Result(catching: { try sourcekitd_plugin_api_functions_t(core.dlHandle) })
+    self.servicePluginApiResult = Result(catching: { try sourcekitd_service_plugin_api_functions_t(core.dlHandle) })
 
-      // We load the plugin-related functions eagerly so the members are initialized and we don't have data races on first
-      // access to eg. `pluginApi`. But if one of the functions is missing, we will only emit that error when that family
-      // of functions is being used. For example, it is expected that the plugin functions are not available in
-      // SourceKit-LSP.
-      self.ideApiResult = Result(catching: { try sourcekitd_ide_api_functions_t(dlhandle) })
-      self.pluginApiResult = Result(catching: { try sourcekitd_plugin_api_functions_t(dlhandle) })
-      self.servicePluginApiResult = Result(catching: { try sourcekitd_service_plugin_api_functions_t(dlhandle) })
-
-      if let pluginPaths {
-        api.register_plugin_path?(pluginPaths.clientPlugin.path, pluginPaths.servicePlugin.path)
-      }
-      if initialize {
-        self.api.initialize()
-      }
-
-      if initialize {
-        self.api.set_notification_handler { [weak self] rawResponse in
-          guard let self, let rawResponse else { return }
-          let response = SKDResponse(rawResponse, sourcekitd: self)
-          self.notificationHandlingQueue.async {
-            let handlers = await self.notificationHandlers.compactMap(\.value)
-
-            for handler in handlers {
-              handler.notification(response)
-            }
+    core.initializeService(
+      api: api,
+      notificationCallback: { [weak self] rawResponse in
+        guard let self else { return }
+        let response = SKDResponse(rawResponse, sourcekitd: self)
+        self.notificationHandlingQueue.async {
+          let handlers = await self.notificationHandlers.compactMap(\.value)
+          for handler in handlers {
+            handler.notification(response)
           }
         }
       }
-    } catch {
-      orLog("Closing dlhandle after opening sourcekitd failed") {
-        try? dlhandle.close()
-      }
-      throw error
-    }
+    )
   }
 
-  deinit {
-    self.api.set_notification_handler(nil)
-    self.api.shutdown()
-    Task.detached(priority: .background) { [dylib, path] in
-      orLog("Closing dylib \(path)") { try dylib.close() }
-    }
+  package init(dylib path: URL, pluginPaths: PluginPaths?) throws {
+    try self.init(core: SourceKitDCoreImpl(dylib: path, pluginPaths: pluginPaths))
   }
 
   /// Adds a new notification handler (referenced weakly).
@@ -470,17 +441,5 @@ package actor SourceKitD {
       documentUrl: nil,
       fileContents: nil
     )
-  }
-}
-
-/// A sourcekitd notification handler in a class to allow it to be uniquely referenced.
-package protocol SKDNotificationHandler: AnyObject, Sendable {
-  func notification(_: SKDResponse)
-}
-
-struct WeakSKDNotificationHandler: Sendable {
-  weak private(set) var value: (any SKDNotificationHandler)?
-  init(_ value: any SKDNotificationHandler) {
-    self.value = value
   }
 }

--- a/Sources/SourceKitD/SourceKitDCore.swift
+++ b/Sources/SourceKitD/SourceKitDCore.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import Csourcekitd
+package import Foundation
+@_spi(SourceKitLSP) import SKLogging
+import SwiftExtensions
+
+/// A loaded sourcekitd dylib connection.
+///
+/// Owns the `DLHandle` and knows how to initialize the sourcekitd service and wire up the
+/// one-shot C notification callback. The high-level API (`send`, UID accessors, plugin APIs)
+/// lives in `SourceKitD`, which wraps `any SourceKitDCore`.
+package protocol SourceKitDCore: Sendable {
+  var dlHandle: DLHandle { get }
+  var path: URL { get }
+
+  /// Called once by `SourceKitD.init(core:)` after loading `sourcekitd_api_functions_t`.
+  ///
+  /// Owns-lifecycle implementations call `api.initialize()` and
+  /// `api.set_notification_handler` here. Pre-initialized cores implement this as a no-op
+  /// (or forward `notificationCallback` through their own notification mechanism).
+  func initializeService(
+    api: sourcekitd_api_functions_t,
+    notificationCallback: @escaping @Sendable (sourcekitd_api_response_t) -> Void
+  )
+}
+
+/// A sourcekitd notification handler in a class to allow it to be uniquely referenced.
+package protocol SKDNotificationHandler: AnyObject, Sendable {
+  func notification(_: SKDResponse)
+}
+
+struct WeakSKDNotificationHandler: Sendable {
+  weak private(set) var value: (any SKDNotificationHandler)?
+  init(_ value: any SKDNotificationHandler) {
+    self.value = value
+  }
+}
+
+/// The standard `SourceKitDCore` implementation that opens a sourcekitd dylib directly.
+///
+/// Responsible only for dylib lifecycle: `dlopen`, `initialize`, `shutdown`, and wiring up the
+/// single C notification callback. All `dlsym`-based API access lives in `SourceKitD`.
+final class SourceKitDCoreImpl: SourceKitDCore, Sendable {
+  let dlHandle: DLHandle
+  let path: URL
+
+  private let pluginPaths: PluginPaths?
+
+  // Written once in `initializeService` (called during `SourceKitD.init`, before the instance
+  // is shared) and read only in `deinit`, so no concurrent access is possible.
+  private nonisolated(unsafe) var shutdown: (@convention(c) () -> Void)?
+  private nonisolated(unsafe) var setNotificationHandler:
+    (@convention(c) ((@Sendable (sourcekitd_api_response_t?) -> Void)?) -> Void)?
+
+  init(dylib path: URL, pluginPaths: PluginPaths?) throws {
+    #if os(Windows)
+    let dlopenModes: DLOpenFlags = []
+    #else
+    let dlopenModes: DLOpenFlags = [.lazy, .local, .first]
+    #endif
+    let dlhandle = try dlopen(path.filePath, mode: dlopenModes)
+    self.path = path
+    self.dlHandle = dlhandle
+    self.pluginPaths = pluginPaths
+  }
+
+  deinit {
+    setNotificationHandler?(nil)
+    shutdown?()
+    Task.detached(priority: .background) { [dlHandle, path] in
+      orLog("Closing dylib \(path)") { try dlHandle.close() }
+    }
+  }
+
+  func initializeService(
+    api: sourcekitd_api_functions_t,
+    notificationCallback: @escaping @Sendable (sourcekitd_api_response_t) -> Void
+  ) {
+    self.shutdown = api.shutdown
+    self.setNotificationHandler = api.set_notification_handler
+    if let pluginPaths {
+      api.register_plugin_path?(pluginPaths.clientPlugin.path, pluginPaths.servicePlugin.path)
+    }
+    api.initialize()
+    api.set_notification_handler { rawResponse in
+      guard let rawResponse else { return }
+      notificationCallback(rawResponse)
+    }
+  }
+}

--- a/Sources/SourceKitD/dlopen.swift
+++ b/Sources/SourceKitD/dlopen.swift
@@ -39,6 +39,14 @@ package final class DLHandle: Sendable {
   package static let rtldDefault = DLHandle(rawValue: Handle(handle: UnsafeMutableRawPointer(bitPattern: -2)!))
   #endif
 
+  /// Wrap a raw handle that is owned by an external system. The caller must call `leak()` before
+  /// `deinit` gets called prevent the assertion, since the external owner manages the lifecycle.
+  #if !os(Windows)
+  package static func adoptExisting(_ rawHandle: UnsafeMutableRawPointer) -> DLHandle {
+    DLHandle(rawValue: Handle(handle: rawHandle))
+  }
+  #endif
+
   fileprivate let rawValue: ThreadSafeBox<Handle?>
 
   fileprivate init(rawValue: Handle) {
@@ -86,8 +94,10 @@ package struct DLOpenFlags: RawRepresentable, OptionSet, Sendable {
   // Platform-specific flags.
   #if os(macOS)
   package static let first: DLOpenFlags = DLOpenFlags(rawValue: RTLD_FIRST)
+  package static let noLoad: DLOpenFlags = DLOpenFlags(rawValue: RTLD_NOLOAD)
   #else
   package static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
+  package static let noLoad: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #endif
   #endif
 

--- a/Sources/SourceKitLSP/Hooks.swift
+++ b/Sources/SourceKitLSP/Hooks.swift
@@ -11,10 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 package import BuildServerIntegration
-import Foundation
+package import Foundation
 @_spi(SourceKitLSP) package import LanguageServerProtocol
 @_spi(SourceKitLSP) import LanguageServerProtocolExtensions
 package import SemanticIndex
+package import SourceKitD
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
@@ -35,6 +36,11 @@ public struct Hooks: Sendable {
   /// This allows tests to simulate a `clangd` process that's unresponsive.
   package var preForwardRequestToClangd: (@Sendable (any RequestType) async -> Void)?
 
+  /// If set, called by `SwiftLanguageService` instead of `SourceKitD.getOrCreate` to obtain a
+  /// pre-initialized sourcekitd connection, avoiding double-initialization when running in-process.
+  /// The URL passed is the toolchain root (`.xctoolchain` bundle path).
+  package var sourcekitdCoreInjector: (@Sendable (URL) throws -> (any SourceKitDCore)?)?
+
   public init() {
     self.init(indexHooks: IndexHooks(), buildServerHooks: BuildServerHooks())
   }
@@ -43,11 +49,13 @@ public struct Hooks: Sendable {
     indexHooks: IndexHooks = IndexHooks(),
     buildServerHooks: BuildServerHooks = BuildServerHooks(),
     preHandleRequest: (@Sendable (any RequestType) async -> Void)? = nil,
-    preForwardRequestToClangd: (@Sendable (any RequestType) async -> Void)? = nil
+    preForwardRequestToClangd: (@Sendable (any RequestType) async -> Void)? = nil,
+    sourcekitdCoreInjector: (@Sendable (URL) throws -> (any SourceKitDCore)?)? = nil
   ) {
     self.indexHooks = indexHooks
     self.buildServerHooks = buildServerHooks
     self.preHandleRequest = preHandleRequest
     self.preForwardRequestToClangd = preForwardRequestToClangd
+    self.sourcekitdCoreInjector = sourcekitdCoreInjector
   }
 }

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -249,7 +249,11 @@ package actor SwiftLanguageService: LanguageService, Sendable {
       logger.fault("Failed to find SourceKit plugin for toolchain at \(toolchain.path.path)")
       pluginPaths = nil
     }
-    self.sourcekitd = try await SourceKitD.getOrCreate(dylibPath: sourcekitd, pluginPaths: pluginPaths)
+    if let core = try hooks.sourcekitdCoreInjector?(toolchain.path) {
+      self.sourcekitd = try await SourceKitD.getOrCreate(core: core)
+    } else {
+      self.sourcekitd = try await SourceKitD.getOrCreate(dylibPath: sourcekitd, pluginPaths: pluginPaths)
+    }
     self.capabilityRegistry = workspace.capabilityRegistry
     self.semanticIndexManagerTask = workspace.semanticIndexManagerTask
     self.hooks = hooks

--- a/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
+++ b/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
@@ -45,11 +45,7 @@ public func sourcekitd_plugin_initialize_2(
     return
   }
 
-  SourceKitD.forPlugin = try! SourceKitD(
-    dylib: pluginPath,
-    pluginPaths: nil,
-    initialize: false
-  )
+  SourceKitD.forPlugin = try! SourceKitD(core: SourceKitDCoreForPlugin(dylibPath: pluginPath))
   let sourcekitd = SourceKitD.forPlugin
 
   let customBufferStart = sourcekitd.pluginApi.plugin_initialize_custom_buffer_start(params)
@@ -59,4 +55,31 @@ public func sourcekitd_plugin_initialize_2(
     arrayBuffKind,
     CompletionResultsArray.arrayFuncs.rawValue
   )
+}
+
+private final class SourceKitDCoreForPlugin: SourceKitDCore, Sendable {
+  let dlHandle: DLHandle
+  let path: URL
+
+  init(dylibPath: URL) throws {
+    #if os(Windows)
+    let dlopenModes: DLOpenFlags = []
+    #else
+    let dlopenModes: DLOpenFlags = [.lazy, .local, .noLoad]
+    #endif
+    self.dlHandle = try dlopen(dylibPath.filePath, mode: dlopenModes)
+    self.path = dylibPath
+  }
+
+  deinit {
+    try? dlHandle.close()
+  }
+
+  func initializeService(
+    api: sourcekitd_api_functions_t,
+    notificationCallback: @escaping @Sendable (sourcekitd_api_response_t) -> Void
+  ) {
+    // Borrowed handle — sourcekitd is already initialized.
+  }
+
 }

--- a/Sources/SwiftSourceKitPlugin/Plugin.swift
+++ b/Sources/SwiftSourceKitPlugin/Plugin.swift
@@ -195,13 +195,13 @@ private extension SourceKitD {
       frameworkUrl
       .appending(components: "sourcekitdInProc.framework", "sourcekitdInProc")
     if FileManager.default.fileExists(at: inProcUrl) {
-      return try SourceKitD(dylib: inProcUrl, pluginPaths: nil, initialize: false)
+      return try SourceKitD(core: SourceKitDCoreForPlugin(dylibPath: inProcUrl))
     }
 
     let sourcekitdUrl =
       frameworkUrl
       .appending(components: "sourcekitd.framework", "sourcekitd")
-    return try SourceKitD(dylib: sourcekitdUrl, pluginPaths: nil, initialize: false)
+    return try SourceKitD(core: SourceKitDCoreForPlugin(dylibPath: sourcekitdUrl))
   }
 }
 #endif
@@ -217,10 +217,7 @@ public func sourcekitd_plugin_initialize_2(
   #if canImport(Darwin)
   if parentLibraryPath == "SOURCEKIT_LSP_PLUGIN_PARENT_LIBRARY_RTLD_DEFAULT" {
     SourceKitD.forPlugin = try! SourceKitD(
-      dlhandle: .rtldDefault,
-      path: URL(string: "rtld-default://")!,
-      pluginPaths: nil,
-      initialize: false
+      core: SourceKitDCoreForPlugin(dlhandle: .rtldDefault, path: URL(string: "rtld-default://")!)
     )
   } else {
     SourceKitD.forPlugin = try! SourceKitD.inProcLibrary(relativeTo: URL(fileURLWithPath: parentLibraryPath))
@@ -228,9 +225,7 @@ public func sourcekitd_plugin_initialize_2(
   #else
   // On other platforms, sourcekitd is always in process, so we can load it straight away.
   SourceKitD.forPlugin = try! SourceKitD(
-    dylib: URL(fileURLWithPath: parentLibraryPath),
-    pluginPaths: nil,
-    initialize: false
+    core: SourceKitDCoreForPlugin(dylibPath: URL(fileURLWithPath: parentLibraryPath))
   )
   #endif
   let sourcekitd = SourceKitD.forPlugin
@@ -284,5 +279,43 @@ public func sourcekitd_plugin_initialize_2(
     case .requestHandled: return true
     case .handleInSourceKitD: return false
     }
+  }
+}
+
+private final class SourceKitDCoreForPlugin: SourceKitDCore, Sendable {
+  let dlHandle: DLHandle
+  let path: URL
+  private let ownsHandle: Bool
+
+  init(dylibPath: URL) throws {
+    #if os(Windows)
+    let dlopenModes: DLOpenFlags = []
+    #else
+    let dlopenModes: DLOpenFlags = [.lazy, .local, .noLoad]
+    #endif
+    self.dlHandle = try dlopen(dylibPath.filePath, mode: dlopenModes)
+    self.path = dylibPath
+    self.ownsHandle = true
+  }
+
+  init(dlhandle: DLHandle, path: URL) {
+    self.dlHandle = dlhandle
+    self.path = path
+    self.ownsHandle = false
+  }
+
+  deinit {
+    if ownsHandle {
+      try? dlHandle.close()
+    } else {
+      dlHandle.leak()
+    }
+  }
+
+  func initializeService(
+    api: sourcekitd_api_functions_t,
+    notificationCallback: @escaping @Sendable (sourcekitd_api_response_t) -> Void
+  ) {
+    // Borrowed handle — sourcekitd is already initialized.
   }
 }

--- a/Tests/SourceKitLSPTests/SourcekitdCoreInjectorTests.swift
+++ b/Tests/SourceKitLSPTests/SourcekitdCoreInjectorTests.swift
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Csourcekitd
+import Foundation
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SKTestSupport
+import SourceKitD
+import SourceKitLSP
+import SwiftExtensions
+@_spi(Testing) import SwiftLanguageService
+import ToolchainRegistry
+import XCTest
+
+final class SourcekitdCoreInjectorTests: SourceKitLSPTestCase {
+  func testSourcekitdCoreInjectorIsNilByDefault() {
+    let hooks = Hooks()
+    XCTAssertNil(hooks.sourcekitdCoreInjector)
+  }
+
+  /// Verifies that when `sourcekitdCoreInjector` returns a pre-initialized `SourceKitDCore`,
+  /// `SwiftLanguageService` uses it to create the `SourceKitD` connection and can process requests.
+  func testSourcekitdCoreInjectorIsUsedBySwiftLanguageService() async throws {
+    let toolchain = try unwrap(await ToolchainRegistry.forTesting.default)
+    let sourcekitdPath = try unwrap(toolchain.sourcekitd)
+
+    // Pre-load sourcekitd so that dlopen with RTLD_NOLOAD below can succeed and also
+    // so the dylib is fully initialized before we borrow its handle.
+    _ = try await SourceKitD.getOrCreate(dylibPath: sourcekitdPath, pluginPaths: sourceKitPluginPaths)
+
+    let injectedCore = try InjectedSourceKitDCore(realDylibPath: sourcekitdPath)
+    let injectorCallCount = ThreadSafeBox(initialValue: 0)
+    let capturedToolchainURL = ThreadSafeBox<URL?>(initialValue: nil)
+
+    let url = URL(fileURLWithPath: "/\(UUID())/a.swift")
+    let uri = DocumentURI(url)
+
+    let testClient = try await TestSourceKitLSPClient(
+      hooks: Hooks(sourcekitdCoreInjector: { toolchainURL in
+        injectorCallCount.value += 1
+        capturedToolchainURL.value = toolchainURL
+        return injectedCore
+      })
+    )
+
+    let positions = testClient.openDocument(
+      "func 1️⃣foo() -> Int { 42 }",
+      uri: uri
+    )
+
+    // Wait until SwiftLanguageService is available for the opened document.
+    let workspace = try await unwrap(testClient.server.workspaceForDocument(uri: uri))
+    let swiftLS = try await unwrap(
+      testClient.server.primaryLanguageService(for: uri, .swift, in: workspace) as? SwiftLanguageService
+    )
+
+    // The injector must have been called with the toolchain root (not the sourcekitd dylib path).
+    XCTAssertGreaterThan(injectorCallCount.value, 0)
+    XCTAssertEqual(capturedToolchainURL.value, toolchain.path)
+
+    // The injected core must have had initializeService called (i.e. SourceKitD was
+    // created with our core, not the cached shared one).
+    XCTAssertEqual(injectedCore.initializeServiceCallCount, 1)
+
+    // Verify the SourceKitD instance held by SwiftLanguageService actually uses our core.
+    let usedCore = await swiftLS.sourcekitd.core
+    XCTAssert(usedCore as AnyObject === injectedCore)
+
+    // Verify that sourcekitd requests work through the injected core.
+    // discard - we just need it not to throw
+    _ = try await testClient.send(
+      HoverRequest(textDocument: TextDocumentIdentifier(url), position: positions["1️⃣"])
+    )
+  }
+}
+
+// MARK: - InjectedSourceKitDCore
+
+/// A `SourceKitDCore` that borrows the handle of an already-loaded sourcekitd dylib without
+/// calling `initialize()`, simulating a pre-initialized connection supplied by an embedding host.
+/// It uses a unique fake `path` so the `SourceKitDRegistry` never deduplicates it with the
+/// shared instance, ensuring `SourceKitD.init(core:)` is actually called with this core.
+private final class InjectedSourceKitDCore: SourceKitDCore, Sendable {
+  let dlHandle: DLHandle
+  /// Unique path so this core is never found in `SourceKitDRegistry.shared`.
+  let path: URL
+
+  private let _initializeServiceCallCount = ThreadSafeBox(initialValue: 0)
+  var initializeServiceCallCount: Int { _initializeServiceCallCount.value }
+
+  init(realDylibPath: URL) throws {
+    #if os(Windows)
+    let dlopenModes: DLOpenFlags = []
+    #else
+    let dlopenModes: DLOpenFlags = [.lazy, .local, .first]
+    #endif
+    self.dlHandle = try dlopen(realDylibPath.filePath, mode: dlopenModes)
+    self.path = URL(fileURLWithPath: "/mock/injected-sourcekitd-\(UUID().uuidString).dylib")
+  }
+
+  deinit {
+    // We opened with normal flags (not RTLD_NOLOAD), so close() correctly decrements the count.
+    // We do NOT call shutdown() because we never called initialize() — lifecycle is owned by
+    // the shared SourceKitDCoreImpl.
+    try? dlHandle.close()
+  }
+
+  func initializeService(
+    api: sourcekitd_api_functions_t,
+    notificationCallback: @escaping @Sendable (sourcekitd_api_response_t) -> Void
+  ) {
+    _initializeServiceCallCount.value += 1
+    // Deliberately a no-op: we don't call sourcekitd_set_notification_handler here because
+    // that would override the handler registered by the shared SourceKitDCoreImpl. For this
+    // test only hover (a direct request/response) is exercised, so notifications are not needed.
+  }
+}


### PR DESCRIPTION
Introduce `SourceKitDCore` as the protocol boundary between dylib lifecycle management and the high-level `SourceKitD` API. Its single lifecycle entry point, `initializeService(api:notificationCallback:)`, receives the already-loaded `sourcekitd_api_functions_t` from `SourceKitD.init(core:)`.

`SourceKitDCoreImpl` is the standard implementation: `init` opens the dylib; `initializeService` registers any plugin paths, calls `api.initialize()`, and wires the notification handler; `deinit` calls `shutdown()` and closes the handle. Pre-initialized conformances implement `initializeService` as a no-op.

Wire a `sourcekitdCoreInjector` hook through `Hooks` so an embedding host can return a pre-initialized `SourceKitDCore` for a given toolchain path, preventing `sourcekitd_initialize()` from being called a second time.

Declare `SourceKitDCoreForPlugin` at its use sites so each call site can express the exact deinit behavior it needs: `dlclose` for handles acquired via `RTLD_NOLOAD`, and `leak` for externally-owned handles.