### PR TITLE
Fix task leaks in TaskScheduler shutdown

### DIFF
--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -459,7 +459,8 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
   /// After `shutDown` has been called, no more tasks will be executed on this `TaskScheduler`.
   package func shutDown() async {
     self.isShutDown = true
-    await self.currentlyExecutingTasks.concurrentForEach { task in
+    let allTasks = self.currentlyExecutingTasks + self.pendingTasks
+    await allTasks.concurrentForEach { task in
       task.cancel()
       do {
         try await withTimeout(.seconds(10)) {


### PR DESCRIPTION
`shutDown` only canceled `currentlyExecutingTasks`, leaving `pendingTasks` untouched. `QueuedTask` were leaked via the `self` retain cycles in with the `resultTask` closure, and the task never completes itself.

And possibly external callers awaiting `waitToFinish()` on a pending task hang forever.

Cancel pending tasks too: `task.cancel()` cancels `resultTask`, the `for await` over the stream exits immediately on cancellation, and `waitToFinish()` returns immediately.

(In reality, I don't believe this affects anything because we only shutdown `SourceKitLSPServer` when process exits)