### PR TITLE
Document the 'Add Explicit Raw Values' refactoring action

### DIFF
--- a/Documentation/Refactoring Actions.md
+++ b/Documentation/Refactoring Actions.md
@@ -81,6 +81,7 @@ The specific refactorings available depend on what code is selected or where the
 | **Move To Extension** | Select one or more member declarations inside a type which aren't stored properties |
 | **Convert To Computed Property** | Select a variable declaration with an initializer |
 | **Expand 'some' parameters to generic parameters** | Cursor on a function declaration using `some` opaque parameter types |
+| **Add Explicit Raw Values** | Cursor on an enum with an integer or `String` raw value type where some cases lack explicit raw values |
 
 ### Source Organization
 


### PR DESCRIPTION
follow-up to #2668: adds the 'Add Explicit Raw Values' code action to Documentation/Refactoring Actions.md, under Types and Protocols.