### PR TITLE
Drop new tasks scheduled after TaskScheduler.shutDown

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -698,6 +698,10 @@ package final actor SemanticIndexManager {
       }
       self.indexProgressStatusDidChange()
     }
+    guard let preparationTask else {
+      // The task scheduler has been shut down.
+      return nil
+    }
     logger.debug(
       "Scheduled \(preparationTask.description.forLogging) at priority \(preparationTask.priority.rawValue, privacy: .public) (caller priority \(Task.currentPriority.rawValue, privacy: .public))"
     )
@@ -797,6 +801,10 @@ package final actor SemanticIndexManager {
         }
       }
       self.indexProgressStatusDidChange()
+    }
+    guard let updateIndexTask else {
+      // The task scheduler has been shut down.
+      return
     }
     logger.debug(
       "Scheduled \(updateIndexTask.description.forLogging) at priority \(updateIndexTask.priority.rawValue, privacy: .public) (caller priority \(Task.currentPriority.rawValue, privacy: .public))"

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -425,6 +425,9 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
 
   /// Enqueue a new task to be executed.
   ///
+  /// Returns `nil` if the scheduler has already been shut down via `shutDown()`; the task is
+  /// not queued in that case.
+  ///
   /// - Important: A task that is scheduled by `TaskScheduler` must never be awaited from a task that runs on
   ///   `TaskScheduler`. Otherwise we might end up in deadlocks, eg. if the inner task cannot be scheduled because the
   ///   outer task is claiming all execution slots in the `TaskScheduler`.
@@ -435,7 +438,12 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
     @_inheritActorContext executionStateChangedCallback: (
       @Sendable (QueuedTask<TaskDescription>, TaskExecutionState) async -> Void
     )? = nil
-  ) async -> QueuedTask<TaskDescription> {
+  ) async -> QueuedTask<TaskDescription>? {
+    if isShutDown {
+      // The scheduler has been shut down — refuse new work. `poke` no longer drains
+      // `pendingTasks` once `isShutDown == true`, so there is no point in queueing.
+      return nil
+    }
     let queuedTask = await QueuedTask(
       priority: priority ?? Task.currentPriority,
       description: taskDescription,

--- a/Tests/SemanticIndexTests/TaskSchedulerTests.swift
+++ b/Tests/SemanticIndexTests/TaskSchedulerTests.swift
@@ -515,7 +515,10 @@ fileprivate extension TaskScheduler<ClosureTaskDescription> {
     )
     // Make sure that we call `schedule` outside of the `Task` because the execution order of `Task`s is not guaranteed
     // and if we called `schedule` inside `Task`, Swift concurrency can re-order the order that we schedule tasks in.
-    let queuedTask = await self.schedule(priority: priority, taskDescription)
+    // The scheduler is never shut down before this call within these tests, so `schedule` always returns a value.
+    guard let queuedTask = await self.schedule(priority: priority, taskDescription) else {
+      preconditionFailure("Scheduler was unexpectedly shut down")
+    }
     return Task(priority: priority) {
       await queuedTask.waitToFinishPropagatingCancellation()
     }


### PR DESCRIPTION
Follow-up to #2699. That PR drained the queues at shutdown but did not stop new work from being scheduled afterwards.

After a preparation task completes (or is cancelled), `SemanticIndexManager.scheduleIndexing` continues and schedules an `UpdateIndexStoreTaskDescription` via `indexTaskScheduler.schedule(...)`. If that `schedule()` call lands after `shutDown()` has cleared the arrays, the new `QueuedTask` goes into `pendingTasks` and leaks.

Make `schedule()` return `nil` when the scheduler is already shut down, and update the two `SemanticIndexManager` call sites to bail out on `nil`. 