### PR TITLE
Always advertise the SourceKit-LSP semantic tokens legend

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -378,13 +378,18 @@ extension ClangLanguageService {
         workspaceFolders: nil
       )
     )
-    self.capabilities = result.capabilities
+    var capabilities = result.capabilities
     if let legend = result.capabilities.semanticTokensProvider?.legend {
+      // Semantic token responses from clangd are translated to SourceKit-LSP's legend below before being sent to the
+      // client, so dynamic registrations must advertise SourceKit-LSP's legend instead of the clangd one.
+      capabilities.semanticTokensProvider?.legend = .sourceKitLSPLegend
       self.semanticTokensTranslator = SemanticTokensLegendTranslator(
         clangdLegend: legend,
         sourceKitLSPLegend: SemanticTokensLegend.sourceKitLSPLegend
       )
     }
+    self.capabilities = capabilities
+
     if let sourceKitLSPServer {
       // Since `ClangLanguageService` is created per toolchain, different clangd
       // instances can report different capabilities. Calling `registerCapabilities`
@@ -392,7 +397,7 @@ extension ClangLanguageService {
       // earlier one. This is fine for now because SourceKitLSPServer more or less
       // ignores the registered capabilities for clangd at the moment.
       await sourceKitLSPServer.registerCapabilities(
-        for: result.capabilities,
+        for: capabilities,
         languages: [.c, .cpp, .objective_c, .objective_cpp],
         registry: workspace.capabilityRegistry
       )

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -303,6 +303,48 @@ final class LocalClangTests: SourceKitLSPTestCase {
     XCTAssertGreaterThanOrEqual(data.count, 0)
   }
 
+  func testSemanticTokensRegisterSourceKitLSPLegend() async throws {
+    let testClient = try await TestSourceKitLSPClient(
+      capabilities: ClientCapabilities(
+        textDocument: TextDocumentClientCapabilities(
+          semanticTokens: TextDocumentClientCapabilities.SemanticTokens(
+            dynamicRegistration: true,
+            requests: TextDocumentClientCapabilities.SemanticTokensRequestsClientCapabilities(
+              range: .bool(true),
+              full: .bool(true)
+            ),
+            tokenTypes: SemanticTokensLegend.sourceKitLSPLegend.tokenTypes,
+            tokenModifiers: SemanticTokensLegend.sourceKitLSPLegend.tokenModifiers,
+            formats: [.relative]
+          )
+        )
+      ),
+      usePullDiagnostics: false
+    )
+    let registeredSemanticTokens = expectation(description: "semantic tokens registered")
+    testClient.handleMultipleRequests { (request: RegisterCapabilityRequest) in
+      for registration in request.registrations where registration.method == SemanticTokensRegistrationOptions.method {
+        let options = SemanticTokensRegistrationOptions(fromLSPAny: registration.registerOptions)
+        XCTAssertEqual(options?.semanticTokenOptions.legend, .sourceKitLSPLegend)
+        registeredSemanticTokens.fulfill()
+      }
+      return VoidResponse()
+    }
+
+    let uri = DocumentURI(for: .objective_c)
+    testClient.openDocument(
+      """
+      @interface Foo
+      - (void)scriptingIsGreaterThan:(id)object;
+      @end
+      """,
+      uri: uri
+    )
+    _ = try await testClient.send(SynchronizeRequest())
+
+    try await fulfillmentOfOrThrow(registeredSemanticTokens)
+  }
+
   func testDocumentDependenciesUpdated() async throws {
     let project = try await MultiFileTestProject(
       files: [


### PR DESCRIPTION
Fixes #2643.

When the client supports dynamic semantic token registration we previously advertised the clangd token legend while still translating the tokens into the SourceKit-LSP legend. This mismatch lead to incorrect highlighting as seen in the linked issue.