### PR TITLE
[6.4] TaskScheduler: use the actual initial priority for handler baseline

### DIFF
--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -200,7 +200,7 @@ package actor QueuedTask<TaskDescription: TaskDescriptionProtocol> {
 
     self.resultTask = Task.detached(priority: priority) {
       await withTaskCancellationHandler {
-        await withTaskPriorityChangedHandler(initialPriority: self.priority) {
+        await withTaskPriorityChangedHandler(initialPriority: priority) {
           for await task in executionTaskCreatedStream {
             switch await task.valuePropagatingCancellation {
             case .cancelledToBeRescheduled:


### PR DESCRIPTION
Cherry-pick #2681 into `release/6.4.x`


* **Explanation**: `QueuedTask.init` passed `self.priority` to `withTaskPriorityChangedHandler` as `initialPriority`. If `elevatePriority(to:)` ran before `resultTask`'s detached body started executing, `self.priority` had already been mutated to the elevated value, so the polling baseline matched `Task.currentPriority` on the first poll and `taskPriorityChanged` was never called. That callback is what calls `TaskScheduler.poke()`, so without it the scheduler never re-evaluated the now-elevated task and it could stall until an upstream 180s `withTimeout` timed out. The fix uses the immutable `priority` parameter — the same value `Task.detached(priority: priority)` uses to launch the task — so the baseline reflects the actual launch priority and the polling handler can detect any subsequent elevation.
* **Scope**: Background indexing task scheduling
* **Risk**: Low. Single-line change to how the polling baseline is computed. In the non-racing case `priority == self.priority` at init time, so behavior is unchanged. The `self.priority = Task.currentPriority` write inside the `taskPriorityChanged` callback keeps `self.priority` in sync after detection.
* **Issues**: rdar://178006261
* **Testing**: Existing `TaskScheduler` tests pass; the race itself is timing-dependent and reproduces only under CI load, so verification relies on a loaded-CI run that previously reproduced the failures clearing up.
* **Reviewer**: Hamish Knight (@hamishknight)