### PR TITLE
TaskScheduler: use the actual initial priority for handler baseline

### DIFF
--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -201,7 +201,7 @@ package actor QueuedTask<TaskDescription: TaskDescriptionProtocol> {
 
     self.resultTask = Task.detached(priority: priority) {
       await withTaskCancellationHandler {
-        await withTaskPriorityChangedHandler(initialPriority: self.priority) {
+        await withTaskPriorityChangedHandler(initialPriority: priority) {
           for await task in executionTaskCreatedStream {
             switch await task.valuePropagatingCancellation {
             case .cancelledToBeRescheduled:


### PR DESCRIPTION
`QueuedTask.resultTask` passed `self.priority` as `initialPriority` to `withTaskPriorityChangedHandler`. If `elevatePriority(to:)` ran before `resultTask`'s body started (e.g. the detached task hadn't been scheduled yet), `self.priority` was already set to the elevated value, so the polling baseline matched `Task.currentPriority` and `taskPriorityChanged` never fired. The callback is what calls `poke()`, so the scheduler never re-evaluated the elevated task and it could stall until an upstream 180s timeout cancelled the chain.

Use the captured `priority` parameter instead. It matches the priority that `Task.detached(priority: priority)` uses to launch the resultTask and isn't subject to mutation by `elevatePriority`.