### PR TITLE
Update BackgroundIndexingTests to work with both build backends

### DIFF
--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -529,11 +529,11 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     var testHooks = Hooks()
     let expectedPreparationTracker = ExpectedIndexTaskTracker(expectedPreparations: [
       [
-        try ExpectedPreparation(target: "LibA", destination: .target),
-        try ExpectedPreparation(target: "LibB", destination: .target),
+        try ExpectedPreparation(targetName: "LibA"),
+        try ExpectedPreparation(targetName: "LibB"),
       ],
       [
-        try ExpectedPreparation(target: "LibB", destination: .target)
+        try ExpectedPreparation(targetName: "LibB")
       ],
     ])
     testHooks.indexHooks = expectedPreparationTracker.testHooks
@@ -628,16 +628,15 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let expectedPreparationTracker = ExpectedIndexTaskTracker(expectedPreparations: [
       // Preparation of targets during the initial of the target
       [
-        try ExpectedPreparation(target: "LibA", destination: .target),
-        try ExpectedPreparation(target: "LibB", destination: .target),
-        try ExpectedPreparation(target: "LibC", destination: .target),
-        try ExpectedPreparation(target: "LibD", destination: .target),
+        try ExpectedPreparation(targetName: "LibA"),
+        try ExpectedPreparation(targetName: "LibB"),
+        try ExpectedPreparation(targetName: "LibC"),
+        try ExpectedPreparation(targetName: "LibD"),
       ],
       // LibB's preparation has already started by the time we browse through the other files, so we finish its preparation
       [
         try ExpectedPreparation(
-          target: "LibB",
-          destination: .target,
+          targetName: "LibB",
           didStart: { libBStartedPreparation.signal() },
           didFinish: { allDocumentsOpened.waitOrXCTFail() }
         )
@@ -645,8 +644,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
       // And now we just want to prepare LibD, and not LibC
       [
         try ExpectedPreparation(
-          target: "LibD",
-          destination: .target,
+          targetName: "LibD",
           didFinish: { libDPreparedForEditing.signal() }
         )
       ],
@@ -2659,13 +2657,13 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     // in a non-deterministic order (due to the way ). If LibB's priority gets elevated before LibA's, then LibB will
     // get prepared first, which is contrary to the background behavior we want to check here.
     try await fulfillmentOfOrThrow(twoPreparationRequestsReceived)
-    XCTAssertEqual(
-      preparationRequests.value.flatMap(\.targets),
-      [
-        try BuildTargetIdentifier(target: "LibA", destination: .target),
-        try BuildTargetIdentifier(target: "LibB", destination: .target),
-      ]
-    )
+    let preparedTargets = preparationRequests.value.flatMap(\.targets)
+    guard preparedTargets.count == 2 else {
+      XCTFail("expected 2 prepared targets, but got: \(preparedTargets)")
+      return
+    }
+    XCTAssert(preparedTargets[0].matchesTargetName("LibA"))
+    XCTAssert(preparedTargets[1].matchesTargetName("LibB"))
     withExtendedLifetime(project) {}
   }
 

--- a/Tests/SourceKitLSPTests/ExpectedIndexTaskTracker.swift
+++ b/Tests/SourceKitLSPTests/ExpectedIndexTaskTracker.swift
@@ -37,35 +37,24 @@ enum BuildDestination {
 }
 
 extension BuildTargetIdentifier {
-  /// - Important: *For testing only*
-  init(target: String, destination: BuildDestination) throws {
-    var components = URLComponents()
-    components.scheme = "swiftpm"
-    components.host = "target"
-    components.queryItems = [
-      URLQueryItem(name: "target", value: target),
-      URLQueryItem(name: "destination", value: destination.id),
-    ]
-
-    struct FailedToConvertSwiftBuildTargetToUrlError: Swift.Error, CustomStringConvertible {
-      var target: String
-      var destination: String
-
-      var description: String {
-        return "Failed to generate URL for target: \(target), destination: \(destination)"
-      }
+  // Determine if the BuildTargetIdentifier corresponds to a target with the given name. Matches
+  // the formats used by the builtin SwiftPM integration and the SwiftPM BSP implementation.
+  func matchesTargetName(_ targetName: String) -> Bool {
+    guard let components = URLComponents(url: self.uri.arbitrarySchemeURL, resolvingAgainstBaseURL: false) else {
+      return false
     }
-
-    guard let url = components.url else {
-      throw FailedToConvertSwiftBuildTargetToUrlError(target: target, destination: destination.id)
+    if let value = components.queryItems?.last(where: { $0.name == "target" })?.value {
+      return value == targetName
     }
-
-    self.init(uri: URI(url))
+    if let value = components.queryItems?.last(where: { $0.name == "targetGUID" })?.value {
+      return value.contains(targetName)
+    }
+    return false
   }
 }
 
 struct ExpectedPreparation {
-  let target: BuildTargetIdentifier
+  let targetName: String
 
   /// A closure that will be executed when a preparation task starts.
   /// This allows the artificial delay of a preparation task to force two preparation task to race.
@@ -76,13 +65,11 @@ struct ExpectedPreparation {
   let didFinish: (@Sendable () -> Void)?
 
   internal init(
-    target: String,
-    destination: BuildDestination,
+    targetName: String,
     didStart: (@Sendable () -> Void)? = nil,
     didFinish: (@Sendable () -> Void)? = nil
   ) throws {
-    // This should match the format in `BuildTargetIdentifier(_: any SwiftBuildTarget)` inside SwiftPMBuildServer.
-    self.target = try BuildTargetIdentifier(target: target, destination: destination)
+    self.targetName = targetName
     self.didStart = didStart
     self.didFinish = didFinish
   }
@@ -154,7 +141,7 @@ actor ExpectedIndexTaskTracker {
       return
     }
     for expectedPreparation in expectedTargetsToPrepare {
-      if taskDescription.targetsToPrepare.contains(expectedPreparation.target) {
+      if taskDescription.targetsToPrepare.contains(where: { $0.matchesTargetName(expectedPreparation.targetName) }) {
         expectedPreparation.didStart?()
       }
     }
@@ -172,13 +159,19 @@ actor ExpectedIndexTaskTracker {
       XCTFail("Didn't expect a preparation but received \(taskDescription.targetsToPrepare)")
       return
     }
-    guard Set(taskDescription.targetsToPrepare).isSubset(of: expectedTargetsToPrepare.map(\.target)) else {
+    guard
+      taskDescription.targetsToPrepare.allSatisfy({ seenTarget in
+        expectedTargetsToPrepare.contains(where: { expectedTarget in
+          seenTarget.matchesTargetName(expectedTarget.targetName)
+        })
+      })
+    else {
       XCTFail("Received unexpected preparation of \(taskDescription.targetsToPrepare)")
       return
     }
     var remainingExpectedTargetsToPrepare: [ExpectedPreparation] = []
     for expectedPreparation in expectedTargetsToPrepare {
-      if taskDescription.targetsToPrepare.contains(expectedPreparation.target) {
+      if taskDescription.targetsToPrepare.contains(where: { $0.matchesTargetName(expectedPreparation.targetName) }) {
         expectedPreparation.didFinish?()
       } else {
         remainingExpectedTargetsToPrepare.append(expectedPreparation)

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1139,7 +1139,7 @@ final class WorkspaceTests: SourceKitLSPTestCase {
           }
           do {
             XCTAssert(
-              task.targetsToPrepare.contains(try BuildTargetIdentifier(target: "LibB", destination: .target)),
+              task.targetsToPrepare.contains(where: { $0.matchesTargetName("LibB") }),
               "Prepared unexpected targets: \(task.targetsToPrepare)"
             )
             try await repeatUntilExpectedResult {
@@ -1384,9 +1384,13 @@ final class WorkspaceTests: SourceKitLSPTestCase {
       enableBackgroundIndexing: true
     )
 
+    let fileAUri = try project.uri(for: "FileA.swift")
+    let workspace = try await unwrap(project.testClient.server.workspaceForDocument(uri: fileAUri))
+    let target = try await unwrap(workspace.buildServerManager.canonicalTarget(for: fileAUri))
+
     let outputPaths = try await project.testClient.send(
       OutputPathsRequest(
-        target: BuildTargetIdentifier(target: "MyLibrary", destination: .target).uri,
+        target: target.uri,
         workspace: DocumentURI(project.scratchDirectory)
       )
     )


### PR DESCRIPTION
Change how these tests compare target identifiers so they're compatible with both the builtin SwiftPM indexing functionality and the new BSP implementation. In combination with https://github.com/swiftlang/swift-build/pull/1526 this fixes many of the remaining test failures if I hardcode the BSP implementation as the default.