### PR TITLE
Replace version-0 sentinel on DocumentSnapshot with explicit Origin

### DIFF
--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -26,6 +26,20 @@ import Synchronization
 /// ``Document``. The purpose of a ``DocumentSnapshot`` is to be able to work
 /// with one version of a document without having to think about it changing.
 package struct DocumentSnapshot: Identifiable, Sendable {
+  /// How a `DocumentSnapshot` was produced. Determines whether the `version` is a real LSP
+  /// version supplied by the client (in which case it tracks content changes monotonically) or a
+  /// placeholder for content that is not tracked by the LSP lifecycle.
+  package enum Origin: Sendable {
+    /// Tracked by `DocumentManager` for an open document. `version` is the LSP version supplied
+    /// by the client.
+    case openDocument
+    /// Read from disk (or another file-system source). `version` is a placeholder and does not
+    /// track content changes.
+    case fromDisk
+    /// Synthesized content (macro expansion, generated interface, …). `version` is a placeholder.
+    case generated
+  }
+
   /// An ID that uniquely identifies the version of the document stored in this
   /// snapshot.
   package struct ID: Hashable, Comparable, Sendable {
@@ -45,6 +59,7 @@ package struct DocumentSnapshot: Identifiable, Sendable {
   package let id: ID
   package let language: Language
   package let lineTable: LineTable
+  package let origin: Origin
 
   package var uri: DocumentURI { id.uri }
   package var version: Int { id.version }
@@ -54,11 +69,13 @@ package struct DocumentSnapshot: Identifiable, Sendable {
     uri: DocumentURI,
     language: Language,
     version: Int,
-    lineTable: LineTable
+    lineTable: LineTable,
+    origin: Origin
   ) {
     self.id = ID(uri: uri, version: version)
     self.language = language
     self.lineTable = lineTable
+    self.origin = origin
   }
 }
 
@@ -81,7 +98,8 @@ package final class Document {
       uri: self.uri,
       language: self.language,
       version: latestVersion,
-      lineTable: latestLineTable
+      lineTable: latestLineTable,
+      origin: .openDocument
     )
   }
 }

--- a/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
@@ -31,6 +31,6 @@ package extension DocumentSnapshot {
   /// Throws an error if the file could not be read.
   init(withContentsFromDisk url: URL, language: Language) throws {
     let contents = try String(contentsOf: url, encoding: .utf8)
-    self.init(uri: DocumentURI(url), language: language, version: 0, lineTable: LineTable(contents))
+    self.init(uri: DocumentURI(url), language: language, version: 0, lineTable: LineTable(contents), origin: .fromDisk)
   }
 }

--- a/Sources/SourceKitLSP/OnDiskDocumentManager.swift
+++ b/Sources/SourceKitLSP/OnDiskDocumentManager.swift
@@ -48,7 +48,8 @@ package actor OnDiskDocumentManager {
       uri: try DocumentURI(filePath: "\(UUID().uuidString)/\(fileURL.filePath)", isDirectory: false),
       language: language,
       version: 0,
-      lineTable: LineTable(try String(contentsOf: fileURL, encoding: .utf8))
+      lineTable: LineTable(try String(contentsOf: fileURL, encoding: .utf8)),
+      origin: .fromDisk
     )
     let languageService = try await workspace.primaryLanguageService(for: uri, language)
 

--- a/Sources/SwiftLanguageService/GeneratedInterfaceManager.swift
+++ b/Sources/SwiftLanguageService/GeneratedInterfaceManager.swift
@@ -151,7 +151,8 @@ actor GeneratedInterfaceManager {
         uri: try document.uri,
         language: .swift,
         version: 0,
-        lineTable: LineTable(contents)
+        lineTable: LineTable(contents),
+        origin: .generated
       ),
       refCount: incrementingRefCount ? 1 : 0
     )

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -318,7 +318,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     switch try? ReferenceDocumentURL(from: uri) {
     case .macroExpansion(let data):
       let content = try await self.macroExpansionManager.macroExpansion(for: data)
-      return DocumentSnapshot(uri: uri, language: .swift, version: 0, lineTable: LineTable(content))
+      return DocumentSnapshot(uri: uri, language: .swift, version: 0, lineTable: LineTable(content), origin: .generated)
     case .generatedInterface(let data):
       return try await self.generatedInterfaceManager.snapshot(of: data)
     case nil:

--- a/Sources/SwiftLanguageService/TestDiscovery.swift
+++ b/Sources/SwiftLanguageService/TestDiscovery.swift
@@ -27,9 +27,9 @@ extension SwiftLanguageService {
   package func syntacticTestItems(
     for snapshot: DocumentSnapshot,
   ) async -> [AnnotatedTestItem]? {
-    // Don't use the `self.syntaxTreeManager` for snapshots with version number 0,
-    // which indicates they were loaded from disk.
-    let syntaxTreeManager = snapshot.version != 0 ? self.syntaxTreeManager : SyntaxTreeManager()
+    // Don't use the `self.syntaxTreeManager` for snapshots that aren't tracked by `DocumentManager`,
+    // because their `version` doesn't track content changes and would cause stale cache hits.
+    let syntaxTreeManager = snapshot.origin == .openDocument ? self.syntaxTreeManager : SyntaxTreeManager()
     async let swiftTestingTests = SyntacticSwiftTestingTestScanner.findTestSymbols(
       in: snapshot,
       syntaxTreeManager: syntaxTreeManager

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -74,7 +74,8 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
 
         }
         """
-      )
+      ),
+      origin: .openDocument
     )
 
     let empty = Position(line: 0, utf16index: 1)..<Position(line: 0, utf16index: 1)


### PR DESCRIPTION
`SwiftLanguageService.syntacticTestItems` used `snapshot.version == 0` as a "loaded from disk" signal to bypass the shared `syntaxTreeManager` cache. The LSP spec doesn't constrain the initial version (VS Code uses 1, 0 is legal too), so a client picking 0 would silently miss the cache for every test discovery scan.

Replace it with a required `DocumentSnapshot.Origin` (`openDocument` / `fromDisk` / `generated`). `DocumentManager` is the only `.openDocument` source; the other creators declare `.fromDisk` or `.generated`. `syntacticTestItems` branches on `origin == .openDocument`, which correctly covers both non-tracked cases.