### PR TITLE
Support qualified name queries in workspace/symbol

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(SourceKitLSP STATIC
   MessageMetadata.swift
   OnDiskDocumentManager.swift
   PlaygroundDiscovery.swift
+  QualifiedWorkspaceSymbolQuery.swift
   ReferenceDocumentURL.swift
   Rename.swift
   SemanticTokensLegend+SourceKitLSPLegend.swift

--- a/Sources/SourceKitLSP/QualifiedWorkspaceSymbolQuery.swift
+++ b/Sources/SourceKitLSP/QualifiedWorkspaceSymbolQuery.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A `workspace/symbol` query split into its qualified parts.
+///
+/// For example:
+///   `"String.description"`   → `containerChain: ["String"], member: "description"`
+///   `"Foo::bar"`             → `containerChain: ["Foo"], member: "bar"`
+///   `"Outer.Inner.method"`   → `containerChain: ["Outer", "Inner"], member: "method"`
+///   `"Foo."`                 → `containerChain: ["Foo"], member: ""`
+///   `"Foo.bar(baz:)"`        → `containerChain: ["Foo"], member: "bar(baz:)"` (a lone `:` is literal)
+///
+/// An unqualified query (no separator, e.g. `"description"`) fails to parse and returns `nil`.
+package struct QualifiedWorkspaceSymbolQuery: Equatable {
+  /// Container chain in outer-to-inner order. Always non-empty for a successfully-parsed query.
+  package let containerChain: [String]
+
+  /// The trailing component the user is searching for. May be empty (e.g. for the query `Foo.`).
+  package let member: String
+
+  /// Parse a `workspace/symbol` query, splitting on the trailing `.` or `::` qualifier separators.
+  ///
+  /// Returns `nil` if the query has no qualifier or the container chain is empty (so callers can fall
+  /// back to the unqualified search path). A trailing separator with an empty member (e.g. `Foo.`)
+  /// is a valid qualified query that lists all members of the container.
+  package init?(_ query: String) {
+    // Split the query into components on the `.` and `::` separators. The last component is the member
+    // being searched for; the preceding components are the container chain. A lone `:` is not a separator
+    // — it is a literal character, e.g. an argument label in `Collection.append(contentsOf:)`.
+    var components =
+      query
+      .replacing("::", with: ".")
+      .split(separator: ".", omittingEmptySubsequences: false)
+      .map(String.init)
+
+    // Without a separator the query isn't qualified; callers fall back to the unqualified search path.
+    guard components.count >= 2 else { return nil }
+    let member = components.removeLast()
+    let containerChain = components
+    // Container chain segments must be non-empty (rejects leading and doubled separators). An empty
+    // member is allowed (e.g. `Foo.` lists all members of the container).
+    guard !containerChain.contains(where: \.isEmpty) else { return nil }
+
+    self.containerChain = containerChain
+    self.member = member
+  }
+}
+
+extension String {
+  /// Returns `true` if the characters of `subsequence` appear in order within `self`, compared
+  /// case-insensitively. An empty `subsequence` always matches.
+  package func fuzzilyContains(subsequence: String) -> Bool {
+    var remaining = Substring(subsequence.lowercased())
+    for character in self.lowercased() where character == remaining.first {
+      remaining = remaining.dropFirst()
+    }
+    return remaining.isEmpty
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1584,6 +1584,11 @@ extension SourceKitLSPServer {
   /// Map a `SymbolOccurrence` from the index to a `WorkspaceSymbolItem`, or `nil` if it has no
   /// representable location.
   ///
+  /// If `useQualifiedName` is `true` and the symbol has a container, the item's `name` is the fully-qualified
+  /// name (e.g. `Foo.bar`) and `containerName` is dropped. This is used for qualified queries so that clients
+  /// which filter workspace symbols by matching the query against the item's `name` (e.g. VS Code) keep the
+  /// result — the qualified query wouldn't match the bare member name otherwise.
+  ///
   /// - Parameter referenceDocumentMainFile: The project file whose build settings are used to open the
   ///   symbol's generated interface. **Passing a non-`nil` value changes the shape of the result**: the
   ///   symbol is returned as a `WorkspaceSymbol` with a `sourcekit-lsp://generated-swift-interface`
@@ -1595,18 +1600,28 @@ extension SourceKitLSPServer {
     for symbolOccurrence: SymbolOccurrence,
     in index: CheckedIndex,
     copiedFileMap: CopiedFileMap,
-    referenceDocumentMainFile: DocumentURI?
+    referenceDocumentMainFile: DocumentURI?,
+    useQualifiedName: Bool = false
   ) throws -> WorkspaceSymbolItem? {
     let containerNames = try index.containerNames(of: symbolOccurrence)
-    let containerName: String? =
-      if !containerNames.isEmpty {
-        switch symbolOccurrence.symbol.language {
-        case .cxx, .c, .objc: containerNames.joined(separator: "::")
-        case .swift: containerNames.joined(separator: ".")
-        }
-      } else {
-        nil
+    let separator =
+      switch symbolOccurrence.symbol.language {
+      case .cxx, .c, .objc: "::"
+      case .swift: "."
       }
+    let containerName: String? = containerNames.isEmpty ? nil : containerNames.joined(separator: separator)
+
+    // For qualified queries, put the qualified name in the label (which clients filter against) and drop the
+    // now-redundant container name.
+    let name: String
+    let displayContainerName: String?
+    if useQualifiedName, let containerName {
+      name = "\(containerName)\(separator)\(symbolOccurrence.symbol.name)"
+      displayContainerName = nil
+    } else {
+      name = symbolOccurrence.symbol.name
+      displayContainerName = containerName
+    }
 
     if let referenceDocumentMainFile {
       let (interfaceModuleName, groupName) = Self.splitModuleNameAndGroup(symbolOccurrence.location.moduleName)
@@ -1625,9 +1640,9 @@ extension SourceKitLSPServer {
       )
       return WorkspaceSymbolItem.workspaceSymbol(
         WorkspaceSymbol(
-          name: symbolOccurrence.symbol.name,
+          name: name,
           kind: symbolOccurrence.symbol.kind.asLspSymbolKind(),
-          containerName: containerName,
+          containerName: displayContainerName,
           location: .uri(.init(uri: try urlData.uri)),
           data: data.encodeToLSPAny()
         )
@@ -1638,11 +1653,11 @@ extension SourceKitLSPServer {
     let location = symbolLocation.adjusted(for: copiedFileMap)
     return WorkspaceSymbolItem.symbolInformation(
       SymbolInformation(
-        name: symbolOccurrence.symbol.name,
+        name: name,
         kind: symbolOccurrence.symbol.kind.asLspSymbolKind(),
         deprecated: nil,
         location: location,
-        containerName: containerName
+        containerName: displayContainerName
       )
     )
   }
@@ -1818,6 +1833,13 @@ extension SourceKitLSPServer {
     guard req.query.count >= minWorkspaceSymbolPatternLength else {
       return []
     }
+    if let qualified = QualifiedWorkspaceSymbolQuery(req.query) {
+      return try await qualifiedWorkspaceSymbols(qualified)
+    }
+    return try await unqualifiedWorkspaceSymbols(query: req.query)
+  }
+
+  private func unqualifiedWorkspaceSymbols(query: String) async throws -> [WorkspaceSymbolItem] {
     var items: [WorkspaceSymbolItem] = []
     for workspace in workspaces {
       guard let index = await workspace.index(checkedFor: .deletedFiles) else {
@@ -1826,7 +1848,7 @@ extension SourceKitLSPServer {
       let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
       var symbols: [SymbolOccurrence] = []
       try index.forEachCanonicalSymbolOccurrence(
-        containing: req.query,
+        containing: query,
         anchorStart: false,
         anchorEnd: false,
         subsequence: true,
@@ -1854,6 +1876,165 @@ extension SourceKitLSPServer {
       }
     }
     return items
+  }
+
+  /// Handle a `workspace/symbol` request whose query contains a qualifier separator (`.` or `::`).
+  ///
+  /// Resolves the container named by the query's container chain and returns the container's members whose
+  /// name matches the query's member component.
+  /// See `members(ofContainerChain:matching:includeSystemSymbols:in:)`.
+  private func qualifiedWorkspaceSymbols(
+    _ query: QualifiedWorkspaceSymbolQuery
+  ) async throws -> [WorkspaceSymbolItem] {
+    // Emitting a generated-interface reference document requires both that the client can open it and that
+    // it will call `workspaceSymbol/resolve` to fill in the range. Unlike `unqualifiedWorkspaceSymbols`,
+    // qualified queries can match SDK/stdlib members (e.g. `String.count`), so they need main files.
+    let canUseGeneratedInterfaceReferenceDocument =
+      (self.capabilityRegistry?.clientHasWorkspaceGetReferenceDocumentSupport ?? false)
+      && (self.capabilityRegistry?.clientSupportsWorkspaceSymbolResolve ?? false)
+    var items: [WorkspaceSymbolItem] = []
+    for workspace in workspaces {
+      guard let index = await workspace.index(checkedFor: .deletedFiles) else {
+        continue
+      }
+      let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+      // Resolve the container named by the container chain, then take its direct members, keeping those
+      // whose name matches `query.member`. An empty member (e.g. the query `Foo.`) lists all members.
+      // System members are only useful if we can point at their generated interface.
+      let symbols = try self.members(
+        ofContainerChain: query.containerChain,
+        fuzzyMatching: query.member,
+        includeSystemSymbols: canUseGeneratedInterfaceReferenceDocument,
+        in: index
+      )
+      var mainFiles: [DocumentURI: DocumentURI] = [:]
+      if canUseGeneratedInterfaceReferenceDocument {
+        mainFiles =
+          await orLog("Resolving generated interface main files") {
+            try await self.generatedInterfaceMainFiles(for: symbols, in: workspace)
+          } ?? [:]
+      }
+      items += try symbols.sorted(by: <).compactMap {
+        try self.workspaceSymbolItem(
+          for: $0,
+          in: index,
+          copiedFileMap: copiedFileMap,
+          referenceDocumentMainFile: $0.location.uri.flatMap { mainFiles[$0] },
+          useQualifiedName: true
+        )
+      }
+    }
+    return items
+  }
+
+  /// Resolve the container named by `chain` (outer-to-inner) and return its direct members (`childOf`)
+  /// whose name fuzzily contains `member`.
+  ///
+  /// The innermost name in the chain is matched exactly (case-insensitive) and its `ancestors` — the
+  /// container chain minus that innermost name — must match its enclosing scopes. `member` is matched as a
+  /// case-insensitive subsequence; an empty `member` matches all members. Members declared in extensions
+  /// are included. Members from all matching containers are unioned and de-duplicated by USR.
+  ///
+  /// System (SDK/stdlib) members are only included if `includeSystemSymbols` is `true`. They can only be
+  /// navigated to through a generated interface, so callers pass `false` when the client can't open one.
+  private nonisolated func members(
+    ofContainerChain chain: [String],
+    fuzzyMatching member: String,
+    includeSystemSymbols: Bool,
+    in index: CheckedIndex
+  ) throws -> [SymbolOccurrence] {
+    guard let containerName = chain.last else {
+      throw ResponseError.internalError("\(#function) requires a non-empty chain")
+    }
+
+    // Lowercased once here because the enclosing scopes of every candidate container are compared against it.
+    let lowercasedAncestors = chain.dropLast().map { $0.lowercased() }
+
+    // Resolve the innermost container(s) by exact name, verifying the outer scope chain.
+    //
+    // `containerUSRs` holds every resolved container, including system ones, because a system type can be
+    // extended from the user's own modules and those members stay reachable even when system symbols are
+    // excluded. `containerUSRsForMemberLookup` is the subset whose children are actually walked.
+    var containerUSRs: Set<String> = []
+    var containerUSRsForMemberLookup: Set<String> = []
+    try index.forEachCanonicalSymbolOccurrence(
+      containing: containerName,
+      anchorStart: true,
+      anchorEnd: true,
+      subsequence: false,
+      ignoreCase: true
+    ) { symbol in
+      if Task.isCancelled {
+        return false
+      }
+      // Resolving a system namespace (e.g. `std`, or a whole module) would enumerate an entire system scope,
+      // so skip those.
+      let isSystemNamespace: Bool =
+        switch symbol.symbol.kind {
+        case .namespace, .namespaceAlias, .module:
+          symbol.location.isSystem
+        default:
+          false
+        }
+      // Match only the suffix of the enclosing scopes, so a chain may name just the inner scopes, e.g.
+      // `Inner` for a container declared as `Outer.Inner`.
+      let enclosingScopes = ((try? index.containerNames(of: symbol)) ?? []).suffix(lowercasedAncestors.count)
+      guard !isSystemNamespace, enclosingScopes.map({ $0.lowercased() }) == lowercasedAncestors else {
+        return true
+      }
+      containerUSRs.insert(symbol.symbol.usr)
+      if includeSystemSymbols || !symbol.location.isSystem {
+        containerUSRsForMemberLookup.insert(symbol.symbol.usr)
+      }
+      return true
+    }
+    try Task.checkCancellation()
+
+    // Members declared in an extension are `childOf` the extension symbol, not the extended type. A
+    // type's occurrences at `extension` sites carry `extendedBy` relations pointing at those extensions,
+    // so add the extension USRs to the set of containers whose children we enumerate. Filtering the
+    // occurrences by the `.extendedBy` role restricts the lookup to those extension sites instead of
+    // returning every reference of the type.
+    //
+    // The extension site's location distinguishes the user's extensions from the SDK's, so system
+    // extensions are skipped before any of their members are enumerated.
+    for typeUSR in containerUSRs {
+      try Task.checkCancellation()
+      for occurrence in try index.occurrences(ofUSR: typeUSR, roles: .extendedBy) {
+        guard includeSystemSymbols || !occurrence.location.isSystem else {
+          continue
+        }
+        for relation in occurrence.relations where relation.roles.contains(.extendedBy) {
+          containerUSRsForMemberLookup.insert(relation.symbol.usr)
+        }
+      }
+    }
+
+    var members: [SymbolOccurrence] = []
+    var seenUSRs: Set<String> = []
+    for containerUSR in containerUSRsForMemberLookup {
+      try Task.checkCancellation()
+      let children = try index.occurrences(relatedToUSR: containerUSR, roles: .childOf)
+      for child in children {
+        guard
+          !child.roles.contains(.accessorOf),
+          includeSystemSymbols || !child.location.isSystem,
+          child.symbol.name.fuzzilyContains(subsequence: member),
+          seenUSRs.insert(child.symbol.usr).inserted
+        else {
+          continue
+        }
+        switch child.symbol.language {
+        case .c, .cxx, .objc:
+          // A C-family symbol can have separate declaration and definition occurrences.
+          members.append((try? index.primaryDefinitionOrDeclarationOccurrence(ofUSR: child.symbol.usr)) ?? child)
+        case .swift:
+          // Swift members have a single declaration site, so use the occurrence directly.
+          members.append(child)
+        }
+      }
+    }
+    return members
   }
 
   /// Forwards a SymbolInfoRequest to the appropriate toolchain service for this document.

--- a/Tests/SourceKitLSPTests/QualifiedWorkspaceSymbolQueryTests.swift
+++ b/Tests/SourceKitLSPTests/QualifiedWorkspaceSymbolQueryTests.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) import SourceKitLSP
+import XCTest
+
+final class QualifiedWorkspaceSymbolQueryTests: XCTestCase {
+  func testUnqualifiedQueriesReturnNil() {
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery("description"))
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery("foo123_bar"))
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery(""))
+  }
+
+  func testDotSeparator() {
+    let q = QualifiedWorkspaceSymbolQuery("String.description")
+    XCTAssertEqual(q?.containerChain, ["String"])
+    XCTAssertEqual(q?.member, "description")
+  }
+
+  func testColonColonSeparator() {
+    let q = QualifiedWorkspaceSymbolQuery("Foo::bar")
+    XCTAssertEqual(q?.containerChain, ["Foo"])
+    XCTAssertEqual(q?.member, "bar")
+  }
+
+  func testMultiLevelDotChain() {
+    let q = QualifiedWorkspaceSymbolQuery("Outer.Inner.method")
+    XCTAssertEqual(q?.containerChain, ["Outer", "Inner"])
+    XCTAssertEqual(q?.member, "method")
+  }
+
+  func testMultiLevelColonChain() {
+    let q = QualifiedWorkspaceSymbolQuery("Outer::Inner::method")
+    XCTAssertEqual(q?.containerChain, ["Outer", "Inner"])
+    XCTAssertEqual(q?.member, "method")
+  }
+
+  func testMixedSeparators() {
+    let q = QualifiedWorkspaceSymbolQuery("Outer::Inner.method")
+    XCTAssertEqual(q?.containerChain, ["Outer", "Inner"])
+    XCTAssertEqual(q?.member, "method")
+  }
+
+  func testTrailingSeparatorListsAllMembers() {
+    // A trailing separator with an empty member is a valid qualified query that lists all members of
+    // the container.
+    let dot = QualifiedWorkspaceSymbolQuery("Foo.")
+    XCTAssertEqual(dot?.containerChain, ["Foo"])
+    XCTAssertEqual(dot?.member, "")
+
+    let colon = QualifiedWorkspaceSymbolQuery("Foo::")
+    XCTAssertEqual(colon?.containerChain, ["Foo"])
+    XCTAssertEqual(colon?.member, "")
+
+    let nested = QualifiedWorkspaceSymbolQuery("Outer.Inner.")
+    XCTAssertEqual(nested?.containerChain, ["Outer", "Inner"])
+    XCTAssertEqual(nested?.member, "")
+  }
+
+  func testLeadingSeparatorRejected() {
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery(".bar"))
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery("::bar"))
+  }
+
+  func testLoneColonRejected() {
+    // A single `:` isn't a qualifier separator; it's a literal character. `Foo:bar` therefore has no
+    // separator at all and is not a qualified query, so the parser returns `nil`.
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery("Foo:bar"))
+  }
+
+  func testArgumentLabelColonsArePartOfMember() {
+    // A lone `:` is a literal, so Swift argument labels survive in the member component.
+    let dotQuery = QualifiedWorkspaceSymbolQuery("Collection.append(contentsOf:)")
+    XCTAssertEqual(dotQuery?.containerChain, ["Collection"])
+    XCTAssertEqual(dotQuery?.member, "append(contentsOf:)")
+
+    // `::` still separates even when the member carries argument-label colons.
+    let colonQuery = QualifiedWorkspaceSymbolQuery("Foo::subscript(at:)")
+    XCTAssertEqual(colonQuery?.containerChain, ["Foo"])
+    XCTAssertEqual(colonQuery?.member, "subscript(at:)")
+  }
+
+  func testEmptyParentSegmentRejected() {
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery("Foo..bar"))
+    XCTAssertNil(QualifiedWorkspaceSymbolQuery("Foo.::bar"))
+  }
+}

--- a/Tests/SourceKitLSPTests/StringFuzzilyContainsTests.swift
+++ b/Tests/SourceKitLSPTests/StringFuzzilyContainsTests.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) import SourceKitLSP
+import XCTest
+
+final class StringFuzzilyContainsTests: XCTestCase {
+  func testEmptySubsequenceAlwaysMatches() {
+    XCTAssertTrue("anything".fuzzilyContains(subsequence: ""))
+    XCTAssertTrue("".fuzzilyContains(subsequence: ""))
+  }
+
+  func testSubsequenceMatching() {
+    XCTAssertTrue("longMethodName()".fuzzilyContains(subsequence: "longMethod"))
+    XCTAssertTrue("longMethodName()".fuzzilyContains(subsequence: "lmn"))
+    XCTAssertTrue("bar()".fuzzilyContains(subsequence: "bar"))
+  }
+
+  func testCaseInsensitive() {
+    XCTAssertTrue("MyMethod".fuzzilyContains(subsequence: "mym"))
+    XCTAssertTrue("mymethod".fuzzilyContains(subsequence: "MYM"))
+  }
+
+  func testNonMatching() {
+    XCTAssertFalse("bar".fuzzilyContains(subsequence: "baz"))
+    XCTAssertFalse("bar".fuzzilyContains(subsequence: "barbar"))
+    XCTAssertFalse("".fuzzilyContains(subsequence: "a"))
+  }
+}

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -193,4 +193,469 @@ class WorkspaceSymbolsTests: SourceKitLSPTestCase {
       return true
     }
   }
+
+  func testQualifiedWorkspaceSymbolMatchesMemberAndParent() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Foo {
+        func 1️⃣bar() {}
+      }
+
+      struct Baz {
+        func bar() {}
+      }
+      """
+    )
+    let expected: [WorkspaceSymbolItem] = [
+      .symbolInformation(
+        SymbolInformation(
+          name: "Foo.bar()",
+          kind: .method,
+          location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+        )
+      )
+    ]
+
+    // Only `Foo`'s member matches; `Baz.bar` is excluded because its container isn't `Foo`.
+    let dotSeparator = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Foo.bar"))
+    XCTAssertEqual(dotSeparator, expected)
+
+    // `::` is accepted as a separator too. The symbol is Swift, so the qualified label still uses the
+    // Swift `.` separator.
+    let colonSeparator = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Foo::bar"))
+    XCTAssertEqual(colonSeparator, expected)
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesExtensionMember() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Foo {}
+
+      extension Foo {
+        func 1️⃣bar() {}
+      }
+      """
+    )
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Foo.bar"))
+    XCTAssertEqual(
+      response,
+      [
+        .symbolInformation(
+          SymbolInformation(
+            name: "Foo.bar()",
+            kind: .method,
+            location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+          )
+        )
+      ]
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesTypeInExtensionOfNestedType() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      enum Namespace {
+        enum Sub {}
+      }
+
+      extension Namespace.Sub {
+        struct 1️⃣Foo {}
+      }
+      """
+    )
+    // `Foo` is `childOf` an extension of the nested type `Namespace.Sub`. Resolving the `Namespace.Sub`
+    // container (verifying `Sub`'s ancestor is `Namespace`) and then reaching `Foo` through that
+    // extension must still find it.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Namespace.Sub.Foo"))
+    assertContains(
+      response ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "Namespace.Sub.Foo",
+          kind: .struct,
+          location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+        )
+      )
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesMemberOfTypeInExtensionOfNestedType() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      enum Namespace {
+        enum Sub {}
+      }
+
+      extension Namespace.Sub {
+        struct Foo {
+          var 1️⃣bar: Int
+        }
+      }
+      """
+    )
+    // `Foo` is `childOf` the extension of the nested type `Namespace.Sub`, so verifying the ancestors of
+    // the `Namespace.Sub.Foo` container has to climb from the extension to the extended type `Sub` (which
+    // is where the `childOf Namespace` link lives). Use `contains` because the query also matches the
+    // synthesized memberwise `init(bar:)`.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Namespace.Sub.Foo.bar"))
+    assertContains(
+      response ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "Namespace.Sub.Foo.bar",
+          kind: .property,
+          location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+        )
+      )
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesMemberOfNestedTypeInExtension() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      enum Namespace {}
+
+      extension Namespace {
+        struct Foo {
+          var 1️⃣bar: Int
+        }
+      }
+      """
+    )
+    // `Foo` is `childOf` an extension of `Namespace`, so resolving the `Namespace.Foo` container has to
+    // match `Foo`'s enclosing extension by name. Use `contains` because the query also matches the
+    // synthesized memberwise `init(bar:)`.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Namespace.Foo.bar"))
+    assertContains(
+      response ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "Namespace.Foo.bar",
+          kind: .property,
+          location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+        )
+      )
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolFuzzyMemberMatch() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Foo {
+        func 1️⃣longMethodName() {}
+      }
+      """
+    )
+    // `lmn` is a non-contiguous subsequence of `longMethodName`, exercising the fuzzy member match.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Foo.lmn"))
+    XCTAssertEqual(
+      response,
+      [
+        .symbolInformation(
+          SymbolInformation(
+            name: "Foo.longMethodName()",
+            kind: .method,
+            location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+          )
+        )
+      ]
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolWithWrongParentReturnsNothing() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Foo {
+        func bar() {}
+      }
+      """
+    )
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Quux.bar"))
+    XCTAssertEqual(response, [])
+  }
+
+  func testQualifiedWorkspaceSymbolMultiLevelChain() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Outer {
+        struct Inner {
+          func 1️⃣method() {}
+        }
+      }
+
+      struct Other {
+        func method() {}
+      }
+      """
+    )
+    let expected: [WorkspaceSymbolItem] = [
+      .symbolInformation(
+        SymbolInformation(
+          name: "Outer.Inner.method()",
+          kind: .method,
+          location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+        )
+      )
+    ]
+
+    // The full chain matches by walking `Inner`'s enclosing scopes up to `Outer`.
+    let fullChain = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Outer.Inner.method"))
+    XCTAssertEqual(fullChain, expected)
+
+    // The nested `Inner` is also resolved by its simple name without naming `Outer`; `Other.method` must
+    // not match since its container isn't `Inner`.
+    let innermostOnly = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Inner.method"))
+    XCTAssertEqual(innermostOnly, expected)
+  }
+
+  func testQualifiedWorkspaceSymbolReturnsSystemMembersAsGeneratedInterface() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      let x: String = ""
+      """,
+      capabilities: ClientCapabilities(
+        workspace: .init(symbol: .init(resolveSupport: .init(properties: ["location"]))),
+        experimental: [GetReferenceDocumentRequest.method: .dictionary(["supported": .bool(true)])]
+      ),
+      indexSystemModules: true
+    )
+    // A qualified query into a stdlib type returns its members as `sourcekit-lsp://generated-swift-interface`
+    // reference-document symbols when the client can open them.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "String."))
+    let generatedInterfaceMembers = (response ?? []).filter { item in
+      guard case .workspaceSymbol(let symbol) = item,
+        case .uri(let uriOnly) = symbol.location,
+        let components = URLComponents(string: uriOnly.uri.arbitrarySchemeURL.absoluteString)
+      else {
+        return false
+      }
+      return components.scheme == "sourcekit-lsp" && components.host == "generated-swift-interface"
+        && symbol.name.contains("String")
+    }
+    XCTAssertFalse(
+      generatedInterfaceMembers.isEmpty,
+      "Expected `String` members as generated-interface reference documents, got \(String(describing: response))"
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolOmitsSystemMembersWithoutGeneratedInterfaceSupport() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      let x: String = ""
+      """,
+      indexSystemModules: true
+    )
+    // Without generated-interface support the client can't navigate to system members, so a qualified query
+    // into a stdlib type returns nothing rather than un-navigable `file://` results.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "String."))
+    XCTAssertEqual(response, [])
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesUserExtensionOfSystemTypeWithoutGeneratedInterfaceSupport()
+    async throws
+  {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      extension String {
+        struct Inner { var 1️⃣member: Int }
+        var 2️⃣isBlank: Bool { false }
+      }
+      """,
+      indexSystemModules: true
+    )
+    // The client can't open generated interfaces, so stdlib members of `String` are excluded. Members the
+    // user declared in their own `extension String` are still in their own source and remain navigable, so
+    // they are returned with a plain `file://` location.
+    let members = try await project.testClient.send(WorkspaceSymbolsRequest(query: "String."))
+    let memberNames = (members ?? []).compactMap { item -> String? in
+      guard case .symbolInformation(let info) = item else { return nil }
+      return info.name
+    }
+    XCTAssertEqual(memberNames.sorted(), ["String.Inner", "String.isBlank"])
+
+    assertContains(
+      members ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "String.isBlank",
+          kind: .property,
+          location: Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))
+        )
+      )
+    )
+
+    // A type nested in the user's extension of a system type is itself non-system, so its members are
+    // returned both through the full chain and by the nested type's simple name.
+    for query in ["String.Inner.member", "Inner.member"] {
+      let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: query))
+      assertContains(
+        response ?? [],
+        .symbolInformation(
+          SymbolInformation(
+            name: "String.Inner.member",
+            kind: .property,
+            location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))
+          )
+        )
+      )
+    }
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesCXXMemberDefinedOutOfLine() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/include/lib.h": """
+        struct FilePathIndex {
+          void foo();
+          void foo(int x);
+        };
+        """,
+        "MyLibrary/lib.cpp": """
+        #include "lib.h"
+        void FilePathIndex::1️⃣foo() {}
+        void FilePathIndex::2️⃣foo(int x) {}
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+    // The overloads of `foo` are declared in the header and defined out-of-line in the `.cpp`. Both are
+    // returned, each pointing at its definition in the `.cpp`.
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "FilePathIndex::foo"))
+    assertContains(
+      response ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "FilePathIndex::foo",
+          kind: .method,
+          location: Location(
+            uri: try project.uri(for: "lib.cpp"),
+            range: try Range(project.position(of: "1️⃣", in: "lib.cpp"))
+          )
+        )
+      )
+    )
+    assertContains(
+      response ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "FilePathIndex::foo",
+          kind: .method,
+          location: Location(
+            uri: try project.uri(for: "lib.cpp"),
+            range: try Range(project.position(of: "2️⃣", in: "lib.cpp"))
+          )
+        )
+      )
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolMatchesCXXMemberInNamespace() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/include/lib.h": """
+        namespace mynamespace {
+          void foo();
+          struct MyStruct {
+            void bar();
+          };
+        }
+        """,
+        "MyLibrary/lib.cpp": """
+        #include "lib.h"
+        namespace mynamespace {
+          void 1️⃣foo() {}
+          void MyStruct::2️⃣bar() {}
+        }
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+    // `foo` is scoped to the C++ namespace `mynamespace`; the qualified query resolves it through the
+    // namespace and returns its out-of-line definition in the `.cpp`.
+    let namespaceResponse = try await project.testClient.send(WorkspaceSymbolsRequest(query: "mynamespace::foo"))
+    assertContains(
+      namespaceResponse ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "mynamespace::foo",
+          kind: .function,
+          location: Location(
+            uri: try project.uri(for: "lib.cpp"),
+            range: try Range(project.position(of: "1️⃣", in: "lib.cpp"))
+          )
+        )
+      )
+    )
+    // A method of a struct nested in the namespace is reached through the full `namespace::type::member`
+    // chain.
+    let nestedResponse = try await project.testClient.send(
+      WorkspaceSymbolsRequest(query: "mynamespace::MyStruct::bar")
+    )
+    assertContains(
+      nestedResponse ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "mynamespace::MyStruct::bar",
+          kind: .method,
+          location: Location(
+            uri: try project.uri(for: "lib.cpp"),
+            range: try Range(project.position(of: "2️⃣", in: "lib.cpp"))
+          )
+        )
+      )
+    )
+    // The struct can also be resolved by its simple name without naming the enclosing namespace.
+    let innermostResponse = try await project.testClient.send(WorkspaceSymbolsRequest(query: "MyStruct::bar"))
+    assertContains(
+      innermostResponse ?? [],
+      .symbolInformation(
+        SymbolInformation(
+          name: "mynamespace::MyStruct::bar",
+          kind: .method,
+          location: Location(
+            uri: try project.uri(for: "lib.cpp"),
+            range: try Range(project.position(of: "2️⃣", in: "lib.cpp"))
+          )
+        )
+      )
+    )
+  }
+
+  func testQualifiedWorkspaceSymbolListsAllMembersWithTrailingSeparator() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Foo {
+        func bar() {}
+        var baz: Int { 0 }
+      }
+
+      struct Other {
+        func qux() {}
+      }
+      """
+    )
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Foo."))
+    let names = (response ?? []).compactMap { item -> String? in
+      guard case .symbolInformation(let info) = item else { return nil }
+      return info.name
+    }
+    // All of `Foo`'s members are listed with their qualified name, and members of other types are not.
+    assertContains(names, "Foo.bar()")
+    assertContains(names, "Foo.baz")
+    XCTAssertFalse(names.contains(where: { $0.contains("qux") }), "\(names)")
+  }
+
+  func testQualifiedWorkspaceSymbolMultiLevelChainRejectsWrongOuter() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Outer {
+        struct Inner {
+          func method() {}
+        }
+      }
+      """
+    )
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Wrong.Inner.method"))
+    XCTAssertEqual(response, [])
+  }
 }


### PR DESCRIPTION
`workspace/symbol` previously matched the query as a flat fuzzy search against bare symbol names, so you couldn't search by qualified name (e.g. `Foo.bar` or `Foo::bar`).

Queries are now split on `.`/`::` into a parent chain + member. A qualified query resolves the container(s) named by the parent chain and returns their members whose name contains the member as a case-insensitive subsequence. An empty member (`Foo.`) lists all members. Both separators are accepted and can be mixed (`Foo::Bar.baz`), and a partial chain works (`Inner.member` resolves a nested type without naming its outer scope). Unqualified queries take the flat-search path unchanged.

Unlike the unqualified path, which filters out system symbols, a qualified query deliberately surfaces system SDK results — `String.description` finds the standard-library member. Those results point into the module's generated interface via a `sourcekit-lsp://generated-swift-interface` location (reusing the existing reference-document mechanism); only system namespaces (e.g. `std`) are skipped, to avoid enumerating an entire system scope.

Qualified results carry the fully-qualified name in `name` (e.g. `Foo.bar()`) with no `containerName`, so clients that filter against the label (e.g. VS Code) don't drop them.

No changes to the protocol, `workspace/symbolNames`/`symbolInfo`, or IndexStoreDB.

(`SourceKitLSPServer.swift` getting pretty long for `workspace/symbol` related code. I'm going to make a follow-up PR just for moving them to a dedicated file)