### PR TITLE
Update minimum macOS version to v15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -692,7 +692,7 @@ if buildOnlyTests {
 
 let package = Package(
   name: "SourceKitLSP",
-  platforms: [.macOS(.v14)],
+  platforms: [.macOS(.v15)],
   products: products,
   dependencies: dependencies,
   targets: targets,

--- a/SourceKitLSPDevUtils/Package.swift
+++ b/SourceKitLSPDevUtils/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "SourceKitLSPDevUtils",
-  platforms: [.macOS(.v14)],
+  platforms: [.macOS(.v15)],
   products: [
     .executable(name: "sourcekit-lsp-dev-utils", targets: ["SourceKitLSPDevUtils"])
   ],


### PR DESCRIPTION
We need to raise the minimum deployment target so that SwiftPM and Swift Build are unblocked from doing so.