### PR TITLE
Use 'weak let' for immutable weak references (SE-0481)

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -51,7 +51,7 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
   /// The ``SourceKitLSPServer`` instance that created this `ClangLanguageService`.
   ///
   /// Used to send requests and notifications to the editor.
-  private weak var sourceKitLSPServer: SourceKitLSPServer?
+  private weak let sourceKitLSPServer: SourceKitLSPServer?
 
   /// The connection to the clangd LSP. `nil` until `startClangdProcesss` has been called.
   var clangd: (any Connection)!

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -21,7 +21,7 @@ package import ToolchainRegistry
 
 package actor DocumentationLanguageService: LanguageService, Sendable {
   /// The ``SourceKitLSPServer`` instance that created this `DocumentationLanguageService`.
-  private(set) weak var sourceKitLSPServer: SourceKitLSPServer?
+  weak let sourceKitLSPServer: SourceKitLSPServer?
 
   let documentationManager: DocCDocumentationManager
 

--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -31,7 +31,7 @@ actor IndexProgressManager {
 
   /// The `SourceKitLSPServer` for which this manages the index progress. It gathers all `SemanticIndexManagers` from
   /// the workspaces in the `SourceKitLSPServer`.
-  private weak var sourceKitLSPServer: SourceKitLSPServer?
+  private weak let sourceKitLSPServer: SourceKitLSPServer?
 
   /// This is the target number of index tasks (eg. the `3` in `1/3 done`).
   ///

--- a/Sources/SourceKitLSP/SharedWorkDoneProgressManager.swift
+++ b/Sources/SourceKitLSP/SharedWorkDoneProgressManager.swift
@@ -47,7 +47,7 @@ extension WorkDoneProgressManager {
 /// doesn't show multiple work done progress in the client. For example, we only want to show one progress indicator
 /// when sourcekitd has crashed, not one per `SwiftLanguageService`.
 package actor SharedWorkDoneProgressManager {
-  private weak var sourceKitLSPServer: SourceKitLSPServer?
+  private weak let sourceKitLSPServer: SourceKitLSPServer?
 
   /// The number of in-progress operations. When greater than 0 `workDoneProgress` is non-nil and a work done progress
   /// is displayed to the user.

--- a/Sources/SwiftLanguageService/GeneratedInterfaceManager.swift
+++ b/Sources/SwiftLanguageService/GeneratedInterfaceManager.swift
@@ -38,7 +38,7 @@ actor GeneratedInterfaceManager {
     var refCount: Int
   }
 
-  private weak var swiftLanguageService: SwiftLanguageService?
+  private weak let swiftLanguageService: SwiftLanguageService?
 
   /// The number of generated interface documents that are not in editor but should still be cached.
   private let cacheSize = 2

--- a/Sources/SwiftLanguageService/MacroExpansion.swift
+++ b/Sources/SwiftLanguageService/MacroExpansion.swift
@@ -33,7 +33,7 @@ actor MacroExpansionManager {
     self.swiftLanguageService = swiftLanguageService
   }
 
-  private weak var swiftLanguageService: SwiftLanguageService?
+  private weak let swiftLanguageService: SwiftLanguageService?
 
   /// The cache that stores reportTasks for a combination of uri, range and build settings.
   ///

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -122,7 +122,7 @@ package struct SwiftCompileCommand: Sendable, Equatable, Hashable {
 
 package actor SwiftLanguageService: LanguageService, Sendable {
   /// The ``SourceKitLSPServer`` instance that created this `SwiftLanguageService`.
-  private(set) weak var sourceKitLSPServer: SourceKitLSPServer?
+  weak let sourceKitLSPServer: SourceKitLSPServer?
 
   private let sourcekitdPath: URL
 


### PR DESCRIPTION
Replace `weak var` with `weak let` for weak reference properties that are set in init and never reassigned, using the Swift 6.3 feature introduced by SE-0481.