### PR TITLE
Add diagnostic logging for indexing scheduling investigation

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -698,6 +698,9 @@ package final actor SemanticIndexManager {
       }
       self.indexProgressStatusDidChange()
     }
+    logger.debug(
+      "Scheduled \(preparationTask.description.forLogging) at priority \(preparationTask.priority.rawValue, privacy: .public) (caller priority \(Task.currentPriority.rawValue, privacy: .public))"
+    )
     for target in targetsToPrepare {
       // If we are preparing the same target for indexing and editor functionality, pick editor functionality as the
       // purpose because it is more significant.
@@ -795,6 +798,9 @@ package final actor SemanticIndexManager {
       }
       self.indexProgressStatusDidChange()
     }
+    logger.debug(
+      "Scheduled \(updateIndexTask.description.forLogging) at priority \(updateIndexTask.priority.rawValue, privacy: .public) (caller priority \(Task.currentPriority.rawValue, privacy: .public))"
+    )
     for fileAndOutputPath in fileAndOutputPaths {
       let fileAndTarget = FileIndexInfo(
         file: fileAndOutputPath.file,
@@ -989,6 +995,9 @@ package final actor SemanticIndexManager {
           let batches = await UpdateIndexStoreTaskDescription.batches(
             toIndex: fileInfos,
             buildServerManager: buildServerManager
+          )
+          logger.debug(
+            "indexTask: preparation finished, scheduling \(batches.count, privacy: .public) update-indexstore batches at priority \(Task.currentPriority.rawValue, privacy: .public)"
           )
           for (target, language, fileBatch) in batches {
             taskGroup.addTask {

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -202,6 +202,11 @@ package actor QueuedTask<TaskDescription: TaskDescriptionProtocol> {
     self.resultTask = Task.detached(priority: priority) {
       await withTaskCancellationHandler {
         await withTaskPriorityChangedHandler(initialPriority: priority) {
+          withLoggingSubsystemAndScope(subsystem: taskSchedulerSubsystem, scope: nil) {
+            logger.debug(
+              "resultTask started for \(self.description.forLogging) (stored priority \(self.priority.rawValue), runtime priority \(Task.currentPriority.rawValue))"
+            )
+          }
           for await task in executionTaskCreatedStream {
             switch await task.valuePropagatingCancellation {
             case .cancelledToBeRescheduled:
@@ -550,6 +555,11 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
         // When the next task finishes, it calls `poke` again.
         // If a low priority task's priority gets elevated that task's priority will get elevated, which will call
         // `poke`.
+        withLoggingSubsystemAndScope(subsystem: taskSchedulerSubsystem, scope: nil) {
+          logger.debug(
+            "Cannot schedule \(task.description.forLogging) at priority \(task.priority.rawValue) (executing: \(self.currentlyExecutingTasks.count), pending: \(self.pendingTasks.count))"
+          )
+        }
         return
       }
       let dependencies = task.description.dependencies(to: currentlyExecutingTasks.map(\.description))


### PR DESCRIPTION
After repeated CI issues where indexing tasks seems to stall in the scheduling pipeline, debug log:

- when scheduleIndexing reaches the post-preparation withTaskGroup
- when schedulePreparation creates a QueuedTask, with priorities
- when updateIndexStore creates a QueuedTask, with priorities
- when poke() rejects a pending task because of budget
- when QueuedTask.resultTask body starts, capturing both the stored and runtime priorities to detect priority elevation races

Together these distinguish whether the indexTask body wedged, a QueuedTask was never created, priority escalation never fired poke() to retry, or the resultTask body started after an elevation had already happened.