### PR TITLE
[Tests] Adjust `testDefinitionInSystemModuleInterface` post stdlib AP…

### DIFF
--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -106,7 +106,7 @@ final class SwiftInterfaceTests: SourceKitLSPTestCase {
       position: project.positions["3️⃣"],
       testClient: project.testClient,
       swiftInterfaceFiles: ["Swift.swiftinterface", "_Concurrency.swiftinterface", "TaskGroup.swift"],
-      lineContains: "public func withTaskGroup"
+      lineContains: "public nonisolated(nonsending) func withTaskGroup"
     )
   }
 


### PR DESCRIPTION
…I changes

`withTaskGroup` and a few other stdlib concurrency APIs are getting `nonisolated(nonsending)` variants now. The test has to be adjusted to account for that.