### PR TITLE
TSCExtensions: make explicit truncation of values

### DIFF
--- a/Sources/TSCExtensions/Process+Run.swift
+++ b/Sources/TSCExtensions/Process+Run.swift
@@ -201,12 +201,12 @@ fileprivate extension TaskPriority {
   var windowsProcessPriority: Int32 {
     if self >= .high {
       // SourceKit-LSP’s request handling runs at `TaskPriority.high`, which corresponds to the normal priority class.
-      return NORMAL_PRIORITY_CLASS
+      return Int32(NORMAL_PRIORITY_CLASS)
     }
     if self >= .medium {
-      return BELOW_NORMAL_PRIORITY_CLASS
+      return Int32(BELOW_NORMAL_PRIORITY_CLASS)
     }
-    return IDLE_PRIORITY_CLASS
+    return Int32(IDLE_PRIORITY_CLASS)
   }
   #else
   var posixProcessPriority: Int32 {


### PR DESCRIPTION
We are silently truncating the values here as these are canonially typed as `DWORD`, i.e. `UInt32`. The conversion to `Int32` is therefore truncating the value. Make this explicit to allow building with changes to the compiler to import windows constants with canonical types.