### PR TITLE
Avoid opening generated interfaces for root workspace modules

### DIFF
--- a/Sources/SourceKitLSP/DefinitionLocations.swift
+++ b/Sources/SourceKitLSP/DefinitionLocations.swift
@@ -64,8 +64,7 @@ package func definitionLocations(
   languageService: any LanguageService,
   buildServerManager: BuildServerManager?
 ) async throws -> DefinitionLocationsResult {
-  // If this symbol is a module then generate a textual interface, unless the build graph says that the module is part
-  // of the root project. SourceKit-LSP has no file/range location for a module target itself in that case.
+  // If this symbol is a module then generate a textual interface
   if symbol.kind == .module {
     if let bestLocalDeclaration = symbol.bestLocalDeclaration {
       return DefinitionLocationsResult(locations: [bestLocalDeclaration])

--- a/Sources/SourceKitLSP/DefinitionLocations.swift
+++ b/Sources/SourceKitLSP/DefinitionLocations.swift
@@ -33,8 +33,8 @@ package struct DefinitionLocationsResult {
 
 /// Returns a source-backed definition location for `moduleName` if it is a module in the root SwiftPM package.
 ///
-/// Swift does not have a source declaration for a module. For a SwiftPM root target, the closest existing source-backed
-/// representation is the package manifest, which is the build server configuration file for SwiftPM workspaces.
+/// Swift does not have a source declaration for a module. For SwiftPM root targets,
+/// use the package manifest as the source-backed definition location.
 private func definitionLocationInWorkspacePackage(
   moduleName: String,
   buildServerManager: BuildServerManager?

--- a/Sources/SourceKitLSP/DefinitionLocations.swift
+++ b/Sources/SourceKitLSP/DefinitionLocations.swift
@@ -12,6 +12,7 @@
 
 package import BuildServerIntegration
 @_spi(SourceKitLSP) import BuildServerProtocol
+import Foundation
 package import IndexStoreDB
 @_spi(SourceKitLSP) package import LanguageServerProtocol
 @_spi(SourceKitLSP) import SKLogging
@@ -30,29 +31,36 @@ package struct DefinitionLocationsResult {
   }
 }
 
-/// Returns whether the build server knows `moduleName` as a root-project module.
-private func moduleIsPartOfRootProject(
+/// Returns a source-backed definition location for `moduleName` if it is a module in the root SwiftPM package.
+///
+/// Swift does not have a source declaration for a module. For a SwiftPM root target, the closest existing source-backed
+/// representation is the package manifest, which is the build server configuration file for SwiftPM workspaces.
+private func definitionLocationInWorkspacePackage(
   moduleName: String,
   buildServerManager: BuildServerManager?
-) async -> Bool? {
+) async -> Location? {
   guard let buildServerManager else {
     return nil
   }
-  return await orLog("Determining whether module belongs to root project") {
+  return await orLog("Determining source location for workspace module") {
     let sourceFiles = try await buildServerManager.sourceFiles(includeNonBuildableFiles: false)
-    var foundDependencyModule = false
     for (uri, sourceFileInfo) in sourceFiles.sorted(by: { $0.key.stringValue < $1.key.stringValue }) {
+      guard sourceFileInfo.isPartOfRootProject else {
+        continue
+      }
       for target in sourceFileInfo.targets.sorted(by: { $0.uri.stringValue < $1.uri.stringValue }) {
         guard await buildServerManager.moduleName(for: uri, in: target) == moduleName else {
           continue
         }
-        if sourceFileInfo.isPartOfRootProject {
-          return true
+        guard let packageManifest = await buildServerManager.configPath,
+          packageManifest.lastPathComponent == "Package.swift"
+        else {
+          return nil
         }
-        foundDependencyModule = true
+        return Location(uri: DocumentURI(packageManifest), range: Range(Position(line: 0, utf16index: 0)))
       }
     }
-    return foundDependencyModule ? false : nil
+    return nil
   }
 }
 
@@ -94,8 +102,11 @@ package func definitionLocations(
       return DefinitionLocationsResult(locations: [])
     }
 
-    if await moduleIsPartOfRootProject(moduleName: moduleName, buildServerManager: buildServerManager) == true {
-      return DefinitionLocationsResult(locations: [])
+    if let workspacePackageLocation = await definitionLocationInWorkspacePackage(
+      moduleName: moduleName,
+      buildServerManager: buildServerManager
+    ) {
+      return DefinitionLocationsResult(locations: [workspacePackageLocation])
     }
 
     let location = try await definitionInInterface(

--- a/Sources/SourceKitLSP/DefinitionLocations.swift
+++ b/Sources/SourceKitLSP/DefinitionLocations.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import BuildServerIntegration
+@_spi(SourceKitLSP) import BuildServerProtocol
 package import IndexStoreDB
 @_spi(SourceKitLSP) package import LanguageServerProtocol
 @_spi(SourceKitLSP) import SKLogging
@@ -28,15 +30,57 @@ package struct DefinitionLocationsResult {
   }
 }
 
+/// Returns whether the build server knows `moduleName` as a root-project module.
+private func moduleIsPartOfRootProject(
+  moduleName: String,
+  buildServerManager: BuildServerManager?
+) async -> Bool? {
+  guard let buildServerManager else {
+    return nil
+  }
+  return await orLog("Determining whether module belongs to root project") {
+    let sourceFiles = try await buildServerManager.sourceFiles(includeNonBuildableFiles: false)
+    var foundDependencyModule = false
+    for (uri, sourceFileInfo) in sourceFiles.sorted(by: { $0.key.stringValue < $1.key.stringValue }) {
+      for target in sourceFileInfo.targets.sorted(by: { $0.uri.stringValue < $1.uri.stringValue }) {
+        guard await buildServerManager.moduleName(for: uri, in: target) == moduleName else {
+          continue
+        }
+        if sourceFileInfo.isPartOfRootProject {
+          return true
+        }
+        foundDependencyModule = true
+      }
+    }
+    return foundDependencyModule ? false : nil
+  }
+}
+
 /// Return the locations for jump to definition from the given `SymbolDetails`.
 package func definitionLocations(
   for symbol: SymbolDetails,
   originatorUri: DocumentURI,
   index: CheckedIndex?,
-  languageService: any LanguageService
+  languageService: any LanguageService,
+  buildServerManager: BuildServerManager?
 ) async throws -> DefinitionLocationsResult {
-  // If this symbol is a module then generate a textual interface
+  // If this symbol is a module then generate a textual interface, unless the build graph says that the module is part
+  // of the root project. SourceKit-LSP has no file/range location for a module target itself in that case.
   if symbol.kind == .module {
+    if let bestLocalDeclaration = symbol.bestLocalDeclaration {
+      return DefinitionLocationsResult(locations: [bestLocalDeclaration])
+    }
+    if let index, let usr = symbol.usr {
+      logger.info("Performing indexed jump-to-definition with USR \(usr)")
+      let occurrences = try index.definitionOrDeclarationOccurrences(ofUSR: usr)
+      if !occurrences.isEmpty {
+        return DefinitionLocationsResult(
+          locations: occurrences.compactMap { $0.location.lspLocation }.sorted(),
+          indexOccurrences: occurrences
+        )
+      }
+    }
+
     // For module symbols, prefer using systemModule information if available
     let moduleName: String
     let groupName: String?
@@ -48,6 +92,10 @@ package func definitionLocations(
       moduleName = name
       groupName = nil
     } else {
+      return DefinitionLocationsResult(locations: [])
+    }
+
+    if await moduleIsPartOfRootProject(moduleName: moduleName, buildServerManager: buildServerManager) == true {
       return DefinitionLocationsResult(locations: [])
     }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2100,7 +2100,8 @@ extension SourceKitLSPServer {
           for: symbol,
           originatorUri: req.textDocument.uri,
           index: index,
-          languageService: languageService
+          languageService: languageService,
+          buildServerManager: workspace.buildServerManager
         )
         locations = definitionResult.locations
         // For dynamic symbols, also include overridden definitions

--- a/Sources/SwiftLanguageService/InlayHintResolve.swift
+++ b/Sources/SwiftLanguageService/InlayHintResolve.swift
@@ -89,12 +89,14 @@ extension SwiftLanguageService {
       return nil
     }
 
-    let index = await sourceKitLSPServer?.workspaceForDocument(uri: snapshot.uri)?.index(checkedFor: .deletedFiles)
+    let workspace = await sourceKitLSPServer?.workspaceForDocument(uri: snapshot.uri)
+    let index = await workspace?.index(checkedFor: .deletedFiles)
     let locations = try await SourceKitLSP.definitionLocations(
       for: typeInfo.symbolInfo,
       originatorUri: snapshot.uri,
       index: index,
-      languageService: self
+      languageService: self,
+      buildServerManager: workspace?.buildServerManager
     ).locations
 
     return locations.only

--- a/Sources/SwiftLanguageService/TypeDefinition.swift
+++ b/Sources/SwiftLanguageService/TypeDefinition.swift
@@ -60,12 +60,14 @@ extension SwiftLanguageService {
       symbol = typeSymbol
     }
 
-    let index = await sourceKitLSPServer?.workspaceForDocument(uri: uri)?.index(checkedFor: .deletedFiles)
+    let workspace = await sourceKitLSPServer?.workspaceForDocument(uri: uri)
+    let index = await workspace?.index(checkedFor: .deletedFiles)
     let locations = try await SourceKitLSP.definitionLocations(
       for: symbol,
       originatorUri: uri,
       index: index,
-      languageService: self
+      languageService: self,
+      buildServerManager: workspace?.buildServerManager
     ).locations
 
     if locations.isEmpty {

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -649,6 +649,8 @@ class DefinitionTests: SourceKitLSPTestCase {
         """
     )
 
+    try await SwiftPMTestProject.build(at: project.scratchDirectory)
+
     let (uri, positions) = try project.openDocument("ImportMyLibraryTests.swift")
     let definitions = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -627,6 +627,58 @@ class DefinitionTests: SourceKitLSPTestCase {
     XCTAssertTrue(definitions?.locations?.first?.uri.pseudoPath.hasSuffix("Lib.swiftinterface") ?? false)
   }
 
+  func testDefinitionOnRootPackageModuleDoesNotOpenGeneratedInterface() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Sources/MyLibrary/Lib.swift": """
+        public func libraryFunction() {}
+        """,
+        "Tests/MyLibraryTests/ImportMyLibraryTests.swift": """
+        @testable import 1️⃣MyLibrary
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyLibrary",
+          products: [.library(name: "MyLibrary", targets: ["MyLibrary"])],
+          targets: [
+            .target(name: "MyLibrary"),
+            .testTarget(name: "MyLibraryTests", dependencies: ["MyLibrary"]),
+          ]
+        )
+        """
+    )
+
+    let (uri, positions) = try project.openDocument("ImportMyLibraryTests.swift")
+    let definitions = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+
+    XCTAssertNil(definitions?.locations)
+  }
+
+  func testDefinitionOnSystemModuleOpensGeneratedInterface() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      import 1️⃣Foundation
+      """,
+      uri: uri
+    )
+
+    let definitions = try await testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+
+    let location = try XCTUnwrap(definitions?.locations?.first)
+    XCTAssertTrue(
+      location.uri.pseudoPath.hasSuffix(".swiftinterface"),
+      "System modules should continue to generate and open .swiftinterface files"
+    )
+  }
+
   func testDefinitionOnLiteralsShouldReturnEmpty() async throws {
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -627,7 +627,7 @@ class DefinitionTests: SourceKitLSPTestCase {
     XCTAssertTrue(definitions?.locations?.first?.uri.pseudoPath.hasSuffix("Lib.swiftinterface") ?? false)
   }
 
-  func testDefinitionOnRootPackageModuleDoesNotOpenGeneratedInterface() async throws {
+  func testDefinitionOnRootPackageModuleJumpsToPackageManifest() async throws {
     let project = try await SwiftPMTestProject(
       files: [
         "Sources/MyLibrary/Lib.swift": """
@@ -656,7 +656,10 @@ class DefinitionTests: SourceKitLSPTestCase {
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
 
-    XCTAssertNil(definitions?.locations)
+    XCTAssertEqual(
+      definitions,
+      .locations([Location(uri: try project.uri(for: "Package.swift"), range: Range(Position(line: 0, utf16index: 0)))])
+    )
   }
 
   func testDefinitionOnSystemModuleOpensGeneratedInterface() async throws {


### PR DESCRIPTION
Fixes #2693 

Update definition lookup for module symbols to prefer local declarations and indexed definitions before falling back to generated interfaces.

- Uses workspace build metadata to detect root-project modules and returns no definition instead of opening a generated .swiftinterface for local package targets.
- Preserves existing behavior for SDK and external modules so they continue to generate interfaces.
- Threads build server context through the shared definition lookup.
- Adds regression tests covering both root package modules and system modules to protect this boundary.