### PR TITLE
Insert array type instead of variadic type in inlay hints

### DIFF
--- a/Sources/SwiftLanguageService/InlayHintManager.swift
+++ b/Sources/SwiftLanguageService/InlayHintManager.swift
@@ -262,7 +262,7 @@ actor InlayHintManager {
       .map { info -> InlayHint in
         let position = info.range.upperBound
         let variableStart = info.range.lowerBound
-        let label = ": \(info.printedType)"
+        let label = ": \(info.annotationType)"
         let textEdits: [TextEdit]?
         if info.canBeFollowedByTypeAnnotation {
           textEdits = [TextEdit(range: position..<position, newText: label)]

--- a/Sources/SwiftLanguageService/VariableTypeInfo.swift
+++ b/Sources/SwiftLanguageService/VariableTypeInfo.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+import Foundation
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SourceKitD
 import SourceKitLSP
@@ -72,6 +73,24 @@ struct VariableTypeInfo {
     self.printedType = printedType
     self.hasExplicitType = hasExplicitType
     self.canBeFollowedByTypeAnnotation = tokenAtOffset?.canBeFollowedByTypeAnnotation ?? true
+  }
+
+  /// The type to use when writing a type annotation for the variable, eg. in an inlay hint.
+  ///
+  /// This differs from ``printedType`` when the variable is bound to a variadic parameter: sourcekitd prints the type
+  /// of such a variable as `T...` (eg. for `func foo(x: Int...) { let y = x }`, the type of `y` is printed as
+  /// `Int...`). The trailing `...` is only valid in a function parameter, so it cannot be used as a type annotation.
+  /// Inside the function body the variable is actually of the corresponding array type, so we rewrite `T...` to `[T]`.
+  var annotationType: String {
+    let trimmed = printedType.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasSuffix("...") else {
+      return printedType
+    }
+    let element = trimmed.dropLast(3).trimmingCharacters(in: .whitespaces)
+    guard !element.isEmpty else {
+      return printedType
+    }
+    return "[\(element)]"
   }
 }
 

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -546,6 +546,25 @@ final class InlayHintTests: SourceKitLSPTestCase {
     )
   }
 
+  func testInferredVariadicParameter() async throws {
+    // A variable bound to a variadic parameter has the type `Int...` as printed by sourcekitd, but inside the function
+    // body it is actually of the corresponding array type. `Int...` is not a valid type annotation, so the hint (which
+    // doubles as the inserted text edit) should use `[Int]` instead.
+    try await runInlayHintTestCase(
+      initialText: """
+        func test(x: Int...) {
+          let y1️⃣ = x
+        }
+        """
+    ) { context in
+      try await context.checkInlayHintsComputedInTheBackgroundMatch(
+        expected: [
+          makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": [Int]")
+        ]
+      )
+    }
+  }
+
   func testInlayHintCacheUpdatesAfterParameterTypeChange() async throws {
     try await runInlayHintTestCase(
       initialText: """


### PR DESCRIPTION
For a variable that is bound to a variadic parameter, sourcekitd's `source.request.variable.type` prints the type with a trailing `...`. For example, in

```swift
func test(x: Int...) {
  let y = x
}
```

the printed type of `y` is `Int...`. The inlay hint code used this string verbatim, both for the displayed label and for the text edit that is applied when the hint is accepted (double-clicked). A trailing `...` is only grammatical on a function parameter, so accepting the hint inserts `let y: Int... = x`, which does not compile.

The variadic spelling is also misleading semantically: inside the function body `y` is not a variadic, it is an `Array`. So the correct annotation is the array type.

The fix rewrites a top-level variadic type `T...` to `[T]` before it is used as the hint label and text edit. The detection is a `hasSuffix("...")` check, which is precise here because the variadic ellipsis is the only Swift type construct that ends in `...` (closure types containing a variadic parameter such as `(Int...) -> Void` end in their return type and are left untouched). Wrapping the element in `[...]` is always valid because it is array sugar that accepts any element type. The transformation lives on `VariableTypeInfo` so the printed type is still available unchanged for any other use.

I verified the change by building `SwiftLanguageService` and running the inlay hint tests. The added regression test fails before the fix (the hint is `: Int...`) and passes after (`: [Int]`), and the rest of `InlayHintTests` continues to pass.

Fixes #2609
