### PR TITLE
Fix InlayHintRequest race against shiftedPosition

### DIFF
--- a/Sources/SourceKitLSP/Hooks.swift
+++ b/Sources/SourceKitLSP/Hooks.swift
@@ -41,6 +41,13 @@ public struct Hooks: Sendable {
   /// The URL passed is the toolchain root (`.xctoolchain` bundle path).
   package var sourcekitdCoreInjector: (@Sendable (URL) throws -> (any SourceKitDCore)?)?
 
+  /// Closure that is executed by the background inlay hint refresh task right after it has computed updated hints
+  /// but before it writes them into the cache.
+  ///
+  /// This allows tests to deterministically pause the background refresh and inspect the cache contents written by
+  /// the synchronous position-shifting logic before the background task's write can race with it.
+  package var inlayHintRefreshWillUpdateCache: (@Sendable () async -> Void)?
+
   public init() {
     self.init(indexHooks: IndexHooks(), buildServerHooks: BuildServerHooks())
   }
@@ -50,12 +57,14 @@ public struct Hooks: Sendable {
     buildServerHooks: BuildServerHooks = BuildServerHooks(),
     preHandleRequest: (@Sendable (any RequestType) async -> Void)? = nil,
     preForwardRequestToClangd: (@Sendable (any RequestType) async -> Void)? = nil,
-    sourcekitdCoreInjector: (@Sendable (URL) throws -> (any SourceKitDCore)?)? = nil
+    sourcekitdCoreInjector: (@Sendable (URL) throws -> (any SourceKitDCore)?)? = nil,
+    inlayHintRefreshWillUpdateCache: (@Sendable () async -> Void)? = nil
   ) {
     self.indexHooks = indexHooks
     self.buildServerHooks = buildServerHooks
     self.preHandleRequest = preHandleRequest
     self.preForwardRequestToClangd = preForwardRequestToClangd
     self.sourcekitdCoreInjector = sourcekitdCoreInjector
+    self.inlayHintRefreshWillUpdateCache = inlayHintRefreshWillUpdateCache
   }
 }

--- a/Sources/SwiftLanguageService/InlayHintManager.swift
+++ b/Sources/SwiftLanguageService/InlayHintManager.swift
@@ -57,6 +57,12 @@ actor InlayHintManager {
   /// Used to avoid scheduling multiple concurrent recomputations for the same document.
   private var inFlightRefreshTasks: [DocumentURI: InFlightInlayHintRefreshTask] = [:]
 
+  private let hooks: Hooks
+
+  init(hooks: Hooks = Hooks()) {
+    self.hooks = hooks
+  }
+
   func getCachedInlayHints(
     swiftLanguageService service: SwiftLanguageService,
     for snapshot: DocumentSnapshot,
@@ -213,6 +219,8 @@ actor InlayHintManager {
           let updatedHints = try await computeTypeInlayHints(swiftLanguageService: service, for: snapshot, range: nil)
 
           try Task.checkCancellation()
+
+          await hooks.inlayHintRefreshWillUpdateCache?()
 
           let updatedEntry = InlayHintCacheEntry(
             version: snapshot.version,

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -159,7 +159,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
   ///   might have finished. This isn't an issue since the tasks do not retain `self`.
   private var inFlightPublishDiagnosticsTasks: [DocumentURI: Task<Void, Never>] = [:]
 
-  let inlayHintManager = InlayHintManager()
+  let inlayHintManager: InlayHintManager
 
   let syntaxTreeManager = SyntaxTreeManager()
 
@@ -260,6 +260,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     self.capabilityRegistry = workspace.capabilityRegistry
     self.semanticIndexManagerTask = workspace.semanticIndexManagerTask
     self.hooks = hooks
+    self.inlayHintManager = InlayHintManager(hooks: hooks)
     self.state = .connected
     self.options = options
 

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -118,12 +118,13 @@ final class InlayHintTests: SourceKitLSPTestCase {
   private func runInlayHintTestCase(
     initialText: String,
     range: (start: String, end: String)? = nil,
+    hooks: Hooks = Hooks(),
     testBody: (InlayHintTestCaseContext) async throws -> Void
   ) async throws {
     let capabilities = ClientCapabilities(
       workspace: WorkspaceClientCapabilities(inlayHint: RefreshRegistrationCapability(refreshSupport: true))
     )
-    let testClient = try await TestSourceKitLSPClient(capabilities: capabilities)
+    let testClient = try await TestSourceKitLSPClient(hooks: hooks, capabilities: capabilities)
     let uri = DocumentURI(for: .swift)
 
     let positions = testClient.openDocument(initialText, uri: uri)
@@ -575,18 +576,31 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWorks() async throws {
+    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
+    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+    var hooks = Hooks()
+    hooks.inlayHintRefreshWillUpdateCache = {
+      // Gate the background refresh so it can't race ahead of the read below, which asserts on the synchronously
+      // shift-computed hints rather than a background recompute.
+      if shouldGateBackgroundRefresh.value {
+        await backgroundRefreshMayProceed.waitOrXCTFail()
+      }
+    }
+
     try await runInlayHintTestCase(
       initialText: """
         let y1️⃣ = 2
         2️⃣
         let x3️⃣ = 4
         """,
+      hooks: hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
         makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Int"),
       ])
 
+      shouldGateBackgroundRefresh.withLock { $0 = true }
       context.sendChange(
         range: context.positions["2️⃣"]..<context.positions["2️⃣"],
         text: """
@@ -605,6 +619,8 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
+      backgroundRefreshMayProceed.signal()
+
       assertHintsEqual(
         shiftedHints,
         [
@@ -616,12 +632,22 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingRemovesHintsInsideDeletedRegion() async throws {
+    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
+    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+    var hooks = Hooks()
+    hooks.inlayHintRefreshWillUpdateCache = {
+      if shouldGateBackgroundRefresh.value {
+        await backgroundRefreshMayProceed.waitOrXCTFail()
+      }
+    }
+
     try await runInlayHintTestCase(
       initialText: """
         let x1️⃣ = 1
         2️⃣let y3️⃣ = 24️⃣
         let z5️⃣ = ""
         """,
+      hooks: hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
@@ -629,6 +655,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
         makeInlayHint(position: context.positions["5️⃣"], kind: .type, label: ": String"),
       ])
 
+      shouldGateBackgroundRefresh.withLock { $0 = true }
       context.sendChange(
         range: context.positions["2️⃣"]..<context.positions["4️⃣"],
         text: ""
@@ -643,6 +670,8 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
+      backgroundRefreshMayProceed.signal()
+
       assertHintsEqual(
         shiftedHints,
         [
@@ -654,15 +683,26 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithInsertionDirectlyBeforeAHint() async throws {
+    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
+    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+    var hooks = Hooks()
+    hooks.inlayHintRefreshWillUpdateCache = {
+      if shouldGateBackgroundRefresh.value {
+        await backgroundRefreshMayProceed.waitOrXCTFail()
+      }
+    }
+
     try await runInlayHintTestCase(
       initialText: """
         let x1️⃣ = 1
         """,
+      hooks: hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int")
       ])
 
+      shouldGateBackgroundRefresh.withLock { $0 = true }
       context.sendChange(
         range: context.positions["1️⃣"]..<context.positions["1️⃣"],
         text: "yz"
@@ -675,6 +715,8 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
+      backgroundRefreshMayProceed.signal()
+
       assertHintsEqual(
         shiftedHints,
         [
@@ -685,16 +727,27 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithMultiCodePointInsertion() async throws {
+    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
+    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+    var hooks = Hooks()
+    hooks.inlayHintRefreshWillUpdateCache = {
+      if shouldGateBackgroundRefresh.value {
+        await backgroundRefreshMayProceed.waitOrXCTFail()
+      }
+    }
+
     try await runInlayHintTestCase(
       initialText: """
         1️⃣let x2️⃣ = 1
         """,
+      hooks: hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Int")
       ]
       )
 
+      shouldGateBackgroundRefresh.withLock { $0 = true }
       let inserted = "👨‍💻"
       context.sendChange(
         range: context.positions["1️⃣"]..<context.positions["1️⃣"],
@@ -708,6 +761,8 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
+      backgroundRefreshMayProceed.signal()
+
       assertHintsEqual(
         shiftedHints,
         [
@@ -718,15 +773,29 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithMultiCodePointAndNewlineInsertionDirectlyBeforeAHint() async throws {
+    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
+    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+    var hooks = Hooks()
+    hooks.inlayHintRefreshWillUpdateCache = {
+      // This edit briefly makes the buffer syntactically invalid (`let xabc` / `👨‍💻 = 1` on two lines), so sourcekitd's
+      // background recompute returns no hints for it. `shouldGateBackgroundRefresh` keeps that background write from
+      // racing ahead of the read below, which asserts on the synchronously shift-computed guess instead.
+      if shouldGateBackgroundRefresh.value {
+        await backgroundRefreshMayProceed.waitOrXCTFail()
+      }
+    }
+
     try await runInlayHintTestCase(
       initialText: """
         let x1️⃣ = 1
         """,
+      hooks: hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int")
       ])
 
+      shouldGateBackgroundRefresh.withLock { $0 = true }
       context.sendChange(
         range: context.positions["1️⃣"]..<context.positions["1️⃣"],
         text: "abc\n👨‍💻"
@@ -740,6 +809,8 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
+      backgroundRefreshMayProceed.signal()
+
       assertHintsEqual(
         shiftedHints,
         [
@@ -750,6 +821,15 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithMultipleChanges() async throws {
+    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
+    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+    var hooks = Hooks()
+    hooks.inlayHintRefreshWillUpdateCache = {
+      if shouldGateBackgroundRefresh.value {
+        await backgroundRefreshMayProceed.waitOrXCTFail()
+      }
+    }
+
     try await runInlayHintTestCase(
       initialText: """
         4️⃣let x1️⃣ = 1
@@ -757,6 +837,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
 
         let z3️⃣ = ""
         """,
+      hooks: hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
@@ -764,6 +845,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
         makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": String"),
       ])
 
+      shouldGateBackgroundRefresh.withLock { $0 = true }
       context.sendChanges(changes: [
         (range: context.positions["4️⃣"]..<context.positions["4️⃣"], text: "let abc = 5\n"),
         (range: Position(line: 2, utf16index: 0)..<Position(line: 3, utf16index: 0), text: ""),
@@ -781,6 +863,8 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
+      backgroundRefreshMayProceed.signal()
+
       assertHintsEqual(
         shiftedHints,
         [

--- a/Tests/SourceKitLSPTests/InlayHintTests.swift
+++ b/Tests/SourceKitLSPTests/InlayHintTests.swift
@@ -181,6 +181,35 @@ final class InlayHintTests: SourceKitLSPTestCase {
     }
   }
 
+  /// Lets a test deterministically block the background inlay hint refresh task right before it writes its
+  /// recomputed hints into the cache, so the test can assert on hints computed by some other means (eg. the
+  /// synchronous position-shifting logic) without racing against that write.
+  private final class InlayHintBackgroundRefreshBlocker: Sendable {
+    private let isEnabled = ThreadSafeBox<Bool>(initialValue: false)
+    private let semaphore = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
+
+    var hooks: Hooks {
+      var hooks = Hooks()
+      hooks.inlayHintRefreshWillUpdateCache = { [isEnabled, semaphore] in
+        if isEnabled.value {
+          await semaphore.waitOrXCTFail()
+        }
+      }
+      return hooks
+    }
+
+    /// From this point on, the background refresh task will block before writing to the cache until `unblock` is
+    /// called.
+    func enable() {
+      isEnabled.withLock { $0 = true }
+    }
+
+    /// Lets a blocked background refresh task proceed.
+    func unblock() {
+      semaphore.signal()
+    }
+  }
+
   // MARK: - Tests
 
   func testEmpty() async throws {
@@ -576,16 +605,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWorks() async throws {
-    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
-    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
-    var hooks = Hooks()
-    hooks.inlayHintRefreshWillUpdateCache = {
-      // Gate the background refresh so it can't race ahead of the read below, which asserts on the synchronously
-      // shift-computed hints rather than a background recompute.
-      if shouldGateBackgroundRefresh.value {
-        await backgroundRefreshMayProceed.waitOrXCTFail()
-      }
-    }
+    let blocker = InlayHintBackgroundRefreshBlocker()
 
     try await runInlayHintTestCase(
       initialText: """
@@ -593,14 +613,14 @@ final class InlayHintTests: SourceKitLSPTestCase {
         2️⃣
         let x3️⃣ = 4
         """,
-      hooks: hooks
+      hooks: blocker.hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
         makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": Int"),
       ])
 
-      shouldGateBackgroundRefresh.withLock { $0 = true }
+      blocker.enable()
       context.sendChange(
         range: context.positions["2️⃣"]..<context.positions["2️⃣"],
         text: """
@@ -619,7 +639,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
-      backgroundRefreshMayProceed.signal()
+      blocker.unblock()
 
       assertHintsEqual(
         shiftedHints,
@@ -632,14 +652,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingRemovesHintsInsideDeletedRegion() async throws {
-    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
-    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
-    var hooks = Hooks()
-    hooks.inlayHintRefreshWillUpdateCache = {
-      if shouldGateBackgroundRefresh.value {
-        await backgroundRefreshMayProceed.waitOrXCTFail()
-      }
-    }
+    let blocker = InlayHintBackgroundRefreshBlocker()
 
     try await runInlayHintTestCase(
       initialText: """
@@ -647,7 +660,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
         2️⃣let y3️⃣ = 24️⃣
         let z5️⃣ = ""
         """,
-      hooks: hooks
+      hooks: blocker.hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
@@ -655,7 +668,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
         makeInlayHint(position: context.positions["5️⃣"], kind: .type, label: ": String"),
       ])
 
-      shouldGateBackgroundRefresh.withLock { $0 = true }
+      blocker.enable()
       context.sendChange(
         range: context.positions["2️⃣"]..<context.positions["4️⃣"],
         text: ""
@@ -670,7 +683,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
-      backgroundRefreshMayProceed.signal()
+      blocker.unblock()
 
       assertHintsEqual(
         shiftedHints,
@@ -683,26 +696,19 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithInsertionDirectlyBeforeAHint() async throws {
-    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
-    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
-    var hooks = Hooks()
-    hooks.inlayHintRefreshWillUpdateCache = {
-      if shouldGateBackgroundRefresh.value {
-        await backgroundRefreshMayProceed.waitOrXCTFail()
-      }
-    }
+    let blocker = InlayHintBackgroundRefreshBlocker()
 
     try await runInlayHintTestCase(
       initialText: """
         let x1️⃣ = 1
         """,
-      hooks: hooks
+      hooks: blocker.hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int")
       ])
 
-      shouldGateBackgroundRefresh.withLock { $0 = true }
+      blocker.enable()
       context.sendChange(
         range: context.positions["1️⃣"]..<context.positions["1️⃣"],
         text: "yz"
@@ -715,7 +721,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
-      backgroundRefreshMayProceed.signal()
+      blocker.unblock()
 
       assertHintsEqual(
         shiftedHints,
@@ -727,27 +733,20 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithMultiCodePointInsertion() async throws {
-    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
-    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
-    var hooks = Hooks()
-    hooks.inlayHintRefreshWillUpdateCache = {
-      if shouldGateBackgroundRefresh.value {
-        await backgroundRefreshMayProceed.waitOrXCTFail()
-      }
-    }
+    let blocker = InlayHintBackgroundRefreshBlocker()
 
     try await runInlayHintTestCase(
       initialText: """
         1️⃣let x2️⃣ = 1
         """,
-      hooks: hooks
+      hooks: blocker.hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["2️⃣"], kind: .type, label: ": Int")
       ]
       )
 
-      shouldGateBackgroundRefresh.withLock { $0 = true }
+      blocker.enable()
       let inserted = "👨‍💻"
       context.sendChange(
         range: context.positions["1️⃣"]..<context.positions["1️⃣"],
@@ -761,7 +760,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
-      backgroundRefreshMayProceed.signal()
+      blocker.unblock()
 
       assertHintsEqual(
         shiftedHints,
@@ -773,29 +772,19 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithMultiCodePointAndNewlineInsertionDirectlyBeforeAHint() async throws {
-    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
-    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
-    var hooks = Hooks()
-    hooks.inlayHintRefreshWillUpdateCache = {
-      // This edit briefly makes the buffer syntactically invalid (`let xabc` / `👨‍💻 = 1` on two lines), so sourcekitd's
-      // background recompute returns no hints for it. `shouldGateBackgroundRefresh` keeps that background write from
-      // racing ahead of the read below, which asserts on the synchronously shift-computed guess instead.
-      if shouldGateBackgroundRefresh.value {
-        await backgroundRefreshMayProceed.waitOrXCTFail()
-      }
-    }
+    let blocker = InlayHintBackgroundRefreshBlocker()
 
     try await runInlayHintTestCase(
       initialText: """
         let x1️⃣ = 1
         """,
-      hooks: hooks
+      hooks: blocker.hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int")
       ])
 
-      shouldGateBackgroundRefresh.withLock { $0 = true }
+      blocker.enable()
       context.sendChange(
         range: context.positions["1️⃣"]..<context.positions["1️⃣"],
         text: "abc\n👨‍💻"
@@ -809,7 +798,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
-      backgroundRefreshMayProceed.signal()
+      blocker.unblock()
 
       assertHintsEqual(
         shiftedHints,
@@ -821,14 +810,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
   }
 
   func testInlayHintShiftingWithMultipleChanges() async throws {
-    let shouldGateBackgroundRefresh = ThreadSafeBox<Bool>(initialValue: false)
-    let backgroundRefreshMayProceed = MultiEntrySemaphore(name: "Inlay hint background refresh may proceed")
-    var hooks = Hooks()
-    hooks.inlayHintRefreshWillUpdateCache = {
-      if shouldGateBackgroundRefresh.value {
-        await backgroundRefreshMayProceed.waitOrXCTFail()
-      }
-    }
+    let blocker = InlayHintBackgroundRefreshBlocker()
 
     try await runInlayHintTestCase(
       initialText: """
@@ -837,7 +819,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
 
         let z3️⃣ = ""
         """,
-      hooks: hooks
+      hooks: blocker.hooks
     ) { context in
       try await context.checkInlayHintsComputedInTheBackgroundMatch(expected: [
         makeInlayHint(position: context.positions["1️⃣"], kind: .type, label: ": Int"),
@@ -845,7 +827,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
         makeInlayHint(position: context.positions["3️⃣"], kind: .type, label: ": String"),
       ])
 
-      shouldGateBackgroundRefresh.withLock { $0 = true }
+      blocker.enable()
       context.sendChanges(changes: [
         (range: context.positions["4️⃣"]..<context.positions["4️⃣"], text: "let abc = 5\n"),
         (range: Position(line: 2, utf16index: 0)..<Position(line: 3, utf16index: 0), text: ""),
@@ -863,7 +845,7 @@ final class InlayHintTests: SourceKitLSPTestCase {
       ).positions
 
       let shiftedHints = try await context.getCachedInlayHints()
-      backgroundRefreshMayProceed.signal()
+      blocker.unblock()
 
       assertHintsEqual(
         shiftedHints,


### PR DESCRIPTION
## Description

The unstructured task `InlayHintRequest` sending to **sourcekitd** will return an empty array of hints with multi-code-point + newline edits like this:

**From**

```swift
let x1️⃣ = 1
```

**To**
```swift
let xabc
    👨‍💻1️⃣ = 1
```

So when `InlayHintManager.processEdits` is triggered, the following two race against each other
1. `InlayHintRequest` to **sourcekitd** that returns nothing. 
2. synchronous position shifting logic that returns `: Int`

The test `testInlayHintShiftingWithMultiCodePointAndNewlineInsertionDirectlyBeforeAHint` is asserting against the second case - position shifting logic, thus it is flaky when the first case wins the race.

The fix is to add a gate inside InlayHintManager to prevent InlayHintRequest's empty response writing to the cache `cache[uri] = []` and let the `shiftedPosition` writing to the cache `cache[uri] = shiftedHints`
