### PR TITLE
Fix build failures in a different build environment

### DIFF
--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -344,7 +344,7 @@ package final actor UncheckedIndex: Sendable {
   /// The set of unit output paths that are currently registered in the underlying `IndexStoreDB`.
   private var unitOutputPaths: Set<String> = []
 
-  package init?(_ index: IndexStoreDB?, usesExplicitOutputPaths: Bool) {
+  package init?(_ index: sending IndexStoreDB?, usesExplicitOutputPaths: Bool) {
     guard let index else {
       return nil
     }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -262,13 +262,13 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
           hooks: hooks.indexHooks,
           indexTaskScheduler: indexTaskScheduler,
           preparationBatchingStrategy: options.preparationBatchingStrategy,
-          logMessageToIndexLog: {
+          logMessageToIndexLog: { [weak sourceKitLSPServer] in
             sourceKitLSPServer?.logMessageToIndexLog(message: $0, type: $1, structure: $2)
           },
-          indexTasksWereScheduled: {
+          indexTasksWereScheduled: { [weak sourceKitLSPServer] in
             sourceKitLSPServer?.indexProgressManager.indexTasksWereScheduled(count: $0)
           },
-          indexProgressStatusDidChange: {
+          indexProgressStatusDidChange: { [weak sourceKitLSPServer] in
             sourceKitLSPServer?.indexProgressManager.indexProgressStatusDidChange()
           }
         )
@@ -399,7 +399,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
         [weak sourceKitLSPServer] (initializationData, mainFilesChangedCallback) -> (any MainFilesProvider)? in
         await createIndex(
           initializationData: initializationData,
-          indexChangedCallback: {
+          indexChangedCallback: { [weak sourceKitLSPServer] in
             // Notify that main files may have changed.
             await mainFilesChangedCallback()
 


### PR DESCRIPTION

* **`Workspace`: explicit weak captures**
  The outer `Task` in `Workspace.init` captures `sourceKitLSPServer` weakly, which makes it a `var` inside the closure. Three inner `@Sendable` closures captured it implicitly, which triggers the `SendableClosureCaptures` diagnostic in compilers without `ImmutableWeakCaptures` enabled. Add explicit `[weak sourceKitLSPServer]` capture lists so each inner closure binds to a fresh weak local instead of the enclosing `var`.

* **`UncheckedIndex`: `sending` parameter**
  `ThreadSafeBox.init` requires `consuming sending Value`. The `IndexStoreDB?` parameter on `UncheckedIndex.init` wasn't marked `sending`, so callers couldn't satisfy the region-isolation requirement under stricter build configurations and the call site failed with `SendingRisksDataRace`. Mark the parameter as `sending` to propagate the requirement up to the call site, where the freshly-constructed `IndexStoreDB` is naturally region-isolated.