### PR TITLE
Support `InsertReplaceEdit` and keep existing arguments when completing function calls

### DIFF
--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(SwiftLanguageService STATIC
   AdjustPositionToStartOfIdentifier.swift
   ClosureCompletionFormat.swift
   CodeCompletion.swift
+  CodeCompletionContext.swift
   CodeCompletionSession.swift
   CommentXML.swift
   CursorInfo.swift

--- a/Sources/SwiftLanguageService/CodeCompletion.swift
+++ b/Sources/SwiftLanguageService/CodeCompletion.swift
@@ -22,6 +22,8 @@ extension SwiftLanguageService {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
 
     let completionPos = await adjustPositionToStartOfIdentifier(req.position, in: snapshot)
+    let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    let requestContext = CompletionRequestContext(req: req, snapshot: snapshot, tree: tree)
     let filterText = String(snapshot.text[snapshot.index(of: completionPos)..<snapshot.index(of: req.position)])
 
     let compileCommand = await compileCommand(for: snapshot.uri, fallbackAfterTimeout: false)
@@ -34,7 +36,7 @@ extension SwiftLanguageService {
       options: options,
       indentationWidth: inferredIndentationWidth,
       completionPosition: completionPos,
-      cursorPosition: req.position,
+      requestContext: requestContext,
       compileCommand: compileCommand,
       clientCapabilities: capabilityRegistry.clientCapabilities,
       filterText: filterText

--- a/Sources/SwiftLanguageService/CodeCompletionContext.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionContext.swift
@@ -19,11 +19,20 @@ struct CompletionRequestContext {
   /// If the completion is triggered in the middle of an identifier, this is the position after the end of the
   /// identifier. This is needed to compute the correct text edit for completions that replace an existing identifier.
   let identifierEndPosition: Position?
+  let followingCallContext: FollowingCallContext
 
   init(req: CompletionRequest, snapshot: DocumentSnapshot, tree: SourceFileSyntax) {
     self.cursorPosition = req.position
     self.identifierEndPosition = findEndOfIdentifier(position: req.position, snapshot: snapshot, tree: tree)
+    self.followingCallContext = findFollowingCallContext(position: req.position, snapshot: snapshot, tree: tree)
   }
+}
+
+enum FollowingCallContext {
+  case none
+  case emptyParens(positionAfterClosingParen: Position)
+  case nonEmptyParens
+  case trailingClosure
 }
 
 private func findEndOfIdentifier(
@@ -40,6 +49,35 @@ private func findEndOfIdentifier(
   return snapshot.position(of: token.endPositionBeforeTrailingTrivia)
 }
 
+private func findIdentifierUnderCursor(
+  position: Position,
+  snapshot: DocumentSnapshot,
+  tree: SourceFileSyntax
+) -> TokenSyntax? {
+  let absolutePosition = snapshot.absolutePosition(of: position)
+  let token = tree.token(at: absolutePosition)
+  guard let token else {
+    return nil
+  }
+
+  // We also consider keywords here for cases where the user is trying to complete a function that also contains a
+  // keyword in its name. If only the keyword part of the function name is typed, we still want to show the completion
+  // for that function.
+  // For example, if the user has a function `func selfTest()`, we want to show the completion for `selfTest` even if
+  // the user has only typed `self` so far.
+  if token.isIdentifierOrKeyword {
+    return token
+  }
+
+  // If the cursor is right after an identifier, we also want to consider that identifier for completion.
+  let previousToken = token.previousToken(viewMode: .sourceAccurate)
+  guard let previousToken, previousToken.isIdentifierOrKeyword, previousToken.endPosition == absolutePosition else {
+    return nil
+  }
+
+  return previousToken
+}
+
 private extension TokenSyntax {
   var isIdentifierOrKeyword: Bool {
     switch tokenKind {
@@ -48,5 +86,77 @@ private extension TokenSyntax {
     default:
       return false
     }
+  }
+}
+
+private func findFollowingCallContext(
+  position: Position,
+  snapshot: DocumentSnapshot,
+  tree: SourceFileSyntax
+) -> FollowingCallContext {
+  guard let identifier = findIdentifierUnderCursor(position: position, snapshot: snapshot, tree: tree),
+    let parent = identifier.parent
+  else {
+    return .none
+  }
+
+  let functionCall: FunctionCallExprSyntax
+  if let declReference = parent.as(DeclReferenceExprSyntax.self) {
+    if let call = declReference.parent?.as(FunctionCallExprSyntax.self) {
+      functionCall = call
+    } else if let memberAccess = declReference.parent?.as(MemberAccessExprSyntax.self),
+      let call = memberAccess.parent?.as(FunctionCallExprSyntax.self)
+    {
+      functionCall = call
+    } else {
+      return .none
+    }
+  } else if let macroExpansion = parent.as(MacroExpansionExprSyntax.self), let leftParen = macroExpansion.leftParen {
+    return determineFollowingCallContextParenthesisKind(
+      leftParen: leftParen,
+      rightParen: macroExpansion.rightParen,
+      snapshot: snapshot
+    )
+  } else {
+    return .none
+  }
+
+  if let leftParen = functionCall.leftParen,
+    // We don't want to report empty parentheses for code like this: `foo() { doSomethingInClosure() }` as that would
+    // lead to the completion logic trying to replace the parentheses with the call argument labels
+    functionCall.trailingClosure == nil
+  {
+    return determineFollowingCallContextParenthesisKind(
+      leftParen: leftParen,
+      rightParen: functionCall.rightParen,
+      snapshot: snapshot
+    )
+  }
+
+  // Braces on the next line are also parsed into a ClosureExprSyntax, so we need to ensure that the left brace is
+  // actually on the same line as the cursor to consider it a trailing closure context.
+  if let trailingClosure = functionCall.trailingClosure,
+    snapshot.position(of: trailingClosure.leftBrace.positionAfterSkippingLeadingTrivia).line == position.line
+  {
+    return .trailingClosure
+  }
+
+  return .none
+}
+
+private func determineFollowingCallContextParenthesisKind(
+  leftParen: TokenSyntax,
+  rightParen: TokenSyntax?,
+  snapshot: DocumentSnapshot
+) -> FollowingCallContext {
+  if let rightParen, leftParen.nextToken(viewMode: .sourceAccurate) == rightParen,
+    // Only actually consider the parens as empty if there is no comment or newline in between. A comment should not be
+    // overwrittten and replacing parens across multiple lines is likely not what the user intended.
+    !leftParen.trailingTrivia.contains(where: { $0.isComment || $0.isNewline }),
+    !rightParen.leadingTrivia.contains(where: { $0.isComment || $0.isNewline })
+  {
+    return .emptyParens(positionAfterClosingParen: snapshot.position(of: rightParen.endPositionBeforeTrailingTrivia))
+  } else {
+    return .nonEmptyParens
   }
 }

--- a/Sources/SwiftLanguageService/CodeCompletionContext.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionContext.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SourceKitLSP
+import SwiftSyntax
+
+struct CompletionRequestContext {
+  let cursorPosition: Position
+  /// If the completion is triggered in the middle of an identifier, this is the position after the end of the
+  /// identifier. This is needed to compute the correct text edit for completions that replace an existing identifier.
+  let identifierEndPosition: Position?
+
+  init(req: CompletionRequest, snapshot: DocumentSnapshot, tree: SourceFileSyntax) {
+    self.cursorPosition = req.position
+    self.identifierEndPosition = findEndOfIdentifier(position: req.position, snapshot: snapshot, tree: tree)
+  }
+}
+
+private func findEndOfIdentifier(
+  position: Position,
+  snapshot: DocumentSnapshot,
+  tree: SourceFileSyntax
+) -> Position? {
+  let token = tree.token(at: snapshot.absolutePosition(of: position))
+
+  guard let token, token.isIdentifierOrKeyword else {
+    return nil
+  }
+
+  return snapshot.position(of: token.endPositionBeforeTrailingTrivia)
+}
+
+private extension TokenSyntax {
+  var isIdentifierOrKeyword: Bool {
+    switch tokenKind {
+    case .identifier, .keyword:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/SwiftLanguageService/CodeCompletionSession.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionSession.swift
@@ -140,7 +140,7 @@ class CodeCompletionSession {
     options: SourceKitLSPOptions,
     indentationWidth: Trivia?,
     completionPosition: Position,
-    cursorPosition: Position,
+    requestContext: CompletionRequestContext,
     compileCommand: SwiftCompileCommand?,
     clientCapabilities: ClientCapabilities,
     filterText: String
@@ -155,7 +155,7 @@ class CodeCompletionSession {
         if isCompatible {
           return try await session.update(
             filterText: filterText,
-            position: cursorPosition,
+            requestContext: requestContext,
             in: snapshot
           )
         }
@@ -174,7 +174,7 @@ class CodeCompletionSession {
         clientCapabilities: clientCapabilities
       )
       completionSessions[ObjectIdentifier(sourcekitd)] = session
-      return try await session.open(filterText: filterText, position: cursorPosition, in: snapshot)
+      return try await session.open(filterText: filterText, requestContext: requestContext, in: snapshot)
     }
 
     return try await task.valuePropagatingCancellation
@@ -226,6 +226,7 @@ class CodeCompletionSession {
   private let position: Position
   private let compileCommand: SwiftCompileCommand?
   private let clientSupportsSnippets: Bool
+  private let clientSupportsInsertReplaceEdits: Bool
   private let clientSupportsDocumentationResolve: Bool
   private var state: State = .closed
 
@@ -254,6 +255,8 @@ class CodeCompletionSession {
     self.position = position
     self.compileCommand = compileCommand
     self.clientSupportsSnippets = clientCapabilities.textDocument?.completion?.completionItem?.snippetSupport ?? false
+    self.clientSupportsInsertReplaceEdits =
+      clientCapabilities.textDocument?.completion?.completionItem?.insertReplaceSupport ?? false
     self.clientSupportsDocumentationResolve =
       clientCapabilities.textDocument?.completion?.completionItem?.resolveSupport?.properties.contains("documentation")
       ?? false
@@ -261,7 +264,7 @@ class CodeCompletionSession {
 
   private func open(
     filterText: String,
-    position cursorPosition: Position,
+    requestContext: CompletionRequestContext,
     in snapshot: DocumentSnapshot
   ) async throws -> CompletionList {
     logger.info("Opening code completion session: \(self.description) filter=\(filterText)")
@@ -292,14 +295,14 @@ class CodeCompletionSession {
       completions,
       in: snapshot,
       completionPos: self.position,
-      requestPosition: cursorPosition,
+      requestContext: requestContext,
       isIncomplete: true
     )
   }
 
   private func update(
     filterText: String,
-    position: Position,
+    requestContext: CompletionRequestContext,
     in snapshot: DocumentSnapshot
   ) async throws -> CompletionList {
     logger.info("Updating code completion session: \(self.description) filter=\(filterText)")
@@ -321,7 +324,7 @@ class CodeCompletionSession {
       completions,
       in: snapshot,
       completionPos: self.position,
-      requestPosition: position,
+      requestContext: requestContext,
       isIncomplete: true
     )
   }
@@ -454,7 +457,7 @@ class CodeCompletionSession {
     _ completions: SKDResponseArray,
     in snapshot: DocumentSnapshot,
     completionPos: Position,
-    requestPosition: Position,
+    requestContext: CompletionRequestContext,
     isIncomplete: Bool
   ) async -> CompletionList {
     let sourcekitd = self.sourcekitd
@@ -493,22 +496,22 @@ class CodeCompletionSession {
         insertText = text
       }
 
-      var textEdit = self.computeCompletionTextEdit(
+      let editRangeStart = computeCompletionTextEditStart(
         completionPos: completionPos,
-        requestPosition: requestPosition,
+        requestPosition: requestContext.cursorPosition,
         utf8CodeUnitsToErase: utf8CodeUnitsToErase,
-        newText: insertText,
         snapshot: snapshot
       )
+      var insertEnd = requestContext.cursorPosition
 
       if completionKind == .method || completionKind == .function, name.first == "(", name.last == ")" {
         // sourcekitd makes an assumption that the editor inserts a matching `)` when the user types a `(` to start
         // argument completions and thus does not contain the closing parentheses in the insert text. Since we can't
         // make that assumption of any editor using SourceKit-LSP, add the closing parenthesis when we are completing
         // function arguments, indicated by the completion kind and the completion's name being wrapped in parentheses.
-        textEdit.newText += ")"
+        insertText += ")"
 
-        let requestIndex = snapshot.index(of: requestPosition)
+        let requestIndex = snapshot.index(of: requestContext.cursorPosition)
         if snapshot.text[requestIndex] == ")",
           let nextIndex = snapshot.text.index(requestIndex, offsetBy: 1, limitedBy: snapshot.text.endIndex)
         {
@@ -519,7 +522,7 @@ class CodeCompletionSession {
           // parenthesis but no new completion request is sent since no character has been inserted (only the implicitly
           // inserted `)` has been overwritten). VS Code will now delete anything from the position that the completion
           // request was run, leaving the user without the closing `)`.
-          textEdit.range = textEdit.range.lowerBound..<snapshot.position(of: nextIndex)
+          insertEnd = snapshot.position(of: nextIndex)
         }
       }
 
@@ -528,7 +531,7 @@ class CodeCompletionSession {
         // we need to prepend the deleted text to filterText.
         // This also works around a behaviour in VS Code that causes completions to not show up
         // if a '.' is being replaced for Optional completion.
-        let filterPrefix = snapshot.text[snapshot.indexRange(of: textEdit.range.lowerBound..<completionPos)]
+        let filterPrefix = snapshot.text[snapshot.indexRange(of: editRangeStart..<completionPos)]
         filterName = filterPrefix + filterName!
       }
 
@@ -579,7 +582,12 @@ class CodeCompletionSession {
         filterText: filterName,
         insertText: insertText,
         insertTextFormat: (isInsertTextSnippet || isKeywordSnippet) ? .snippet : .plain,
-        textEdit: CompletionItemEdit.textEdit(textEdit),
+        textEdit: createCompletionItemEdit(
+          newText: insertText,
+          start: editRangeStart,
+          insertEnd: insertEnd,
+          replaceEnd: requestContext.identifierEndPosition
+        ),
         data: data.encodeToLSPAny()
       )
     }
@@ -638,20 +646,22 @@ class CodeCompletionSession {
     return response[sourcekitd.keys.docBrief]
   }
 
-  private func computeCompletionTextEdit(
-    completionPos: Position,
-    requestPosition: Position,
-    utf8CodeUnitsToErase: Int,
+  private func createCompletionItemEdit(
     newText: String,
-    snapshot: DocumentSnapshot
-  ) -> TextEdit {
-    let textEditRangeStart = computeCompletionTextEditStart(
-      completionPos: completionPos,
-      requestPosition: requestPosition,
-      utf8CodeUnitsToErase: utf8CodeUnitsToErase,
-      snapshot: snapshot
-    )
-    return TextEdit(range: textEditRangeStart..<requestPosition, newText: newText)
+    start: Position,
+    insertEnd: Position,
+    replaceEnd: Position?
+  ) -> CompletionItemEdit {
+    if clientSupportsInsertReplaceEdits, let replaceEnd {
+      return .insertReplaceEdit(
+        InsertReplaceEdit(
+          newText: newText,
+          insert: start..<insertEnd,
+          replace: start..<replaceEnd
+        )
+      )
+    }
+    return .textEdit(TextEdit(range: start..<insertEnd, newText: newText))
   }
 
   private func computeCompletionTextEditStart(

--- a/Sources/SwiftLanguageService/CodeCompletionSession.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionSession.swift
@@ -480,21 +480,10 @@ class CodeCompletionSession {
         insertText = multilineFormatted
       }
 
-      let text = rewriteSourceKitPlaceholders(in: insertText, clientSupportsSnippets: clientSupportsSnippets)
-      let isInsertTextSnippet = clientSupportsSnippets && text != insertText
-
       let kind: sourcekitd_api_uid_t? = value[sourcekitd.keys.kind]
       let completionKind = kind?.asCompletionItemKind(sourcekitd.values) ?? .value
 
-      // Check if this is a keyword that should be converted to a snippet. If so, prefer the snippet text
-      // as the completion insert text and only compute the `TextEdit` once below.
-      var isKeywordSnippet = false
-      if completionKind == .keyword, let snippetText = keywordSnippet(for: name) {
-        insertText = snippetText
-        isKeywordSnippet = true
-      } else {
-        insertText = text
-      }
+      var insertTextFormat: InsertTextFormat = .plain
 
       let editRangeStart = computeCompletionTextEditStart(
         completionPos: completionPos,
@@ -503,6 +492,7 @@ class CodeCompletionSession {
         snapshot: snapshot
       )
       var insertEnd = requestContext.cursorPosition
+      var replaceEnd = requestContext.identifierEndPosition
 
       if completionKind == .method || completionKind == .function, name.first == "(", name.last == ")" {
         // sourcekitd makes an assumption that the editor inserts a matching `)` when the user types a `(` to start
@@ -524,6 +514,53 @@ class CodeCompletionSession {
           // request was run, leaving the user without the closing `)`.
           insertEnd = snapshot.position(of: nextIndex)
         }
+      }
+
+      let followingCallContext = requestContext.followingCallContext
+      // .value is for macros that are completed with their call pattern, e.g. `#myMacro(x: , y: )`.
+      if [.method, .function, .constructor, .enumMember, .value].contains(completionKind),
+        // This is check is only a heuristic to avoid processing completions of kind .value other than macros
+        insertText.contains("(") || insertText.contains("{")
+      {
+        // If the completion is a call and the call is followed by either non-empty parentheses or a trailing closure,
+        // trim the argument list from the completion insert text to prevent duplicated argument lists in the editor.
+        // For example, if the completion item is `foo(x: , y: )` and the user invoked completion on `fo|(x: 5, y: 3)`,
+        // then we want to trim the `(x: , y: )` from the completion insert text since those parentheses are already
+        // present in the code and the user likely wants to keep them instead of ending up with
+        // `foo(x: , y: )(x: 5, y: 3)`.
+        // Note, that this currently does not look at the actual contents between the parentheses or braces to determine
+        // whether the labels match
+        switch followingCallContext {
+        case .nonEmptyParens, .trailingClosure:
+          insertText = trimCallPatternIfPresent(in: insertText, context: followingCallContext)
+        case let .emptyParens(positionAfterClosingParen):
+          // When autocompleting a function call and empty parentheses are already present after the cursor, make sure to
+          // overwrite those parentheses with the completion's insert text, which also contains parentheses. This is
+          // needed to prevent the user from ending up with duplicated parentheses when accepting a completion item that
+          // contains a call pattern, e.g. `foo(x: 5)()`.
+          if replaceEnd != nil {
+            // The completion was started from the middle of an existing identifier, e.g. `fo|o()`.
+            replaceEnd = positionAfterClosingParen
+          } else {
+            // The completion was started from a position where there is no existing identifier, e.g. `fo|()`.
+            insertEnd = positionAfterClosingParen
+          }
+        default:
+          break
+        }
+      }
+
+      // Check if this is a keyword that should be converted to a snippet. If so, prefer the snippet text
+      // as the completion insert text and only compute the `TextEdit` once below.
+      if completionKind == .keyword, let snippetText = keywordSnippet(for: name) {
+        insertText = snippetText
+        insertTextFormat = .snippet
+      } else {
+        let text = rewriteSourceKitPlaceholders(in: insertText, clientSupportsSnippets: clientSupportsSnippets)
+        if clientSupportsSnippets && text != insertText {
+          insertTextFormat = .snippet
+        }
+        insertText = text
       }
 
       if utf8CodeUnitsToErase != 0, filterName != nil {
@@ -581,12 +618,12 @@ class CodeCompletionSession {
         sortText: sortText,
         filterText: filterName,
         insertText: insertText,
-        insertTextFormat: (isInsertTextSnippet || isKeywordSnippet) ? .snippet : .plain,
+        insertTextFormat: insertTextFormat,
         textEdit: createCompletionItemEdit(
           newText: insertText,
           start: editRangeStart,
           insertEnd: insertEnd,
-          replaceEnd: requestContext.identifierEndPosition
+          replaceEnd: replaceEnd
         ),
         data: data.encodeToLSPAny()
       )
@@ -662,6 +699,29 @@ class CodeCompletionSession {
       )
     }
     return .textEdit(TextEdit(range: start..<insertEnd, newText: newText))
+  }
+
+  private func trimCallPatternIfPresent(
+    in insertText: String,
+    context: FollowingCallContext
+  ) -> String {
+    if case .nonEmptyParens = context, let openParenIndex = insertText.firstIndex(of: "(") {
+      return String(insertText[..<openParenIndex])
+    }
+
+    if case .trailingClosure = context, let braceIndex = insertText.firstIndex(of: "{") {
+      // For a function declaration like `func foo(x: () -> Void)`, there are two different completion patterns that
+      // SourceKit can return, they require different handling as in either case we only want to keep the `foo` part
+      if let openParenIndex = insertText.firstIndex(of: "(") {
+        // SourceKit returned `foo(x: <#{ <#T##code##Void#> }#>)`
+        return String(insertText[..<openParenIndex].trimmingCharacters(in: .whitespaces))
+      } else {
+        // SourceKit returned `foo { <#code#> }`
+        return String(insertText[..<braceIndex].trimmingCharacters(in: .whitespaces))
+      }
+    }
+
+    return insertText
   }
 
   private func computeCompletionTextEditStart(

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -29,6 +29,14 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
     )
   )
 
+  private var insertReplaceEditCapabilities = ClientCapabilities(
+    textDocument: TextDocumentClientCapabilities(
+      completion: TextDocumentClientCapabilities.Completion(
+        completionItem: TextDocumentClientCapabilities.Completion.CompletionItem(insertReplaceSupport: true)
+      )
+    )
+  )
+
   // MARK: - Tests
 
   func testCompletionBasic() async throws {
@@ -188,6 +196,90 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
       XCTAssertEqual(test.insertText, "test(${1:Int})")
       XCTAssertEqual(test.insertTextFormat, .snippet)
     }
+  }
+
+  func testCompletionInsertReplaceEditSupport() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct S {
+        var abc: Int
+        var def: S
+
+        func test() {
+          self.1️⃣ab2️⃣c3️⃣
+          self.4️⃣ab5️⃣c6️⃣+1
+          self.7️⃣ab8️⃣c9️⃣()
+          self.🔟ab0️⃣cℹ️.def
+        }
+      }
+      """,
+      uri: uri
+    )
+
+    func assertABCInsertReplace(_ start: String, _ cursor: String, _ end: String) async throws {
+      let completions = try await testClient.send(
+        CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions[cursor])
+      )
+
+      guard let abc = completions.items.first(where: { $0.label == "abc" }) else {
+        XCTFail("No completion item with label 'abc'")
+        return
+      }
+
+      XCTAssertEqual(
+        abc.textEdit,
+        .insertReplaceEdit(
+          InsertReplaceEdit(
+            newText: "abc",
+            insert: positions[start]..<positions[cursor],
+            replace: positions[start]..<positions[end]
+          )
+        )
+      )
+    }
+
+    // Replacement should stop before whitespace.
+    try await assertABCInsertReplace("1️⃣", "2️⃣", "3️⃣")
+    // Replacement should stop before an operator token.
+    try await assertABCInsertReplace("4️⃣", "5️⃣", "6️⃣")
+    // Replacement should stop before punctuation like '('.
+    try await assertABCInsertReplace("7️⃣", "8️⃣", "9️⃣")
+    // Replacement should stop before member access '.'.
+    try await assertABCInsertReplace("🔟", "0️⃣", "ℹ️")
+  }
+
+  func testCompletionNoInsertReplaceEditAtEndOfIdentifier() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct S {
+        var foobar: Int
+
+        func test() {
+          self.1️⃣foo2️⃣
+        }
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+
+    guard let abc = completions.items.first(where: { $0.label == "foobar" }) else {
+      XCTFail("No completion item with label 'foobar'")
+      return
+    }
+
+    XCTAssertEqual(abc.textEdit, .textEdit(TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "foobar")))
   }
 
   func testCompletionNoSnippetSupport() async throws {

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -37,6 +37,17 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
     )
   )
 
+  private var insertReplaceEditAndSnippetCapabilities = ClientCapabilities(
+    textDocument: TextDocumentClientCapabilities(
+      completion: TextDocumentClientCapabilities.Completion(
+        completionItem: TextDocumentClientCapabilities.Completion.CompletionItem(
+          snippetSupport: true,
+          insertReplaceSupport: true
+        )
+      )
+    )
+  )
+
   // MARK: - Tests
 
   func testCompletionBasic() async throws {
@@ -1105,6 +1116,32 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
     )
   }
 
+  func testCompletionWithExistingTrailingClosureDoesNotTrimAtSnippetBrace() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
+    let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct MyArray {
+          func myMap(_ body: (Int) -> Bool) {}
+      }
+      func test(x: MyArray) {
+          x.1️⃣myM2️⃣ { _ in true }
+      }
+      """,
+      uri: uri
+    )
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("myMap") })
+    XCTAssertEqual(
+      completion.textEdit,
+      .textEdit(TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "myMap"))
+    )
+  }
+
   func testExpandClosurePlaceholderOnOptional() async throws {
     try await SkipUnless.sourcekitdSupportsPlugin()
 
@@ -1616,6 +1653,654 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
     )
     let completion = try XCTUnwrap(completions.items.only)
     XCTAssertEqual(completion.textEdit, .textEdit(TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: ")")))
+  }
+
+  func testFunctionCompletionDoesNotInsertArgumentsIfTheyAlreadyExist() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(x: 5, y: 3)
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionDoesNotInsertArgumentsIfTheyAlreadyExistWithSnippets() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(x: 5, y: 3)
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+    XCTAssertEqual(completion.insertTextFormat, .plain)
+  }
+
+  func testFunctionCompletionTreatsExistingParensAfterWhitespaceAsExistingCall() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣   (x: 5, y: 3)
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionTreatsExistingMultilineCallAsExistingCall() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(
+          x: 5,
+          y: 3
+        )
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionDoesNotTreatNextLineParensAsExistingCall() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣
+        (x: 5, y: 3)
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar(x: , y: )")
+  }
+
+  func testFunctionCompletionReplacesExistingEmptyParens() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣()3️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["3️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar(x: , y: )")
+  }
+
+  func testFunctionCompletionReplacesExistingEmptyParensWithSnippets() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣()3️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["3️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar(x: ${1:Int}, y: ${2:Int})")
+    XCTAssertEqual(completion.insertTextFormat, .snippet)
+  }
+
+  func testFunctionCompletionWithEmptyParensAndExistingTrailingClosure() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: () -> Void) {}
+
+      func test() {
+        1️⃣foo2️⃣() {
+          doSomethingInTrailingClosure()
+        }
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionReplacesWhitespaceOnlyExistingParens() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(                 )3️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["3️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar(x: , y: )")
+  }
+
+  func testFunctionCompletionDoesNotOverwriteMultilineParens() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(
+
+        )
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionWithExistingTrailingClosure() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(body: () -> Void) {}
+
+      func test() {
+        1️⃣foobar2️⃣ {}
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { !$0.label.contains("(") })
+
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionWithExistingBraceButFunctionDoesNotTakeClosure() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int) {}
+
+      func test() {
+        1️⃣foobar2️⃣ {}
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.only)
+
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar(x: )")
+  }
+
+  func testFunctionCompletionDoesNotTreatCommentOnlyParensAsEmpty() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(/*keep me*/)
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionWithExistingOpeningParen() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣fooba2️⃣(
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("foobar") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "foobar")
+  }
+
+  func testFunctionCompletionWithInsertReplaceEditAndExistingParens() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func foobar(x: Int, y: Int) {}
+      func foobaz(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣foob2️⃣ar()3️⃣
+        4️⃣foob5️⃣ar6️⃣(x: 5, y: 3)
+      }
+      """,
+      uri: uri
+    )
+
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "1️⃣",
+      cursor: "2️⃣",
+      insertEnd: "2️⃣",
+      replaceEnd: "3️⃣",
+      matching: { $0.label.contains("foobaz") },
+      expectedNewText: "foobaz(x: , y: )"
+    )
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "4️⃣",
+      cursor: "5️⃣",
+      insertEnd: "5️⃣",
+      replaceEnd: "6️⃣",
+      matching: { $0.label.contains("foobaz") },
+      expectedNewText: "foobaz"
+    )
+  }
+
+  func testEnumCaseCompletionDoesNotInsertArgumentsIfTheyAlreadyExist() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      enum MyEnum {
+        case foobar(x: Int, y: Int)
+      }
+
+      func test(value: MyEnum) {
+        switch value {
+        case .1️⃣foo2️⃣baz3️⃣(x: 5, y: 3):
+          break
+        case .4️⃣fooba5️⃣z()6️⃣:
+          break
+        }
+      }
+      """,
+      uri: uri
+    )
+
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "1️⃣",
+      cursor: "2️⃣",
+      insertEnd: "2️⃣",
+      replaceEnd: "3️⃣",
+      matching: { $0.label.contains("foobar") },
+      expectedNewText: "foobar"
+    )
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "4️⃣",
+      cursor: "5️⃣",
+      insertEnd: "5️⃣",
+      replaceEnd: "6️⃣",
+      matching: { $0.label.contains("foobar") },
+      expectedNewText: "foobar(x: , y: )"
+    )
+  }
+
+  func testInitializerCompletionWithExistingArguments() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct Box {
+        init(x: Int, y: Int) {}
+      }
+
+      func test() {
+        let b = 1️⃣Bo2️⃣x3️⃣(x: 5, y: 3)
+        let c = 4️⃣Bo5️⃣x6️⃣()7️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "1️⃣",
+      cursor: "2️⃣",
+      insertEnd: "2️⃣",
+      replaceEnd: "3️⃣",
+      matching: { $0.kind == .constructor || $0.label.contains("Box") },
+      expectedNewText: "Box"
+    )
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "4️⃣",
+      cursor: "5️⃣",
+      insertEnd: "5️⃣",
+      replaceEnd: "6️⃣",
+      matching: { $0.kind == .constructor || $0.label.contains("Box") },
+      expectedNewText: "Box"
+    )
+  }
+
+  func testStaticFactoryCompletionWithExistingAndEmptyParens() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct Maker {
+        static func build(x: Int, y: Int) -> Maker { Maker() }
+      }
+
+      func test() {
+        _ = Maker.1️⃣buil2️⃣d3️⃣(x: 5, y: 3)
+        _ = Maker.4️⃣buil5️⃣d6️⃣()7️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "1️⃣",
+      cursor: "2️⃣",
+      insertEnd: "2️⃣",
+      replaceEnd: "3️⃣",
+      matching: { $0.label.contains("build") },
+      expectedNewText: "build"
+    )
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "4️⃣",
+      cursor: "5️⃣",
+      insertEnd: "5️⃣",
+      replaceEnd: "7️⃣",
+      matching: { $0.label.contains("build") },
+      expectedNewText: "build(x: , y: )"
+    )
+  }
+
+  func testMacroCompletionWithExistingAndEmptyParens() async throws {
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: insertReplaceEditAndSnippetCapabilities
+    )
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      @freestanding(expression)
+      macro myMacro(fn: (Int) -> String) = #externalMacro(module: "", type: "")
+
+      func test() {
+        _ = #1️⃣myMac2️⃣ro3️⃣(fn: { _ in "x" })
+        _ = #4️⃣myMac5️⃣ro()6️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "1️⃣",
+      cursor: "2️⃣",
+      insertEnd: "2️⃣",
+      replaceEnd: "3️⃣",
+      matching: { $0.label.contains("myMacro") },
+      expectedNewTextContains: "myMacro"
+    )
+    try await assertInsertReplaceCompletion(
+      testClient: testClient,
+      uri: uri,
+      positions: positions,
+      start: "4️⃣",
+      cursor: "5️⃣",
+      insertEnd: "5️⃣",
+      replaceEnd: "6️⃣",
+      matching: { $0.label.contains("myMacro") },
+      expectedNewTextContains: "myMacro"
+    )
+  }
+
+  private func assertInsertReplaceCompletion(
+    testClient: TestSourceKitLSPClient,
+    uri: DocumentURI,
+    positions: DocumentPositions,
+    start: String,
+    cursor: String,
+    insertEnd: String,
+    replaceEnd: String,
+    matching isMatchingCompletion: (CompletionItem) -> Bool,
+    expectedNewText: String? = nil,
+    expectedNewTextContains: String? = nil,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions[cursor])
+    )
+    let completion = try XCTUnwrap(
+      completions.items.first(where: isMatchingCompletion),
+      "No matching completion item",
+      file: file,
+      line: line
+    )
+    guard case let .insertReplaceEdit(edit)? = completion.textEdit else {
+      XCTFail("Expected insert-replace edit", file: file, line: line)
+      return
+    }
+    XCTAssertEqual(edit.insert, positions[start]..<positions[insertEnd], file: file, line: line)
+    XCTAssertEqual(edit.replace, positions[start]..<positions[replaceEnd], file: file, line: line)
+    if let expectedNewText {
+      XCTAssertEqual(edit.newText, expectedNewText, file: file, line: line)
+    }
+    if let expectedNewTextContains {
+      XCTAssertTrue(edit.newText.contains(expectedNewTextContains), file: file, line: line)
+    }
+  }
+
+  func testCompletionWithExistingArgumentsAndKeywordAsIdentifier() async throws {
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      func selfTest(x: Int, y: Int) {}
+
+      func test() {
+        1️⃣self2️⃣(x: 5, y: 3)
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+    let completion = try XCTUnwrap(completions.items.first { $0.label.contains("selfTest") })
+    guard case let .textEdit(textEdit)? = completion.textEdit else {
+      XCTFail("Expected text edit")
+      return
+    }
+    XCTAssertEqual(textEdit.range, positions["1️⃣"]..<positions["2️⃣"])
+    XCTAssertEqual(textEdit.newText, "selfTest")
   }
 }
 


### PR DESCRIPTION
This PR implements two closely related features for code completion. 

## `InsertReplaceEdit` Support
First, it adds support for [`InsertReplaceEdit`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#insertReplaceEdit) allowing the user to choose between inserting (Enter in VSCode) the function name or replacing (Tab in VSCode) the existing rest of the identifier if the completion was invoked in the middle of an identifier. This often happens when changing which function is called. Example showing the difference:

https://github.com/user-attachments/assets/77e34a8d-6444-4dcd-8ea7-a7ee501d2294

## Reusing Existing Parentheses

The second feature this PR implements is not inserting parentheses or braces if they are already present in the document. This is useful in general, but was especially needed for the use case of changing which function is called. This example shows what happens with just the `InsertReplaceEdit` changes:


https://github.com/user-attachments/assets/b9bf1921-68ef-4fd4-b0ed-7040fe7c97b0

Compare this to the behavior when using the changes from both commits:

https://github.com/user-attachments/assets/abb41db1-c969-4f66-be07-827a7fcf8151

Below is an example of the general case of completing a function call with already present parentheses. Previously, the parentheses and argument labels would always be inserted and the user would end up with `testabc(x: , y: )(x: 3, y: 5)`.

https://github.com/user-attachments/assets/ed39ae5e-0aeb-4b02-8038-57d4df975c5d

If the parentheses already contain arguments, they are kept, even if the labels don't match the function call. I also thought about using an `InsertReplaceEdit` to let the user decide whether to replace the arguments or keep the existing ones. This however leads to a problem in situations like this: `foo|bar(x: 1, y: 2)`. Here, the replace operation could be for replacing just `bar` or replacing `bar(x: 1, y: 2)`. I also could not find another language server that does it that way, so I opted for not implementing this for now. But then again, no other language (that I know of) has mandatory argument labels where autocomplete is a real benefit. In Rust for example, the only benefit of autocomplete in this case would be inserting the commas between the arguments.

If the parentheses are empty, they are overwritten with the argument labels:

https://github.com/user-attachments/assets/cf852ae2-0095-4124-babd-2fc7f3ff8ff0

While this feature was primarily intended for the use case of completing function calls, I also ensured that it works for other similar cases, like enum case completion and macros.

