### PR TITLE
Document that code actions should preferably be implemented in terms of `SyntaxRefactoringCodeActionProvider`

### DIFF
--- a/Contributor Documentation/Code Action.md
+++ b/Contributor Documentation/Code Action.md
@@ -18,6 +18,6 @@ Before implementing a new code action, contributors should first file a GitHub i
 
 ## Implementation location
 
-Code actions should generally be implemented in [**sourcekit-lsp**](https://github.com/swiftlang/sourcekit-lsp/tree/main/Sources/SwiftSyntaxCodeActions), since they are primarily a language-server feature.
+Code actions should generally be implemented in [**sourcekit-lsp**](https://github.com/swiftlang/sourcekit-lsp/tree/main/Sources/SwiftSyntaxCodeActions), since they are primarily a language-server feature. They should be implemented as a type conforming to `SyntaxRefactoringCodeActionProvider` unless there is a clear reason to drop down to the more low-level `SyntaxCodeActionProvider`.
 
 They should only be implemented in [**swift-syntax**](https://github.com/swiftlang/swift-syntax/tree/main/Sources/SwiftRefactor) when there is a clear reason to do so, such as when the functionality needs to be reused outside of the language server.


### PR DESCRIPTION
`SyntaxRefactoringCodeActionProvider` is a more structured protocol that extracts some common logic and requires explicit thought about the node to refactor. It should thus be preferred over `SyntaxCodeActionProvider`.