### PR TITLE
Update testDeploymentTargetSwift to use a newer deployment target

### DIFF
--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -713,10 +713,10 @@ struct SwiftPMBuildServerTests {
         files: [
           "pkg/Sources/lib/a.swift": "",
           "pkg/Package.swift": """
-          // swift-tools-version:5.0
+          // swift-tools-version:5.7
           import PackageDescription
           let package = Package(name: "a",
-            platforms: [.macOS(.v10_13)],
+            platforms: [.macOS(.v13)],
             targets: [.target(name: "lib")]
           )
           """,
@@ -748,7 +748,7 @@ struct SwiftPMBuildServerTests {
       #if os(macOS)
       try await expectArgumentsContain(
         "-target",
-        hostTriple.tripleString(forPlatformVersion: "10.13"),
+        hostTriple.tripleString(forPlatformVersion: "13.0"),
         arguments: arguments
       )
       #else


### PR DESCRIPTION
Update the deployment target used by this test to avoid unnecessary rev lock with https://github.com/swiftlang/swift-package-manager/pull/10191