### PR TITLE
Bound task-scheduler shutdown wait to 10s and log process completion

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -873,6 +873,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
         stderr: { @Sendable bytes in stderrHandler.handleDataFromPipe(Data(bytes)) }
       )
     )
+    logger.debug("'swift build' for target \(target.forLogging) returned")
     let exitStatus = result.exitStatus.exhaustivelySwitchable
     self.connectionToSourceKitLSP.send(
       BuildServerProtocol.OnBuildLogMessageNotification(

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -461,7 +461,15 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
     self.isShutDown = true
     await self.currentlyExecutingTasks.concurrentForEach { task in
       task.cancel()
-      await task.waitToFinish()
+      do {
+        try await withTimeout(.seconds(10)) {
+          await task.waitToFinish()
+        }
+      } catch {
+        logger.error(
+          "Timed out waiting for task \(task.description.forLogging) to finish during shutdown"
+        )
+      }
     }
   }
 

--- a/Sources/TSCExtensions/Process+Run.swift
+++ b/Sources/TSCExtensions/Process+Run.swift
@@ -37,7 +37,9 @@ extension Process {
       defer {
         hasExited.withLock { $0 = true }
       }
-      return try await waitUntilExit()
+      let result = try await waitUntilExit()
+      logger.debug("Process exited: \(self.arguments)")
+      return result
     } onCancel: {
       logger.debug("Terminating process using SIGINT because task was cancelled: \(self.arguments)")
       signal(SIGINT)


### PR DESCRIPTION
Wrap each `task.waitToFinish()` in `TaskScheduler.shutDown()` with a 10s `withTimeout` so a stuck QueuedTask cannot block sourcekit-lsp's shutdown indefinitely; on timeout, log the task description so the offender is identifiable. The QueuedTask is already cancelled via `task.cancel()` and continues winding down in the background.

Add debug logs after `Process.waitUntilExit()` returns and after `Process.run` returns inside `prepare(singleTarget:)`, so a future shutdown hang can be triaged: did the swift build process actually exit, did `Process.run` propagate the result, or is the stall higher up in the prepare chain.

Motivated by a recurring Windows CI hang in
`BackgroundIndexingTests.testSymlinkedTargetReferringToSameSourceFile` where `prepareForExit` seemed to stall for the full test timeout with no log output during shutdown.