### PR TITLE
Add 'Add Explicit Raw Values' code action

### DIFF
--- a/Sources/SwiftSyntaxCodeActions/AddExplicitEnumRawValues.swift
+++ b/Sources/SwiftSyntaxCodeActions/AddExplicitEnumRawValues.swift
@@ -1,0 +1,203 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftRefactor
+import SwiftSyntax
+
+/// Syntactic code action provider that adds explicit raw values to all cases of
+/// an enum whose first inherited type is `Int`/`UInt` (any width) or `String`.
+///
+/// For an enum with an integer raw value type, the action computes raw values
+/// following Swift's implicit numbering rules: counting starts at zero and
+/// continues from the last explicit value. For a `String` raw value type, each
+/// case without an explicit value is given a raw value equal to the case name.
+///
+/// ### Example
+///
+/// Before:
+///
+/// ```swift
+/// enum Status: Int {
+///     case active
+///     case inactive
+///     case pending = 10
+///     case archived
+/// }
+/// ```
+///
+/// After:
+///
+/// ```swift
+/// enum Status: Int {
+///     case active = 0
+///     case inactive = 1
+///     case pending = 10
+///     case archived = 11
+/// }
+/// ```
+struct AddExplicitEnumRawValues: EditRefactoringProvider {
+  static func textRefactor(syntax: EnumDeclSyntax, in context: Void) throws -> [SourceEdit] {
+    guard let rawValueType = syntax.rawValueType else {
+      throw RefactoringNotApplicableError("Enum does not have an Int, UInt, or String raw value type")
+    }
+
+    // Attached macros applied to the enum can introduce new cases via
+    // attribute-level macro expansion, which is not visible to a syntactic
+    // walk. Bail conservatively whenever there are any attributes; a follow-up
+    // can narrow this once we have a reliable way to tell apart attribute
+    // macros from non-macro attributes such as `@available`.
+    if !syntax.attributes.isEmpty {
+      throw RefactoringNotApplicableError("Enum has attributes that may be attached macros")
+    }
+
+    // `#if` blocks and freestanding macro expansions can introduce or hide
+    // enum cases without that being visible to a purely syntactic walk. In
+    // either case the implicit raw value counter cannot be computed safely,
+    // so bail rather than risk emitting values that disagree with the active
+    // configuration or expanded source.
+    for member in syntax.memberBlock.members {
+      if member.decl.is(IfConfigDeclSyntax.self) {
+        throw RefactoringNotApplicableError("Enum contains #if directives")
+      }
+      if member.decl.is(MacroExpansionDeclSyntax.self) {
+        throw RefactoringNotApplicableError("Enum contains a freestanding macro expansion")
+      }
+    }
+
+    let caseElements = syntax.memberBlock.members.flatMap { member -> [EnumCaseElementSyntax] in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else { return [] }
+      return Array(caseDecl.elements)
+    }
+
+    // Cases with associated values cannot have raw values; mixing them inside a
+    // raw-value enum is invalid Swift, but a user might be editing toward that
+    // state. Don't attempt the refactor in that case.
+    if caseElements.contains(where: { $0.parameterClause != nil }) {
+      throw RefactoringNotApplicableError("Enum has cases with associated values")
+    }
+
+    guard caseElements.contains(where: { $0.rawValue == nil }) else {
+      throw RefactoringNotApplicableError("All cases already have explicit raw values")
+    }
+
+    var edits: [SourceEdit] = []
+
+    switch rawValueType {
+    case .signedInt, .unsignedInt:
+      let allowNegative = rawValueType == .signedInt
+      var nextValue = 0
+      for element in caseElements {
+        if let rawValue = element.rawValue {
+          // Only proceed when the existing raw value is a recognised integer
+          // literal (optionally with a leading minus). Anything else, such as a
+          // reference to a constant or an arithmetic expression, is rejected so
+          // the refactoring never emits values that disagree with the source.
+          guard let intValue = rawValue.value.signedIntegerLiteralValue else {
+            throw RefactoringNotApplicableError("Unsupported raw value expression")
+          }
+          if !allowNegative, intValue < 0 {
+            throw RefactoringNotApplicableError("Negative raw value on an unsigned-integer enum")
+          }
+          let (next, overflow) = intValue.addingReportingOverflow(1)
+          if overflow {
+            throw RefactoringNotApplicableError("Raw value continuation would overflow Int")
+          }
+          nextValue = next
+        } else {
+          let insertion = " = \(nextValue)"
+          let position = element.name.endPositionBeforeTrailingTrivia
+          edits.append(SourceEdit(range: position..<position, replacement: insertion))
+          let (next, overflow) = nextValue.addingReportingOverflow(1)
+          if overflow {
+            throw RefactoringNotApplicableError("Raw value continuation would overflow Int")
+          }
+          nextValue = next
+        }
+      }
+
+    case .string:
+      for element in caseElements where element.rawValue == nil {
+        // Swift's implicit string raw value uses the canonical identifier name
+        // without any surrounding backticks (e.g. `` case `default` `` has the
+        // implicit raw value `"default"`, not `` "`default`" ``).
+        let name = element.name.identifier?.name ?? element.name.text
+        let insertion = " = \"\(name)\""
+        let position = element.name.endPositionBeforeTrailingTrivia
+        edits.append(SourceEdit(range: position..<position, replacement: insertion))
+      }
+    }
+
+    if edits.isEmpty {
+      throw RefactoringNotApplicableError("No cases to transform")
+    }
+
+    return edits
+  }
+}
+
+extension AddExplicitEnumRawValues: SyntaxRefactoringCodeActionProvider {
+  static let title: String = "Add Explicit Raw Values"
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> EnumDeclSyntax? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: EnumDeclSyntax.self,
+      stoppingIf: { $0.is(CodeBlockSyntax.self) }
+    )
+  }
+}
+
+private enum RawValueKind {
+  case signedInt
+  case unsignedInt
+  case string
+}
+
+private extension EnumDeclSyntax {
+  /// The raw value kind if the first inherited type is a supported integer
+  /// type or `String`. Only the first type in the inheritance clause may
+  /// specify a raw value, so all other inherited types are protocols.
+  var rawValueType: RawValueKind? {
+    guard let firstType = inheritanceClause?.inheritedTypes.first else {
+      return nil
+    }
+    switch firstType.type.trimmedDescription {
+    case "Int", "Int8", "Int16", "Int32", "Int64", "Int128":
+      return .signedInt
+    case "UInt", "UInt8", "UInt16", "UInt32", "UInt64", "UInt128":
+      return .unsignedInt
+    case "String":
+      return .string
+    default:
+      return nil
+    }
+  }
+}
+
+private extension ExprSyntax {
+  /// Parse this expression as a signed integer literal. Uses swift-syntax's
+  /// `IntegerLiteralExprSyntax.representedLiteralValue` for plain integer
+  /// literals (all bases and underscore separators), and unwraps a unary minus
+  /// prefix expression for negative literals. Returns `nil` for anything else.
+  var signedIntegerLiteralValue: Int? {
+    if let intLit = self.as(IntegerLiteralExprSyntax.self) {
+      return intLit.representedLiteralValue
+    }
+    if let prefix = self.as(PrefixOperatorExprSyntax.self),
+      prefix.operator.text == "-",
+      let intLit = prefix.expression.as(IntegerLiteralExprSyntax.self),
+      let positive = intLit.representedLiteralValue
+    {
+      return -positive
+    }
+    return nil
+  }
+}

--- a/Sources/SwiftSyntaxCodeActions/CMakeLists.txt
+++ b/Sources/SwiftSyntaxCodeActions/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(SwiftSyntaxCodeActions STATIC
   AddDocumentation.swift
+  AddExplicitEnumRawValues.swift
   ApplyDeMorganLaw.swift
   ConvertCommentToDocComment.swift
   ConvertIfLetToGuard.swift

--- a/Sources/SwiftSyntaxCodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftSyntaxCodeActions/SyntaxCodeActions.swift
@@ -17,6 +17,7 @@ import SwiftRefactor
 package let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
   var result: [any SyntaxCodeActionProvider.Type] = [
     AddDocumentation.self,
+    AddExplicitEnumRawValues.self,
     AddSeparatorsToIntegerLiteral.self,
     ApplyDeMorganLaw.self,
     ConvertComputedPropertyToStored.self,

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -776,6 +776,325 @@ final class CodeActionTests: SourceKitLSPTestCase {
     }
   }
 
+  func testAddExplicitEnumRawValuesInt() async throws {
+    try await assertCodeActions(
+      """
+      1️⃣enum Status: Int {
+        case active2️⃣
+        case inactive3️⃣
+        case pending = 10
+        case archived4️⃣
+      }
+      """,
+      markers: ["1️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add Explicit Raw Values",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(range: positions["2️⃣"]..<positions["2️⃣"], newText: " = 0"),
+                TextEdit(range: positions["3️⃣"]..<positions["3️⃣"], newText: " = 1"),
+                TextEdit(range: positions["4️⃣"]..<positions["4️⃣"], newText: " = 11"),
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddExplicitEnumRawValuesString() async throws {
+    try await assertCodeActions(
+      """
+      1️⃣enum Direction: String {
+        case north2️⃣
+        case south = "down"
+        case east3️⃣
+      }
+      """,
+      markers: ["1️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add Explicit Raw Values",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(range: positions["2️⃣"]..<positions["2️⃣"], newText: " = \"north\""),
+                TextEdit(range: positions["3️⃣"]..<positions["3️⃣"], newText: " = \"east\""),
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddExplicitEnumRawValuesContinuesAfterNegativeLiteral() async throws {
+    try await assertCodeActions(
+      """
+      1️⃣enum Offset: Int {
+        case low = -5
+        case medium2️⃣
+        case high3️⃣
+      }
+      """,
+      markers: ["1️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add Explicit Raw Values",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(range: positions["2️⃣"]..<positions["2️⃣"], newText: " = -4"),
+                TextEdit(range: positions["3️⃣"]..<positions["3️⃣"], newText: " = -3"),
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddExplicitEnumRawValuesContinuesAfterHexLiteral() async throws {
+    try await assertCodeActions(
+      """
+      1️⃣enum Mask: Int {
+        case bit0 = 0x10
+        case bit12️⃣
+      }
+      """,
+      markers: ["1️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add Explicit Raw Values",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(range: positions["2️⃣"]..<positions["2️⃣"], newText: " = 17")
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWhenAllCasesExplicit() async throws {
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Status: Int {
+          case active = 0
+          case inactive = 1
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWithoutRawValueType() async throws {
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Direction {
+          case north
+          case south
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWithUnsupportedRawValue() async throws {
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        let base = 10
+        1️⃣enum Tier: Int {
+          case low = base
+          case high
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesStripsBackticksInImplicitStringRawValue() async throws {
+    try await assertCodeActions(
+      """
+      1️⃣enum Keyword: String {
+        case `default`2️⃣
+        case ifBranch = "if"
+        case `class`3️⃣
+      }
+      """,
+      markers: ["1️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add Explicit Raw Values",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(range: positions["2️⃣"]..<positions["2️⃣"], newText: " = \"default\""),
+                TextEdit(range: positions["3️⃣"]..<positions["3️⃣"], newText: " = \"class\""),
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWhenRawValueTypeIsNotFirst() async throws {
+    // Per Swift's grammar, only the first inherited type may specify a raw
+    // value. `: CaseIterable, Int` is invalid Swift, so the code action must
+    // not be offered.
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Status: CaseIterable, Int {
+          case active
+          case inactive
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWithIfConfigMembers() async throws {
+    // `#if` blocks change which cases are active in a given configuration, so
+    // the implicit raw value counter cannot be computed purely syntactically.
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Mode: Int {
+          case a
+          #if DEBUG
+          case b
+          #endif
+          case c
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWithFreestandingMacro() async throws {
+    // Freestanding declaration macros can expand to enum cases, so the counter
+    // cannot be computed without expanding the macro.
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Mode: Int {
+          case a
+          #generatedCases()
+          case b
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWithAssociatedValues() async throws {
+    // Cases with associated values cannot have raw values. Mixing them inside
+    // a raw-value enum is invalid Swift; the refactor should bail rather than
+    // produce broken output like `case payload = 0(String)`.
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Event: Int {
+          case empty
+          case payload(String)
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesUInt() async throws {
+    try await assertCodeActions(
+      """
+      1️⃣enum Mask: UInt {
+        case bit02️⃣
+        case bit13️⃣
+        case bit2 = 4
+        case bit34️⃣
+      }
+      """,
+      markers: ["1️⃣"],
+      exhaustive: false
+    ) { uri, positions in
+      [
+        CodeAction(
+          title: "Add Explicit Raw Values",
+          kind: .refactorInline,
+          diagnostics: nil,
+          edit: WorkspaceEdit(
+            changes: [
+              uri: [
+                TextEdit(range: positions["2️⃣"]..<positions["2️⃣"], newText: " = 0"),
+                TextEdit(range: positions["3️⃣"]..<positions["3️⃣"], newText: " = 1"),
+                TextEdit(range: positions["4️⃣"]..<positions["4️⃣"], newText: " = 5"),
+              ]
+            ]
+          )
+        )
+      ]
+    }
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedForUnsignedEnumWithNegativeRawValue() async throws {
+    // `case = -1` is invalid Swift for an unsigned-integer raw type, so the
+    // refactor must not insert further values based on it.
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        1️⃣enum Mask: UInt {
+          case a = -1
+          case b
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
+  func testAddExplicitEnumRawValuesNotOfferedWhenEnumHasAttribute() async throws {
+    // Attached attribute macros can introduce members at expansion time, so
+    // the refactor bails whenever the enum has any attributes.
+    try await assertNoCodeAction(
+      titled: "Add Explicit Raw Values",
+      in: """
+        @available(*, deprecated)
+        1️⃣enum Status: Int {
+          case active
+          case inactive
+        }
+        """,
+      atMarker: "1️⃣"
+    )
+  }
+
   func testFormatRawStringLiteral() async throws {
     try await assertCodeActions(
       """
@@ -2086,6 +2405,35 @@ final class CodeActionTests: SourceKitLSPTestCase {
         )
       }
     }
+  }
+
+  /// Assert that no code action with the given title is offered at the given marker.
+  private func assertNoCodeAction(
+    titled title: String,
+    in markedText: String,
+    atMarker marker: String,
+    testName: String = #function,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
+    let uri = DocumentURI(for: .swift, testName: testName)
+    let positions = testClient.openDocument(markedText, uri: uri)
+    let position = positions[marker]
+    let result = try await testClient.send(
+      CodeActionRequest(
+        range: position..<position,
+        context: .init(),
+        textDocument: TextDocumentIdentifier(uri)
+      )
+    )
+    let codeActions = result?.codeActions ?? []
+    XCTAssertFalse(
+      codeActions.contains(where: { $0.title == title }),
+      "did not expect code action titled '\(title)' at marker \(marker), got: \(codeActions.map(\.title))",
+      file: file,
+      line: line
+    )
   }
 }
 


### PR DESCRIPTION
resolves #2516.

adds a syntactic refactoring action that converts implicit raw values to explicit ones for enums whose first inherited type is an integer (any width up to Int128/UInt128) or String.

before:

    enum Status: Int {
        case active
        case inactive
        case pending = 10
        case archived
    }

after:

    enum Status: Int {
        case active = 0
        case inactive = 1
        case pending = 10
        case archived = 11
    }

design follows the feedback @ahoppen left on #2536: implemented as `SyntaxRefactoringCodeActionProvider`, only the first inherited type is consulted for the raw value type, raw value expressions are validated as integer literals and the action is suppressed when they cannot be parsed, Int128 and UInt128 are accepted in the type list, and the action is suppressed when there is nothing to transform.

beyond #2536, the action also handles:
- negative integer raw values (`case low = -5` followed by implicit cases continues at -4)
- alternate-base integer literals with underscore separators (`case bit0 = 0x10` continues at 17)
- backticked case identifiers in String enums (``case `default`` becomes `= "default"`, not `= "`default`"`)
- integer overflow during continuation (suppresses the action rather than trapping)
- enums containing `#if` directives (rintaro flagged this on the original issue)
- enums containing freestanding macro expansions
- cases with associated values (suppresses rather than producing `case payload = 0(String)`)

### motivation

making implicit raw values explicit is a common refactor before serialising values or relying on their numeric identity. doing it by hand is error-prone once any cases already have explicit values, because the continuation rule must be reapplied for every gap.

### modifications

- new `Sources/SwiftSyntaxCodeActions/AddExplicitEnumRawValues.swift`
- registered in `Sources/SwiftSyntaxCodeActions/SyntaxCodeActions.swift` and `Sources/SwiftSyntaxCodeActions/CMakeLists.txt`
- 12 LSP-level tests in `Tests/SourceKitLSPTests/CodeActionTests.swift` covering positive cases (Int, String, negative continuation, hex continuation, backtick stripping) and negative cases (no raw value type, raw value type not first, all cases explicit, unsupported raw value expression, `#if` directives, freestanding macros, associated value cases)

### result

when the cursor is on an enum declaration with a supported raw value type and at least one case missing an explicit raw value, sourcekit-lsp offers "Add Explicit Raw Values" and inserts the missing values in place. existing positive and negative cases continue to behave as before.

all 12 new tests pass locally.