### PR TITLE
Replace manual LSPAny data handling with typed structs

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -370,138 +370,19 @@ package struct CopiedFileMap: Sendable {
     return map[uri]
   }
 
-  /// Check if the URI referenced by `location` has been copied during the preparation phase. If so, adjust the URI to
-  /// the original source file.
-  package func locationAdjustedForCopiedFiles(_ location: Location) -> Location {
-    guard let originalUri = map[location.uri] else {
-      return location
+  /// If `uri` refers to a copy of a source file created during preparation, returns the URI of the
+  /// original source file (provided it exists on disk). Otherwise returns `uri` unchanged.
+  package func adjustedURI(for uri: DocumentURI) -> DocumentURI {
+    guard let originalUri = map[uri] else {
+      return uri
     }
-
     if let fileUrl = originalUri.fileURL, !FileManager.default.fileExists(at: fileUrl) {
-      return location
+      return uri
     }
     // If we regularly get issues that the copied file is out-of-sync with its original, we can check that the contents
     // of the lines touched by the location match and only return the original URI if they do. For now, we avoid this
     // check due to its performance cost of reading files from disk.
-    return Location(uri: originalUri, range: location.range)
-  }
-
-  /// Check if the URI referenced by `location` has been copied during the preparation phase. If so, adjust the URI to
-  /// the original source file.
-  package func locationsAdjustedForCopiedFiles(_ locations: [Location]) -> [Location] {
-    return locations.map { locationAdjustedForCopiedFiles($0) }
-  }
-
-  private func uriAdjustedForCopiedFiles(_ uri: DocumentURI) -> DocumentURI {
-    guard let originalUri = map[uri] else {
-      return uri
-    }
     return originalUri
-  }
-
-  package func workspaceEditAdjustedForCopiedFiles(_ workspaceEdit: WorkspaceEdit?) -> WorkspaceEdit? {
-    guard var edit = workspaceEdit else {
-      return nil
-    }
-    if let changes = edit.changes {
-      var newChanges: [DocumentURI: [TextEdit]] = [:]
-      for (uri, edits) in changes {
-        let newUri = self.uriAdjustedForCopiedFiles(uri)
-        newChanges[newUri, default: []] += edits
-      }
-      edit.changes = newChanges
-    }
-    if let documentChanges = edit.documentChanges {
-      edit.documentChanges = documentChanges.map { change in
-        switch change {
-        case .textDocumentEdit(var textEdit):
-          textEdit.textDocument.uri = self.uriAdjustedForCopiedFiles(textEdit.textDocument.uri)
-          return .textDocumentEdit(textEdit)
-        case .createFile(var create):
-          create.uri = self.uriAdjustedForCopiedFiles(create.uri)
-          return .createFile(create)
-        case .renameFile(var rename):
-          rename.oldUri = self.uriAdjustedForCopiedFiles(rename.oldUri)
-          rename.newUri = self.uriAdjustedForCopiedFiles(rename.newUri)
-          return .renameFile(rename)
-        case .deleteFile(var delete):
-          delete.uri = self.uriAdjustedForCopiedFiles(delete.uri)
-          return .deleteFile(delete)
-        }
-      }
-    }
-    return edit
-  }
-
-  package func locationsOrLocationLinksAdjustedForCopiedFiles(
-    _ response: LocationsOrLocationLinksResponse?
-  ) -> LocationsOrLocationLinksResponse? {
-    guard let response = response else {
-      return nil
-    }
-    switch response {
-    case .locations(let locations):
-      let remappedLocations = self.locationsAdjustedForCopiedFiles(locations)
-      return .locations(remappedLocations)
-    case .locationLinks(let locationLinks):
-      let remappedLinks = locationLinks.map { link -> LocationLink in
-        let adjustedTargetLocation = self.locationAdjustedForCopiedFiles(
-          Location(uri: link.targetUri, range: link.targetRange)
-        )
-        let adjustedTargetSelectionLocation = self.locationAdjustedForCopiedFiles(
-          Location(uri: link.targetUri, range: link.targetSelectionRange)
-        )
-        return LocationLink(
-          originSelectionRange: link.originSelectionRange,
-          targetUri: adjustedTargetLocation.uri,
-          targetRange: adjustedTargetLocation.range,
-          targetSelectionRange: adjustedTargetSelectionLocation.range
-        )
-      }
-      return .locationLinks(remappedLinks)
-    }
-  }
-
-  package func typeHierarchyItemAdjustedForCopiedFiles(_ item: TypeHierarchyItem) -> TypeHierarchyItem {
-    let adjustedLocation = self.locationAdjustedForCopiedFiles(Location(uri: item.uri, range: item.range))
-    let adjustedSelectionLocation = self.locationAdjustedForCopiedFiles(
-      Location(uri: item.uri, range: item.selectionRange)
-    )
-    return TypeHierarchyItem(
-      name: item.name,
-      kind: item.kind,
-      tags: item.tags,
-      detail: item.detail,
-      uri: adjustedLocation.uri,
-      range: adjustedLocation.range,
-      selectionRange: adjustedSelectionLocation.range,
-      data: item.data
-    )
-  }
-
-  package func callHierarchyItemAdjustedForCopiedFiles(_ item: CallHierarchyItem) -> CallHierarchyItem {
-    let adjustedLocation = self.locationAdjustedForCopiedFiles(Location(uri: item.uri, range: item.range))
-    let adjustedSelectionLocation = self.locationAdjustedForCopiedFiles(
-      Location(uri: item.uri, range: item.selectionRange)
-    )
-    return CallHierarchyItem(
-      name: item.name,
-      kind: item.kind,
-      tags: item.tags,
-      detail: item.detail,
-      uri: adjustedLocation.uri,
-      range: adjustedLocation.range,
-      selectionRange: adjustedSelectionLocation.range,
-      data: .dictionary([
-        "usr": item.data.flatMap { data in
-          if case let .dictionary(dict) = data {
-            return dict["usr"]
-          }
-          return nil
-        } ?? .null,
-        "uri": .string(adjustedLocation.uri.stringValue),
-      ])
-    )
   }
 }
 

--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -487,7 +487,8 @@ extension ClangLanguageService {
     guard let workspace = self.workspace.value else {
       return result
     }
-    return await workspace.buildServerManager.cachedCopiedFileMap.locationsOrLocationLinksAdjustedForCopiedFiles(result)
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+    return result?.adjusted(for: copiedFileMap)
   }
 
   package func typeDefinition(_ req: TypeDefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
@@ -636,7 +637,8 @@ extension ClangLanguageService {
     guard let workspace = self.workspace.value else {
       return workspaceEdit
     }
-    return await workspace.buildServerManager.cachedCopiedFileMap.workspaceEditAdjustedForCopiedFiles(workspaceEdit)
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+    return workspaceEdit.map { $0.adjusted(for: copiedFileMap) }
   }
 
   // MARK: - Other
@@ -656,9 +658,9 @@ extension ClangLanguageService {
     guard let workspace = self.workspace.value else {
       return (workspaceEdit, symbolDetail?.usr)
     }
-    let remappedEdit = await workspace.buildServerManager.cachedCopiedFileMap
-      .workspaceEditAdjustedForCopiedFiles(workspaceEdit)
-    return (remappedEdit ?? WorkspaceEdit(), symbolDetail?.usr)
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+    let remappedEdit = workspaceEdit.adjusted(for: copiedFileMap)
+    return (remappedEdit, symbolDetail?.usr)
   }
 
   package func syntacticTestItems(for snapshot: DocumentSnapshot) async -> [AnnotatedTestItem]? {

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(SourceKitLSP STATIC
   LogMessageNotification+representingStructureUsingEmojiPrefixIfNecessary.swift
   MacroExpansionReferenceDocumentURLData.swift
   MessageHandlingDependencyTracker.swift
+  MessageMetadata.swift
   OnDiskDocumentManager.swift
   PlaygroundDiscovery.swift
   ReferenceDocumentURL.swift

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(SourceKitLSP STATIC
   LanguageService.swift
   LanguageServiceRegistry.swift
   LogMessageNotification+representingStructureUsingEmojiPrefixIfNecessary.swift
+  LSP+CopiedFileMap.swift
   MacroExpansionReferenceDocumentURLData.swift
   MessageHandlingDependencyTracker.swift
   MessageMetadata.swift

--- a/Sources/SourceKitLSP/LSP+CopiedFileMap.swift
+++ b/Sources/SourceKitLSP/LSP+CopiedFileMap.swift
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import BuildServerIntegration
+@_spi(SourceKitLSP) package import LanguageServerProtocol
+
+extension Location {
+  package func adjusted(for copiedFileMap: CopiedFileMap) -> Location {
+    return Location(uri: copiedFileMap.adjustedURI(for: uri), range: range)
+  }
+}
+
+extension [Location] {
+  package func adjusted(for copiedFileMap: CopiedFileMap) -> [Location] {
+    return self.map { $0.adjusted(for: copiedFileMap) }
+  }
+}
+
+extension WorkspaceEdit {
+  package func adjusted(for copiedFileMap: CopiedFileMap) -> WorkspaceEdit {
+    var edit = self
+    if let changes = self.changes {
+      var newChanges: [DocumentURI: [TextEdit]] = [:]
+      for (uri, edits) in changes {
+        newChanges[copiedFileMap.originalURI(for: uri) ?? uri, default: []] += edits
+      }
+      edit.changes = newChanges
+    }
+    if let documentChanges = self.documentChanges {
+      edit.documentChanges = documentChanges.map { change in
+        switch change {
+        case .textDocumentEdit(var textEdit):
+          textEdit.textDocument.uri =
+            copiedFileMap.originalURI(for: textEdit.textDocument.uri) ?? textEdit.textDocument.uri
+          return .textDocumentEdit(textEdit)
+        case .createFile(var create):
+          create.uri = copiedFileMap.originalURI(for: create.uri) ?? create.uri
+          return .createFile(create)
+        case .renameFile(var rename):
+          rename.oldUri = copiedFileMap.originalURI(for: rename.oldUri) ?? rename.oldUri
+          rename.newUri = copiedFileMap.originalURI(for: rename.newUri) ?? rename.newUri
+          return .renameFile(rename)
+        case .deleteFile(var delete):
+          delete.uri = copiedFileMap.originalURI(for: delete.uri) ?? delete.uri
+          return .deleteFile(delete)
+        }
+      }
+    }
+    return edit
+  }
+}
+
+extension LocationsOrLocationLinksResponse {
+  package func adjusted(for copiedFileMap: CopiedFileMap) -> LocationsOrLocationLinksResponse {
+    switch self {
+    case .locations(let locations):
+      return .locations(locations.adjusted(for: copiedFileMap))
+    case .locationLinks(let locationLinks):
+      return .locationLinks(
+        locationLinks.map { link in
+          let adjustedTarget = Location(uri: link.targetUri, range: link.targetRange)
+            .adjusted(for: copiedFileMap)
+          let adjustedTargetSelection = Location(uri: link.targetUri, range: link.targetSelectionRange)
+            .adjusted(for: copiedFileMap)
+          return LocationLink(
+            originSelectionRange: link.originSelectionRange,
+            targetUri: adjustedTarget.uri,
+            targetRange: adjustedTarget.range,
+            targetSelectionRange: adjustedTargetSelection.range
+          )
+        }
+      )
+    }
+  }
+}
+
+extension TypeHierarchyItem {
+  package func adjusted(for copiedFileMap: CopiedFileMap) -> TypeHierarchyItem {
+    let adjustedLocation = Location(uri: uri, range: range).adjusted(for: copiedFileMap)
+    let adjustedSelectionLocation = Location(uri: uri, range: selectionRange).adjusted(for: copiedFileMap)
+    return TypeHierarchyItem(
+      name: name,
+      kind: kind,
+      tags: tags,
+      detail: detail,
+      uri: adjustedLocation.uri,
+      range: adjustedLocation.range,
+      selectionRange: adjustedSelectionLocation.range,
+      data: data
+    )
+  }
+}
+
+extension CallHierarchyItem {
+  package func adjusted(for copiedFileMap: CopiedFileMap) -> CallHierarchyItem {
+    let adjustedLocation = Location(uri: uri, range: range).adjusted(for: copiedFileMap)
+    let adjustedSelectionLocation = Location(uri: uri, range: selectionRange).adjusted(for: copiedFileMap)
+    let adjustedData =
+      HierarchyItemData(fromLSPAny: data).map { itemData in
+        HierarchyItemData(uri: adjustedLocation.uri, usr: itemData.usr).encodeToLSPAny()
+      } ?? self.data
+    return CallHierarchyItem(
+      name: name,
+      kind: kind,
+      tags: tags,
+      detail: detail,
+      uri: adjustedLocation.uri,
+      range: adjustedLocation.range,
+      selectionRange: adjustedSelectionLocation.range,
+      data: adjustedData
+    )
+  }
+}

--- a/Sources/SourceKitLSP/MessageMetadata.swift
+++ b/Sources/SourceKitLSP/MessageMetadata.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+
+/// Metadata stored in `CallHierarchyItem.data` and `TypeHierarchyItem.data` to support
+/// incoming/outgoing call and supertype/subtype lookups.
+struct HierarchyItemData: Codable, Hashable, LSPAnyCodable {
+  var uri: DocumentURI
+  var usr: String
+
+  init(uri: DocumentURI, usr: String) {
+    self.uri = uri
+    self.usr = usr
+  }
+}
+
+/// Metadata stored in `CompletionItem.data` and `InlayHint.data` at the server level to route
+/// resolve requests to the correct language service.
+struct ResolveItemData: Codable, Hashable, LSPAnyCodable {
+  var uri: DocumentURI
+
+  init(uri: DocumentURI) {
+    self.uri = uri
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1798,7 +1798,7 @@ extension SourceKitLSPServer {
       for symbolOccurrence in symbols.sorted(by: <) {
         try Task.checkCancellation()
         guard let symbolLocation = symbolOccurrence.location.lspLocation else { continue }
-        let location = copiedFileMap.locationAdjustedForCopiedFiles(symbolLocation)
+        let location = symbolLocation.adjusted(for: copiedFileMap)
 
         let containerNames = try index.containerNames(of: symbolOccurrence)
         let containerName: String?
@@ -2219,10 +2219,10 @@ extension SourceKitLSPServer {
     if indexBasedResponse.isEmpty {
       return await orLog("Fallback definition request", level: .info) {
         let result = try await languageService.definition(req)
-        return copiedFileMap.locationsOrLocationLinksAdjustedForCopiedFiles(result)
+        return result?.adjusted(for: copiedFileMap)
       }
     }
-    let remappedLocations = copiedFileMap.locationsAdjustedForCopiedFiles(indexBasedResponse)
+    let remappedLocations = indexBasedResponse.adjusted(for: copiedFileMap)
     return .locations(remappedLocations)
   }
 
@@ -2249,8 +2249,8 @@ extension SourceKitLSPServer {
 
       return occurrences.compactMap { $0.location.lspLocation }
     }
-    let remappedLocations = await workspace.buildServerManager.cachedCopiedFileMap
-      .locationsAdjustedForCopiedFiles(locations)
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+    let remappedLocations = locations.adjusted(for: copiedFileMap)
     return .locations(remappedLocations.sorted())
   }
 
@@ -2277,8 +2277,8 @@ extension SourceKitLSPServer {
       }
       return try index.occurrences(ofUSR: usr, roles: roles).compactMap { $0.location.lspLocation }
     }
-    let remappedLocations = await workspace.buildServerManager.cachedCopiedFileMap
-      .locationsAdjustedForCopiedFiles(locations)
+    let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+    let remappedLocations = locations.adjusted(for: copiedFileMap)
     return remappedLocations.unique.sorted()
   }
 
@@ -2340,7 +2340,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPCallHierarchyItem2(definition: definition, index: index) else {
         continue
       }
-      callHierarchyItems.append(copiedFileMap.callHierarchyItemAdjustedForCopiedFiles(item))
+      callHierarchyItems.append(item.adjusted(for: copiedFileMap))
     }
     callHierarchyItems.sort(by: { Location(uri: $0.uri, range: $0.range) < Location(uri: $1.uri, range: $1.range) })
 
@@ -2399,7 +2399,7 @@ extension SourceKitLSPServer {
       }
 
       let locations = callsList.compactMap { $0.location.lspLocation }.sorted()
-      let remappedLocations = copiedFileMap.locationsAdjustedForCopiedFiles(locations)
+      let remappedLocations = locations.adjusted(for: copiedFileMap)
       guard !remappedLocations.isEmpty else {
         continue
       }
@@ -2407,7 +2407,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPCallHierarchyItem2(definition: definition, index: index) else {
         continue
       }
-      let remappedItem = copiedFileMap.callHierarchyItemAdjustedForCopiedFiles(item)
+      let remappedItem = item.adjusted(for: copiedFileMap)
 
       calls.append(CallHierarchyIncomingCall(from: remappedItem, fromRanges: remappedLocations.map(\.range)))
     }
@@ -2442,7 +2442,7 @@ extension SourceKitLSPServer {
       guard let location = occurrence.location.lspLocation else {
         continue
       }
-      let remappedLocation = copiedFileMap.locationAdjustedForCopiedFiles(location)
+      let remappedLocation = location.adjusted(for: copiedFileMap)
 
       // Resolve the callee's definition to find its location
       guard let definition = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: occurrence.symbol.usr) else {
@@ -2452,7 +2452,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPCallHierarchyItem2(definition: definition, index: index) else {
         continue
       }
-      let remappedItem = copiedFileMap.callHierarchyItemAdjustedForCopiedFiles(item)
+      let remappedItem = item.adjusted(for: copiedFileMap)
 
       calls.append(CallHierarchyOutgoingCall(to: remappedItem, fromRanges: [remappedLocation.range]))
     }
@@ -2576,7 +2576,7 @@ extension SourceKitLSPServer {
       guard let item = try indexToLSPTypeHierarchyItem2(definition: info, moduleName: moduleName, index: index) else {
         continue
       }
-      typeHierarchyItems.append(copiedFileMap.typeHierarchyItemAdjustedForCopiedFiles(item))
+      typeHierarchyItems.append(item.adjusted(for: copiedFileMap))
     }
     typeHierarchyItems.sort(by: { $0.name < $1.name })
 
@@ -2645,7 +2645,7 @@ extension SourceKitLSPServer {
       else {
         continue
       }
-      types.append(copiedFileMap.typeHierarchyItemAdjustedForCopiedFiles(item))
+      types.append(item.adjusted(for: copiedFileMap))
     }
     return types.sorted(by: { $0.name < $1.name })
   }
@@ -2698,7 +2698,7 @@ extension SourceKitLSPServer {
       else {
         continue
       }
-      types.append(copiedFileMap.typeHierarchyItemAdjustedForCopiedFiles(item))
+      types.append(item.adjusted(for: copiedFileMap))
     }
     return types.sorted { $0.name < $1.name }
   }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1727,9 +1727,7 @@ extension SourceKitLSPServer {
     request: CompletionItemResolveRequest
   ) async throws -> CompletionItem {
     // Swift completion items specify the URI of the item they originate from in the `data`
-    guard case .dictionary(let dict) = request.item.data, case .string(let uriString) = dict["uri"],
-      let uri = try? DocumentURI(string: uriString)
-    else {
+    guard let uri = ResolveItemData(fromLSPAny: request.item.data)?.uri else {
       return request.item
     }
     guard let workspace = await self.workspaceForDocument(uri: uri) else {
@@ -2033,10 +2031,7 @@ extension SourceKitLSPServer {
   func inlayHintResolve(
     request: InlayHintResolveRequest
   ) async throws -> InlayHint {
-    guard case .dictionary(let dict) = request.inlayHint.data,
-      case .string(let uriString) = dict["uri"],
-      let uri = try? DocumentURI(string: uriString)
-    else {
+    guard let uri = ResolveItemData(fromLSPAny: request.inlayHint.data)?.uri else {
       return request.inlayHint
     }
     guard let workspace = await self.workspaceForDocument(uri: uri) else {
@@ -2305,10 +2300,7 @@ extension SourceKitLSPServer {
       range: location.range,
       selectionRange: location.range,
       // We encode usr and uri for incoming/outgoing call lookups in the implementation-specific data field
-      data: .dictionary([
-        "usr": .string(symbol.usr),
-        "uri": .string(location.uri.stringValue),
-      ])
+      data: HierarchyItemData(uri: location.uri, usr: symbol.usr).encodeToLSPAny()
     )
   }
 
@@ -2357,24 +2349,8 @@ extension SourceKitLSPServer {
     return Array(callHierarchyItems.prefix(1))
   }
 
-  /// Extracts our implementation-specific data about a call hierarchy
-  /// item as encoded in `indexToLSPCallHierarchyItem`.
-  ///
-  /// - Parameter data: The opaque data structure to extract
-  /// - Returns: The extracted data if successful or nil otherwise
-  private nonisolated func extractCallHierarchyItemData(_ rawData: LSPAny?) -> (uri: DocumentURI, usr: String)? {
-    guard case let .dictionary(data) = rawData,
-      case let .string(uriString) = data["uri"],
-      case let .string(usr) = data["usr"],
-      let uri = orLog("DocumentURI for call hierarchy item", { try DocumentURI(string: uriString) })
-    else {
-      return nil
-    }
-    return (uri: uri, usr: usr)
-  }
-
   func incomingCalls(_ req: CallHierarchyIncomingCallsRequest) async throws -> [CallHierarchyIncomingCall]? {
-    guard let data = extractCallHierarchyItemData(req.item.data),
+    guard let data = HierarchyItemData(fromLSPAny: req.item.data),
       let workspace = await self.workspaceForDocument(uri: data.uri),
       let index = await workspace.index(checkedFor: .deletedFiles)
     else {
@@ -2439,7 +2415,7 @@ extension SourceKitLSPServer {
   }
 
   func outgoingCalls(_ req: CallHierarchyOutgoingCallsRequest) async throws -> [CallHierarchyOutgoingCall]? {
-    guard let data = extractCallHierarchyItemData(req.item.data),
+    guard let data = HierarchyItemData(fromLSPAny: req.item.data),
       let workspace = await self.workspaceForDocument(uri: data.uri),
       let index = await workspace.index(checkedFor: .deletedFiles)
     else {
@@ -2529,10 +2505,7 @@ extension SourceKitLSPServer {
       range: location.range,
       selectionRange: location.range,
       // We encode usr and uri for incoming/outgoing type lookups in the implementation-specific data field
-      data: .dictionary([
-        "usr": .string(symbol.usr),
-        "uri": .string(location.uri.stringValue),
-      ])
+      data: HierarchyItemData(uri: location.uri, usr: symbol.usr).encodeToLSPAny()
     )
   }
 
@@ -2619,24 +2592,8 @@ extension SourceKitLSPServer {
     return Array(typeHierarchyItems.prefix(1))
   }
 
-  /// Extracts our implementation-specific data about a type hierarchy
-  /// item as encoded in `indexToLSPTypeHierarchyItem`.
-  ///
-  /// - Parameter data: The opaque data structure to extract
-  /// - Returns: The extracted data if successful or nil otherwise
-  private nonisolated func extractTypeHierarchyItemData(_ rawData: LSPAny?) -> (uri: DocumentURI, usr: String)? {
-    guard case let .dictionary(data) = rawData,
-      case let .string(uriString) = data["uri"],
-      case let .string(usr) = data["usr"],
-      let uri = orLog("DocumentURI for type hierarchy item", { try DocumentURI(string: uriString) })
-    else {
-      return nil
-    }
-    return (uri: uri, usr: usr)
-  }
-
   func supertypes(_ req: TypeHierarchySupertypesRequest) async throws -> [TypeHierarchyItem]? {
-    guard let data = extractTypeHierarchyItemData(req.item.data),
+    guard let data = HierarchyItemData(fromLSPAny: req.item.data),
       let workspace = await self.workspaceForDocument(uri: data.uri),
       let index = await workspace.index(checkedFor: .deletedFiles)
     else {
@@ -2694,7 +2651,7 @@ extension SourceKitLSPServer {
   }
 
   func subtypes(_ req: TypeHierarchySubtypesRequest) async throws -> [TypeHierarchyItem]? {
-    guard let data = extractTypeHierarchyItemData(req.item.data),
+    guard let data = HierarchyItemData(fromLSPAny: req.item.data),
       let workspace = await self.workspaceForDocument(uri: data.uri),
       let index = await workspace.index(checkedFor: .deletedFiles)
     else {


### PR DESCRIPTION
Introduce `HierarchyItemData` and `ResolveItemData` structs in `MessageMetadata.swift` conforming to `LSPAnyCodable`, replacing manual `LSPAny` dictionary construction and pattern matching for `CallHierarchyItem.data`, `TypeHierarchyItem.data`, `CompletionItem.data`, and `InlayHint.data`.

To use `HierarchyItemData`...

Move `CopiedFileMap` location/response adjustment logic out of `BuildServerIntegration` and into `adjusted(for: CopiedFileMap)` extensions on each LSP type (`Location`, `[Location]`, `LocationsOrLocationLinksResponse`, `WorkspaceEdit`, `CallHierarchyItem`, `TypeHierarchyItem`) in a new `LSP+CopiedFileMap.swift`.

The primitive URI remapping is extracted into `CopiedFileMap.adjustedURI(for:)`, which remains in `BuildServerIntegration`. This removes the awkward layering where a build-system module encoded knowledge of high-level LSP message shapes.
