### PR TITLE
[6.4] Preserve language service when closing generated interface

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1457,7 +1457,9 @@ extension SourceKitLSPServer {
       await languageService.closeDocument(notification)
     }
 
-    workspace.removeLanguageServices(for: uri)
+    if !documentManager.openDocuments.contains(where: { $0.buildSettingsFile == uri.buildSettingsFile }) {
+      workspace.removeLanguageServices(for: uri)
+    }
 
     workspaceQueue.async {
       self.workspaceForUri[notification.textDocument.uri] = nil

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1457,9 +1457,7 @@ extension SourceKitLSPServer {
       await languageService.closeDocument(notification)
     }
 
-    if !documentManager.openDocuments.contains(where: { $0.buildSettingsFile == uri.buildSettingsFile }) {
-      workspace.removeLanguageServices(for: uri)
-    }
+    workspace.removeLanguageServices(for: uri)
 
     workspaceQueue.async {
       self.workspaceForUri[notification.textDocument.uri] = nil

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -476,9 +476,17 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   }
 
   /// Remove the language services association for a document when it is closed.
+  ///
+  /// If any other open document shares the same build-settings file as `uri`, the language service
+  /// is still in use and will not be removed.
   func removeLanguageServices(for uri: DocumentURI) {
+    let key = uri.buildSettingsFile
+    let openDocuments = sourceKitLSPServer?.documentManager.openDocuments ?? []
+    guard !openDocuments.contains(where: { $0.buildSettingsFile == key }) else {
+      return
+    }
     languageServices.withLock { languageServices in
-      languageServices[uri.buildSettingsFile] = nil
+      languageServices[key] = nil
     }
   }
 

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -395,6 +395,41 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
     XCTAssertEqual(transformLocation.uri.scheme, "sourcekit-lsp")
     assertContains(transformLocation.uri.pseudoPath, "Foundation.NSAffineTransform.swiftinterface")
   }
+
+  func testClosingGeneratedInterfacePreservesOriginatingLanguageService() async throws {
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(experimental: [
+        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
+      ])
+    )
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      func test(x: 1️⃣String) {
+        let y: 2️⃣Int = 1
+      }
+      """,
+      uri: uri
+    )
+
+    let definition = try await testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let interfaceUri = try XCTUnwrap(definition?.locations?.only?.uri)
+    let interfaceContents = try await testClient.send(GetReferenceDocumentRequest(uri: interfaceUri))
+    testClient.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(uri: interfaceUri, language: .swift, version: 0, text: interfaceContents.content)
+      )
+    )
+    testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(interfaceUri)))
+
+    let hover = try await testClient.send(
+      HoverRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    XCTAssertNotNil(hover)
+  }
 }
 
 private func assertSystemSwiftInterface(

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -397,36 +397,38 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
   }
 
   func testClosingGeneratedInterfacePreservesOriginatingLanguageService() async throws {
-    let testClient = try await TestSourceKitLSPClient(
-      capabilities: ClientCapabilities(experimental: [
-        GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])
-      ])
-    )
-    let uri = DocumentURI(for: .swift)
-
-    let positions = testClient.openDocument(
+    let project = try await IndexedSingleSwiftFileTestProject(
       """
       func test(x: 1️⃣String) {
         let y: 2️⃣Int = 1
       }
       """,
-      uri: uri
+      capabilities: ClientCapabilities(experimental: [
+        GetReferenceDocumentRequest.method: .dictionary(["supported": true])
+      ]),
+      extraCompilerArguments: Self.ignoreModuleSourceInfoFlags
     )
 
-    let definition = try await testClient.send(
-      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
-    )
-    let interfaceUri = try XCTUnwrap(definition?.locations?.only?.uri)
-    let interfaceContents = try await testClient.send(GetReferenceDocumentRequest(uri: interfaceUri))
-    testClient.send(
-      DidOpenTextDocumentNotification(
-        textDocument: TextDocumentItem(uri: interfaceUri, language: .swift, version: 0, text: interfaceContents.content)
+    let definition = try await project.testClient.send(
+      DefinitionRequest(
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["1️⃣"]
       )
     )
-    testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(interfaceUri)))
+    let interfaceUri = try XCTUnwrap(definition?.locations?.only?.uri)
+    let interfaceContents = try await project.testClient.send(GetReferenceDocumentRequest(uri: interfaceUri))
+    project.testClient.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(uri: interfaceUri, language: .swift, version: 1, text: interfaceContents.content)
+      )
+    )
+    project.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(interfaceUri)))
 
-    let hover = try await testClient.send(
-      HoverRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    let hover = try await project.testClient.send(
+      HoverRequest(
+        textDocument: TextDocumentIdentifier(project.fileURI),
+        position: project.positions["2️⃣"]
+      )
     )
     XCTAssertNotNil(hover)
   }


### PR DESCRIPTION
Cherry-pick #2648 into `release/6.4.x`

* **Explanation**: Closing a generated document (e.g. a Swift interface opened via jump-to-definition) was incorrectly removing the language service for the originating source file. Both the generated interface and its originating file share the same `buildSettingsFile` key in `Workspace.languageServices`, so closing the interface evicted the service while the source document was still open. Subsequent requests (hover, completion, etc.) on the source file would silently fail. The fix guards `removeLanguageServices(for:)` so it only removes the service when no other open document shares the same key.
* **Scope**: Language service management
* **Risk**: Low. At worst, a language service that should have been released is retained slightly longer. This fix is a strict improvement over the status quo where the service was incorrectly dropped.. 
* **Issues**: rdar://176574004
* **Testing**: Added regression test cases
* **Reviewer**: Hamish Knight (@hamishknight)