### PR TITLE
Filter enclosing syntactic tokens during semantic token merging

### DIFF
--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -89,7 +89,8 @@ extension SwiftLanguageService {
       }
 
     return SyntaxHighlightingTokens(
-      sortedTokens: tree
+      sortedTokens:
+        tree
         .classifications(in: range)
         .flatMap { $0.highlightingTokens(in: snapshot).tokens }
     )

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -88,11 +88,11 @@ extension SwiftLanguageService {
         tree.range
       }
 
-    let tokens = tree
-      .classifications(in: range)
-      .flatMap { $0.highlightingTokens(in: snapshot).tokens }
-
-    return SyntaxHighlightingTokens(sortedTokens: tokens)
+    return SyntaxHighlightingTokens(
+      sortedTokens: tree
+        .classifications(in: range)
+        .flatMap { $0.highlightingTokens(in: snapshot).tokens }
+    )
   }
 
   package func documentSemanticTokens(

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -61,8 +61,8 @@ extension SwiftLanguageService {
     try Task.checkCancellation()
 
     async let semanticTokens =
-          await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
-          ?? SyntaxHighlightingTokens(sortedTokens: [])
+        await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
+        ?? SyntaxHighlightingTokens(sortedTokens: [])
 
     let tokens =
       if self.options.reportSyntacticHighlightInSemanticTokensOrDefault {

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -61,8 +61,8 @@ extension SwiftLanguageService {
     try Task.checkCancellation()
 
     async let semanticTokens =
-        await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
-        ?? SyntaxHighlightingTokens(sortedTokens: [])
+      await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
+      ?? SyntaxHighlightingTokens(sortedTokens: [])
 
     let tokens =
       if self.options.reportSyntacticHighlightInSemanticTokensOrDefault {

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -70,7 +70,7 @@ extension SwiftLanguageService {
       } else {
         await semanticTokens
       }
-    return tokens.sorted({ $0.start < $1.start })
+    return tokens
   }
 
   private func syntacticTokens(

--- a/Sources/SwiftLanguageService/SemanticTokens.swift
+++ b/Sources/SwiftLanguageService/SemanticTokens.swift
@@ -61,8 +61,8 @@ extension SwiftLanguageService {
     try Task.checkCancellation()
 
     async let semanticTokens =
-      await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
-      ?? SyntaxHighlightingTokens(tokens: [])
+          await orLog("Loading semantic tokens") { try await semanticHighlightingTokens(for: snapshot) }
+          ?? SyntaxHighlightingTokens(sortedTokens: [])
 
     let tokens =
       if self.options.reportSyntacticHighlightInSemanticTokensOrDefault {
@@ -88,11 +88,11 @@ extension SwiftLanguageService {
         tree.range
       }
 
-    return
-      tree
+    let tokens = tree
       .classifications(in: range)
-      .map { $0.highlightingTokens(in: snapshot) }
-      .reduce(into: SyntaxHighlightingTokens(tokens: [])) { $0.tokens += $1.tokens }
+      .flatMap { $0.highlightingTokens(in: snapshot).tokens }
+
+    return SyntaxHighlightingTokens(sortedTokens: tokens)
   }
 
   package func documentSemanticTokens(
@@ -126,7 +126,7 @@ extension SwiftLanguageService {
 extension SyntaxClassifiedRange {
   fileprivate func highlightingTokens(in snapshot: DocumentSnapshot) -> SyntaxHighlightingTokens {
     guard let (kind, modifiers) = self.kind.highlightingKindAndModifiers else {
-      return SyntaxHighlightingTokens(tokens: [])
+      return SyntaxHighlightingTokens(sortedTokens: [])
     }
 
     let multiLineRange = snapshot.positionRange(of: self.range)
@@ -140,7 +140,7 @@ extension SyntaxClassifiedRange {
       )
     }
 
-    return SyntaxHighlightingTokens(tokens: tokens)
+    return SyntaxHighlightingTokens(sortedTokens: tokens)
   }
 }
 

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
@@ -27,7 +27,7 @@ struct SyntaxHighlightingTokenParser {
   private func parseTokens(
     _ response: SKDResponseDictionary,
     in snapshot: DocumentSnapshot,
-    into tokens: inout SyntaxHighlightingTokens
+    into tokens: inout [SyntaxHighlightingToken]
   ) {
     let keys = sourcekitd.keys
 
@@ -52,7 +52,7 @@ struct SyntaxHighlightingTokenParser {
       let multiLineRange = snapshot.positionOf(utf8Offset: offset)..<snapshot.positionOf(utf8Offset: offset + length)
       let ranges = multiLineRange.splitToSingleLineRanges(in: snapshot)
 
-      tokens.tokens += ranges.map {
+      tokens += ranges.map {
         SyntaxHighlightingToken(
           range: $0,
           kind: kind,
@@ -69,7 +69,7 @@ struct SyntaxHighlightingTokenParser {
   private func parseTokens(
     _ response: SKDResponseArray,
     in snapshot: DocumentSnapshot,
-    into tokens: inout SyntaxHighlightingTokens
+    into tokens: inout [SyntaxHighlightingToken]
   ) {
     // swift-format-ignore: ReplaceForEachWithForLoop
     // Reference is to `SKDResponseArray.forEach`, not `Array.forEach`.
@@ -80,9 +80,9 @@ struct SyntaxHighlightingTokenParser {
   }
 
   func parseTokens(_ response: SKDResponseArray, in snapshot: DocumentSnapshot) -> SyntaxHighlightingTokens {
-    var tokens: SyntaxHighlightingTokens = SyntaxHighlightingTokens(tokens: [])
+    var tokens: [SyntaxHighlightingToken] = []
     parseTokens(response, in: snapshot, into: &tokens)
-    return tokens
+    return SyntaxHighlightingTokens(sortedTokens: tokens)
   }
 
   private func parseKindAndModifiers(

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokenParser.swift
@@ -82,7 +82,7 @@ struct SyntaxHighlightingTokenParser {
   func parseTokens(_ response: SKDResponseArray, in snapshot: DocumentSnapshot) -> SyntaxHighlightingTokens {
     var tokens: [SyntaxHighlightingToken] = []
     parseTokens(response, in: snapshot, into: &tokens)
-    return SyntaxHighlightingTokens(sortedTokens: tokens)
+    return SyntaxHighlightingTokens(tokens: tokens)
   }
 
   private func parseKindAndModifiers(

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
@@ -56,16 +56,35 @@ package struct SyntaxHighlightingTokens: Sendable {
   }
 
   /// Merges the tokens in this array into a new token array,
-  /// preferring the given array's tokens if duplicate ranges are
+  /// preferring the given array's tokens if overlapping ranges are
   /// found.
   package func mergingTokens(with other: SyntaxHighlightingTokens) -> SyntaxHighlightingTokens {
-    let otherRanges = Set(other.tokens.map(\.range))
-    return SyntaxHighlightingTokens(tokens: tokens.filter { !otherRanges.contains($0.range) } + other.tokens)
+    return self.mergingTokens(with: other.tokens)
   }
 
   package func mergingTokens(with other: [SyntaxHighlightingToken]) -> SyntaxHighlightingTokens {
-    let otherRanges = Set(other.map(\.range))
-    return SyntaxHighlightingTokens(tokens: tokens.filter { !otherRanges.contains($0.range) } + other)
+    let otherRanges = other.map(\.range).sorted { $0.lowerBound < $1.lowerBound }
+
+    let filteredTokens = tokens.filter { token in
+      var low = 0
+      var high = otherRanges.count - 1
+
+      while low <= high {
+        let mid = low + (high - low) / 2
+        let otherRange = otherRanges[mid]
+
+        if token.range.clamped(to: otherRange) == otherRange || otherRange.clamped(to: token.range) == token.range {
+          return false
+        } else if otherRange.lowerBound >= token.range.upperBound {
+          high = mid - 1
+        } else {
+          low = mid + 1
+        }
+      }
+      return true
+    }
+
+    return SyntaxHighlightingTokens(tokens: filteredTokens + other)
   }
 
   /// Sorts the tokens in this array by their start position.

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
@@ -59,50 +59,32 @@ package struct SyntaxHighlightingTokens: Sendable {
   /// preferring the given array's tokens if overlapping ranges are
   /// found.
   package func mergingTokens(with other: SyntaxHighlightingTokens) -> SyntaxHighlightingTokens {
-    return self.mergingTokens(with: other.tokens)
-  }
-
-  package func mergingTokens(with other: [SyntaxHighlightingToken]) -> SyntaxHighlightingTokens {
     var filteredTokens: [SyntaxHighlightingToken] = []
     filteredTokens.reserveCapacity(tokens.count)
 
-    var selfIndex = 0
-    var otherIndex = 0
+    var selfIterator = tokens.makeIterator()
+    var otherIterator = other.tokens.makeIterator()
 
-    while selfIndex < tokens.count && otherIndex < other.count {
-      let token = tokens[selfIndex]
-      let otherToken = other[otherIndex]
+    var currentToken = selfIterator.next()
+    var currentOtherToken = otherIterator.next()
 
-      if otherToken.range.upperBound <= token.range.lowerBound {
-        otherIndex += 1
-      } else if token.range.upperBound <= otherToken.range.lowerBound {
-        filteredTokens.append(token)
-        selfIndex += 1
+    while let token = currentToken, let otherToken = currentOtherToken {
+      if token.range.overlaps(otherToken.range) {
+        currentToken = selfIterator.next()
+      } else if otherToken.range.upperBound <= token.range.lowerBound {
+        currentOtherToken = otherIterator.next()
       } else {
-        let tokenRange = token.range
-        let otherRange = otherToken.range
-
-        let syntacticEnclosesSemantic = tokenRange.lowerBound <= otherRange.lowerBound && tokenRange.upperBound >= otherRange.upperBound
-        let semanticEnclosesSyntactic = otherRange.lowerBound <= tokenRange.lowerBound && otherRange.upperBound >= tokenRange.upperBound
-
-        if syntacticEnclosesSemantic || semanticEnclosesSyntactic {
-          selfIndex += 1
-        } else {
-          if tokenRange.upperBound <= otherRange.upperBound {
-            filteredTokens.append(token)
-            selfIndex += 1
-          } else {
-            otherIndex += 1
-          }
-        }
+        filteredTokens.append(token)
+        currentToken = selfIterator.next()
       }
     }
 
-    if selfIndex < tokens.count {
-      filteredTokens.append(contentsOf: tokens[selfIndex...])
+    while let token = currentToken {
+        filteredTokens.append(token)
+        currentToken = selfIterator.next()
     }
 
-    return SyntaxHighlightingTokens(tokens: filteredTokens + other)
+    return SyntaxHighlightingTokens(tokens: filteredTokens + other.tokens)
   }
 
   /// Sorts the tokens in this array by their start position.

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
@@ -20,6 +20,10 @@ package struct SyntaxHighlightingTokens: Sendable {
   package var tokens: [SyntaxHighlightingToken]
 
   package init(tokens: [SyntaxHighlightingToken]) {
+    assert(
+      zip(tokens, tokens.dropFirst()).allSatisfy { $0.start <= $1.start },
+      "Tokens must always be sorted by their start position"
+    )
     self.tokens = tokens
   }
 
@@ -59,8 +63,8 @@ package struct SyntaxHighlightingTokens: Sendable {
   /// preferring the given array's tokens if overlapping ranges are
   /// found.
   package func mergingTokens(with other: SyntaxHighlightingTokens) -> SyntaxHighlightingTokens {
-    var filteredTokens: [SyntaxHighlightingToken] = []
-    filteredTokens.reserveCapacity(tokens.count)
+    var merged: [SyntaxHighlightingToken] = []
+    merged.reserveCapacity(tokens.count + other.tokens.count)
 
     var selfIterator = tokens.makeIterator()
     var otherIterator = other.tokens.makeIterator()
@@ -71,27 +75,26 @@ package struct SyntaxHighlightingTokens: Sendable {
     while let token = currentToken, let otherToken = currentOtherToken {
       if token.range.overlaps(otherToken.range) {
         currentToken = selfIterator.next()
-      } else if otherToken.range.upperBound <= token.range.lowerBound {
-        currentOtherToken = otherIterator.next()
-      } else {
-        filteredTokens.append(token)
+      } else if token.start < otherToken.start {
+        merged.append(token)
         currentToken = selfIterator.next()
+      } else {
+        merged.append(otherToken)
+        currentOtherToken = otherIterator.next()
       }
     }
 
     while let token = currentToken {
-        filteredTokens.append(token)
-        currentToken = selfIterator.next()
+      merged.append(token)
+      currentToken = selfIterator.next()
     }
 
-    return SyntaxHighlightingTokens(tokens: filteredTokens + other.tokens)
-  }
+    while let otherToken = currentOtherToken {
+      merged.append(otherToken)
+      currentOtherToken = otherIterator.next()
+    }
 
-  /// Sorts the tokens in this array by their start position.
-  package func sorted(
-    _ areInIncreasingOrder: (SyntaxHighlightingToken, SyntaxHighlightingToken) -> Bool
-  ) -> SyntaxHighlightingTokens {
-    SyntaxHighlightingTokens(tokens: tokens.sorted(by: areInIncreasingOrder))
+    return SyntaxHighlightingTokens(tokens: merged)
   }
 }
 

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
@@ -21,11 +21,22 @@ package struct SyntaxHighlightingTokens: Sendable {
   /// Syntax highlighting tokens sorted by their start position.
   package let tokens: [SyntaxHighlightingToken]
 
-  /// Creates a syntax highlighting token collection.
+  /// Creates a syntax highlighting token collection from an sorted array.
   ///
   /// - Parameter sortedTokens: Syntax highlighting tokens sorted by their start position.
   package init(sortedTokens: [SyntaxHighlightingToken]) {
-    self.tokens = sortedTokens.sorted { $0.start < $1.start }
+    assert(
+      zip(sortedTokens, sortedTokens.dropFirst()).allSatisfy { $0.start <= $1.start },
+      "Tokens must always be sorted by their start position"
+    )
+    self.tokens = sortedTokens
+  }
+
+  /// Creates a syntax highlighting token collection from a potentially unsorted array.
+  ///
+  /// - Parameter tokens: Syntax highlighting tokens that will be sorted by their start position.
+  package init(tokens: [SyntaxHighlightingToken]) {
+    self.init(sortedTokens: tokens.sorted { $0.start < $1.start })
   }
 
   /// The LSP representation of syntax highlighting tokens. Note that this
@@ -102,10 +113,9 @@ package struct SyntaxHighlightingTokens: Sendable {
 extension SyntaxHighlightingTokens {
   /// Decodes the LSP representation of syntax highlighting tokens
   package init(lspEncodedTokens rawTokens: [UInt32]) {
-    self.init(sortedTokens: [])
     assert(rawTokens.count.isMultiple(of: 5))
-    var tokens: [SyntaxHighlightingToken] = []
-    tokens.reserveCapacity(rawTokens.count / 5)
+    var parsedTokens: [SyntaxHighlightingToken] = []
+    parsedTokens.reserveCapacity(rawTokens.count / 5)
 
     var current = Position(line: 0, utf16index: 0)
 
@@ -127,7 +137,7 @@ extension SyntaxHighlightingTokens {
       let kind = SemanticTokenTypes.all[Int(rawKind)]
       let modifiers = SemanticTokenModifiers(rawValue: rawModifiers)
 
-      tokens.append(
+      parsedTokens.append(
         SyntaxHighlightingToken(
           start: current,
           utf16length: length,
@@ -135,7 +145,7 @@ extension SyntaxHighlightingTokens {
           modifiers: modifiers
         )
       )
-      self.init(sortedTokens: tokens)
     }
+    self.init(sortedTokens: parsedTokens)
   }
 }

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
@@ -63,25 +63,43 @@ package struct SyntaxHighlightingTokens: Sendable {
   }
 
   package func mergingTokens(with other: [SyntaxHighlightingToken]) -> SyntaxHighlightingTokens {
-    let otherRanges = other.map(\.range).sorted { $0.lowerBound < $1.lowerBound }
+    var filteredTokens: [SyntaxHighlightingToken] = []
+    filteredTokens.reserveCapacity(tokens.count)
 
-    let filteredTokens = tokens.filter { token in
-      var low = 0
-      var high = otherRanges.count - 1
+    var selfIndex = 0
+    var otherIndex = 0
 
-      while low <= high {
-        let mid = low + (high - low) / 2
-        let otherRange = otherRanges[mid]
+    while selfIndex < tokens.count && otherIndex < other.count {
+      let token = tokens[selfIndex]
+      let otherToken = other[otherIndex]
 
-        if token.range.clamped(to: otherRange) == otherRange || otherRange.clamped(to: token.range) == token.range {
-          return false
-        } else if otherRange.lowerBound >= token.range.upperBound {
-          high = mid - 1
+      if otherToken.range.upperBound <= token.range.lowerBound {
+        otherIndex += 1
+      } else if token.range.upperBound <= otherToken.range.lowerBound {
+        filteredTokens.append(token)
+        selfIndex += 1
+      } else {
+        let tokenRange = token.range
+        let otherRange = otherToken.range
+
+        let syntacticEnclosesSemantic = tokenRange.lowerBound <= otherRange.lowerBound && tokenRange.upperBound >= otherRange.upperBound
+        let semanticEnclosesSyntactic = otherRange.lowerBound <= tokenRange.lowerBound && otherRange.upperBound >= tokenRange.upperBound
+
+        if syntacticEnclosesSemantic || semanticEnclosesSyntactic {
+          selfIndex += 1
         } else {
-          low = mid + 1
+          if tokenRange.upperBound <= otherRange.upperBound {
+            filteredTokens.append(token)
+            selfIndex += 1
+          } else {
+            otherIndex += 1
+          }
         }
       }
-      return true
+    }
+
+    if selfIndex < tokens.count {
+      filteredTokens.append(contentsOf: tokens[selfIndex...])
     }
 
     return SyntaxHighlightingTokens(tokens: filteredTokens + other)

--- a/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
+++ b/Sources/SwiftLanguageService/SyntaxHighlightingTokens.swift
@@ -17,14 +17,15 @@ import SourceKitLSP
 
 /// A wrapper around an array of syntax highlighting tokens.
 package struct SyntaxHighlightingTokens: Sendable {
-  package var tokens: [SyntaxHighlightingToken]
 
-  package init(tokens: [SyntaxHighlightingToken]) {
-    assert(
-      zip(tokens, tokens.dropFirst()).allSatisfy { $0.start <= $1.start },
-      "Tokens must always be sorted by their start position"
-    )
-    self.tokens = tokens
+  /// Syntax highlighting tokens sorted by their start position.
+  package let tokens: [SyntaxHighlightingToken]
+
+  /// Creates a syntax highlighting token collection.
+  ///
+  /// - Parameter sortedTokens: Syntax highlighting tokens sorted by their start position.
+  package init(sortedTokens: [SyntaxHighlightingToken]) {
+    self.tokens = sortedTokens.sorted { $0.start < $1.start }
   }
 
   /// The LSP representation of syntax highlighting tokens. Note that this
@@ -94,16 +95,17 @@ package struct SyntaxHighlightingTokens: Sendable {
       currentOtherToken = otherIterator.next()
     }
 
-    return SyntaxHighlightingTokens(tokens: merged)
+    return SyntaxHighlightingTokens(sortedTokens: merged)
   }
 }
 
 extension SyntaxHighlightingTokens {
   /// Decodes the LSP representation of syntax highlighting tokens
   package init(lspEncodedTokens rawTokens: [UInt32]) {
-    self.init(tokens: [])
+    self.init(sortedTokens: [])
     assert(rawTokens.count.isMultiple(of: 5))
-    self.tokens.reserveCapacity(rawTokens.count / 5)
+    var tokens: [SyntaxHighlightingToken] = []
+    tokens.reserveCapacity(rawTokens.count / 5)
 
     var current = Position(line: 0, utf16index: 0)
 
@@ -125,7 +127,7 @@ extension SyntaxHighlightingTokens {
       let kind = SemanticTokenTypes.all[Int(rawKind)]
       let modifiers = SemanticTokenModifiers(rawValue: rawModifiers)
 
-      self.tokens.append(
+      tokens.append(
         SyntaxHighlightingToken(
           start: current,
           utf16length: length,
@@ -133,6 +135,7 @@ extension SyntaxHighlightingTokens {
           modifiers: modifiers
         )
       )
+      self.init(sortedTokens: tokens)
     }
   }
 }

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -24,7 +24,7 @@ private typealias Token = SyntaxHighlightingToken
 
 final class SemanticTokensTests: SourceKitLSPTestCase {
   func testIntArrayCoding() async throws {
-    let tokens = SyntaxHighlightingTokens(tokens: [
+    let tokens = SyntaxHighlightingTokens(sortedTokens: [
       Token(
         start: Position(line: 2, utf16index: 3),
         utf16length: 5,

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -1048,6 +1048,25 @@ final class SemanticTokensTests: SourceKitLSPTestCase {
     )
     try await fulfillmentOfOrThrow(receivedSemanticTokensResponse)
   }
+
+  func testAttachedMacroSemanticTokens() async throws {
+    try await assertSemanticTokens(
+      markedContents: """
+        @attached(accessor) @attached(peer, names: prefixed(`$`))
+        public macro TaskLocal() = #externalMacro(module: "SwiftMacros", type: "TaskLocal")
+
+        class C {
+            1️⃣@2️⃣TaskLocal3️⃣
+            static var taskLocalLogger: 4️⃣String = ""
+        }
+        """,
+      range: ("1️⃣", "3️⃣"),
+      expected: [
+        TokenSpec(marker: "2️⃣", length: 9, kind: .macro, isSourceKit: true),
+        TokenSpec(marker: "4️⃣", length: 6, kind: .struct, modifiers: .defaultLibrary, isSourceKit: true),
+      ]
+    )
+  }
 }
 
 private struct TokenSpec {


### PR DESCRIPTION
Fixes #2708 

Update SyntaxHighlightingTokens.mergingTokens to treat containing ranges as overlapping during token merging, allowing more specific semantic tokens to replace enclosing syntactic tokens instead of only removing tokens with identical ranges. This avoids retaining redundant syntactic tokens, such as the attribute modifier covering `@TaskLocal` when a semantic macro token already exists for TaskLocal, while preserving the existing behavior for unrelated tokens. Add a regression test covering attached macro highlighting.