### PR TITLE
Allow configuring `--pkg-config-path`

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -24,6 +24,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `triple: string`: Equivalent to SwiftPM's `--triple` option.
   - `sdk: string`: Equivalent to SwiftPM's `--sdk` option.
   - `toolsets: string[]`: Equivalent to SwiftPM's `--toolset` option.
+  - `pkgConfigPaths: string[]`: Equivalent to SwiftPM's `--pkg-config-path` option.
   - `traits: string[]`: Traits to enable for the package. Equivalent to SwiftPM's `--traits` option.
   - `cCompilerFlags: string[]`: Extra arguments passed to the compiler for C files. Equivalent to SwiftPM's `-Xcc` option.
   - `cxxCompilerFlags: string[]`: Extra arguments passed to the compiler for C++ files. Equivalent to SwiftPM's `-Xcxx` option.

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -130,6 +130,10 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
   /// root.
   private let toolsets: [AbsolutePath]
 
+  /// Paths to any pkg-config directories provided in `SourceKitLSPOptions`, with any relative paths resolved based on
+  /// the project root.
+  private let pkgConfigDirectories: [AbsolutePath]
+
   /// A `ObservabilitySystem` from `SwiftPM` that logs.
   private let observabilitySystem: ObservabilitySystem
 
@@ -278,6 +282,10 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       try options.swiftPMOrDefault.toolsets?.map {
         try AbsolutePath(validating: $0, relativeTo: absProjectRoot)
       } ?? []
+    self.pkgConfigDirectories =
+      try options.swiftPMOrDefault.pkgConfigPaths?.map {
+        try AbsolutePath(validating: $0, relativeTo: absProjectRoot)
+      } ?? []
 
     let hostSDK = try SwiftSDK.hostSwiftSDK(AbsolutePath(validating: destinationToolchainBinDir.filePath))
     let hostSwiftPMToolchain = try UserToolchain(swiftSDK: hostSDK)
@@ -365,6 +373,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       toolchain: hostSwiftPMToolchain,
       flags: buildFlags,
       buildSystemKind: .native,
+      pkgConfigDirectories: pkgConfigDirectories,
     )
 
     self.destinationBuildParameters = try BuildParameters(
@@ -377,6 +386,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       triple: destinationSDK.targetTriple,
       flags: buildFlags,
       buildSystemKind: .native,
+      pkgConfigDirectories: pkgConfigDirectories,
       prepareForIndexing: options.backgroundPreparationModeOrDefault.toSwiftPMPreparation
     )
 
@@ -815,6 +825,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
       arguments += ["--traits", traits.joined(separator: ",")]
     }
     arguments += toolsets.flatMap { ["--toolset", $0.pathString] }
+    arguments += pkgConfigDirectories.flatMap { ["--pkg-config-path", $0.pathString] }
     arguments += options.swiftPMOrDefault.cCompilerFlags?.flatMap { ["-Xcc", $0] } ?? []
     arguments += options.swiftPMOrDefault.cxxCompilerFlags?.flatMap { ["-Xcxx", $0] } ?? []
     arguments += options.swiftPMOrDefault.swiftCompilerFlags?.flatMap { ["-Xswiftc", $0] } ?? []

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -50,6 +50,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
     /// Equivalent to SwiftPM's `--toolset` option.
     public var toolsets: [String]?
 
+    /// Equivalent to SwiftPM's `--pkg-config-path` option.
+    public var pkgConfigPaths: [String]?
+
     /// Traits to enable for the package. Equivalent to SwiftPM's `--traits` option.
     public var traits: [String]?
 
@@ -94,6 +97,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
       triple: String? = nil,
       sdk: String? = nil,
       toolsets: [String]? = nil,
+      pkgConfigDirectories: [String]? = nil,
       traits: [String]? = nil,
       cCompilerFlags: [String]? = nil,
       cxxCompilerFlags: [String]? = nil,
@@ -112,6 +116,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
       self.triple = triple
       self.sdk = sdk
       self.toolsets = toolsets
+      self.pkgConfigPaths = pkgConfigDirectories
       self.traits = traits
       self.cCompilerFlags = cCompilerFlags
       self.cxxCompilerFlags = cxxCompilerFlags
@@ -132,6 +137,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
         triple: override?.triple ?? base.triple,
         sdk: override?.sdk ?? base.sdk,
         toolsets: override?.toolsets ?? base.toolsets,
+        pkgConfigDirectories: override?.pkgConfigPaths ?? base.pkgConfigPaths,
         traits: override?.traits ?? base.traits,
         cCompilerFlags: override?.cCompilerFlags ?? base.cCompilerFlags,
         cxxCompilerFlags: override?.cxxCompilerFlags ?? base.cxxCompilerFlags,

--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -1245,6 +1245,51 @@ struct SwiftPMBuildServerTests {
     #expect(diagnostics.isEmpty)
   }
 
+  @Test func testPkgConfigDirectories() async throws {
+    var options = try await SourceKitLSPOptions.testDefault(experimentalFeatures: [.sourceKitOptionsRequest])
+    options.swiftPMOrDefault.pkgConfigPaths = ["pcfiles"]
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyExecutable/main.swift": """
+        import MyClib
+        """,
+        "MyClib/module.modulemap": """
+        module MyClib [system] {
+          header "shim.h"
+          link "myclib"
+          export *
+        }
+        """,
+        "MyClib/shim.h": "",
+        "/pcfiles/myclib.pc": """
+        Name: myclib
+        Cflags: -I/sourcekit-lsp-test-pkg-config-include
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyPkg",
+          targets: [
+            .executableTarget(name: "MyExecutable", dependencies: ["MyClib"]),
+            .systemLibrary(name: "MyClib", pkgConfig: "myclib"),
+          ]
+        )
+        """,
+      options: options
+    )
+
+    let uri = try project.openDocument("main.swift").uri
+
+    let buildSettings = try await project.testClient.send(
+      SourceKitOptionsRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        prepareTarget: false,
+        allowFallbackSettings: false
+      )
+    )
+    #expect(buildSettings.compilerArguments.contains("-I/sourcekit-lsp-test-pkg-config-include"))
+  }
+
   // MARK: - Package reload filtering
 
   /// Creates a minimal package containing a zip-based binary target and returns the server ready

--- a/config.schema.json
+++ b/config.schema.json
@@ -295,6 +295,14 @@
           "markdownDescription" : "Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.",
           "type" : "array"
         },
+        "pkgConfigPaths" : {
+          "description" : "Equivalent to SwiftPM's `--pkg-config-path` option.",
+          "items" : {
+            "type" : "string"
+          },
+          "markdownDescription" : "Equivalent to SwiftPM's `--pkg-config-path` option.",
+          "type" : "array"
+        },
         "scratchPath" : {
           "description" : "Build artifacts directory path. If nil, the build system may choose a default value. This path can be specified as a relative path, which will be interpreted relative to the project root. Equivalent to SwiftPM's `--scratch-path` option.",
           "markdownDescription" : "Build artifacts directory path. If nil, the build system may choose a default value. This path can be specified as a relative path, which will be interpreted relative to the project root. Equivalent to SwiftPM's `--scratch-path` option.",


### PR DESCRIPTION
Add a SourceKit-LSP configuration option equivalent to SwiftPM’s `--pkg-config-path`.