### PR TITLE
[Tests] Add coverage for ReferencesContext.includeDeclaration

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2273,7 +2273,7 @@ extension SourceKitLSPServer {
       logger.info("Finding references for USR \(usr)")
       var roles: SymbolRole = [.reference]
       if req.context.includeDeclaration {
-        roles.formUnion([.declaration, .definition])
+        roles.formUnion([.declaration])
       }
       return try index.occurrences(ofUSR: usr, roles: roles).compactMap { $0.location.lspLocation }
     }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2273,7 +2273,7 @@ extension SourceKitLSPServer {
       logger.info("Finding references for USR \(usr)")
       var roles: SymbolRole = [.reference]
       if req.context.includeDeclaration {
-        roles.formUnion([.declaration])
+        roles.formUnion([.declaration, .definition])
       }
       return try index.occurrences(ofUSR: usr, roles: roles).compactMap { $0.location.lspLocation }
     }

--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -40,8 +40,34 @@ final class ReferencesTests: SourceKitLSPTestCase {
     XCTAssertEqual(
       response,
       [
-        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
+        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+      ]
+    )
+  }
+
+  func testReferencesExcludesOwnDefinition() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      func 1️⃣foo() {}
+
+      func bar() {
+        2️⃣foo()
+        3️⃣foo()
+      }
+      """
+    )
+    let response = try await project.testClient.send(
+      ReferencesRequest(
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"],
+        context: ReferencesContext(includeDeclaration: true)
+      )
+    )
+    XCTAssertEqual(
+      response,
+      [
         Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
+        Location(uri: project.fileURI, range: Range(project.positions["3️⃣"])),
       ]
     )
   }

--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -72,32 +72,4 @@ final class ReferencesTests: SourceKitLSPTestCase {
       ]
     )
   }
-
-  func testReferencesWithDeclaration() async throws {
-    let project = try await IndexedSingleSwiftFileTestProject(
-      """
-      func 1️⃣foo() {}
-
-      func bar() {
-        2️⃣foo()
-        3️⃣foo()
-      }
-      """
-    )
-    let response = try await project.testClient.send(
-      ReferencesRequest(
-        textDocument: TextDocumentIdentifier(project.fileURI),
-        position: project.positions["1️⃣"],
-        context: ReferencesContext(includeDeclaration: true)
-      )
-    )
-    XCTAssertEqual(
-      response,
-      [
-        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
-        Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
-        Location(uri: project.fileURI, range: Range(project.positions["3️⃣"])),
-      ]
-    )
-  }
 }

--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -40,12 +40,40 @@ final class ReferencesTests: SourceKitLSPTestCase {
     XCTAssertEqual(
       response,
       [
-        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
+        Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
       ]
     )
   }
 
-  func testReferencesExcludesOwnDefinition() async throws {
+  func testReferencesWithoutDeclaration() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      func 1️⃣foo() {}
+
+      func bar() {
+        2️⃣foo()
+        3️⃣foo()
+      }
+      """
+    )
+    let response = try await project.testClient.send(
+      ReferencesRequest(
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"],
+        context: ReferencesContext(includeDeclaration: false)
+      )
+    )
+    XCTAssertEqual(
+      response,
+      [
+        Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
+        Location(uri: project.fileURI, range: Range(project.positions["3️⃣"])),
+      ]
+    )
+  }
+
+  func testReferencesWithDeclaration() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       func 1️⃣foo() {}
@@ -66,6 +94,7 @@ final class ReferencesTests: SourceKitLSPTestCase {
     XCTAssertEqual(
       response,
       [
+        Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
         Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
         Location(uri: project.fileURI, range: Range(project.positions["3️⃣"])),
       ]


### PR DESCRIPTION
## Description

Following the discussion in #2638, SourceKit-LSP's `textDocument/references` behavior appears to already comply with the LSP specification. When `includeDeclaration` is `true`, the declaration is included. When `includeDeclaration` is `false`, the declaration is excluded.

The behavior reported in #2638, where the definition appears in "Find All References" results in VS Code, appears to be caused by the VS Code Swift extension sending `includeDeclaration: true` for that command, rather than by a server-side bug ([verified here](https://github.com/swiftlang/sourcekit-lsp/issues/2638#issuecomment-4432518139)).

This PR reverts the earlier behavior change and instead adds test coverage for the `includeDeclaration: false` case, which wasn't previously covered. The `includeDeclaration: true` case is already covered by existing tests `testReferencesInMacro`, `CopyDestinationTests`, `IndexTests`, `SwiftPMIntegrationTests`.

## Tests added

- `testReferencesWithoutDeclaration`: verifies that `includeDeclaration: false` returns only use sites

The test passes against the current behavior.

## Note on the original issue

The UX concern, where the definition appears in the results, is best addressed on the client side. For example, the VS Code Swift extension could send `includeDeclaration: false` for "Find All References". I would be happy to follow up on `vscode-swift` after this PR is reviewed.

Related to #2638