### PR TITLE
Add `forOpenDocument` label to language service lookup methods

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -496,7 +496,7 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
   /// for `uri` is fully processed (and `setLanguageServices` called) before the cache is read.
   package func primaryLanguageService(for uri: DocumentURI) async throws -> (any LanguageService)? {
     _ = try await send(SynchronizeRequest())
-    return await server.workspaceForDocument(uri: uri)?.primaryLanguageService(for: uri)
+    return try await unwrap(server.workspaceForDocument(uri: uri)).primaryLanguageService(forOpenDocument: uri)
   }
 }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -380,7 +380,7 @@ package actor SourceKitLSPServer {
 
     // This should be created as soon as we receive an open call, even if the document
     // isn't yet ready.
-    for languageService in workspace.languageServices(for: doc) {
+    for languageService in workspace.languageServices(forOpenDocument: doc) {
       await notificationHandler(notification, languageService)
     }
   }
@@ -399,7 +399,7 @@ package actor SourceKitLSPServer {
       guard let workspace = await self.workspaceForDocument(uri: request.textDocument.uri) else {
         throw ResponseError.workspaceNotOpen(request.textDocument.uri)
       }
-      let languageServices = workspace.languageServices(for: doc)
+      let languageServices = workspace.languageServices(forOpenDocument: doc)
       if languageServices.isEmpty {
         throw ResponseError.unknown("No language service for '\(request.textDocument.uri)' found")
       }
@@ -431,7 +431,7 @@ package actor SourceKitLSPServer {
       guard let workspace = await self.workspaceForDocument(uri: documentUri) else {
         continue
       }
-      guard workspace.languageServices(for: documentUri).contains(where: { $0 === languageService }) else {
+      guard workspace.languageServices(forOpenDocument: documentUri).contains(where: { $0 === languageService }) else {
         continue
       }
       guard let snapshot = try? self.documentManager.latestSnapshot(documentUri) else {
@@ -1237,7 +1237,7 @@ extension SourceKitLSPServer {
       return
     }
 
-    workspace.setLanguageServices(for: uri, languageServices)
+    workspace.setLanguageServices(forOpenDocument: uri, languageServices)
 
     await workspace.buildServerManager.registerForChangeNotifications(for: uri, language: language)
 
@@ -1267,7 +1267,7 @@ extension SourceKitLSPServer {
       return
     }
 
-    for languageService in workspace.languageServices(for: uri) {
+    for languageService in workspace.languageServices(forOpenDocument: uri) {
       await languageService.reopenDocument(notification)
     }
   }
@@ -1283,11 +1283,11 @@ extension SourceKitLSPServer {
 
     await workspace.buildServerManager.unregisterForChangeNotifications(for: uri)
 
-    for languageService in workspace.languageServices(for: uri) {
+    for languageService in workspace.languageServices(forOpenDocument: uri) {
       await languageService.closeDocument(notification)
     }
 
-    workspace.removeLanguageServices(for: uri)
+    workspace.removeLanguageServices(forOpenDocument: uri)
 
     workspaceQueue.async {
       self.workspaceForUri[notification.textDocument.uri] = nil
@@ -1317,7 +1317,7 @@ extension SourceKitLSPServer {
       // Already logged failure
       return
     }
-    for languageService in workspace.languageServices(for: uri) {
+    for languageService in workspace.languageServices(forOpenDocument: uri) {
       await languageService.changeDocument(
         notification,
         preEditSnapshot: preEditSnapshot,
@@ -1526,8 +1526,8 @@ extension SourceKitLSPServer {
     guard let workspace = await self.workspaceForDocument(uri: uri) else {
       throw ResponseError.workspaceNotOpen(uri)
     }
-    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
-    return try await workspace.primaryLanguageService(for: uri, language).completionItemResolve(request)
+    let languageService = try workspace.primaryLanguageService(forOpenDocument: uri)
+    return try await languageService.completionItemResolve(request)
   }
 
   func doccDocumentation(
@@ -1927,16 +1927,15 @@ extension SourceKitLSPServer {
     guard let workspace = await self.workspaceForDocument(uri: uri) else {
       throw ResponseError.workspaceNotOpen(uri)
     }
-    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
     // First, check if we have a language service that explicitly declares support for this command.
-    if let languageService = await workspace.languageServices(for: uri, language)
+    if let languageService = workspace.languageServices(forOpenDocument: uri)
       .first(where: { type(of: $0).builtInCommands.contains(req.command) })
     {
       return try await languageService.executeCommand(executeCommand)
     }
     // Otherwise handle it in the primary language service. This is important to handle eg. commands in clangd, which
     // are not declared as built-in commands.
-    return try await workspace.primaryLanguageService(for: uri, language).executeCommand(executeCommand)
+    return try await workspace.primaryLanguageService(forOpenDocument: uri).executeCommand(executeCommand)
   }
 
   func getReferenceDocument(_ req: GetReferenceDocumentRequest) async throws -> GetReferenceDocumentResponse {
@@ -1989,9 +1988,8 @@ extension SourceKitLSPServer {
     var forwardedReq = req
     forwardedReq.codeAction.data = resolveMetadata.underlyingData
 
-    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
-    return try await workspace.primaryLanguageService(for: uri, language)
-      .codeActionResolve(forwardedReq)
+    let languageService = try workspace.primaryLanguageService(forOpenDocument: uri)
+    return try await languageService.codeActionResolve(forwardedReq)
   }
 
   func codeLens(
@@ -2019,8 +2017,8 @@ extension SourceKitLSPServer {
     guard let workspace = await self.workspaceForDocument(uri: uri) else {
       return request.inlayHint
     }
-    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
-    return try await workspace.primaryLanguageService(for: uri, language).inlayHintResolve(request)
+    let languageService = try workspace.primaryLanguageService(forOpenDocument: uri)
+    return try await languageService.inlayHintResolve(request)
   }
 
   func documentDiagnostic(

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -248,7 +248,8 @@ struct TestDiscovery {
         documentManager.snapshotHasInMemoryModifications(snapshot)
       {
         // In-memory modified files. Perform syntactic scan now.
-        if let scannedTests = await workspace.primaryLanguageService(for: uri)?.syntacticTestItems(for: snapshot) {
+        let languageService = try workspace.primaryLanguageService(forOpenDocument: uri)
+        if let scannedTests = await languageService.syntacticTestItems(for: snapshot) {
           syntacticTests += scannedTests
           // The file has in-memory modifications, so the semantic index is out-of-date. Don't use it.
         } else {

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -199,7 +199,8 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   }
 
   /// Language service for an open document, if available.
-  private let languageServices: ThreadSafeBox<[DocumentURI: [any LanguageService]]> = ThreadSafeBox(initialValue: [:])
+  private let languageServicesForOpenDocument: ThreadSafeBox<[DocumentURI: [any LanguageService]]> =
+    ThreadSafeBox(initialValue: [:])
 
   /// All language services that are registered with this workspace.
   var allLanguageServices: [any LanguageService] {
@@ -542,8 +543,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     for uri: DocumentURI,
     _ language: Language
   ) async -> [any LanguageService] {
-    let cached = languageServices.value[uri.buildSettingsFile]
-    if let cached, !cached.isEmpty {
+    if let cached = languageServicesForOpenDocument.value[uri.buildSettingsFile] {
       return cached
     }
 
@@ -594,24 +594,29 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   ///
   /// Callers should try to merge the results from the different language services or prefer results
   /// from language services that occur earlier in this array, whichever is more suitable.
-  package func languageServices(for uri: DocumentURI) -> [any LanguageService] {
-    return languageServices.value[uri.buildSettingsFile] ?? []
+  package func languageServices(forOpenDocument uri: DocumentURI) -> [any LanguageService] {
+    return languageServicesForOpenDocument.value[uri.buildSettingsFile] ?? []
   }
 
   /// The primary language service for an open document.
   ///
-  /// Convenience wrapper around the sync `languageServices(for:)`. Returns `nil` if the document
-  /// has not been opened or has already been closed.
-  package func primaryLanguageService(for uri: DocumentURI) -> (any LanguageService)? {
-    return languageServices(for: uri).first
+  /// Convenience wrapper around `languageServices(forOpenDocument:)`. Throws if the document has
+  /// not been opened or has already been closed.
+  package func primaryLanguageService(forOpenDocument uri: DocumentURI) throws -> any LanguageService {
+    let services = languageServices(forOpenDocument: uri)
+    if let first = services.first {
+      return first
+    }
+    throw ResponseError.unknown("No language service for '\(uri)' found")
   }
 
   /// Set the language services for a document URI.
   ///
   /// This should only be called from `openDocument` to ensure there are no race conditions.
-  func setLanguageServices(for uri: DocumentURI, _ newLanguageService: [any LanguageService]) {
-    languageServices.withLock { languageServices in
-      languageServices[uri.buildSettingsFile] = newLanguageService
+  func setLanguageServices(forOpenDocument uri: DocumentURI, _ services: [any LanguageService]) {
+    guard !services.isEmpty else { return }  // Don't cache empty value.
+    languageServicesForOpenDocument.withLock { languageServices in
+      languageServices[uri.buildSettingsFile] = services
     }
   }
 
@@ -619,19 +624,19 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   ///
   /// If any other open document shares the same build-settings file as `uri`, the language service
   /// is still in use and will not be removed.
-  func removeLanguageServices(for uri: DocumentURI) {
+  func removeLanguageServices(forOpenDocument uri: DocumentURI) {
     let key = uri.buildSettingsFile
     let openDocuments = sourceKitLSPServer?.documentManager.openDocuments ?? []
     guard !openDocuments.contains(where: { $0.buildSettingsFile == key }) else {
       return
     }
-    languageServices.withLock { languageServices in
+    languageServicesForOpenDocument.withLock { languageServices in
       languageServices[key] = nil
     }
   }
 
   func shutdown() async {
-    logger.info("Shutting down workspace \(self.rootUri?.description ?? "<nil>")")
+    logger.info("Shutting down workspace \(self.rootUri.forLogging)")
     async let languageServiceShutdown = shutdownAllLanguageServices()
     async let buildServerShutdown = buildServerManager.shutdown()
     async let indexClose = uncheckedIndex?.close()
@@ -654,7 +659,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   /// - Changed settings for an already open file
   package func fileBuildSettingsChanged(_ changedFiles: Set<DocumentURI>) async {
     for uri in changedFiles {
-      for languageService in languageServices(for: uri) {
+      for languageService in languageServices(forOpenDocument: uri) {
         await languageService.documentUpdatedBuildSettings(uri)
       }
     }
@@ -667,7 +672,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     var documentsByService: [ObjectIdentifier: (Set<DocumentURI>, any LanguageService)] = [:]
     for uri in changedFiles {
       logger.log("Dependencies updated for file \(uri.forLogging)")
-      for languageService in languageServices(for: uri) {
+      for languageService in languageServices(forOpenDocument: uri) {
         documentsByService[ObjectIdentifier(languageService), default: ([], languageService)].0.insert(uri)
       }
     }


### PR DESCRIPTION
Rename `languageServices(for:)`, `primaryLanguageService(for:)`, and their internal counterparts to use the `forOpenDocument` label, so the precondition that the document must already be open is visible at call sites.

Also make `primaryLanguageService(forOpenDocument:)` throw instead of returning an optional, and switch several resolve-style handlers from the find-or-create `primaryLanguageService(for:_:)` to `primaryLanguageService(forOpenDocument:)`, since those call sites already have an open document in hand.