### PR TITLE
Release in-flight QueuedTasks when TaskScheduler.shutDown returns

### DIFF
--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -465,6 +465,13 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
   package func shutDown() async {
     self.isShutDown = true
     let allTasks = self.currentlyExecutingTasks + self.pendingTasks
+    // Drop `QueuedTask` references from the scheduler's storage now (the local `allTasks`
+    // continues to hold them while we await cancellation), so the `TaskDescription`s they hold —
+    // and anything those descriptions transitively retain (`BuildServerManager`,
+    // `SemanticIndexManager`, `ToolchainRegistry`) — can be deallocated even if a `waitToFinish`
+    // below times out, and so the actor's storage is free of stale entries before we yield.
+    self.currentlyExecutingTasks.removeAll()
+    self.pendingTasks.removeAll()
     await allTasks.concurrentForEach { task in
       task.cancel()
       do {


### PR DESCRIPTION
`TaskScheduler.shutDown()` cancelled and waited for in-flight tasks but never emptied `currentlyExecutingTasks` / `pendingTasks`. That left a retain cycle through the scheduler's own queues:

```
  TaskScheduler.{currentlyExecuting,pending}Tasks
    → QueuedTask
      → executionStateChangedCallback (captures self of SemanticIndexManager)
        → SemanticIndexManager.indexTaskScheduler
          → TaskScheduler
```

Once the external strong refs went away (`SourceKitLSPServer.indexTaskScheduler` and `Workspace.semanticIndexManagerTask`) the cycle kept both `TaskScheduler` and `SemanticIndexManager` rooted, which transitively kept `BuildServerManager`, the per-task `UpToDateTracker`s, `ToolchainRegistry`, and assorted caches alive.
