### PR TITLE
[6.4] Update testDeploymentTargetSwift to use a newer deployment target

### DIFF
--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -712,10 +712,10 @@ struct SwiftPMBuildServerTests {
         files: [
           "pkg/Sources/lib/a.swift": "",
           "pkg/Package.swift": """
-          // swift-tools-version:5.0
+          // swift-tools-version:5.7
           import PackageDescription
           let package = Package(name: "a",
-            platforms: [.macOS(.v10_13)],
+            platforms: [.macOS(.v13)],
             targets: [.target(name: "lib")]
           )
           """,
@@ -747,7 +747,7 @@ struct SwiftPMBuildServerTests {
       #if os(macOS)
       try await expectArgumentsContain(
         "-target",
-        hostTriple.tripleString(forPlatformVersion: "10.13"),
+        hostTriple.tripleString(forPlatformVersion: "13.0"),
         arguments: arguments
       )
       #else


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/sourcekit-lsp/pull/2690 into release/6.4.x

Explanation: Update a test to avoid conflicts with https://github.com/swiftlang/swift-package-manager/pull/10191, which updates PackageDescription for macOS 27 aligned SDKs.
Scope: Test-only change
Risk: Low, trivial test change
Testing: Existing tests
Reviewer: @ahoppen @rintaro 