### PR TITLE
Migrate test-case atomic usages to ThreadSafeBox / Atomic

### DIFF
--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -1327,8 +1327,8 @@ struct SwiftPMBuildServerTests {
   @Test
   func testBinaryTargetArtifactEventsDoNotTriggerPackageReload() async throws {
     try await withTestScratchDir { tempDir in
-      let packageInitialized = AtomicBool(initialValue: false)
-      let unexpectedReloadStarted = AtomicBool(initialValue: false)
+      let packageInitialized = ThreadSafeBox<Bool>(initialValue: false)
+      let unexpectedReloadStarted = ThreadSafeBox<Bool>(initialValue: false)
 
       let (server, projectRoot) = try await makeServerWithBinaryTargetAndWaitForInitialLoad(
         in: tempDir,
@@ -1380,8 +1380,8 @@ struct SwiftPMBuildServerTests {
     try await withTestScratchDir { tempDir in
       let customScratch = tempDir.appending(component: "custom-scratch")
 
-      let packageInitialized = AtomicBool(initialValue: false)
-      let unexpectedReloadStarted = AtomicBool(initialValue: false)
+      let packageInitialized = ThreadSafeBox<Bool>(initialValue: false)
+      let unexpectedReloadStarted = ThreadSafeBox<Bool>(initialValue: false)
 
       let (server, projectRoot) = try await makeServerWithBinaryTargetAndWaitForInitialLoad(
         in: tempDir,

--- a/Tests/SemanticIndexTests/TaskSchedulerTests.swift
+++ b/Tests/SemanticIndexTests/TaskSchedulerTests.swift
@@ -248,7 +248,7 @@ final class TaskSchedulerTests: SourceKitLSPTestCase {
     let taskScheduler = TaskScheduler<ClosureTaskDescription>(maxConcurrentTasksByPriority: [(.low, 1)])
 
     /// True after the job was cancelled and is now being re-scheduled after increasing the number of execution slots.
-    let taskExecutedBefore = AtomicBool(initialValue: false)
+    let taskExecutedBefore = ThreadSafeBox<Bool>(initialValue: false)
 
     let taskStartedExecuting = self.expectation(description: "Task started executing")
     let executionSlotsReduced = self.expectation(description: "Execution slots reduced")

--- a/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
@@ -15,6 +15,7 @@ import Csourcekitd
 import SKTestSupport
 import SourceKitD
 import SwiftExtensions
+import Synchronization
 import TSCBasic
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 import XCTest
@@ -62,13 +63,13 @@ final class SourceKitDRegistryTests: SourceKitLSPTestCase {
   }
 }
 
-private let nextToken = AtomicUInt32(initialValue: 0)
+private let nextToken = Atomic<UInt32>(0)
 
 final class FakeSourceKitD: Sendable {
   let token: UInt32
 
   private init() {
-    token = nextToken.fetchAndIncrement()
+    token = nextToken.wrappingAdd(1, ordering: .relaxed).oldValue
   }
 
   static func getOrCreate(_ url: URL, in registry: SourceKitDRegistry<FakeSourceKitD>) async -> FakeSourceKitD {

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1379,7 +1379,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
   }
 
   func testAddingRandomSwiftFileDoesNotTriggerPackageReload() async throws {
-    let packageInitialized = AtomicBool(initialValue: false)
+    let packageInitialized = ThreadSafeBox<Bool>(initialValue: false)
 
     var testHooks = Hooks()
     testHooks.buildServerHooks.swiftPMTestHooks.reloadPackageDidStart = {
@@ -2152,7 +2152,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
   }
 
   func testIndexingProgressIfNonIndexableFileIsInPackage() async throws {
-    let receivedReportProgressNotification = AtomicBool(initialValue: false)
+    let receivedReportProgressNotification = ThreadSafeBox<Bool>(initialValue: false)
 
     let project = try await SwiftPMTestProject(
       files: [
@@ -2579,7 +2579,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
   }
 
   func testEnsureSymbolsLoadedIntoIndexstoreDbWhenIndexingHasFinished() async throws {
-    let testSetupComplete = AtomicBool(initialValue: false)
+    let testSetupComplete = ThreadSafeBox<Bool>(initialValue: false)
     let updateIndexStoreStarted = self.expectation(description: "Update index store started")
     let project = try await SwiftPMTestProject(
       files: [

--- a/Tests/SourceKitLSPTests/ClangdTests.swift
+++ b/Tests/SourceKitLSPTests/ClangdTests.swift
@@ -136,7 +136,7 @@ final class ClangdTests: SourceKitLSPTestCase {
 
   func testRestartClangdIfItDoesntReply() async throws {
     // We simulate clangd not replying until it is restarted using a hook.
-    let clangdRestarted = AtomicBool(initialValue: false)
+    let clangdRestarted = ThreadSafeBox<Bool>(initialValue: false)
     let clangdRestartedExpectation = self.expectation(description: "clangd restarted")
     let hooks = Hooks(preForwardRequestToClangd: { request in
       if !clangdRestarted.value {

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -110,7 +110,7 @@ final class WorkspaceTestDiscoveryTests: SourceKitLSPTestCase {
   func testSyntacticOrIndexBasedXCTestsBasedOnWhetherFileIsIndexed() async throws {
     try SkipUnless.longTestsEnabled()
 
-    let initialIndexingFinished = AtomicBool(initialValue: false)
+    let initialIndexingFinished = ThreadSafeBox<Bool>(initialValue: false)
     let syntacticWorkspaceRequestSent = WrappedSemaphore(name: "Syntactic workspace request sent")
 
     let project = try await SwiftPMTestProject(

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1111,7 +1111,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
   }
 
   func testDidChangeActiveEditorDocument() async throws {
-    let didChangeBaseLib = AtomicBool(initialValue: false)
+    let didChangeBaseLib = ThreadSafeBox<Bool>(initialValue: false)
     let didPrepareLibBAfterChangingBaseLib = self.expectation(description: "Did prepare LibB after changing base lib")
     let project = try await SwiftPMTestProject(
       files: [
@@ -1225,7 +1225,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
   }
 
   func testSourceKitOptionsTriggersPrepare() async throws {
-    let didChangeBaseLib = AtomicBool(initialValue: false)
+    let didChangeBaseLib = ThreadSafeBox<Bool>(initialValue: false)
     let didPrepareAfterChangingBaseLib = self.expectation(description: "Did prepare after changing base lib")
 
     let project = try await SwiftPMTestProject(


### PR DESCRIPTION
Migrate remaining `AtomicBool` / `AtomicUInt32` usages in test cases to ThreadSafeBox / Atomic.

- Closure-captured `AtomicBool` flags become `ThreadSafeBox<Bool>` for now.
  _We will revisit this when eliminating ThreadSafeBox._
- One `AtomicUInt32` counter (SourceKitDRegistryTests.swift's `nextToken`) to `Atomic<UInt32>`.