### PR TITLE
Use ExpressibleByLiteral conformances for LSPAny

### DIFF
--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -36,7 +36,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
   package static var experimentalCapabilities: [String: LSPAny] {
     return [
-      DoccDocumentationRequest.method: .dictionary(["version": .int(1)])
+      DoccDocumentationRequest.method: ["version": 1]
     ]
   }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1168,18 +1168,18 @@ extension SourceKitLSPServer {
       : ExecuteCommandOptions(commands: languageServiceRegistry.languageServices.flatMap { $0.type.builtInCommands })
 
     var experimentalCapabilities: [String: LSPAny] = [
-      WorkspaceTestsRequest.method: .dictionary(["version": .int(2)]),
-      WorkspaceTestsRefreshRequest.method: .dictionary(["version": .int(1)]),
-      DocumentTestsRequest.method: .dictionary(["version": .int(2)]),
-      TriggerReindexRequest.method: .dictionary(["version": .int(1)]),
-      GetReferenceDocumentRequest.method: .dictionary(["version": .int(1)]),
-      DidChangeActiveDocumentNotification.method: .dictionary(["version": .int(1)]),
-      WorkspacePlaygroundsRefreshRequest.method: .dictionary(["version": .int(1)]),
-      WorkspaceSymbolNamesRequest.method: .dictionary(["version": .int(1)]),
-      WorkspaceSymbolInfoRequest.method: .dictionary(["version": .int(1)]),
+      WorkspaceTestsRequest.method: ["version": 2],
+      WorkspaceTestsRefreshRequest.method: ["version": 1],
+      DocumentTestsRequest.method: ["version": 2],
+      TriggerReindexRequest.method: ["version": 1],
+      GetReferenceDocumentRequest.method: ["version": 1],
+      DidChangeActiveDocumentNotification.method: ["version": 1],
+      WorkspacePlaygroundsRefreshRequest.method: ["version": 1],
+      WorkspaceSymbolNamesRequest.method: ["version": 1],
+      WorkspaceSymbolInfoRequest.method: ["version": 1],
     ]
     if let toolchain = await toolchainRegistry.preferredToolchain(containing: [\.swiftc]), toolchain.swiftPlay != nil {
-      experimentalCapabilities[WorkspacePlaygroundsRequest.method] = .dictionary(["version": .int(1)])
+      experimentalCapabilities[WorkspacePlaygroundsRequest.method] = ["version": 1]
     }
     for (key, value) in languageServiceRegistry.languageServices.flatMap({ $0.type.experimentalCapabilities }) {
       if let existingValue = experimentalCapabilities[key] {

--- a/Tests/BuildServerIntegrationTests/ExternalBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/ExternalBuildServerTests.swift
@@ -428,7 +428,7 @@ final class ExternalBuildServerTests: SourceKitLSPTestCase {
         allowFallbackSettings: false
       )
     )
-    XCTAssertEqual(options.data, LSPAny.dictionary(["custom": .string("value")]))
+    XCTAssertEqual(options.data, ["custom": "value"])
   }
 
   func testBuildSettingsForFilePartOfMultipleTargets() async throws {

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -58,10 +58,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: uri,
             range: Range(positions["2️⃣"]),
             selectionRange: Range(positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:9MyLibrary3baryyF"),
+            data: [
+              "usr": "s:9MyLibrary3baryyF",
               "uri": .string(uri.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(positions["3️⃣"])]
         )
@@ -101,10 +101,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: try project.uri(for: "MyOtherFile.swift"),
             range: Range(try project.position(of: "2️⃣", in: "MyOtherFile.swift")),
             selectionRange: Range(try project.position(of: "2️⃣", in: "MyOtherFile.swift")),
-            data: .dictionary([
-              "usr": .string("s:9MyLibrary3baryyF"),
+            data: [
+              "usr": "s:9MyLibrary3baryyF",
               "uri": .string(try project.uri(for: "MyOtherFile.swift").stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(try project.position(of: "3️⃣", in: "MyOtherFile.swift"))]
         )
@@ -154,10 +154,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: try project.uri(for: "MyOtherFile.swift"),
             range: Range(try project.position(of: "2️⃣", in: "MyOtherFile.swift")),
             selectionRange: Range(try project.position(of: "2️⃣", in: "MyOtherFile.swift")),
-            data: .dictionary([
-              "usr": .string("s:4LibB3baryyF"),
+            data: [
+              "usr": "s:4LibB3baryyF",
               "uri": .string(try project.uri(for: "MyOtherFile.swift").stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(try project.position(of: "3️⃣", in: "MyOtherFile.swift"))]
         )
@@ -274,10 +274,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: testFileUri,
             range: try project.range(from: "2️⃣", to: "2️⃣", in: "Test.swift"),
             selectionRange: try project.range(from: "2️⃣", to: "2️⃣", in: "Test.swift"),
-            data: .dictionary([
-              "usr": .string("s:9MyLibrary4testyyF"),
+            data: [
+              "usr": "s:9MyLibrary4testyyF",
               "uri": .string(testFileUri.stringValue),
-            ])
+            ]
           ),
           fromRanges: [try project.range(from: "3️⃣", to: "3️⃣", in: "Test.swift")]
         )
@@ -318,10 +318,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: uri,
             range: Range(positions["2️⃣"]),
             selectionRange: Range(positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("c:@F@test"),
+            data: [
+              "usr": "c:@F@test",
               "uri": .string(uri.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(positions["3️⃣"])]
         )
@@ -454,10 +454,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: otherFileUri,
             range: Range(otherFilePositions["2️⃣"]),
             selectionRange: Range(otherFilePositions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:9MyLibrary3baryyF"),
+            data: [
+              "usr": "s:9MyLibrary3baryyF",
               "uri": .string(otherFileUri.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(otherFilePositions["3️⃣"])]
         )
@@ -514,10 +514,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: uri,
             range: Range(newPositions["2️⃣"]),
             selectionRange: Range(newPositions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("c:@F@test"),
+            data: [
+              "usr": "c:@F@test",
               "uri": .string(uri.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(newPositions["3️⃣"])]
         )
@@ -1442,10 +1442,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         uri: try project.uri(for: "LibB.swift"),
         range: try project.range(from: "2️⃣", to: "2️⃣", in: "LibB.swift"),
         selectionRange: try project.range(from: "2️⃣", to: "2️⃣", in: "LibB.swift"),
-        data: .dictionary([
-          "usr": .string("s:4LibB4testSiyF"),
+        data: [
+          "usr": "s:4LibB4testSiyF",
           "uri": .string(try project.uri(for: "LibB.swift").stringValue),
-        ])
+        ]
       ),
       fromRanges: [try project.range(from: "3️⃣", to: "3️⃣", in: "LibB.swift")]
     )
@@ -2859,10 +2859,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: try project.uri(for: "MyOtherFile.swift"),
             range: Range(try project.position(of: "2️⃣", in: "MyOtherFile.swift")),
             selectionRange: Range(try project.position(of: "2️⃣", in: "MyOtherFile.swift")),
-            data: .dictionary([
-              "usr": .string("s:4main3baryyF"),
+            data: [
+              "usr": "s:4main3baryyF",
               "uri": .string(try project.uri(for: "MyOtherFile.swift").stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(try project.position(of: "3️⃣", in: "MyOtherFile.swift"))]
         )
@@ -2958,10 +2958,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: try project.uri(for: "MyOtherFile.swift"),
             range: Range(try project.position(of: "4️⃣", in: "MyOtherFile.swift")),
             selectionRange: Range(try project.position(of: "4️⃣", in: "MyOtherFile.swift")),
-            data: .dictionary([
-              "usr": .string("s:4main3baryyF"),
+            data: [
+              "usr": "s:4main3baryyF",
               "uri": .string(try project.uri(for: "MyOtherFile.swift").stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(try project.position(of: "5️⃣", in: "MyOtherFile.swift"))]
         ),
@@ -2973,10 +2973,10 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
             uri: try project.uri(for: "MyFile.swift"),
             range: Range(try project.position(of: "2️⃣", in: "MyFile.swift")),
             selectionRange: Range(try project.position(of: "2️⃣", in: "MyFile.swift")),
-            data: .dictionary([
-              "usr": .string("s:4main3booyyF"),
+            data: [
+              "usr": "s:4main3booyyF",
               "uri": .string(try project.uri(for: "MyFile.swift").stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(try project.position(of: "3️⃣", in: "MyFile.swift"))]
         ),

--- a/Tests/SourceKitLSPTests/CallHierarchyTests.swift
+++ b/Tests/SourceKitLSPTests/CallHierarchyTests.swift
@@ -102,10 +102,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
         uri: project.fileURI,
         range: Range(position),
         selectionRange: Range(position),
-        data: .dictionary([
+        data: [
           "usr": .string(usr),
           "uri": .string(project.fileURI.stringValue),
-        ])
+        ]
       )
     }
 
@@ -218,10 +218,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
           uri: try project.uri(for: "lib.cpp"),
           range: try Range(project.position(of: "2️⃣", in: "lib.cpp")),
           selectionRange: try Range(project.position(of: "2️⃣", in: "lib.cpp")),
-          data: LSPAny.dictionary([
-            "usr": .string("c:@S@FilePathIndex@F@foo#"),
+          data: [
+            "usr": "c:@S@FilePathIndex@F@foo#",
             "uri": .string(try project.uri(for: "lib.cpp").stringValue),
-          ])
+          ]
         )
       ]
     )
@@ -257,10 +257,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test0A4Func1xySS_tF"),
+            data: [
+              "usr": "s:4test0A4Func1xySS_tF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -304,10 +304,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test0A3VarSivg"),
+            data: [
+              "usr": "s:4test0A3VarSivg",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -328,10 +328,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["4️⃣"]),
             selectionRange: Range(project.positions["4️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test0A4FuncyyF"),
+            data: [
+              "usr": "s:4test0A4FuncyyF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["5️⃣"])]
         )
@@ -369,10 +369,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test0A4FuncyyF"),
+            data: [
+              "usr": "s:4test0A4FuncyyF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"]), Range(project.positions["4️⃣"])]
         )
@@ -409,10 +409,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["1️⃣"]),
             selectionRange: Range(project.positions["1️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test3fooSivg"),
+            data: [
+              "usr": "s:4test3fooSivg",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -448,10 +448,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["1️⃣"]),
             selectionRange: Range(project.positions["1️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test0A4FuncSiyF"),
+            data: [
+              "usr": "s:4test0A4FuncSiyF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -496,10 +496,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4testAA5protoyAA10MyProtocol_p_tF"),
+            data: [
+              "usr": "s:4testAA5protoyAA10MyProtocol_p_tF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -544,10 +544,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4testAA4baseyAA4BaseC_tF"),
+            data: [
+              "usr": "s:4testAA4baseyAA4BaseC_tF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -586,10 +586,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["1️⃣"]),
             selectionRange: Range(project.positions["1️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test7MyClassC3fooyyF"),
+            data: [
+              "usr": "s:4test7MyClassC3fooyyF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["2️⃣"])]
         )
@@ -626,10 +626,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test0A4Func1xySS_tF"),
+            data: [
+              "usr": "s:4test0A4Func1xySS_tF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -666,10 +666,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["1️⃣"]),
             selectionRange: Range(project.positions["1️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test3fooyyF"),
+            data: [
+              "usr": "s:4test3fooyyF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -706,10 +706,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test5myVarSivp"),
+            data: [
+              "usr": "s:4test5myVarSivp",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -746,10 +746,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["1️⃣"]),
             selectionRange: Range(project.positions["1️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test3fooSiyF"),
+            data: [
+              "usr": "s:4test3fooSiyF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -788,10 +788,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test3BarVACycfc"),
+            data: [
+              "usr": "s:4test3BarVACycfc",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -832,10 +832,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test5OuterV3BarVAEycfc"),
+            data: [
+              "usr": "s:4test5OuterV3BarVAEycfc",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -877,10 +877,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test3FooV0A3VarSivg"),
+            data: [
+              "usr": "s:4test3FooV0A3VarSivg",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["3️⃣"])]
         )
@@ -927,10 +927,10 @@ final class CallHierarchyTests: SourceKitLSPTestCase {
             uri: project.fileURI,
             range: Range(project.positions["2️⃣"]),
             selectionRange: Range(project.positions["2️⃣"]),
-            data: .dictionary([
-              "usr": .string("s:4test3foo4taskyAA6MyTaskV_tF"),
+            data: [
+              "usr": "s:4test3foo4taskyAA6MyTaskV_tF",
               "uri": .string(project.fileURI.stringValue),
-            ])
+            ]
           ),
           fromRanges: [Range(project.positions["1️⃣"])]
         )

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -147,14 +147,14 @@ final class CodeActionTests: SourceKitLSPTestCase {
       let data = try JSONEncoder().encode(metadata)
       return try JSONDecoder().decode(LSPAny.self, from: data)
     }()
-    XCTAssertEqual(expectedCommandMetadata, .dictionary(["sourcekitlsp_textDocument": ["uri": "file:///a.swift"]]))
+    XCTAssertEqual(expectedCommandMetadata, ["sourcekitlsp_textDocument": ["uri": "file:///a.swift"]])
 
     let expectedResolveMetadata: LSPAny = try {
       let metadata = CodeActionResolveMetadata(textDocument: textDocument)
       let data = try JSONEncoder().encode(metadata)
       return try JSONDecoder().decode(LSPAny.self, from: data)
     }()
-    XCTAssertEqual(expectedResolveMetadata, .dictionary(["textDocument": ["uri": "file:///a.swift"]]))
+    XCTAssertEqual(expectedResolveMetadata, ["textDocument": ["uri": "file:///a.swift"]])
 
     let command = Command(title: "Title", command: "Command", arguments: [1, "text", 2.2, nil])
     let codeAction = CodeAction(title: "1")
@@ -200,7 +200,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
     let url = URL(fileURLWithPath: "/a.swift")
     let textDocument = TextDocumentIdentifier(url)
 
-    let originalData: LSPAny = .dictionary(["custom": "value"])
+    let originalData: LSPAny = ["custom": "value"]
     var codeAction = CodeAction(title: "With data")
     codeAction.data = originalData
 

--- a/Tests/SourceKitLSPTests/CodeLensTests.swift
+++ b/Tests/SourceKitLSPTests/CodeLensTests.swift
@@ -130,11 +130,11 @@ final class CodeLensTests: SourceKitLSPTestCase {
       [
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Run MyApp", command: "swift.run", arguments: [.string("MyApp")])
+          command: Command(title: "Run MyApp", command: "swift.run", arguments: ["MyApp"])
         ),
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: [.string("MyApp")])
+          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: ["MyApp"])
         ),
         CodeLens(
           range: positions["3️⃣"]..<positions["4️⃣"],
@@ -281,11 +281,11 @@ final class CodeLensTests: SourceKitLSPTestCase {
       [
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Run MyApp", command: "swift.run", arguments: [.string("MyApp")])
+          command: Command(title: "Run MyApp", command: "swift.run", arguments: ["MyApp"])
         ),
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: [.string("MyApp")])
+          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: ["MyApp"])
         ),
       ]
     )

--- a/Tests/SourceKitLSPTests/ExpandMacroTests.swift
+++ b/Tests/SourceKitLSPTests/ExpandMacroTests.swift
@@ -55,8 +55,8 @@ final class ExpandMacroTests: SourceKitLSPTestCase {
       files: files,
       manifest: SwiftPMTestProject.minimalMacroPackageManifest,
       capabilities: ClientCapabilities(experimental: [
-        PeekDocumentsRequest.method: .dictionary(["supported": .bool(peekDocuments)]),
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(getReferenceDocument)]),
+        PeekDocumentsRequest.method: ["supported": .bool(peekDocuments)],
+        GetReferenceDocumentRequest.method: ["supported": .bool(getReferenceDocument)],
       ]),
       options: SourceKitLSPOptions.testDefault(),
       enableBackgroundIndexing: true
@@ -207,8 +207,8 @@ final class ExpandMacroTests: SourceKitLSPTestCase {
       files: files,
       manifest: SwiftPMTestProject.minimalMacroPackageManifest,
       capabilities: ClientCapabilities(experimental: [
-        PeekDocumentsRequest.method: .dictionary(["supported": .bool(peekDocuments)]),
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(getReferenceDocument)]),
+        PeekDocumentsRequest.method: ["supported": .bool(peekDocuments)],
+        GetReferenceDocumentRequest.method: ["supported": .bool(getReferenceDocument)],
       ]),
       options: SourceKitLSPOptions.testDefault(),
       enableBackgroundIndexing: true
@@ -359,8 +359,8 @@ final class ExpandMacroTests: SourceKitLSPTestCase {
       files: files,
       manifest: SwiftPMTestProject.minimalMacroPackageManifest,
       capabilities: ClientCapabilities(experimental: [
-        PeekDocumentsRequest.method: .dictionary(["supported": .bool(true)]),
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)]),
+        PeekDocumentsRequest.method: ["supported": true],
+        GetReferenceDocumentRequest.method: ["supported": true],
       ]),
       options: SourceKitLSPOptions.testDefault(),
       enableBackgroundIndexing: true

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -46,7 +46,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
   func testSystemModuleInterfaceReferenceDocument() async throws {
     let testClient = try await TestSourceKitLSPClient(
       capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+        GetReferenceDocumentRequest.method: ["supported": true]
       ])
     )
     let uri = DocumentURI(for: .swift)
@@ -121,7 +121,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       }
       """,
       capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+        GetReferenceDocumentRequest.method: ["supported": true]
       ]),
       indexSystemModules: true,
       extraCompilerArguments: Self.ignoreModuleSourceInfoFlags
@@ -215,7 +215,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
         )
         """,
       capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+        GetReferenceDocumentRequest.method: ["supported": true]
       ]),
       enableBackgroundIndexing: true
     )
@@ -309,7 +309,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
     let testClient = try await TestSourceKitLSPClient(
       options: options,
       capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+        GetReferenceDocumentRequest.method: ["supported": true]
       ])
     )
     let uri = DocumentURI(for: .swift)
@@ -340,7 +340,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
   func testFoundationImportNavigation() async throws {
     let testClient = try await TestSourceKitLSPClient(
       capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+        GetReferenceDocumentRequest.method: ["supported": true]
       ])
     )
     let uri = DocumentURI(for: .swift)
@@ -367,7 +367,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
 
     let testClient = try await TestSourceKitLSPClient(
       capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+        GetReferenceDocumentRequest.method: ["supported": true]
       ])
     )
     let uri = DocumentURI(for: .swift)

--- a/Tests/SourceKitLSPTests/WorkspacePlaygroundDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspacePlaygroundDiscoveryTests.swift
@@ -556,7 +556,7 @@ final class WorkspacePlaygroundDiscoveryTests: SourceKitLSPTestCase {
         """
       ],
       capabilities: ClientCapabilities(experimental: [
-        WorkspacePlaygroundsRefreshRequest.method: .bool(true)
+        WorkspacePlaygroundsRefreshRequest.method: true
       ]),
       toolchainRegistry: toolchainRegistry,
       preInitialization: { testClient in
@@ -595,7 +595,7 @@ final class WorkspacePlaygroundDiscoveryTests: SourceKitLSPTestCase {
         """
       ],
       capabilities: ClientCapabilities(experimental: [
-        WorkspacePlaygroundsRefreshRequest.method: .bool(true)
+        WorkspacePlaygroundsRefreshRequest.method: true
       ]),
       toolchainRegistry: toolchainRegistry,
       preInitialization: { testClient in
@@ -651,7 +651,7 @@ final class WorkspacePlaygroundDiscoveryTests: SourceKitLSPTestCase {
         """
       ],
       capabilities: ClientCapabilities(experimental: [
-        WorkspacePlaygroundsRefreshRequest.method: .bool(true)
+        WorkspacePlaygroundsRefreshRequest.method: true
       ]),
       toolchainRegistry: toolchainRegistry,
       preInitialization: { testClient in
@@ -681,7 +681,7 @@ final class WorkspacePlaygroundDiscoveryTests: SourceKitLSPTestCase {
         "Sources/MyLibrary/Test.swift": ""
       ],
       capabilities: ClientCapabilities(experimental: [
-        WorkspacePlaygroundsRefreshRequest.method: .bool(true)
+        WorkspacePlaygroundsRefreshRequest.method: true
       ]),
       toolchainRegistry: toolchainRegistry
     )
@@ -732,7 +732,7 @@ final class WorkspacePlaygroundDiscoveryTests: SourceKitLSPTestCase {
         """,
       ],
       capabilities: ClientCapabilities(experimental: [
-        WorkspacePlaygroundsRefreshRequest.method: .bool(true)
+        WorkspacePlaygroundsRefreshRequest.method: true
       ]),
       toolchainRegistry: toolchainRegistry,
       preInitialization: { testClient in

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -1177,7 +1177,7 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
       ],
       manifest: packageManifestWithTestTarget,
       capabilities: ClientCapabilities(experimental: [
-        WorkspaceTestsRefreshRequest.method: .bool(true)
+        WorkspaceTestsRefreshRequest.method: true
       ]),
       preInitialization: { testClient in
         testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
@@ -1222,7 +1222,7 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
       ],
       manifest: packageManifestWithTestTarget,
       capabilities: ClientCapabilities(experimental: [
-        WorkspaceTestsRefreshRequest.method: .bool(true)
+        WorkspaceTestsRefreshRequest.method: true
       ]),
       preInitialization: { testClient in
         testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
@@ -1284,7 +1284,7 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
       ],
       manifest: packageManifestWithTestTarget,
       capabilities: ClientCapabilities(experimental: [
-        WorkspaceTestsRefreshRequest.method: .bool(true)
+        WorkspaceTestsRefreshRequest.method: true
       ]),
       preInitialization: { testClient in
         testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in
@@ -1313,7 +1313,7 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
       ],
       manifest: packageManifestWithTestTarget,
       capabilities: ClientCapabilities(experimental: [
-        WorkspaceTestsRefreshRequest.method: .bool(true)
+        WorkspaceTestsRefreshRequest.method: true
       ])
     )
 
@@ -1370,7 +1370,7 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
       ],
       manifest: packageManifestWithTestTarget,
       capabilities: ClientCapabilities(experimental: [
-        WorkspaceTestsRefreshRequest.method: .bool(true)
+        WorkspaceTestsRefreshRequest.method: true
       ]),
       preInitialization: { testClient in
         testClient.handleSingleRequest { (_: WorkspaceTestsRefreshRequest) in

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1126,7 +1126,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
         )
         """,
       capabilities: ClientCapabilities(experimental: [
-        DidChangeActiveDocumentNotification.method: .dictionary(["supported": .bool(true)])
+        DidChangeActiveDocumentNotification.method: ["supported": true]
       ]),
       hooks: Hooks(
         indexHooks: IndexHooks(preparationTaskDidStart: { task in


### PR DESCRIPTION
Replaces LSPAny case constructors with literal syntax #2630