### PR TITLE
Scope language service lifetime to workspace

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -87,10 +87,6 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
   /// Used to make sure we are not restarting `clangd` twice.
   private var clangRestartScheduled = false
 
-  /// The `InitializeRequest` with which `clangd` was originally initialized.
-  /// Stored so we can replay the initialization when clangd crashes.
-  private var initializeRequest: InitializeRequest?
-
   /// The workspace this `ClangLanguageServer` was opened for.
   ///
   /// `clangd` doesn't have support for multi-root workspaces, so we need to start a separate `clangd` instance for every workspace root.
@@ -128,7 +124,8 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
     self.workspace = WeakWorkspace(workspace)
     self.state = .connected
     self.sourceKitLSPServer = sourceKitLSPServer
-    try startClangdProcess()
+
+    try await self.initialize()
   }
 
   private func buildSettings(for document: DocumentURI, fallbackAfterTimeout: Bool) async -> ClangBuildSettings? {
@@ -147,9 +144,8 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
     return ClangBuildSettings(settings, clangPath: clangPath)
   }
 
-  package nonisolated func canHandle(workspace: Workspace, toolchain: Toolchain) -> Bool {
-    // We launch different clangd instance for each workspace because clangd doesn't have multi-root workspace support.
-    return workspace === self.workspace.value && self.clangdPath == toolchain.clangd
+  package nonisolated func canHandle(toolchain: Toolchain) -> Bool {
+    return self.clangdPath == toolchain.clangd
   }
 
   package func addStateChangeHandler(handler: @escaping (LanguageServerState, LanguageServerState) -> Void) {
@@ -207,8 +203,8 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
     precondition(self.clangRestartScheduled == false)
     self.clangRestartScheduled = true
 
-    guard let initializeRequest = self.initializeRequest else {
-      logger.error("clangd crashed before it was sent an InitializeRequest.")
+    guard self.capabilities != nil else {
+      logger.error("clangd crashed before initialization completed.")
       return
     }
 
@@ -225,12 +221,7 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
       try await Task.sleep(for: restartDelay)
       self.clangRestartScheduled = false
       do {
-        try self.startClangdProcess()
-        // We assume that clangd will return the same capabilities after restarting.
-        // Theoretically they could have changed and we would need to inform SourceKitLSPServer about them.
-        // But since SourceKitLSPServer more or less ignores them right now anyway, this should be fine for now.
-        _ = try await self.initialize(initializeRequest)
-        await self.clientInitialized(InitializedNotification())
+        try await self.initialize()
         if let sourceKitLSPServer {
           await sourceKitLSPServer.reopenDocuments(for: self)
         } else {
@@ -369,11 +360,22 @@ extension ClangLanguageService {
 
 extension ClangLanguageService {
 
-  package func initialize(_ initialize: InitializeRequest) async throws -> InitializeResult {
-    // Store the initialize request so we can replay it in case clangd crashes
-    self.initializeRequest = initialize
-
-    let result = try await clangd.send(initialize)
+  private func initialize() async throws {
+    guard let workspace = self.workspace.value else {
+      throw ResponseError.internalError("Workspace no longer exists")
+    }
+    try self.startClangdProcess()
+    let result = try await clangd.send(
+      InitializeRequest(
+        processId: Int(ProcessInfo.processInfo.processIdentifier),
+        rootPath: nil,
+        rootURI: workspace.rootUri,
+        initializationOptions: nil,
+        capabilities: workspace.capabilityRegistry.clientCapabilities,
+        trace: .off,
+        workspaceFolders: nil
+      )
+    )
     self.capabilities = result.capabilities
     if let legend = result.capabilities.semanticTokensProvider?.legend {
       self.semanticTokensTranslator = SemanticTokensLegendTranslator(
@@ -381,11 +383,28 @@ extension ClangLanguageService {
         sourceKitLSPLegend: SemanticTokensLegend.sourceKitLSPLegend
       )
     }
-    return result
-  }
-
-  package func clientInitialized(_ initialized: InitializedNotification) async {
-    clangd.send(initialized)
+    if let sourceKitLSPServer {
+      // Since `ClangLanguageService` is created per toolchain, different clangd
+      // instances can report different capabilities. Calling `registerCapabilities`
+      // here means a later instance may overwrite capabilities registered by an
+      // earlier one. This is fine for now because SourceKitLSPServer more or less
+      // ignores the registered capabilities for clangd at the moment.
+      await sourceKitLSPServer.registerCapabilities(
+        for: result.capabilities,
+        languages: [.c, .cpp, .objective_c, .objective_cpp],
+        registry: workspace.capabilityRegistry
+      )
+    }
+    var syncKind: TextDocumentSyncKind
+    switch result.capabilities.textDocumentSync {
+    case .options(let options): syncKind = options.change ?? .incremental
+    case .kind(let kind): syncKind = kind
+    default: syncKind = .incremental
+    }
+    guard syncKind == .incremental else {
+      throw ResponseError.internalError("non-incremental update not implemented")
+    }
+    clangd.send(InitializedNotification())
   }
 
   package func shutdown() async {

--- a/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
+++ b/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
@@ -110,10 +110,9 @@ extension DocumentationLanguageService {
             ofDocCSymbolLink: symbolLink,
             fetchSymbolGraph: { location in
               guard let uri = location.uri else { return nil }
-              return try await sourceKitLSPServer.primaryLanguageService(
+              return try await workspace.primaryLanguageService(
                 for: uri,
-                workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri),
-                in: workspace
+                workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri)
               )
               .symbolGraph(forOnDiskContentsAt: location, in: workspace, manager: onDiskDocumentManager)
             }
@@ -124,10 +123,9 @@ extension DocumentationLanguageService {
         guard let uri = symbolOccurrence.location.uri else {
           throw ResponseError.unknown("Symbol location has no file path")
         }
-        let symbolGraph = try await sourceKitLSPServer.primaryLanguageService(
+        let symbolGraph = try await workspace.primaryLanguageService(
           for: uri,
-          workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri),
-          in: workspace
+          workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri)
         ).symbolGraph(forOnDiskContentsAt: symbolOccurrence.location, in: workspace, manager: onDiskDocumentManager)
         return try await documentationManager.renderDocCDocumentation(
           symbolUSR: symbolOccurrence.symbol.usr,
@@ -161,10 +159,9 @@ extension DocumentationLanguageService {
     guard let sourceKitLSPServer else {
       throw ResponseError.internalError("SourceKit-LSP is shutting down")
     }
-    let (symbolGraph, symbolUSR, overrideDocComments) = try await sourceKitLSPServer.primaryLanguageService(
+    let (symbolGraph, symbolUSR, overrideDocComments) = try await workspace.primaryLanguageService(
       for: snapshot.uri,
-      snapshot.language,
-      in: workspace
+      snapshot.language
     ).symbolGraph(for: snapshot, at: position)
     // Locate the documentation extension and include it in the request if one exists
     let markupExtensionFile = await sourceKitLSPServer.withOnDiskDocumentManager {
@@ -178,10 +175,9 @@ extension DocumentationLanguageService {
           for: symbolUSR,
           fetchSymbolGraph: { location in
             guard let uri = location.uri else { return nil }
-            return try await sourceKitLSPServer.primaryLanguageService(
+            return try await workspace.primaryLanguageService(
               for: uri,
-              snapshot.language,
-              in: workspace
+              snapshot.language
             )
             .symbolGraph(forOnDiskContentsAt: location, in: workspace, manager: onDiskDocumentManager)
           }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -51,16 +51,8 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager)
   }
 
-  package nonisolated func canHandle(workspace: Workspace, toolchain: Toolchain) -> Bool {
+  package nonisolated func canHandle(toolchain: Toolchain) -> Bool {
     return true
-  }
-
-  package func initialize(
-    _ initialize: InitializeRequest
-  ) async throws -> InitializeResult {
-    return InitializeResult(
-      capabilities: ServerCapabilities()
-    )
   }
 
   package func shutdown() async {

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -489,6 +489,15 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
 
     return DocumentPositions(markers: markers, textWithoutMarkers: textWithoutMarkers)
   }
+
+  /// Returns the primary language service for the given document URI.
+  ///
+  /// Sends a `SynchronizeRequest` first so that any pending `DidOpenTextDocumentNotification`
+  /// for `uri` is fully processed (and `setLanguageServices` called) before the cache is read.
+  package func primaryLanguageService(for uri: DocumentURI) async throws -> (any LanguageService)? {
+    _ = try await send(SynchronizeRequest())
+    return await server.workspaceForDocument(uri: uri)?.primaryLanguageService(for: uri)
+  }
 }
 
 // MARK: - DocumentPositions

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -115,11 +115,10 @@ package protocol LanguageService: AnyObject, Sendable {
     workspace: Workspace
   ) async throws
 
-  /// Returns `true` if this instance of the language server can handle documents in `workspace` using the given
-  /// toolchain.
+  /// Returns `true` if this instance can serve requests for the given toolchain.
   ///
-  /// If this returns `false`, a new language server will be started for `workspace`.
-  func canHandle(workspace: Workspace, toolchain: Toolchain) -> Bool
+  /// If this returns `false`, a new language server will be started for the toolchain.
+  func canHandle(toolchain: Toolchain) -> Bool
 
   /// Identifiers of the commands that this language service can handle.
   static var builtInCommands: [String] { get }
@@ -127,18 +126,7 @@ package protocol LanguageService: AnyObject, Sendable {
   /// Experimental capabilities that should be reported to the client if this language service is enabled.
   static var experimentalCapabilities: [String: LSPAny] { get }
 
-  /// Whether this language service should be kept alive when its workspace is closed.
-  ///
-  /// When `true`, the language service will not be shut down even if all workspaces referencing it are closed.
-  /// This is useful for language services that use global state (like sourcekitd) where shutting down and
-  /// restarting would cause unnecessary overhead since the new instance will just reinitialize the same
-  /// global state.
-  static var isImmortal: Bool { get }
-
   // MARK: - Lifetime
-
-  func initialize(_ initialize: InitializeRequest) async throws -> InitializeResult
-  func clientInitialized(_ initialized: InitializedNotification) async
 
   /// Shut the server down and return once the server has finished shutting down
   func shutdown() async
@@ -358,10 +346,6 @@ package extension LanguageService {
   static var builtInCommands: [String] { [] }
 
   static var experimentalCapabilities: [String: LSPAny] { [:] }
-
-  static var isImmortal: Bool { false }
-
-  func clientInitialized(_ initialized: InitializedNotification) async {}
 
   func openOnDiskDocument(snapshot: DocumentSnapshot, buildSettings: FileBuildSettings) async throws {
     throw ResponseError.unknown("\(#function) not implemented in \(Self.self) for \(snapshot.uri)")

--- a/Sources/SourceKitLSP/OnDiskDocumentManager.swift
+++ b/Sources/SourceKitLSP/OnDiskDocumentManager.swift
@@ -49,7 +49,7 @@ package actor OnDiskDocumentManager {
       version: 0,
       lineTable: LineTable(try String(contentsOf: fileURL, encoding: .utf8))
     )
-    let languageService = try await sourceKitLSPServer.primaryLanguageService(for: uri, language, in: workspace)
+    let languageService = try await workspace.primaryLanguageService(for: uri, language)
 
     let originalBuildSettings = await workspace.buildServerManager.buildSettingsInferredFromMainFile(
       for: uri,
@@ -70,7 +70,7 @@ package actor OnDiskDocumentManager {
     for (snapshot, _, workspace) in openSnapshots.values {
       await orLog("Closing snapshot from on-disk contents: \(snapshot.uri.forLogging)") {
         let languageService =
-          try await sourceKitLSPServer.primaryLanguageService(for: snapshot.uri, snapshot.language, in: workspace)
+          try await workspace.primaryLanguageService(for: snapshot.uri, snapshot.language)
         try await languageService.closeOnDiskDocument(uri: snapshot.uri)
       }
     }

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -128,7 +128,7 @@ extension SourceKitLSPServer {
       return nil
     }
     let swiftLanguageService = await orLog("Getting NameTranslatorService") {
-      try await self.primaryLanguageService(for: uri, .swift, in: workspace) as? (any NameTranslatorService)
+      try await workspace.primaryLanguageService(for: uri, .swift) as? (any NameTranslatorService)
     }
     guard let swiftLanguageService else {
       return nil
@@ -217,10 +217,9 @@ extension SourceKitLSPServer {
       return CrossLanguageName(clangName: definitionName, swiftName: swiftName, definitionLanguage: definitionLanguage)
     case .swift:
       guard
-        let swiftLanguageService = try await self.primaryLanguageService(
+        let swiftLanguageService = try await workspace.primaryLanguageService(
           for: definitionDocumentUri,
-          definitionLanguage,
-          in: workspace
+          definitionLanguage
         ) as? (any NameTranslatorService)
       else {
         throw ResponseError.unknown("Failed to get language service for the document defining \(usr)")
@@ -285,7 +284,7 @@ extension SourceKitLSPServer {
     guard let workspace = await workspaceForDocument(uri: uri) else {
       throw ResponseError.workspaceNotOpen(uri)
     }
-    let primaryFileLanguageService = try await primaryLanguageService(for: uri, snapshot.language, in: workspace)
+    let primaryFileLanguageService = try await workspace.primaryLanguageService(for: uri, snapshot.language)
 
     // Determine the local edits and the USR to rename
     let renameResult = try await primaryFileLanguageService.rename(request)
@@ -401,7 +400,7 @@ extension SourceKitLSPServer {
           return nil
         }
         let languageService = await orLog("Getting language service to compute edits in file") {
-          try await self.primaryLanguageService(for: uri, language, in: workspace)
+          try await workspace.primaryLanguageService(for: uri, language)
         }
         guard let languageService else {
           return nil

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -74,8 +74,6 @@ package actor SourceKitLSPServer {
 
   let languageServiceRegistry: LanguageServiceRegistry
 
-  var languageServices: [LanguageServiceType: [any LanguageService]] = [:]
-
   package nonisolated let documentManager = DocumentManager()
 
   /// The `TaskScheduler` that schedules all background indexing tasks.
@@ -458,165 +456,6 @@ package actor SourceKitLSPServer {
     }
   }
 
-  /// If a language service of type `serverType` that can handle `workspace` using the given toolchain has already been
-  /// started, return it, otherwise return `nil`.
-  private func existingLanguageService(
-    _ serverType: any LanguageService.Type,
-    toolchain: Toolchain,
-    workspace: Workspace
-  ) -> (any LanguageService)? {
-    for languageService in languageServices[LanguageServiceType(serverType), default: []] {
-      if languageService.canHandle(workspace: workspace, toolchain: toolchain) {
-        return languageService
-      }
-    }
-    return nil
-  }
-
-  /// Get the language services that can handle the given languages in the given workspace using the given toolchain.
-  ///
-  /// If we have language services that can handle this combination but that haven't been started yet, start them.
-  func languageServices(
-    for toolchain: Toolchain,
-    _ language: Language,
-    in workspace: Workspace
-  ) async -> [any LanguageService] {
-    var result: [any LanguageService] = []
-    for serverType in languageServiceRegistry.languageServices(for: language) {
-      if let languageService = existingLanguageService(serverType, toolchain: toolchain, workspace: workspace) {
-        result.append(languageService)
-        continue
-      }
-
-      // Start a new service.
-      let languageService: (any LanguageService)? = await orLog("failed to start language service") {
-        [options = workspace.options, hooks] in
-        let service = try await serverType.init(
-          sourceKitLSPServer: self,
-          toolchain: toolchain,
-          options: options,
-          hooks: hooks,
-          workspace: workspace
-        )
-
-        let pid = Int(ProcessInfo.processInfo.processIdentifier)
-        let resp = try await service.initialize(
-          InitializeRequest(
-            processId: pid,
-            rootPath: nil,
-            rootURI: workspace.rootUri,
-            initializationOptions: nil,
-            capabilities: workspace.capabilityRegistry.clientCapabilities,
-            trace: .off,
-            workspaceFolders: nil
-          )
-        )
-        let languages = languageClass(for: language)
-        await self.registerCapabilities(
-          for: resp.capabilities,
-          languages: languages,
-          registry: workspace.capabilityRegistry
-        )
-
-        var syncKind: TextDocumentSyncKind
-        switch resp.capabilities.textDocumentSync {
-        case .options(let options):
-          syncKind = options.change ?? .incremental
-        case .kind(let kind):
-          syncKind = kind
-        default:
-          syncKind = .incremental
-        }
-        guard syncKind == .incremental else {
-          throw ResponseError.internalError("non-incremental update not implemented")
-        }
-
-        await service.clientInitialized(InitializedNotification())
-
-        if let concurrentlyInitializedService = existingLanguageService(
-          serverType,
-          toolchain: toolchain,
-          workspace: workspace
-        ) {
-          // Since we 'await' above, another call to languageService might have
-          // happened concurrently, passed the `existingLanguageService` check at
-          // the top and started initializing another language service.
-          // If this race happened, just shut down our server and return the
-          // other one.
-          await service.shutdown()
-          return concurrentlyInitializedService
-        }
-
-        languageServices[LanguageServiceType(serverType), default: []].append(service)
-        return service
-      }
-      guard let languageService else {
-        // If a language service fails to start, don't try starting language services with lower precedence. Otherwise
-        // we get into a situation where eg. `SwiftLanguageService`` fails to start (eg. because the toolchain doesn't
-        // contain sourcekitd) and the `DocumentationLanguageService` now becomes the primary language service for the
-        // document, trying to serve documentation, completion etc. which is not intended.
-        break
-      }
-      result.append(languageService)
-    }
-    if result.isEmpty {
-      logger.error("Unable to infer language server type for language '\(language)'")
-    }
-    return result
-  }
-
-  /// Get the language services that can handle the given document.
-  ///
-  /// If we have language services that can handle this document but that haven't been started yet, start them.
-  package func languageServices(
-    for uri: DocumentURI,
-    _ language: Language,
-    in workspace: Workspace
-  ) async -> [any LanguageService] {
-    let existingLanguageServices = workspace.languageServices(for: uri)
-    if !existingLanguageServices.isEmpty {
-      return existingLanguageServices
-    }
-
-    let toolchain = await workspace.buildServerManager.toolchain(
-      for: await workspace.buildServerManager.canonicalTarget(for: uri),
-      language: language
-    )
-    guard let toolchain else {
-      logger.error("Failed to determine toolchain for \(uri)")
-      return []
-    }
-    let languageServices = await self.languageServices(for: toolchain, language, in: workspace)
-
-    if languageServices.isEmpty {
-      logger.error("No language service found to handle \(uri.forLogging)")
-    }
-
-    logger.log(
-      """
-      Using toolchain at \(toolchain.path.description) (\(toolchain.identifier, privacy: .public)) \
-      for \(uri.forLogging)
-      """
-    )
-
-    return languageServices
-  }
-
-  /// The language service with the highest precedence that can handle the given document.
-  ///
-  /// If we have language services that can handle this document but that haven't been started yet, start them.
-  ///
-  /// If no language service exists for this document, throw an error.
-  package func primaryLanguageService(
-    for uri: DocumentURI,
-    _ language: Language,
-    in workspace: Workspace
-  ) async throws -> any LanguageService {
-    guard let languageService = await languageServices(for: uri, language, in: workspace).first else {
-      throw ResponseError.unknown("No language service found for \(uri)")
-    }
-    return languageService
-  }
 }
 
 // MARK: - MessageHandler
@@ -964,6 +803,7 @@ extension SourceKitLSPServer {
       toolchainRegistry: self.toolchainRegistry,
       options: options,
       hooks: hooks,
+      languageServiceRegistry: languageServiceRegistry,
       indexTaskScheduler: indexTaskScheduler
     )
     return workspace
@@ -1079,6 +919,7 @@ extension SourceKitLSPServer {
           toolchainRegistry: self.toolchainRegistry,
           options: options,
           hooks: hooks,
+          languageServiceRegistry: self.languageServiceRegistry,
           indexTaskScheduler: self.indexTaskScheduler
         )
 
@@ -1238,7 +1079,7 @@ extension SourceKitLSPServer {
     )
   }
 
-  func registerCapabilities(
+  package func registerCapabilities(
     for server: ServerCapabilities,
     languages: [Language],
     registry: CapabilityRegistry
@@ -1297,9 +1138,6 @@ extension SourceKitLSPServer {
   //     possible shutdown sequences, including pipe failure.
   package func prepareForExit() async {
     // We are shutting down / closing all workspaces and language services, so clear the arrays caching them.
-    let languageServices = self.languageServices
-    self.languageServices = [:]
-
     let workspaces = await self.workspaceQueue.async {
       let workspaces = self.workspaces
       self.workspacesAndIsImplicit = []
@@ -1307,26 +1145,9 @@ extension SourceKitLSPServer {
     }.valuePropagatingCancellation
 
     // Concurrently shut all things down.
-    await withTaskGroup(of: Void.self) { taskGroup in
-      taskGroup.addTask {
-        await orLog("Shutting down index scheduler") {
-          await self.indexTaskScheduler.shutDown()
-        }
-      }
-      for service in languageServices.values.flatMap({ $0 }) {
-        taskGroup.addTask {
-          await service.shutdown()
-        }
-      }
-      for workspace in workspaces {
-        taskGroup.addTask {
-          await orLog("Shutting down build server") {
-            await workspace.buildServerManager.shutdown()
-          }
-          await workspace.uncheckedIndex?.close()
-        }
-      }
-    }
+    async let taskSchedulerShutdown = self.indexTaskScheduler.shutDown()
+    async let workspaceShutdown = workspaces.concurrentForEach { await $0.shutdown() }
+    _ = await (taskSchedulerShutdown, workspaceShutdown)
 
     // Make sure we emit all pending log messages. When we're not using `NonDarwinLogger` this is a no-op.
     await NonDarwinLogger.flush()
@@ -1409,13 +1230,14 @@ extension SourceKitLSPServer {
     let uri = textDocument.uri
     let language = textDocument.language
 
-    let languageServices = await languageServices(for: uri, language, in: workspace)
-    workspace.setLanguageServices(for: uri, languageServices)
+    let languageServices = await workspace.languageServices(for: uri, language)
 
     if languageServices.isEmpty {
       // If we can't create a service, this document is unsupported and we can bail here.
       return
     }
+
+    workspace.setLanguageServices(for: uri, languageServices)
 
     await workspace.buildServerManager.registerForChangeNotifications(for: uri, language: language)
 
@@ -1571,14 +1393,18 @@ extension SourceKitLSPServer {
     for docUri in self.documentManager.openDocuments {
       preChangeWorkspaces[docUri] = await self.workspaceForDocument(uri: docUri)
     }
+    // Capture the workspaces that will be removed so we can shut down their services after.
+    var removedWorkspaces: [Workspace] = []
     await workspaceQueue.async {
       if let removed = notification.event.removed {
-        self.workspacesAndIsImplicit.removeAll { workspace in
+        var entries = self.workspacesAndIsImplicit
+        let firstIndexToRemove = entries.partition { entry in
           // Close all implicit workspaces as well because we could have opened a new explicit workspace that now contains
           // files from a previous implicit workspace.
-          return workspace.isImplicit
-            || removed.contains(where: { workspaceFolder in workspace.workspace.rootUri == workspaceFolder.uri })
+          entry.isImplicit || removed.contains { $0.uri == entry.workspace.rootUri }
         }
+        self.workspacesAndIsImplicit = Array(entries[..<firstIndexToRemove])
+        removedWorkspaces = Array(entries[firstIndexToRemove...]).map(\.workspace)
       }
       if let added = notification.event.added {
         let newWorkspaces = await added.asyncCompactMap { workspaceFolder in
@@ -1590,47 +1416,10 @@ extension SourceKitLSPServer {
       }
     }.value
 
-    // Shut down any language services that are no longer referenced by any workspace.
-    await self.shutdownOrphanedLanguageServices()
-  }
-
-  /// Shuts down any language services that are no longer referenced by any open workspace.
-  ///
-  /// This method gathers all language services that are currently referenced by open workspaces
-  /// and shuts down any language services that are not in that set.
-  private func shutdownOrphanedLanguageServices() async {
-    // Gather all language services referenced by open workspaces
-    var referencedServices: Set<ObjectIdentifier> = []
-    for workspace in workspaces {
-      for languageService in workspace.allLanguageServices {
-        referencedServices.insert(ObjectIdentifier(languageService))
-      }
-    }
-
-    // Find and remove orphaned language services, skipping immortal ones
-    var orphanedServices: [any LanguageService] = []
-    for (serviceType, services) in languageServices {
-      var remainingServices: [any LanguageService] = []
-      for service in services {
-        if referencedServices.contains(ObjectIdentifier(service)) || type(of: service).isImmortal {
-          remainingServices.append(service)
-        } else {
-          orphanedServices.append(service)
-        }
-      }
-      if remainingServices.count != services.count {
-        languageServices[serviceType] = remainingServices.isEmpty ? nil : remainingServices
-      }
-    }
-
-    // Shut down orphaned services in a background task to avoid blocking other requests.
-
-    if !orphanedServices.isEmpty {
+    // Shut down orphaned workspaces in a background task to avoid blocking other requests.
+    if !removedWorkspaces.isEmpty {
       Task {
-        for service in orphanedServices {
-          logger.info("Shutting down orphaned language service: \(type(of: service))")
-          await service.shutdown()
-        }
+        await removedWorkspaces.concurrentForEach { await $0.shutdown() }
       }
     }
   }
@@ -1642,10 +1431,6 @@ extension SourceKitLSPServer {
     // (e.g. Package.swift doesn't have build settings but affects build
     // settings). Inform the build server about all file changes.
     await workspaces.concurrentForEach { await $0.filesDidChange(notification.changes) }
-
-    for languageService in languageServices.values.flatMap(\.self) {
-      await languageService.filesDidChange(notification.changes)
-    }
 
     // Schedule updating entry point cache.
     await entryPointManager.refresh()
@@ -1742,7 +1527,7 @@ extension SourceKitLSPServer {
       throw ResponseError.workspaceNotOpen(uri)
     }
     let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
-    return try await primaryLanguageService(for: uri, language, in: workspace).completionItemResolve(request)
+    return try await workspace.primaryLanguageService(for: uri, language).completionItemResolve(request)
   }
 
   func doccDocumentation(
@@ -1955,7 +1740,7 @@ extension SourceKitLSPServer {
       guard let mainFile else {
         continue
       }
-      let languageService = try await primaryLanguageService(for: mainFile, .swift, in: workspace)
+      let languageService = try await workspace.primaryLanguageService(for: mainFile, .swift)
       let details = await orLog("Opening generated interface in workspaceSymbol/resolve") {
         try await languageService.openGeneratedInterface(
           document: mainFile,
@@ -2144,14 +1929,14 @@ extension SourceKitLSPServer {
     }
     let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
     // First, check if we have a language service that explicitly declares support for this command.
-    if let languageService = await languageServices(for: uri, language, in: workspace)
+    if let languageService = await workspace.languageServices(for: uri, language)
       .first(where: { type(of: $0).builtInCommands.contains(req.command) })
     {
       return try await languageService.executeCommand(executeCommand)
     }
     // Otherwise handle it in the primary language service. This is important to handle eg. commands in clangd, which
     // are not declared as built-in commands.
-    return try await primaryLanguageService(for: uri, language, in: workspace).executeCommand(executeCommand)
+    return try await workspace.primaryLanguageService(for: uri, language).executeCommand(executeCommand)
   }
 
   func getReferenceDocument(_ req: GetReferenceDocumentRequest) async throws -> GetReferenceDocumentResponse {
@@ -2176,7 +1961,7 @@ extension SourceKitLSPServer {
       throw ResponseError.unknown("Unable to infer language for \(buildSettingsUri)")
     }
 
-    return try await primaryLanguageService(for: buildSettingsUri, language, in: workspace).getReferenceDocument(req)
+    return try await workspace.primaryLanguageService(for: buildSettingsUri, language).getReferenceDocument(req)
   }
 
   func codeAction(
@@ -2205,7 +1990,7 @@ extension SourceKitLSPServer {
     forwardedReq.codeAction.data = resolveMetadata.underlyingData
 
     let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
-    return try await primaryLanguageService(for: uri, language, in: workspace)
+    return try await workspace.primaryLanguageService(for: uri, language)
       .codeActionResolve(forwardedReq)
   }
 
@@ -2235,7 +2020,7 @@ extension SourceKitLSPServer {
       return request.inlayHint
     }
     let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
-    return try await primaryLanguageService(for: uri, language, in: workspace).inlayHintResolve(request)
+    return try await workspace.primaryLanguageService(for: uri, language).inlayHintResolve(request)
   }
 
   func documentDiagnostic(

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -172,6 +172,12 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   private let sourceFilesWithSameRealpathInferrer: SourceFilesWithSameRealpathInferrer
 
   let options: SourceKitLSPOptions
+  let hooks: Hooks
+  let languageServiceRegistry: LanguageServiceRegistry
+
+  /// Language service instances owned by this workspace, keyed by service type.
+  private let languageServiceInstances: ThreadSafeBox<[LanguageServiceType: [any LanguageService]]> =
+    ThreadSafeBox(initialValue: [:])
 
   /// The source code index, if available.
   ///
@@ -197,7 +203,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
 
   /// All language services that are registered with this workspace.
   var allLanguageServices: [any LanguageService] {
-    return languageServices.value.values.flatMap { $0 }
+    return languageServiceInstances.value.values.flatMap { $0 }
   }
 
   /// The task that constructs the `SemanticIndexManager`, which keeps track of whose file's index is up-to-date in the
@@ -229,6 +235,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     capabilityRegistry: CapabilityRegistry,
     options: SourceKitLSPOptions,
     hooks: Hooks,
+    languageServiceRegistry: LanguageServiceRegistry,
     buildServerManager: BuildServerManager,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>
   ) async {
@@ -236,6 +243,8 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     self.rootUri = rootUri
     self.capabilityRegistry = capabilityRegistry
     self.options = options
+    self.hooks = hooks
+    self.languageServiceRegistry = languageServiceRegistry
     self.buildServerManager = buildServerManager
     self.sourceFilesWithSameRealpathInferrer = SourceFilesWithSameRealpathInferrer(
       buildServerManager: buildServerManager
@@ -281,7 +290,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
         guard let self else {
           return []
         }
-        return await sourceKitLSPServer.languageServices(for: snapshot.uri, snapshot.language, in: self).asyncFlatMap {
+        return await self.languageServices(for: snapshot.uri, snapshot.language).asyncFlatMap {
           await $0.syntacticTestItems(for: snapshot) ?? []
         }
       },
@@ -292,7 +301,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
         else {
           return []
         }
-        return await sourceKitLSPServer.languageServices(for: snapshot.uri, snapshot.language, in: self).asyncFlatMap {
+        return await self.languageServices(for: snapshot.uri, snapshot.language).asyncFlatMap {
           await $0.syntacticPlaygrounds(for: snapshot, in: self)
         }
       }
@@ -314,6 +323,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     toolchainRegistry: ToolchainRegistry,
     options: SourceKitLSPOptions,
     hooks: Hooks,
+    languageServiceRegistry: LanguageServiceRegistry,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>
   ) async {
     struct ConnectionToClient: BuildServerManagerConnectionToClient {
@@ -413,6 +423,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
       capabilityRegistry: capabilityRegistry,
       options: options,
       hooks: hooks,
+      languageServiceRegistry: languageServiceRegistry,
       buildServerManager: buildServerManager,
       indexTaskScheduler: indexTaskScheduler
     )
@@ -449,20 +460,148 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
       return ($0, sourceFileInfo)
     }
 
-    async let updateSyntacticIndex: Void = await syntacticIndex.filesDidChange(eventsWithSourceFileInfo)
-    async let updateSemanticIndex: Void? = await semanticIndexManager?.filesDidChange(events)
-    _ = await (updateSyntacticIndex, updateSemanticIndex)
+    async let updateSyntacticIndex = syntacticIndex.filesDidChange(eventsWithSourceFileInfo)
+    async let updateSemanticIndex = semanticIndexManager?.filesDidChange(events)
+    async let updateLanguageServices = allLanguageServices.concurrentForEach { [events] in
+      await $0.filesDidChange(events)
+    }
+    _ = await (updateSyntacticIndex, updateSemanticIndex, updateLanguageServices)
   }
 
-  /// The language services that can handle the given document. Callers should try to merge the results from the
-  /// different language service or prefer results from language services that occur earlier in this array, whichever is
-  /// more suitable.
-  func languageServices(for uri: DocumentURI) -> [any LanguageService] {
+  // MARK: - Language service management
+
+  /// Returns an existing service instance of the given type that can handle the given toolchain, or `nil`.
+  private func existingLanguageService(
+    _ serviceType: any LanguageService.Type,
+    toolchain: Toolchain
+  ) -> (any LanguageService)? {
+    languageServiceInstances.value[LanguageServiceType(serviceType)]?.first {
+      $0.canHandle(toolchain: toolchain)
+    }
+  }
+
+  /// Get or create service instances for the given toolchain and language.
+  ///
+  /// Within the workspace, one service instance is reused for all documents that share the same
+  /// toolchain, determined by `LanguageService.canHandle(toolchain:)`.
+  private func languageServicesForToolchain(
+    _ toolchain: Toolchain,
+    _ language: Language
+  ) async -> [any LanguageService] {
+    guard let sourceKitLSPServer else { return [] }
+    var result: [any LanguageService] = []
+    for serviceType in languageServiceRegistry.languageServices(for: language) {
+      if let service = existingLanguageService(serviceType, toolchain: toolchain) {
+        result.append(service)
+        continue
+      }
+
+      // Start a new service.
+      let service: (any LanguageService)? = await orLog("Failed to start language service") {
+        let svc = try await serviceType.init(
+          sourceKitLSPServer: sourceKitLSPServer,
+          toolchain: toolchain,
+          options: options,
+          hooks: hooks,
+          workspace: self
+        )
+
+        if let concurrent = existingLanguageService(serviceType, toolchain: toolchain) {
+          // Since we 'await' above, another call may have concurrently passed the
+          // `existingLanguageService` check and started the same service. Shut down the
+          // duplicate and return the one that won the race.
+          await svc.shutdown()
+          return concurrent
+        }
+
+        languageServiceInstances.withLock { $0[LanguageServiceType(serviceType), default: []].append(svc) }
+        return svc
+      }
+      guard let service else {
+        // If a language service fails to start, don't try starting language services with lower
+        // precedence. Otherwise we get into a situation where e.g. `SwiftLanguageService` fails
+        // to start (because the toolchain doesn't contain sourcekitd) and
+        // `DocumentationLanguageService` becomes the primary service for Swift documents.
+        break
+      }
+      result.append(service)
+    }
+    if result.isEmpty {
+      logger.error("Unable to infer language server type for language '\(language)'")
+    }
+    return result
+  }
+
+  /// Find or create language services for the given URI and language.
+  ///
+  /// Use this only when the document may not have been opened yet (e.g. in `openDocument` itself,
+  /// or for requests that can target non-open files). Do not use this as a substitute for the sync
+  /// overload in document-lifecycle handlers.
+  package func languageServices(
+    for uri: DocumentURI,
+    _ language: Language
+  ) async -> [any LanguageService] {
+    let cached = languageServices.value[uri.buildSettingsFile]
+    if let cached, !cached.isEmpty {
+      return cached
+    }
+
+    let toolchain = await buildServerManager.toolchain(
+      for: await buildServerManager.canonicalTarget(for: uri),
+      language: language
+    )
+    guard let toolchain else {
+      logger.error("Failed to determine toolchain for \(uri)")
+      return []
+    }
+
+    let services = await languageServicesForToolchain(toolchain, language)
+
+    if services.isEmpty {
+      logger.error("No language service found to handle \(uri.forLogging)")
+    } else {
+      logger.log(
+        """
+        Using toolchain at \(toolchain.path.description) (\(toolchain.identifier, privacy: .public)) \
+        for \(uri.forLogging)
+        """
+      )
+    }
+
+    return services
+  }
+
+  /// Find or create the primary language service for the given URI and language.
+  ///
+  /// Convenience wrapper around `languageServices(for:_:)` that throws if no service is available.
+  /// Use this only when the document may not have been opened yet.
+  package func primaryLanguageService(
+    for uri: DocumentURI,
+    _ language: Language
+  ) async throws -> any LanguageService {
+    guard let service = await languageServices(for: uri, language).first else {
+      throw ResponseError.unknown("No language service found for \(uri)")
+    }
+    return service
+  }
+
+  /// The language services for an open document.
+  ///
+  /// Returns the services established when the document was opened. Returns an empty array if the
+  /// document has not been opened or has already been closed. Use this for document-lifecycle
+  /// operations (change, save, close, diagnostics, etc.) where the document is known to be open.
+  ///
+  /// Callers should try to merge the results from the different language services or prefer results
+  /// from language services that occur earlier in this array, whichever is more suitable.
+  package func languageServices(for uri: DocumentURI) -> [any LanguageService] {
     return languageServices.value[uri.buildSettingsFile] ?? []
   }
 
-  /// The language service with the highest precedence that can handle the given document.
-  func primaryLanguageService(for uri: DocumentURI) -> (any LanguageService)? {
+  /// The primary language service for an open document.
+  ///
+  /// Convenience wrapper around the sync `languageServices(for:)`. Returns `nil` if the document
+  /// has not been opened or has already been closed.
+  package func primaryLanguageService(for uri: DocumentURI) -> (any LanguageService)? {
     return languageServices(for: uri).first
   }
 
@@ -488,6 +627,24 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     languageServices.withLock { languageServices in
       languageServices[key] = nil
     }
+  }
+
+  func shutdown() async {
+    logger.info("Shutting down workspace \(self.rootUri?.description ?? "<nil>")")
+    async let languageServiceShutdown = shutdownAllLanguageServices()
+    async let buildServerShutdown = buildServerManager.shutdown()
+    async let indexClose = uncheckedIndex?.close()
+    _ = await (languageServiceShutdown, buildServerShutdown, indexClose)
+  }
+
+  /// Shut down all language service instances owned by this workspace.
+  private func shutdownAllLanguageServices() async {
+    let services = languageServiceInstances.withLock { instances in
+      let services = Array(instances.values.flatMap { $0 })
+      instances = [:]
+      return services
+    }
+    await services.concurrentForEach { await $0.shutdown() }
   }
 
   /// Handle a build settings change notification from the build server.

--- a/Sources/SwiftLanguageService/SwiftCommand.swift
+++ b/Sources/SwiftLanguageService/SwiftCommand.swift
@@ -55,11 +55,4 @@ extension SwiftLanguageService {
       command.identifier
     }
   }
-
-  /// `SwiftLanguageService` is immortal because sourcekitd uses global state.
-  ///
-  /// Since all instances of `SwiftLanguageService` share the same underlying sourcekitd process,
-  /// shutting down and restarting would cause unnecessary overhead as the new instance would
-  /// just reinitialize the same global state. Instead, we keep the service alive.
-  package static var isImmortal: Bool { true }
 }

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -304,6 +304,8 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     // Create sub-directories for each type of generated file
     try FileManager.default.createDirectory(at: generatedInterfacesPath, withIntermediateDirectories: true)
     try FileManager.default.createDirectory(at: generatedMacroExpansionsPath, withIntermediateDirectories: true)
+
+    await self.initialize()
   }
 
   /// - Important: For testing only
@@ -359,7 +361,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     )
   }
 
-  package nonisolated func canHandle(workspace: Workspace, toolchain: Toolchain) -> Bool {
+  package nonisolated func canHandle(toolchain: Toolchain) -> Bool {
     return self.sourcekitdPath == toolchain.sourcekitd
   }
 
@@ -398,12 +400,11 @@ package actor SwiftLanguageService: LanguageService, Sendable {
 }
 
 extension SwiftLanguageService {
-
-  package func initialize(_ initialize: InitializeRequest) async throws -> InitializeResult {
+  private func initialize() async {
     await sourcekitd.addNotificationHandler(self)
 
-    return InitializeResult(
-      capabilities: ServerCapabilities(
+    await sourceKitLSPServer?.registerCapabilities(
+      for: ServerCapabilities(
         textDocumentSync: .options(
           TextDocumentSyncOptions(
             openClose: true,
@@ -427,7 +428,7 @@ extension SwiftLanguageService {
         documentSymbolProvider: .bool(true),
         codeActionProvider: .value(
           CodeActionServerCapabilities(
-            clientCapabilities: initialize.capabilities.textDocument?.codeAction,
+            clientCapabilities: capabilityRegistry.clientCapabilities.textDocument?.codeAction,
             codeActionOptions: CodeActionOptions(codeActionKinds: [.quickFix, .refactor]),
             supportsCodeActions: true
           )
@@ -449,12 +450,17 @@ extension SwiftLanguageService {
           workspaceDiagnostics: false
         ),
         selectionRangeProvider: .bool(true)
-      )
+      ),
+      languages: [.swift],
+      registry: capabilityRegistry
     )
   }
 
   package func shutdown() async {
-    await self.sourcekitd.removeNotificationHandler(self)
+    await sourcekitd.removeNotificationHandler(self)
+    if state == .connectionInterrupted || state == .semanticFunctionalityDisabled {
+      await sourceKitLSPServer?.sourcekitdCrashedWorkDoneProgress.end()
+    }
   }
 
   package func canonicalDeclarationPosition(of position: Position, in uri: DocumentURI) async -> Position? {

--- a/Tests/SourceKitLSPTests/ClangdTests.swift
+++ b/Tests/SourceKitLSPTests/ClangdTests.swift
@@ -159,11 +159,7 @@ final class ClangdTests: SourceKitLSPTestCase {
     )
 
     // Monitor clangd to notice when it gets restarted
-    let clangdServer = try await testClient.server.primaryLanguageService(
-      for: uri,
-      .c,
-      in: unwrap(testClient.server.workspaceForDocument(uri: uri))
-    )
+    let clangdServer = try await unwrap(testClient.primaryLanguageService(for: uri))
     await clangdServer.addStateChangeHandler { oldState, newState in
       if oldState == .connectionInterrupted, newState == .connected {
         clangdRestarted.value = true

--- a/Tests/SourceKitLSPTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitLSPTests/CrashRecoveryTests.swift
@@ -80,14 +80,7 @@ final class CrashRecoveryTests: SourceKitLSPTestCase {
 
     // Crash sourcekitd
 
-    let swiftLanguageService =
-      try unwrap(
-        await testClient.server.primaryLanguageService(
-          for: uri,
-          .swift,
-          in: testClient.server.workspaceForDocument(uri: uri)!
-        ) as? SwiftLanguageService
-      )
+    let swiftLanguageService = try await unwrap(testClient.primaryLanguageService(for: uri) as? SwiftLanguageService)
 
     await swiftLanguageService.crash()
 
@@ -121,11 +114,7 @@ final class CrashRecoveryTests: SourceKitLSPTestCase {
   }
 
   private func crashClangd(for testClient: TestSourceKitLSPClient, document docUri: DocumentURI) async throws {
-    let clangdServer = try await testClient.server.primaryLanguageService(
-      for: docUri,
-      .cpp,
-      in: testClient.server.workspaceForDocument(uri: docUri)!
-    )
+    let clangdServer = try await unwrap(testClient.primaryLanguageService(for: docUri))
 
     let clangdCrashed = self.expectation(description: "clangd crashed")
     let clangdRestarted = self.expectation(description: "clangd restarted")
@@ -268,11 +257,7 @@ final class CrashRecoveryTests: SourceKitLSPTestCase {
 
     // Keep track of clangd crashes
 
-    let clangdServer = try await testClient.server.primaryLanguageService(
-      for: uri,
-      .cpp,
-      in: testClient.server.workspaceForDocument(uri: uri)!
-    )
+    let clangdServer = try await unwrap(testClient.primaryLanguageService(for: uri))
 
     let clangdCrashed = self.expectation(description: "clangd crashed")
     clangdCrashed.assertForOverFulfill = false
@@ -334,14 +319,7 @@ final class CrashRecoveryTests: SourceKitLSPTestCase {
       uri: uri
     )
 
-    let swiftLanguageService =
-      try unwrap(
-        await testClient.server.primaryLanguageService(
-          for: uri,
-          .swift,
-          in: testClient.server.workspaceForDocument(uri: uri)!
-        ) as? SwiftLanguageService
-      )
+    let swiftLanguageService = try await unwrap(testClient.primaryLanguageService(for: uri) as? SwiftLanguageService)
 
     await swiftLanguageService.crash()
 
@@ -374,13 +352,7 @@ final class CrashRecoveryTests: SourceKitLSPTestCase {
     )
 
     // Monitor sourcekitd to notice when it gets terminated
-    let swiftService = try await unwrap(
-      testClient.server.primaryLanguageService(
-        for: uri,
-        .swift,
-        in: unwrap(testClient.server.workspaceForDocument(uri: uri))
-      ) as? SwiftLanguageService
-    )
+    let swiftService = try await unwrap(testClient.primaryLanguageService(for: uri) as? SwiftLanguageService)
     await swiftService.addStateChangeHandler { oldState, newState in
       logger.debug("sourcekitd changed state: \(String(describing: oldState)) -> \(String(describing: newState))")
       if newState == .connectionInterrupted {

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -341,11 +341,7 @@ final class LocalClangTests: SourceKitLSPTestCase {
     struct MyObject * newObject();
     """.writeWithRetry(to: XCTUnwrap(headerUri.fileURL))
 
-    let clangdServer = try await project.testClient.server.primaryLanguageService(
-      for: mainUri,
-      .c,
-      in: project.testClient.server.workspaceForDocument(uri: mainUri)!
-    )
+    let clangdServer = try await unwrap(project.testClient.primaryLanguageService(for: mainUri))
 
     await clangdServer.documentDependenciesUpdated([mainUri])
 

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1358,18 +1358,6 @@ final class LocalSwiftTests: SourceKitLSPTestCase {
 
     let reusedNodeCallback = self.expectation(description: "reused node callback called")
     let reusedNodes = ThreadSafeBox<[Syntax]>(initialValue: [])
-    let swiftLanguageService =
-      try await unwrap(
-        testClient.server.primaryLanguageService(
-          for: uri,
-          .swift,
-          in: unwrap(testClient.server.workspaceForDocument(uri: uri))
-        ) as? SwiftLanguageService
-      )
-    await swiftLanguageService.setReusedNodeCallback {
-      reusedNodes.value.append($0)
-      reusedNodeCallback.fulfill()
-    }
 
     testClient.openDocument(
       """
@@ -1380,6 +1368,11 @@ final class LocalSwiftTests: SourceKitLSPTestCase {
       """,
       uri: uri
     )
+    let swiftLanguageService = try await unwrap(testClient.primaryLanguageService(for: uri) as? SwiftLanguageService)
+    await swiftLanguageService.setReusedNodeCallback {
+      reusedNodes.value.append($0)
+      reusedNodeCallback.fulfill()
+    }
 
     // Send a request that triggers a syntax tree to be built.
     _ = try await testClient.send(FoldingRangeRequest(textDocument: .init(uri)))

--- a/Tests/SourceKitLSPTests/SourcekitdCoreInjectorTests.swift
+++ b/Tests/SourceKitLSPTests/SourcekitdCoreInjectorTests.swift
@@ -56,12 +56,7 @@ final class SourcekitdCoreInjectorTests: SourceKitLSPTestCase {
       "func 1️⃣foo() -> Int { 42 }",
       uri: uri
     )
-
-    // Wait until SwiftLanguageService is available for the opened document.
-    let workspace = try await unwrap(testClient.server.workspaceForDocument(uri: uri))
-    let swiftLS = try await unwrap(
-      testClient.server.primaryLanguageService(for: uri, .swift, in: workspace) as? SwiftLanguageService
-    )
+    let swiftLS = try await unwrap(testClient.primaryLanguageService(for: uri) as? SwiftLanguageService)
 
     // The injector must have been called with the toolchain root (not the sourcekitd dylib path).
     XCTAssertGreaterThan(injectorCallCount.value, 0)

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1427,11 +1427,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
     )
 
     // Get the language service for WorkspaceB before closing
-    let clangLanguageServiceBeforeClose = try await project.testClient.server.primaryLanguageService(
-      for: mainUri,
-      .c,
-      in: unwrap(project.testClient.server.workspaceForDocument(uri: mainUri))
-    )
+    let clangLanguageServiceBeforeClose = try await unwrap(project.testClient.primaryLanguageService(for: mainUri))
 
     // close the document
     project.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(mainUri)))
@@ -1460,11 +1456,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
       DocumentSymbolRequest(textDocument: TextDocumentIdentifier(dummyUri))
     )
 
-    let clangLanguageServiceForWorkspaceA = try await project.testClient.server.primaryLanguageService(
-      for: dummyUri,
-      .c,
-      in: unwrap(project.testClient.server.workspaceForDocument(uri: dummyUri))
-    )
+    let clangLanguageServiceForWorkspaceA = try await unwrap(project.testClient.primaryLanguageService(for: dummyUri))
 
     XCTAssertFalse(
       clangLanguageServiceBeforeClose === clangLanguageServiceForWorkspaceA,
@@ -1472,8 +1464,9 @@ final class WorkspaceTests: SourceKitLSPTestCase {
     )
   }
 
-  func testOrphanedSwiftLanguageServiceIsImmortal() async throws {
-    try await SkipUnless.sourcekitdSupportsPlugin()
+  func testOrphanedSwiftLanguageServiceIsShutDown() async throws {
+    // Test that when a workspace is removed, its SwiftLanguageService is shut down
+    // and WorkspaceA gets an independent service instance — mirroring the Clang behavior.
 
     let project = try await MultiFileTestProject(
       files: [
@@ -1507,6 +1500,8 @@ final class WorkspaceTests: SourceKitLSPTestCase {
         """,
       ],
       workspaces: { scratchDir in
+        try await SwiftPMTestProject.resolvePackageDependencies(at: scratchDir.appending(component: "WorkspaceA"))
+        try await SwiftPMTestProject.resolvePackageDependencies(at: scratchDir.appending(component: "WorkspaceB"))
         return [
           WorkspaceFolder(uri: DocumentURI(scratchDir.appending(component: "WorkspaceA"))),
           WorkspaceFolder(uri: DocumentURI(scratchDir.appending(component: "WorkspaceB"))),
@@ -1514,24 +1509,29 @@ final class WorkspaceTests: SourceKitLSPTestCase {
       }
     )
 
+    // Wait for SwiftPM to finish loading the package graph before opening documents.
+    _ = try await project.testClient.send(SynchronizeRequest(index: true))
+
     let (libBUri, libBPositions) = try project.openDocument("LibB.swift")
 
-    let initialHover = try await project.testClient.send(
+    // Send a request to ensure the SwiftLanguageService for WorkspaceB is up.
+    _ = try await project.testClient.send(
       HoverRequest(textDocument: TextDocumentIdentifier(libBUri), position: libBPositions["2️⃣"])
     )
-    XCTAssertNotNil(initialHover, "Should get hover response for LibB.swift")
 
-    // Get the SwiftLanguageService before closing WorkspaceB
-    let swiftLanguageServiceBeforeClose = try await project.testClient.server.primaryLanguageService(
-      for: libBUri,
-      .swift,
-      in: unwrap(project.testClient.server.workspaceForDocument(uri: libBUri))
+    // Capture the identity of WorkspaceB's SwiftLanguageService before removal.
+    let libBServiceID = try await ObjectIdentifier(unwrap(project.testClient.primaryLanguageService(for: libBUri)))
+
+    // Open a file in WorkspaceA before removing WorkspaceB, to verify the service survives the removal.
+    let (libAUri, libAPositions) = try project.openDocument("LibA.swift")
+
+    // Capture the identity of WorkspaceA's service before the removal.
+    let libAServiceIDBefore = try await ObjectIdentifier(
+      unwrap(project.testClient.primaryLanguageService(for: libAUri))
     )
 
-    // Close the document in WorkspaceB
+    // Close the document and remove WorkspaceB.
     project.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(libBUri)))
-
-    // Remove WorkspaceB
     let workspaceBUri = DocumentURI(project.scratchDirectory.appending(component: "WorkspaceB"))
     project.testClient.send(
       DidChangeWorkspaceFoldersNotification(
@@ -1540,26 +1540,23 @@ final class WorkspaceTests: SourceKitLSPTestCase {
     )
     _ = try await project.testClient.send(SynchronizeRequest())
 
-    // Open a file in WorkspaceA
-    let (libAUri, libAPositions) = try project.openDocument("LibA.swift")
-
-    // Verify that the language service in WorkspaceA still works correctly
+    // WorkspaceA's service should still work after WorkspaceB is removed.
     let hover = try await project.testClient.send(
       HoverRequest(textDocument: TextDocumentIdentifier(libAUri), position: libAPositions["1️⃣"])
     )
     XCTAssertNotNil(hover, "Should still get hover response after removing WorkspaceB")
     assertContains(hover?.contents.markupContent?.value ?? "", "foo")
 
-    // Verify that the same SwiftLanguageService is reused (immortal, not shut down)
-    let swiftLanguageServiceForWorkspaceA = try await project.testClient.server.primaryLanguageService(
-      for: libAUri,
-      .swift,
-      in: unwrap(project.testClient.server.workspaceForDocument(uri: libAUri))
+    let libAService = try await unwrap(project.testClient.primaryLanguageService(for: libAUri))
+    XCTAssertEqual(
+      libAServiceIDBefore,
+      ObjectIdentifier(libAService),
+      "WorkspaceA's service should be the same instance"
     )
-
-    XCTAssertTrue(
-      swiftLanguageServiceBeforeClose === swiftLanguageServiceForWorkspaceA,
-      "SwiftLanguageService should be immortal and reused across workspaces"
+    XCTAssertNotEqual(
+      libBServiceID,
+      ObjectIdentifier(libAService),
+      "WorkspaceA and WorkspaceB must use independent service instances"
     )
   }
 }


### PR DESCRIPTION
Previously `SourceKitLSPServer` owned all language service instances and managed an N-workspace-to-M-service mapping itself. This meant the server had to track which services belonged to which workspaces, decide when to shut them down, and special-case services that should survive workspace closure (`isImmortal`). At the same time, services held workspace-specific state — `DocumentationLanguageService` held a reference to `Workspace.buildServerManager`, `SwiftLanguageService` held `Workspace.semanticIndexManagerTask` — so sharing them across workspaces was never truly safe anyway.

This PR resolves both problems by introducing a clean ownership hierarchy: one server owns N workspaces, each workspace owns its own language services. Services are created on demand within a workspace and shut down when that workspace closes. Because each service now belongs to exactly one workspace, holding workspace-specific state is natural and correct.

Simplified `LanguageService` protocol:
- `initialize(_:)` and `clientInitialized(_:)` are removed; each service's `init` now performs its own initialization and capability registration.
- `isImmortal` is removed; each service is shut down with its workspace.
- The workspace parameter is removed from `canHandle(toolchain:)`; since each workspace has its own service pool, a service only needs to check the toolchain to decide whether it can be reused for a new document.