### PR TITLE
Fix completion replacement range extending into the next token

### DIFF
--- a/Sources/SwiftLanguageService/CodeCompletionContext.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionContext.swift
@@ -40,9 +40,10 @@ private func findEndOfIdentifier(
   snapshot: DocumentSnapshot,
   tree: SourceFileSyntax
 ) -> Position? {
-  let token = tree.token(at: snapshot.absolutePosition(of: position))
+  let absolutePosition = snapshot.absolutePosition(of: position)
+  let token = tree.token(at: absolutePosition)
 
-  guard let token, token.isIdentifierOrKeyword else {
+  guard let token, token.isIdentifierOrKeyword, token.trimmedRange.contains(absolutePosition) else {
     return nil
   }
 

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -293,6 +293,38 @@ final class SwiftCompletionTests: SourceKitLSPTestCase {
     XCTAssertEqual(abc.textEdit, .textEdit(TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "foobar")))
   }
 
+  func testCompletionNoInsertReplaceEditAtEndOfIdentifierWithFollowingStatement() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
+    let testClient = try await TestSourceKitLSPClient(capabilities: insertReplaceEditCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct Foo {
+        let bar: Int
+      }
+
+      func test() {
+        let x = Foo(bar: 1)
+        x.1️⃣ba2️⃣
+        print("abc")
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
+    )
+
+    guard let bar = completions.items.first(where: { $0.label == "bar" }) else {
+      XCTFail("No completion item with label 'bar'")
+      return
+    }
+
+    XCTAssertEqual(bar.textEdit, .textEdit(TextEdit(range: positions["1️⃣"]..<positions["2️⃣"], newText: "bar")))
+  }
+
   func testCompletionNoSnippetSupport() async throws {
     try await SkipUnless.sourcekitdSupportsPlugin()
 


### PR DESCRIPTION
Fixes #2721

`findEndOfIdentifier` could incorrectly return the end position of the next token, if that token was also an identifier or keyword.