### PR TITLE
Use Mutex directly instead of ThreadSafeBox  for class/actor stored properties

### DIFF
--- a/Sources/DocumentationLanguageService/DocCReferenceResolutionService.swift
+++ b/Sources/DocumentationLanguageService/DocCReferenceResolutionService.swift
@@ -18,7 +18,7 @@ import IndexStoreDB
 import SemanticIndex
 @_spi(Linkcompletion) @preconcurrency import SwiftDocC
 import SwiftExtensions
-@_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
+import Synchronization
 
 final class DocCReferenceResolutionService: DocumentationService, Sendable {
   /// The message type that this service accepts.
@@ -29,7 +29,7 @@ final class DocCReferenceResolutionService: DocumentationService, Sendable {
 
   static let handlingTypes = [symbolResolutionMessageType]
 
-  private let contextMap = ThreadSafeBox<[String: DocCReferenceResolutionContext]>(initialValue: [:])
+  private let contextMap: Mutex<[String: DocCReferenceResolutionContext]> = Mutex([:])
 
   init() {}
 
@@ -42,7 +42,7 @@ final class DocCReferenceResolutionService: DocumentationService, Sendable {
   }
 
   func context(forKey key: String) -> DocCReferenceResolutionContext? {
-    contextMap.value[key]
+    contextMap.withLock { $0[key] }
   }
 
   func process(

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -67,7 +67,7 @@ private struct NotificationTimeoutError: Error, CustomStringConvertible {
 /// `AsyncStream.Iterator.next` is cancelled and we want to be able to wait for new notifications even if waiting for a
 /// a previous notification timed out.
 final class PendingNotifications: Sendable {
-  private let values = ThreadSafeBox<[any NotificationType]>(initialValue: [])
+  private let values: Mutex<[any NotificationType]> = Mutex([])
 
   nonisolated func add(_ value: any NotificationType) {
     values.withLock { $0.insert(value, at: 0) }
@@ -124,8 +124,7 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
   ///
   /// `isOneShort` if the request handler should only serve a single request and should be removed from
   /// `requestHandlers` after it has been called.
-  private let requestHandlers: ThreadSafeBox<[(requestHandler: any Sendable, isOneShot: Bool)]> =
-    ThreadSafeBox(initialValue: [])
+  private let requestHandlers: Mutex<[(requestHandler: any Sendable, isOneShot: Bool)]> = Mutex([])
 
   /// A closure that is called when the `TestSourceKitLSPClient` is destructed.
   ///

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -16,6 +16,7 @@ package import Foundation
 @_spi(SourceKitLSP) package import LanguageServerProtocol
 @_spi(SourceKitLSP) import SKLogging
 import SwiftExtensions
+import Synchronization
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
 /// Essentially a `DocumentManager` from the `SourceKitLSP` module.
@@ -330,11 +331,11 @@ package final class CheckedIndex {
 /// calling `underlyingIndexStoreDB`) and we don't accidentally call into the `IndexStoreDB` when we wanted a
 /// `CheckedIndex`.
 package final actor UncheckedIndex: Sendable {
-  // Ideally, this would be an isolated member instead of a `ThreadSafeBox`, but that causes issues with the workarounds
+  // Ideally, this would be an isolated member instead of a `Mutex`, but that causes issues with the workarounds
   // around https://github.com/swiftlang/swift/issues/75600 when all functions become async.
-  private nonisolated let _underlyingIndexStoreDB: ThreadSafeBox<IndexStoreDB?>
+  private nonisolated let _underlyingIndexStoreDB: Mutex<IndexStoreDB?>
   package nonisolated var underlyingIndexStoreDB: IndexStoreDB? {
-    _underlyingIndexStoreDB.value
+    _underlyingIndexStoreDB.withLock { $0 }
   }
 
   /// Whether the underlying `IndexStoreDB` uses has `useExplicitOutputUnits` enabled and thus needs to receive updates
@@ -349,7 +350,7 @@ package final actor UncheckedIndex: Sendable {
       return nil
     }
     self.usesExplicitOutputPaths = usesExplicitOutputPaths
-    self._underlyingIndexStoreDB = ThreadSafeBox(initialValue: index)
+    self._underlyingIndexStoreDB = Mutex(index)
   }
 
   /// Close the index store, writing it to the `saved` directory on disk.

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -14,17 +14,20 @@ package import Csourcekitd
 package import Foundation
 @_spi(SourceKitLSP) import SKLogging
 import SwiftExtensions
+import Synchronization
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
 extension sourcekitd_api_keys: @unchecked Sendable {}
 extension sourcekitd_api_requests: @unchecked Sendable {}
 extension sourcekitd_api_values: @unchecked Sendable {}
 
-fileprivate extension ThreadSafeBox {
+fileprivate extension Mutex {
   /// If the wrapped value is `nil`, run `compute` and store the computed value. If it is not `nil`, return the stored
   /// value.
-  func computeIfNil<WrappedValue: Sendable>(compute: () -> WrappedValue) -> WrappedValue where Value == WrappedValue? {
-    return withLock { (value: inout WrappedValue?) -> WrappedValue in
+  borrowing func computeIfNil<WrappedValue: Sendable>(
+    compute: () -> WrappedValue
+  ) -> WrappedValue where Value == WrappedValue? {
+    return withLock { value in
       if let value {
         return value
       }
@@ -140,7 +143,7 @@ package actor SourceKitD {
   ///
   /// These need to be computed dynamically so that a client has the chance to register a UID handler between the
   /// initialization of the SourceKit plugin and the first request being handled by it.
-  private let _keys: ThreadSafeBox<sourcekitd_api_keys?> = ThreadSafeBox(initialValue: nil)
+  private let _keys: Mutex<sourcekitd_api_keys?> = Mutex(nil)
   package nonisolated var keys: sourcekitd_api_keys {
     _keys.computeIfNil { sourcekitd_api_keys(api: self.api) }
   }
@@ -149,7 +152,7 @@ package actor SourceKitD {
   ///
   /// These need to be computed dynamically so that a client has the chance to register a UID handler between the
   /// initialization of the SourceKit plugin and the first request being handled by it.
-  private let _requests: ThreadSafeBox<sourcekitd_api_requests?> = ThreadSafeBox(initialValue: nil)
+  private let _requests: Mutex<sourcekitd_api_requests?> = Mutex(nil)
   package nonisolated var requests: sourcekitd_api_requests {
     _requests.computeIfNil { sourcekitd_api_requests(api: self.api) }
   }
@@ -158,7 +161,7 @@ package actor SourceKitD {
   ///
   /// These need to be computed dynamically so that a client has the chance to register a UID handler between the
   /// initialization of the SourceKit plugin and the first request being handled by it.
-  private let _values: ThreadSafeBox<sourcekitd_api_values?> = ThreadSafeBox(initialValue: nil)
+  private let _values: Mutex<sourcekitd_api_values?> = Mutex(nil)
   package nonisolated var values: sourcekitd_api_values {
     _values.computeIfNil { sourcekitd_api_values(api: self.api) }
   }

--- a/Sources/SourceKitD/dlopen.swift
+++ b/Sources/SourceKitD/dlopen.swift
@@ -12,7 +12,7 @@
 
 @_spi(SourceKitLSP) import SKLogging
 import SwiftExtensions
-@_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
+import Synchronization
 
 #if os(Windows)
 import CRT
@@ -48,14 +48,14 @@ package final class DLHandle: Sendable {
   }
   #endif
 
-  fileprivate let rawValue: ThreadSafeBox<Handle?>
+  fileprivate let rawValue: Mutex<Handle?>
 
   fileprivate init(rawValue: Handle) {
-    self.rawValue = .init(initialValue: rawValue)
+    self.rawValue = Mutex(rawValue)
   }
 
   deinit {
-    if rawValue.value != nil {
+    if rawValue.withLock({ $0 != nil }) {
       logger.fault("DLHandle must be closed or explicitly leaked before destroying")
     }
   }
@@ -129,11 +129,11 @@ package func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {
 
 package func dlsym<T>(_ handle: DLHandle, symbol: String) -> T? {
   #if os(Windows)
-  guard let ptr = GetProcAddress(handle.rawValue.value!.handle, symbol) else {
+  guard let ptr = handle.rawValue.withLock({ GetProcAddress($0!.handle, symbol) }) else {
     return nil
   }
   #else
-  guard let ptr = dlsym(handle.rawValue.value!.handle, symbol) else {
+  guard let ptr = handle.rawValue.withLock({ dlsym($0!.handle, symbol) }) else {
     return nil
   }
   #endif

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -17,7 +17,7 @@ package import SKUtilities
 import SemanticIndex
 import SwiftExtensions
 package import SwiftSyntax
-@_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
+import Synchronization
 
 /// An immutable snapshot of a document at a given time.
 ///
@@ -93,8 +93,8 @@ package final class DocumentManager: InMemoryDocumentManager, Sendable {
     case missingDocument(DocumentURI)
   }
 
-  // Documents storage, protected by a `ThreadSafeBox` to ensure thread safety without making APIs async.
-  private let documents: ThreadSafeBox<[DocumentURI: Document]> = ThreadSafeBox(initialValue: [:])
+  // Documents storage, protected by a `Mutex` to ensure thread safety without making APIs async.
+  private let documents: Mutex<[DocumentURI: Document]> = Mutex([:])
 
   package init() {}
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -23,6 +23,7 @@ package import SKOptions
 import SemanticIndex
 import SourceKitD
 import SwiftExtensions
+import Synchronization
 package import ToolchainRegistry
 @_spi(SourceKitLSP) package import ToolsProtocolsSwiftExtensions
 
@@ -61,9 +62,9 @@ package actor SourceKitLSPServer {
   /// Initialization can be awaited using `waitUntilInitialized`.
   private var initialized: Bool = false
 
-  private let _options: ThreadSafeBox<SourceKitLSPOptions>
+  private let _options: Mutex<SourceKitLSPOptions>
   nonisolated package var options: SourceKitLSPOptions {
-    _options.value
+    _options.withLock { $0 }
   }
 
   package let hooks: Hooks
@@ -173,7 +174,7 @@ package actor SourceKitLSPServer {
   ) {
     self.toolchainRegistry = toolchainRegistry
     self.languageServiceRegistry = languageServerRegistry
-    self._options = ThreadSafeBox(initialValue: options)
+    self._options = Mutex(options)
     self.hooks = hooks
     self.onExit = onExit
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -20,6 +20,7 @@ import IndexStoreDB
 import SKOptions
 package import SemanticIndex
 import SwiftExtensions
+import Synchronization
 import TSCExtensions
 import ToolchainRegistry
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
@@ -176,8 +177,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   let languageServiceRegistry: LanguageServiceRegistry
 
   /// Language service instances owned by this workspace, keyed by service type.
-  private let languageServiceInstances: ThreadSafeBox<[LanguageServiceType: [any LanguageService]]> =
-    ThreadSafeBox(initialValue: [:])
+  private let languageServiceInstances: Mutex<[LanguageServiceType: [any LanguageService]]> = Mutex([:])
 
   /// The source code index, if available.
   ///
@@ -199,12 +199,11 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   }
 
   /// Language service for an open document, if available.
-  private let languageServicesForOpenDocument: ThreadSafeBox<[DocumentURI: [any LanguageService]]> =
-    ThreadSafeBox(initialValue: [:])
+  private let languageServicesForOpenDocument: Mutex<[DocumentURI: [any LanguageService]]> = Mutex([:])
 
   /// All language services that are registered with this workspace.
   var allLanguageServices: [any LanguageService] {
-    return languageServiceInstances.value.values.flatMap { $0 }
+    return languageServiceInstances.withLock { $0.values.flatMap { $0 } }
   }
 
   /// The task that constructs the `SemanticIndexManager`, which keeps track of whose file's index is up-to-date in the
@@ -477,8 +476,10 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     _ serviceType: any LanguageService.Type,
     toolchain: Toolchain
   ) -> (any LanguageService)? {
-    languageServiceInstances.value[LanguageServiceType(serviceType)]?.first {
-      $0.canHandle(toolchain: toolchain)
+    languageServiceInstances.withLock { instances in
+      instances[LanguageServiceType(serviceType)]?.first {
+        $0.canHandle(toolchain: toolchain)
+      }
     }
   }
 
@@ -543,7 +544,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     for uri: DocumentURI,
     _ language: Language
   ) async -> [any LanguageService] {
-    if let cached = languageServicesForOpenDocument.value[uri.buildSettingsFile] {
+    if let cached = languageServicesForOpenDocument.withLock({ $0[uri.buildSettingsFile] }) {
       return cached
     }
 
@@ -595,7 +596,7 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
   /// Callers should try to merge the results from the different language services or prefer results
   /// from language services that occur earlier in this array, whichever is more suitable.
   package func languageServices(forOpenDocument uri: DocumentURI) -> [any LanguageService] {
-    return languageServicesForOpenDocument.value[uri.buildSettingsFile] ?? []
+    return languageServicesForOpenDocument.withLock { $0[uri.buildSettingsFile] } ?? []
   }
 
   /// The primary language service for an open document.

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -14,6 +14,7 @@ package import Foundation
 import RegexBuilder
 @_spi(SourceKitLSP) import SKLogging
 import SwiftExtensions
+import Synchronization
 import TSCExtensions
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
@@ -108,7 +109,7 @@ public final class Toolchain: Sendable {
   /// The path to the indexstore library if available.
   package let libIndexStore: URL?
 
-  private let swiftVersionTask = ThreadSafeBox<Task<SwiftVersion, any Error>?>(initialValue: nil)
+  private let swiftVersionTask: Mutex<Task<SwiftVersion, any Error>?> = Mutex(nil)
 
   /// The Swift version installed in the toolchain. Throws an error if the version could not be parsed or if no Swift
   /// compiler is installed in the toolchain.


### PR DESCRIPTION
`ThreadSafeBox` is a `class` wrapping a `Mutex<Value>`. When stored as a property of another class or actor, the outer reference type already provides identity, so the extra indirection is just a redundant heap allocation. Replace `ThreadSafeBox<T>` with `Mutex<T>` at those sites.

Port `SourceKitD`'s fileprivate `computeIfNil` extension from `ThreadSafeBox` to `Mutex` (now `borrowing`).