### PR TITLE
Fix issues causing `Remove Unused Imports` to not show up in VS Code

### DIFF
--- a/Sources/SwiftLanguageService/RemoveUnusedImports.swift
+++ b/Sources/SwiftLanguageService/RemoveUnusedImports.swift
@@ -96,7 +96,7 @@ extension SwiftLanguageService {
     return [
       CodeAction(
         title: command.title,
-        kind: .sourceOrganizeImports,
+        kind: .refactor,
         diagnostics: nil,
         edit: nil,
         command: command.asCommand()

--- a/Sources/SwiftLanguageService/SwiftCommand.swift
+++ b/Sources/SwiftLanguageService/SwiftCommand.swift
@@ -51,6 +51,7 @@ extension SwiftLanguageService {
     [
       SemanticRefactorCommand.self,
       ExpandMacroCommand.self,
+      RemoveUnusedImportsCommand.self,
     ].map { (command: any SwiftCommand.Type) in
       command.identifier
     }


### PR DESCRIPTION
We had two issues here:
1. VS Code does not show code actions with kind `sourceOrganizeImports` in the lightbulb menu. Change it to `empty` so that it does show up.
2. We didn’t declare the command in `SwiftLanguageService`, so VS Code didn’t know to invoke SourceKit-LSP to perform the `remove.unused.imports.command`