### PR TITLE
provide proper start and end positions in the LSP protocol

### DIFF
--- a/Sources/SwiftLanguageService/CursorInfo.swift
+++ b/Sources/SwiftLanguageService/CursorInfo.swift
@@ -77,8 +77,10 @@ struct CursorInfo {
           documentManager.latestSnapshotOrDisk(uri, language: .swift)
         }
       if let snapshot {
-        let position = snapshot.positionOf(zeroBasedLine: line - 1, utf8Column: column - 1)
-        location = Location(uri: uri, range: Range(position))
+        let length = (dict[keys.length] ?? 0)
+        let positionStart = snapshot.positionOf(zeroBasedLine: line - 1, utf8Column: column - 1)
+        let positionEnd = snapshot.positionOf(zeroBasedLine: line - 1, utf8Column: column + length - 1)
+        location = Location(uri: uri, range: positionStart..<positionEnd)
       } else {
         logger.error("Failed to get snapshot for \(uri.forLogging) to convert position")
         location = nil

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1079,7 +1079,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let project = try await SwiftPMTestProject(
       files: [
         "Lib/MyFile.swift": """
-        public func 1️⃣foo() {}
+        public func 1️⃣foo3️⃣() {}
         """,
         "MyExec/MyExec.swift": """
         import Lib
@@ -1119,7 +1119,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let definition = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    XCTAssertEqual(definition, .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")]))
+    XCTAssertEqual(definition, .locations([try project.location(from: "1️⃣", to: "3️⃣", in: "MyFile.swift")]))
   }
 
   func testCrossModuleFunctionalityEvenIfLowLevelModuleHasErrors() async throws {
@@ -1135,7 +1135,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         "LibB/LibB.swift": """
         import LibA
 
-        public func 1️⃣libBTest() -> Int {
+        public func 1️⃣libBTest3️⃣() -> Int {
           return libATest()
         }
         """,
@@ -1165,7 +1165,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    XCTAssertEqual(response, .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "LibB.swift")]))
+    XCTAssertEqual(response, .locations([try project.location(from: "1️⃣", to: "3️⃣", in: "LibB.swift")]))
   }
 
   func testCrossModuleFunctionalityWithErrors() async throws {
@@ -1174,7 +1174,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
-        public func 1️⃣libATest() -> Invalid {
+        public func 1️⃣libATest3️⃣() -> Invalid {
           return ""
         }
         """,
@@ -1203,7 +1203,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    XCTAssertEqual(response, .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "LibA.swift")]))
+    XCTAssertEqual(response, .locations([try project.location(from: "1️⃣", to: "3️⃣", in: "LibA.swift")]))
   }
 
   func testCrossModuleFunctionalityWithPreparationNoSkipping() async throws {
@@ -1219,7 +1219,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         "LibB/LibB.swift": """
         import LibA
 
-        public func 1️⃣libBTest() -> Int {
+        public func 1️⃣libBTest3️⃣() -> Int {
           return libATest()
         }
         """,
@@ -1249,7 +1249,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    XCTAssertEqual(response, .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "LibB.swift")]))
+    XCTAssertEqual(response, .locations([try project.location(from: "1️⃣", to: "3️⃣", in: "LibB.swift")]))
   }
 
   func testUpdatePackageDependency() async throws {
@@ -1644,7 +1644,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
       "LibA.swift",
       newMarkedContents: """
         public struct LibA {
-          public func 2️⃣test() {}
+          public func 2️⃣test3️⃣() {}
         }
         """
     )
@@ -1655,7 +1655,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
       let definitionAfterEdit = try await project.testClient.send(
         DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
       )
-      return definitionAfterEdit?.locations == [Location(uri: libAUri, range: Range(newAMarkers["2️⃣"]))]
+      return definitionAfterEdit?.locations == [Location(uri: libAUri, range: newAMarkers["2️⃣"]..<newAMarkers["3️⃣"])]
     }
   }
 

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -25,7 +25,7 @@ class DefinitionTests: SourceKitLSPTestCase {
 
     let positions = testClient.openDocument(
       """
-      let 1️⃣foo = 1
+      let 1️⃣foo3️⃣ = 1
       _ = foo2️⃣
       """,
       uri: uri
@@ -34,7 +34,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     let response = try await testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    XCTAssertEqual(response?.locations, [Location(uri: uri, range: Range(positions["1️⃣"]))])
+    XCTAssertEqual(response?.locations, [Location(uri: uri, range: positions["1️⃣"]..<positions["3️⃣"])])
   }
 
   func testJumpToDefinitionIncludesOverrides() async throws {
@@ -180,8 +180,8 @@ class DefinitionTests: SourceKitLSPTestCase {
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
-      struct 1️⃣Foo {
-        2️⃣init() {}
+      struct 1️⃣Foo4️⃣ {
+        2️⃣init()5️⃣ {}
       }
       _ = 3️⃣Foo()
       """,
@@ -194,8 +194,8 @@ class DefinitionTests: SourceKitLSPTestCase {
     XCTAssertEqual(
       response,
       .locations([
-        Location(uri: uri, range: Range(positions["1️⃣"])),
-        Location(uri: uri, range: Range(positions["2️⃣"])),
+        Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+        Location(uri: uri, range: positions["2️⃣"]..<positions["5️⃣"]),
       ])
     )
   }
@@ -205,8 +205,8 @@ class DefinitionTests: SourceKitLSPTestCase {
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
       """
-      func 1️⃣foo() -> Int { 1 }
-      func 2️⃣foo() -> String { "" }
+      func 1️⃣foo()4️⃣ -> Int { 1 }
+      func 2️⃣foo()5️⃣ -> String { "" }
       func test() {
         _ = 3️⃣foo()
       }
@@ -220,8 +220,8 @@ class DefinitionTests: SourceKitLSPTestCase {
     XCTAssertEqual(
       response,
       .locations([
-        Location(uri: uri, range: Range(positions["1️⃣"])),
-        Location(uri: uri, range: Range(positions["2️⃣"])),
+        Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
+        Location(uri: uri, range: positions["2️⃣"]..<positions["5️⃣"]),
       ])
     )
   }
@@ -314,7 +314,7 @@ class DefinitionTests: SourceKitLSPTestCase {
 
     let positions = testClient.openDocument(
       """
-      class 1️⃣Foo {}
+      class 1️⃣Foo3️⃣ {}
 
       func test() {
         2️⃣Foo()
@@ -328,7 +328,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     )
     XCTAssertEqual(
       response?.locations,
-      [Location(uri: uri, range: Range(positions["1️⃣"]))]
+      [Location(uri: uri, range: positions["1️⃣"]..<positions["3️⃣"])]
     )
   }
 
@@ -358,7 +358,7 @@ class DefinitionTests: SourceKitLSPTestCase {
 
     let (aUri, updatedAPositions) = try await project.changeFileOnDisk(
       "FileA.swift",
-      newMarkedContents: "func 2️⃣sayHello() {}"
+      newMarkedContents: "func 2️⃣sayHello()3️⃣ {}"
     )
 
     // Wait until SourceKit-LSP has handled the `DidChangeWatchedFilesNotification` (which it only does after a delay
@@ -375,7 +375,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     )
     XCTAssertEqual(
       afterChangingFileA,
-      .locations([Location(uri: aUri, range: Range(updatedAPositions["2️⃣"]))])
+      .locations([Location(uri: aUri, range: updatedAPositions["2️⃣"]..<updatedAPositions["3️⃣"])])
     )
 
     let afterChange = try await project.testClient.send(
@@ -383,7 +383,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     )
     XCTAssertEqual(
       afterChange,
-      .locations([Location(uri: aUri, range: Range(updatedAPositions["2️⃣"]))])
+      .locations([Location(uri: aUri, range: updatedAPositions["2️⃣"]..<updatedAPositions["3️⃣"])])
     )
   }
 
@@ -392,7 +392,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
-        public func 1️⃣sayHello() {}
+        public func 1️⃣sayHello3️⃣() {}
         """,
         "LibB/LibB.swift": """
         import LibA
@@ -447,7 +447,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     )
     XCTAssertEqual(
       afterBuilding,
-      .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "LibA.swift")])
+      .locations([try project.location(from: "1️⃣", to: "3️⃣", in: "LibA.swift")])
     )
   }
 

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -383,7 +383,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
   func testInlayHintResolve() async throws {
     try await runInlayHintTestCase(
       initialText: """
-        struct 1️⃣MyType {}
+        struct 1️⃣MyType3️⃣ {}
         let x2️⃣ = MyType()
         """,
     ) { context in
@@ -411,7 +411,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       }
 
       XCTAssertEqual(location.uri, context.uri)
-      XCTAssertEqual(location.range, Range(context.positions["1️⃣"]))
+      XCTAssertEqual(location.range, context.positions["1️⃣"]..<context.positions["3️⃣"])
     }
   }
 

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -497,7 +497,7 @@ final class SwiftPMIntegrationTests: SourceKitLSPTestCase {
       let topLocation = try XCTUnwrap(topResult?.locations?.only)
       XCTAssertTrue(topLocation.uri.pseudoPath.hasSuffix("generated.swift"))
       XCTAssertEqual(topLocation.range.lowerBound, Position(line: 0, utf16index: 4))
-      XCTAssertEqual(topLocation.range.upperBound, Position(line: 0, utf16index: 4))
+      XCTAssertEqual(topLocation.range.upperBound, Position(line: 0, utf16index: 16))
 
       let targetResult = try await project.testClient.send(
         DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
@@ -505,7 +505,7 @@ final class SwiftPMIntegrationTests: SourceKitLSPTestCase {
       let targetLocation = try XCTUnwrap(targetResult?.locations?.only)
       XCTAssertTrue(targetLocation.uri.pseudoPath.hasSuffix("generated.swift"))
       XCTAssertEqual(targetLocation.range.lowerBound, Position(line: 1, utf16index: 4))
-      XCTAssertEqual(targetLocation.range.upperBound, Position(line: 1, utf16index: 4))
+      XCTAssertEqual(targetLocation.range.upperBound, Position(line: 1, utf16index: 19))
     }
 
     // Make a change to the top level input file of the plugin command

--- a/Tests/SourceKitLSPTests/TypeDefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/TypeDefinitionTests.swift
@@ -22,7 +22,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
 
     let positions = testClient.openDocument(
       """
-      struct 1️⃣MyType {}
+      struct 1️⃣MyType3️⃣ {}
       let 2️⃣x = MyType()
       """,
       uri: uri
@@ -41,7 +41,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
     }
 
     XCTAssertEqual(location.uri, uri)
-    XCTAssertEqual(location.range, Range(positions["1️⃣"]))
+    XCTAssertEqual(location.range, positions["1️⃣"]..<positions["3️⃣"])
   }
 
   func testTypeDefinitionCrossModule() async throws {
@@ -93,7 +93,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
 
     let positions = testClient.openDocument(
       """
-      struct 1️⃣Container<T> {
+      struct 1️⃣Container3️⃣<T> {
         var value: T
       }
       let 2️⃣x = Container(value: 42)
@@ -114,7 +114,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
     }
 
     XCTAssertEqual(location.uri, uri)
-    XCTAssertEqual(location.range, Range(positions["1️⃣"]))
+    XCTAssertEqual(location.range, positions["1️⃣"]..<positions["3️⃣"])
   }
 
   func testTypeDefinitionOnTypeAnnotation() async throws {
@@ -123,7 +123,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
 
     let positions = testClient.openDocument(
       """
-      struct 1️⃣MyType {}
+      struct 1️⃣MyType3️⃣ {}
       let x: 2️⃣MyType = MyType()
       """,
       uri: uri
@@ -142,7 +142,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
     }
 
     XCTAssertEqual(location.uri, uri)
-    XCTAssertEqual(location.range, Range(positions["1️⃣"]))
+    XCTAssertEqual(location.range, positions["1️⃣"]..<positions["3️⃣"])
   }
 
   func testTypeDefinitionFunctionParameter() async throws {
@@ -151,7 +151,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
 
     let positions = testClient.openDocument(
       """
-      struct 1️⃣MyType {}
+      struct 1️⃣MyType3️⃣ {}
       func process(_ 2️⃣value: MyType) {}
       """,
       uri: uri
@@ -170,7 +170,7 @@ final class TypeDefinitionTests: SourceKitLSPTestCase {
     }
 
     XCTAssertEqual(location.uri, uri)
-    XCTAssertEqual(location.range, Range(positions["1️⃣"]))
+    XCTAssertEqual(location.range, positions["1️⃣"]..<positions["3️⃣"])
   }
 
   func testTypeDefinitionGeneratedInterface() async throws {

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -779,7 +779,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
         """,
         "Sources/lib/lib.swift": """
         public struct Lib {
-          public func 5️⃣foo() {}
+          public func 5️⃣foo6️⃣() {}
           public init() {}
         }
         """,
@@ -804,10 +804,14 @@ final class WorkspaceTests: SourceKitLSPTestCase {
     let fooDefinitionResponse = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(mainUri), position: mainPositions["3️⃣"])
     )
+
     XCTAssertEqual(
       fooDefinitionResponse,
       .locations([
-        Location(uri: try project.uri(for: "lib.swift"), range: try Range(project.position(of: "5️⃣", in: "lib.swift")))
+        Location(
+          uri: try project.uri(for: "lib.swift"),
+          range: try project.range(from: "5️⃣", to: "6️⃣", in: "lib.swift")
+        )
       ])
     )
 


### PR DESCRIPTION
vscode provides an alternative action if the target of goto definition is in the same character range we requested. this requires the start and end in the LSP response to be properly set, so vscode can see that the current character is actually part of the request. Currently, this functionality only works when invoking "go to definition" on the start of the character range.

<img width="674" height="214" alt="Screenshot 2026-05-18 at 00 09 05" src="https://github.com/user-attachments/assets/5284b7b7-4c1d-4a3d-8fae-3e1bbd5d8a41" />


https://github.com/user-attachments/assets/cdcda3c7-eed5-420f-9681-5904d7101ea1


https://github.com/user-attachments/assets/ac5909a1-65d0-4981-91ff-0623830ac25a

