### PR TITLE
Release SemanticIndexManager state on workspace shutdown

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -295,6 +295,37 @@ package final actor SemanticIndexManager {
     self.indexProgressStatusDidChange = indexProgressStatusDidChange
   }
 
+  /// Cancels any in-progress preparation/index Tasks and drops references to them so that
+  /// `SemanticIndexManager` (and the `TaskScheduler` it transitively retains) can be deallocated
+  /// once the workspace tears down.
+  ///
+  /// The `Task<Void, Never>` values stored in `inProgressIndexTasks` /
+  /// `fileOrBuildTargetChangedTasks` capture `self`, forming a self-cycle through these
+  /// dictionaries. The cycle is normally broken by the scheduler's per-task `.finished` callback
+  /// clearing the entry — but that callback is only invoked from `QueuedTask.execute` /
+  /// `finalizeExecution`, so a task that was paused in `pendingTasks` and cancelled by
+  /// `TaskScheduler.shutDown` without ever executing leaves its entry behind.
+  package func shutDown() {
+    for inProgress in inProgressIndexTasks.values {
+      switch inProgress.state {
+      case .creatingIndexTask:
+        break
+      case .waitingForPreparation(_, let indexTask),
+        .preparing(_, let indexTask),
+        .updatingIndexStore(_, let indexTask):
+        indexTask.cancel()
+      }
+    }
+    inProgressIndexTasks = [:]
+    inProgressPreparationTasks = [:]
+    inProgressPrepareForEditorTask?.task.cancel()
+    inProgressPrepareForEditorTask = nil
+    for task in fileOrBuildTargetChangedTasks.values {
+      task.cancel()
+    }
+    fileOrBuildTargetChangedTasks = [:]
+  }
+
   /// Regenerate the build graph (also resolving package dependencies) and then index all the source files known to the
   /// build server that don't currently have a unit with a timestamp that matches the mtime of the file.
   ///

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -672,9 +672,11 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
     finishStatus: QueuedTask<TaskDescription>.ExecutionTaskFinishStatus
   ) async {
     currentlyExecutingTasks.removeAll(where: { $0.description.id == task.description.id })
-    switch finishStatus {
-    case .terminated: break
-    case .cancelledToBeRescheduled: pendingTasks.append(task)
+    // Don't re-queue a `cancelledToBeRescheduled` task once shutdown has begun - the entry would
+    // sit in `pendingTasks` forever (since `poke` is a no-op on `isShutDown`) and keep the task
+    // (and the SemanticIndexManager its callback captures) alive past teardown.
+    if !isShutDown, case .cancelledToBeRescheduled = finishStatus {
+      pendingTasks.append(task)
     }
     self.poke()
   }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -642,8 +642,9 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     logger.info("Shutting down workspace \(self.rootUri.forLogging)")
     async let languageServiceShutdown = shutdownAllLanguageServices()
     async let buildServerShutdown = buildServerManager.shutdown()
+    async let semanticIndexShutdown = semanticIndexManager?.shutDown()
     async let indexClose = uncheckedIndex?.close()
-    _ = await (languageServiceShutdown, buildServerShutdown, indexClose)
+    _ = await (languageServiceShutdown, buildServerShutdown, semanticIndexShutdown, indexClose)
   }
 
   /// Shut down all language service instances owned by this workspace.


### PR DESCRIPTION
  Release `SemanticIndexManager` (and the `TaskScheduler` / `BuildServerManager` / `ToolchainRegistry` chain it transitively retains) when its workspace tears down. Two related retain cycles kept it alive past shutdown, surfacing as leaks in tests that exit while indexing is paused or in-flight (e.g. `testPausingBackgroundIndexingDoesNotStopPreparation`). 
  
  - Add `SemanticIndexManager.shutDown` that cancels every Task in `inProgressIndexTasks`, `inProgressPreparationTasks`, `inProgressPrepareForEditorTask`, and `fileOrBuildTargetChangedTasks`, and drops those dictionaries. Without this, a `.low`-priority `UpdateIndexStoreTaskDescription` that sat in `pendingTasks` and was cancelled by `TaskScheduler.shutDown` without ever executing left its `inProgressIndexTasks` entry behind — the entry's `indexTask` captures `self`, forming a self-cycle. The scheduler's per-task `.finished` callback normally clears the entry, but it's only fired from `QueuedTask.execute` / `finalizeExecution`. Call it from `Workspace.shutdown`.
  
  - Gate `TaskScheduler.finalizeTaskExecution`'s re-add of `.cancelledToBeRescheduled` tasks on `!isShutDown`. After `shutDown` clears `pendingTasks`, a racing `cancelToBeRescheduled` (from a `setMaxConcurrentTasksByPriority`-driven `Task.sleep` that elapses mid-shutdown) would otherwise re-populate the array. The re-added entry never drains — `poke` early-returns on `isShutDown` — and keeps the `QueuedTask` alive.
