### PR TITLE
Add "Flip operands" code action for binary expressions

### DIFF
--- a/Sources/SwiftSyntaxCodeActions/CMakeLists.txt
+++ b/Sources/SwiftSyntaxCodeActions/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(SwiftSyntaxCodeActions STATIC
   ConvertStringConcatenationToStringInterpolation.swift
   ConvertZeroParameterFunctionToComputedProperty.swift
   DeclModifierRemover.swift
+  FlipOperands.swift
   FormatRawStringLiteral.swift
   IndentationRemover.swift
   IntegerLiteralUtilities.swift

--- a/Sources/SwiftSyntaxCodeActions/FlipOperands.swifta
+++ b/Sources/SwiftSyntaxCodeActions/FlipOperands.swifta
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftRefactor
+package import SwiftSyntax
+
+/// Swaps the operands of a binary expression, flipping comparison operators to preserve semantics.
+///
+/// For comparison operators, the operator direction is also flipped:
+///
+/// ## Before
+///
+/// ```swift
+/// if 5 < count {
+///     process()
+/// }
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// if count > 5 {
+///     process()
+/// }
+/// ```
+///
+/// For commutative operators, only the operands are swapped:
+///
+/// ## Before
+///
+/// ```swift
+/// let sum = 1 + value
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// let sum = value + 1
+/// ```
+package struct FlipOperands: SyntaxRefactoringProvider {
+  /// Maps comparison operators to their direction-flipped equivalents.
+  static let comparisonFlipMap: [String: String] = [
+    "<": ">",
+    ">": "<",
+    "<=": ">=",
+    ">=": "<=",
+  ]
+
+  /// Commutative binary operators for which swapping operands preserves semantics.
+  static let commutativeOperators: Set<String> = [
+    "+", "*", "==", "!=", "===", "!==", "&&", "||", "&", "|", "^",
+  ]
+
+  package static func refactor(
+    syntax: SequenceExprSyntax,
+    in context: Void
+  ) throws -> SequenceExprSyntax {
+    guard !syntax.hasError else {
+      throw RefactoringNotApplicableError("syntax has errors")
+    }
+
+    let elements = Array(syntax.elements)
+
+    // Only handle simple binary expressions: [left, binaryOp, right]
+    guard elements.count == 3,
+      let binOp = elements[1].as(BinaryOperatorExprSyntax.self)
+    else {
+      throw RefactoringNotApplicableError("not a simple binary expression")
+    }
+
+    let opText = binOp.operator.text
+
+    let newOpText: String
+    if let flipped = comparisonFlipMap[opText] {
+      newOpText = flipped
+    } else if commutativeOperators.contains(opText) {
+      newOpText = opText
+    } else {
+      throw RefactoringNotApplicableError("'\(opText)' cannot be flipped without changing semantics")
+    }
+
+    let left = elements[0]
+    let right = elements[2]
+
+    // Swap the operands, preserving the original leading/trailing trivia positions.
+    let newLeft = right
+      .with(\.leadingTrivia, left.leadingTrivia)
+      .with(\.trailingTrivia, left.trailingTrivia)
+    let newRight = left
+      .with(\.leadingTrivia, right.leadingTrivia)
+      .with(\.trailingTrivia, right.trailingTrivia)
+    let newOp = binOp.with(\.operator.tokenKind, .binaryOperator(newOpText))
+
+    return syntax.with(
+      \.elements,
+      ExprListSyntax([newLeft, ExprSyntax(newOp), newRight])
+    )
+  }
+}

--- a/Sources/SwiftSyntaxCodeActions/SyntaxCodeActions.swift
+++ b/Sources/SwiftSyntaxCodeActions/SyntaxCodeActions.swift
@@ -27,6 +27,7 @@ package let allSyntaxCodeActions: [any SyntaxCodeActionProvider.Type] = {
     ConvertJSONToCodableStruct.self,
     ConvertStringConcatenationToStringInterpolation.self,
     ConvertZeroParameterFunctionToComputedProperty.self,
+    FlipOperands.self,
     FormatRawStringLiteral.self,
     MigrateToNewIfLetSyntax.self,
     OpaqueParameterToGeneric.self,

--- a/Sources/SwiftSyntaxCodeActions/SyntaxRefactoringCodeActionProvider.swift
+++ b/Sources/SwiftSyntaxCodeActions/SyntaxRefactoringCodeActionProvider.swift
@@ -248,6 +248,17 @@ extension ConvertZeroParameterFunctionToComputedProperty: SyntaxRefactoringCodeA
   }
 }
 
+extension FlipOperands: SyntaxRefactoringCodeActionProvider {
+  package static var title: String { "Flip operands" }
+
+  static func nodeToRefactor(in scope: SyntaxCodeActionScope) -> SequenceExprSyntax? {
+    return scope.innermostNodeContainingRange?.findParentOfSelf(
+      ofType: SequenceExprSyntax.self,
+      stoppingIf: { $0.is(CodeBlockSyntax.self) || $0.is(MemberBlockSyntax.self) }
+    )
+  }
+}
+
 //==========================================================================//
 // IMPORTANT: If you are tempted to add a new refactoring action here       //
 // please insert it in alphabetical order above                             //

--- a/Tests/SwiftSyntaxCodeActionsTests/FlipOperandsTests.swift
+++ b/Tests/SwiftSyntaxCodeActionsTests/FlipOperandsTests.swift
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftParser
+import SwiftRefactor
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxCodeActions
+import XCTest
+
+final class FlipOperandsTests: XCTestCase {
+
+  // MARK: - Comparison operators
+
+  func testFlipLessThan() throws {
+    try assertFlipOperands("5 < count", expected: "count > 5")
+  }
+
+  func testFlipGreaterThan() throws {
+    try assertFlipOperands("count > 5", expected: "5 < count")
+  }
+
+  func testFlipLessThanOrEqual() throws {
+    try assertFlipOperands("index <= limit", expected: "limit >= index")
+  }
+
+  func testFlipGreaterThanOrEqual() throws {
+    try assertFlipOperands("limit >= index", expected: "index <= limit")
+  }
+
+  // MARK: - Commutative operators
+
+  func testFlipAddition() throws {
+    try assertFlipOperands("1 + value", expected: "value + 1")
+  }
+
+  func testFlipMultiplication() throws {
+    try assertFlipOperands("2 * n", expected: "n * 2")
+  }
+
+  func testFlipEquality() throws {
+    try assertFlipOperands("x == nil", expected: "nil == x")
+  }
+
+  func testFlipInequality() throws {
+    try assertFlipOperands("x != nil", expected: "nil != x")
+  }
+
+  func testFlipLogicalAnd() throws {
+    try assertFlipOperands("a && b", expected: "b && a")
+  }
+
+  func testFlipLogicalOr() throws {
+    try assertFlipOperands("a || b", expected: "b || a")
+  }
+
+  func testFlipBitwiseOr() throws {
+    try assertFlipOperands("flags | mask", expected: "mask | flags")
+  }
+
+  func testFlipBitwiseAnd() throws {
+    try assertFlipOperands("flags & mask", expected: "mask & flags")
+  }
+
+  // MARK: - Non-flippable operators (should be unchanged)
+
+  func testPreservesSubtraction() throws {
+    try assertFlipOperands("a - b")
+  }
+
+  func testPreservesDivision() throws {
+    try assertFlipOperands("a / b")
+  }
+
+  func testPreservesRemainder() throws {
+    try assertFlipOperands("a % b")
+  }
+
+  // MARK: - Trivia preservation
+
+  func testPreservesSpacing() throws {
+    try assertFlipOperands("5  <  count", expected: "count  >  5")
+  }
+
+  func testPreservesLeadingTrivia() throws {
+    try assertFlipOperands("/* a */ 5 < count", expected: "/* a */ count > 5")
+  }
+
+  // MARK: - In context
+
+  func testFlipInIfCondition() throws {
+    try assertFlipOperands(
+      "if 5 < count { }",
+      expected: "if count > 5 { }"
+    )
+  }
+
+  func testFlipInWhileCondition() throws {
+    try assertFlipOperands(
+      "while index < limit { }",
+      expected: "while limit > index { }"
+    )
+  }
+
+  func testFlipWithComplexOperands() throws {
+    try assertFlipOperands("foo() == bar()", expected: "bar() == foo()")
+  }
+
+  func testFlipWithMemberAccess() throws {
+    try assertFlipOperands("x.count > 0", expected: "0 < x.count")
+  }
+}
+
+// MARK: - Test Helper
+
+/// Applies `FlipOperands` to all sequence expressions in the input and compares to expected.
+/// When `expected` is `nil`, asserts that the input is unchanged (refactoring not applicable).
+private func assertFlipOperands(
+  _ input: String,
+  expected: String? = nil,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) throws {
+  var parser = Parser(input)
+  let inputSyntax = SourceFileSyntax.parse(from: &parser)
+
+  let rewriter = FlipOperandsRewriter()
+  let result = rewriter.visit(inputSyntax)
+
+  if let error = rewriter.unexpectedError {
+    throw error
+  }
+
+  let resultString = result.description.trimmingCharacters(in: .newlines)
+  assertStringsEqualWithDiff(resultString, expected ?? input, file: file, line: line)
+}
+
+private class FlipOperandsRewriter: SyntaxRewriter {
+  var unexpectedError: (any Error)?
+
+  override func visit(_ node: SequenceExprSyntax) -> ExprSyntax {
+    let visited = super.visit(node)
+    guard let seq = visited.as(SequenceExprSyntax.self) else {
+      return visited
+    }
+    do {
+      return ExprSyntax(try FlipOperands.refactor(syntax: seq, in: ()))
+    } catch is RefactoringNotApplicableError {
+      return ExprSyntax(seq)
+    } catch {
+      unexpectedError = error
+      return ExprSyntax(seq)
+    }
+  }
+}


### PR DESCRIPTION
Adds a new `FlipOperands` code action that swaps the left and right operands of a binary expression.

I noticed while browsing the open issues that #2520 had been filed for this — it's a handy refactoring that I reach for pretty often when reading conditions like `if 0 < count` and wanting them the more natural way around.

**What it does:**

For comparison operators, the operator direction is flipped to preserve semantics:
```swift
// Before
if 5 < count { process() }

// After
if count > 5 { process() }
```

For commutative operators (`+`, `*`, `==`, `!=`, `===`, `!==`, `&&`, `||`, `&`, `|`, `^`), only the operands are swapped:
```swift
// Before
let sum = 1 + value

// After
let sum = value + 1
```

Operators where swapping would change semantics (`-`, `/`, `%`, etc.) are not offered.

**Implementation:**
- `FlipOperands.swift` — implements `SyntaxRefactoringProvider` on `SequenceExprSyntax`
- Wired into `SyntaxRefactoringCodeActionProvider` adapter
- Registered in `allSyntaxCodeActions`
- Tests follow the same pattern as `RemoveRedundantParenthesesTests`

**Limitation:** Only handles simple three-element sequences (one binary operator). Compound expressions like `a + b + c` aren't offered since they require operator folding to know which sub-expression to flip.

Closes #2520