### PR TITLE
[Test] Fix deployment target mismatch in SwiftPMBuildServerTests

### DIFF
--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -189,10 +189,11 @@ struct SwiftPMBuildServerTests {
         files: [
           "pkg/Sources/lib/a.swift": "",
           "pkg/Package.swift": """
-          // swift-tools-version:4.2
+          // swift-tools-version:5.8
           import PackageDescription
           let package = Package(
             name: "a",
+            platforms: [.macOS(.v13)],
             targets: [.target(name: "lib")]
           )
           """,
@@ -229,7 +230,7 @@ struct SwiftPMBuildServerTests {
 
       expectArgumentsContain("-target", arguments: arguments)  // Only one!
       #if os(macOS)
-      let versionString = PackageModel.Platform.macOS.oldestSupportedVersion.versionString
+      let versionString = "13.0"  // matches the explicit platforms: [.macOS(.v13)] above
       if options.swiftPMOrDefault.buildSystem == .swiftbuild {
         expectArgumentsContain(
           "-target",
@@ -1214,6 +1215,7 @@ struct SwiftPMBuildServerTests {
       manifest: """
         let package = Package(
           name: "MyLibrary",
+          platforms: [.macOS(.v13)],
           targets: [
             .target(name: "Foo", dependencies: ["Bar"]),
             .target(name: "Bar"),


### PR DESCRIPTION

- `testToolsets`: sourcekit-lsp is built against a just-built SwiftPM, which can use macOS 10.13 as the minimum deployment target for  packages with no explicit `platforms` requirement. The preparation  step runs the toolchain's `swift build`, which can use a higher macOS  minimum. The resulting module embeds a higher deployment target,  causing a spurious mismatch diagnostic when the other target imports  it.
- `testBasicSwiftArgs` (swiftbuild variant): `swift-build` can clamp  the deployment target to the SDK's `MinimumDeploymentTarget`, which  can be above the 10.13 `PackageModel.Platform.macOS.oldestSupportedVersion`

Fix these by explicit set the deployment target to 13.0