### PR TITLE
Fix textDocument/implementation for protocol requirements

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2227,18 +2227,59 @@ extension SourceKitLSPServer {
     guard let index = await workspaceForDocument(uri: req.textDocument.uri)?.index(checkedFor: .deletedFiles) else {
       return nil
     }
-    let locations = try symbols.flatMap { (symbol) -> [Location] in
-      guard let usr = symbol.usr else { return [] }
-      var occurrences = try index.occurrences(ofUSR: usr, roles: .baseOf)
-      if occurrences.isEmpty {
-        occurrences = try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
-      }
 
-      return occurrences.compactMap { $0.location.lspLocation }
+    // Preserve baseOf-first dispatch used for type hierarchies (subclasses / protocol conformers).
+    // When baseOf is empty (typical for methods), keep explicit overrideOf definition/declaration
+    // locations and remap only pure-implicit sites to their primary definition (e.g. protocol
+    // requirement satisfied in a type body with a separate conformance extension).
+    // See https://github.com/swiftlang/sourcekit-lsp/issues/1600
+    var candidateLocations: [Location] = []
+    var fallbackOccurrences: [SymbolOccurrence] = []
+
+    for symbol in symbols {
+      guard let usr = symbol.usr else { continue }
+      let baseOccurrences = try index.occurrences(ofUSR: usr, roles: .baseOf)
+      if !baseOccurrences.isEmpty {
+        candidateLocations += baseOccurrences.compactMap { $0.location.lspLocation }
+      } else {
+        fallbackOccurrences += try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
+      }
     }
+
+    // Deduplicate USRs only for pure-implicit occurrences that need primary-definition lookup.
+    var implicitUSRsNeedingLookup = Set<String>()
+    var uniqueImplicitUSRsInOrder: [String] = []
+
+    for occurrence in fallbackOccurrences {
+      let isExplicitDefinitionOrDeclaration =
+        occurrence.roles.contains(.definition) || occurrence.roles.contains(.declaration)
+      if isExplicitDefinitionOrDeclaration {
+        // Preserve every explicit declaration/definition location (important for C++ where
+        // in-class declaration and out-of-line definition share a USR).
+        if let location = occurrence.location.lspLocation {
+          candidateLocations.append(location)
+        }
+      } else if occurrence.roles.contains(.implicit) {
+        let implUSR = occurrence.symbol.usr
+        if implicitUSRsNeedingLookup.insert(implUSR).inserted {
+          uniqueImplicitUSRsInOrder.append(implUSR)
+        }
+      }
+      // Other non-explicit, non-implicit roles: ignore.
+    }
+
+    for implUSR in uniqueImplicitUSRsInOrder {
+      if let primary = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: implUSR),
+        let location = primary.location.lspLocation
+      {
+        candidateLocations.append(location)
+      }
+      // Pure implicit with no resolvable primary: drop (avoids subclass / conformance sites).
+    }
+
     let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
-    let remappedLocations = locations.adjusted(for: copiedFileMap)
-    return .locations(remappedLocations.sorted())
+    let remappedLocations = candidateLocations.adjusted(for: copiedFileMap)
+    return .locations(remappedLocations.unique.sorted())
   }
 
   func references(

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2228,36 +2228,32 @@ extension SourceKitLSPServer {
       return nil
     }
 
-    // Preserve baseOf-first dispatch used for type hierarchies (subclasses / protocol conformers).
-    // When baseOf is empty (typical for methods), keep explicit overrideOf definition/declaration
-    // locations and remap only pure-implicit sites to their primary definition (e.g. protocol
-    // requirement satisfied in a type body with a separate conformance extension).
+    // Report baseOf locations used for type hierarchies (subclasses / protocol conformers). For overrideOf
+    // occurrences, keep explicit definition/declaration locations and remap only pure-implicit sites to their primary
+    // definition (e.g. a protocol requirement satisfied in a type body with a separate conformance extension).
     // See https://github.com/swiftlang/sourcekit-lsp/issues/1600
-    var candidateLocations: [Location] = []
-    var fallbackOccurrences: [SymbolOccurrence] = []
+    var resultLocations: [Location] = []
+    var overrideOccurrences: [SymbolOccurrence] = []
 
     for symbol in symbols {
       guard let usr = symbol.usr else { continue }
       let baseOccurrences = try index.occurrences(ofUSR: usr, roles: .baseOf)
-      if !baseOccurrences.isEmpty {
-        candidateLocations += baseOccurrences.compactMap { $0.location.lspLocation }
-      } else {
-        fallbackOccurrences += try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
-      }
+      resultLocations += baseOccurrences.compactMap { $0.location.lspLocation }
+      overrideOccurrences += try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
     }
 
     // Deduplicate USRs only for pure-implicit occurrences that need primary-definition lookup.
     var implicitUSRsNeedingLookup = Set<String>()
     var uniqueImplicitUSRsInOrder: [String] = []
 
-    for occurrence in fallbackOccurrences {
+    for occurrence in overrideOccurrences {
       let isExplicitDefinitionOrDeclaration =
         occurrence.roles.contains(.definition) || occurrence.roles.contains(.declaration)
       if isExplicitDefinitionOrDeclaration {
         // Preserve every explicit declaration/definition location (important for C++ where
         // in-class declaration and out-of-line definition share a USR).
         if let location = occurrence.location.lspLocation {
-          candidateLocations.append(location)
+          resultLocations.append(location)
         }
       } else if occurrence.roles.contains(.implicit) {
         let implUSR = occurrence.symbol.usr
@@ -2272,13 +2268,13 @@ extension SourceKitLSPServer {
       if let primary = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: implUSR),
         let location = primary.location.lspLocation
       {
-        candidateLocations.append(location)
+        resultLocations.append(location)
       }
       // Pure implicit with no resolvable primary: drop (avoids subclass / conformance sites).
     }
 
     let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
-    let remappedLocations = candidateLocations.adjusted(for: copiedFileMap)
+    let remappedLocations = resultLocations.adjusted(for: copiedFileMap)
     return .locations(remappedLocations.unique.sorted())
   }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2243,6 +2243,19 @@ extension SourceKitLSPServer {
       overrideOccurrences += try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
     }
 
+    func preferredImplicitOccurrence(_ lhs: SymbolOccurrence, _ rhs: SymbolOccurrence) -> SymbolOccurrence {
+      let lhsIsContainedByExtension = lhs.relations.contains {
+        $0.roles.contains(.containedBy) && $0.symbol.kind == .extension
+      }
+      let rhsIsContainedByExtension = rhs.relations.contains {
+        $0.roles.contains(.containedBy) && $0.symbol.kind == .extension
+      }
+      if lhsIsContainedByExtension != rhsIsContainedByExtension {
+        return lhsIsContainedByExtension ? lhs : rhs
+      }
+      return min(lhs, rhs)
+    }
+
     // Retain one deterministic fallback occurrence for each USR that needs primary-definition lookup.
     var implicitOccurrencesNeedingLookup: [String: SymbolOccurrence] = [:]
 
@@ -2255,7 +2268,10 @@ extension SourceKitLSPServer {
         }
       } else if occurrence.roles.contains(.implicit) {
         let usr = occurrence.symbol.usr
-        implicitOccurrencesNeedingLookup[usr] = min(implicitOccurrencesNeedingLookup[usr] ?? occurrence, occurrence)
+        implicitOccurrencesNeedingLookup[usr] = preferredImplicitOccurrence(
+          implicitOccurrencesNeedingLookup[usr] ?? occurrence,
+          occurrence
+        )
       } else {
         logger.fault(
           "Ignoring override occurrence \(occurrence.symbol.usr) with unexpected roles \(occurrence.roles)"

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2244,28 +2244,25 @@ extension SourceKitLSPServer {
 
     // Deduplicate USRs only for pure-implicit occurrences that need primary-definition lookup.
     var implicitUSRsNeedingLookup = Set<String>()
-    var uniqueImplicitUSRsInOrder: [String] = []
 
     for occurrence in overrideOccurrences {
-      let isExplicitDefinitionOrDeclaration =
-        occurrence.roles.contains(.definition) || occurrence.roles.contains(.declaration)
-      if isExplicitDefinitionOrDeclaration {
+      if occurrence.roles.contains(.definition) || occurrence.roles.contains(.declaration) {
         // Preserve every explicit declaration/definition location (important for C++ where
         // in-class declaration and out-of-line definition share a USR).
         if let location = occurrence.location.lspLocation {
           resultLocations.append(location)
         }
       } else if occurrence.roles.contains(.implicit) {
-        let implUSR = occurrence.symbol.usr
-        if implicitUSRsNeedingLookup.insert(implUSR).inserted {
-          uniqueImplicitUSRsInOrder.append(implUSR)
-        }
+        implicitUSRsNeedingLookup.insert(occurrence.symbol.usr)
+      } else {
+        logger.fault(
+          "Ignoring override occurrence \(occurrence.symbol.usr) with unexpected roles \(occurrence.roles)"
+        )
       }
-      // Other non-explicit, non-implicit roles: ignore.
     }
 
-    for implUSR in uniqueImplicitUSRsInOrder {
-      if let primary = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: implUSR),
+    for implicitUSR in implicitUSRsNeedingLookup {
+      if let primary = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: implicitUSR),
         let location = primary.location.lspLocation
       {
         resultLocations.append(location)

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2243,6 +2243,11 @@ extension SourceKitLSPServer {
       overrideOccurrences += try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
     }
 
+    /// Prefer implicit occurrences in extensions because they identify where a conformance is introduced.
+    ///
+    /// For example, when a class conforms to a protocol in an extension, subclasses inherit that conformance and can
+    /// produce implicit occurrences for the same requirement. If no indexed definition or declaration is available,
+    /// reporting the extension is more useful than reporting one of those subclasses.
     func preferredImplicitOccurrence(_ lhs: SymbolOccurrence, _ rhs: SymbolOccurrence) -> SymbolOccurrence {
       let lhsIsContainedByExtension = lhs.relations.contains {
         $0.roles.contains(.containedBy) && $0.symbol.kind == .extension

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2229,8 +2229,9 @@ extension SourceKitLSPServer {
     }
 
     // Report baseOf locations used for type hierarchies (subclasses / protocol conformers). For overrideOf
-    // occurrences, keep explicit definition/declaration locations and remap only pure-implicit sites to their primary
-    // definition (e.g. a protocol requirement satisfied in a type body with a separate conformance extension).
+    // occurrences, keep explicit definition/declaration locations and remap pure-implicit sites to their primary
+    // definition when possible (e.g. a protocol requirement satisfied in a type body with a separate conformance
+    // extension). If no primary occurrence is indexed, report one representative implicit location.
     // See https://github.com/swiftlang/sourcekit-lsp/issues/1600
     var resultLocations: [Location] = []
     var overrideOccurrences: [SymbolOccurrence] = []
@@ -2242,8 +2243,8 @@ extension SourceKitLSPServer {
       overrideOccurrences += try index.occurrences(relatedToUSR: usr, roles: .overrideOf)
     }
 
-    // Deduplicate USRs only for pure-implicit occurrences that need primary-definition lookup.
-    var implicitUSRsNeedingLookup = Set<String>()
+    // Retain one deterministic fallback occurrence for each USR that needs primary-definition lookup.
+    var implicitOccurrencesNeedingLookup: [String: SymbolOccurrence] = [:]
 
     for occurrence in overrideOccurrences {
       if occurrence.roles.contains(.definition) || occurrence.roles.contains(.declaration) {
@@ -2253,7 +2254,8 @@ extension SourceKitLSPServer {
           resultLocations.append(location)
         }
       } else if occurrence.roles.contains(.implicit) {
-        implicitUSRsNeedingLookup.insert(occurrence.symbol.usr)
+        let usr = occurrence.symbol.usr
+        implicitOccurrencesNeedingLookup[usr] = min(implicitOccurrencesNeedingLookup[usr] ?? occurrence, occurrence)
       } else {
         logger.fault(
           "Ignoring override occurrence \(occurrence.symbol.usr) with unexpected roles \(occurrence.roles)"
@@ -2261,13 +2263,11 @@ extension SourceKitLSPServer {
       }
     }
 
-    for implicitUSR in implicitUSRsNeedingLookup {
-      if let primary = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: implicitUSR),
-        let location = primary.location.lspLocation
-      {
+    for (implicitUSR, implicitOccurrence) in implicitOccurrencesNeedingLookup {
+      let occurrence = try index.primaryDefinitionOrDeclarationOccurrence(ofUSR: implicitUSR) ?? implicitOccurrence
+      if let location = occurrence.location.lspLocation {
         resultLocations.append(location)
       }
-      // Pure implicit with no resolvable primary: drop (avoids subclass / conformance sites).
     }
 
     let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -308,4 +308,44 @@ final class ImplementationTests: SourceKitLSPTestCase {
       [Location(uri: try project.uri(for: "b.swift"), range: Range(try project.position(of: "2️⃣", in: "b.swift")))]
     )
   }
+
+  /// C++ virtual overrides often share a USR between the in-class declaration and the out-of-line definition.
+  /// Implementation must preserve both explicit locations (not collapse to a single primary definition).
+  func testCppVirtualOverridePreservesDeclarationAndDefinition() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/include/empty.h": "",
+        "MyLibrary/Test.cpp": """
+        struct Base {
+          virtual void 1️⃣foo();
+        };
+
+        struct Derived : Base {
+          void 2️⃣foo() override;
+        };
+
+        void Base::foo() {}
+        void Derived::3️⃣foo() {}
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+
+    let (uri, positions) = try project.openDocument("Test.cpp", language: .cpp)
+
+    let response = try await project.testClient.send(
+      ImplementationRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    XCTAssertEqual(
+      response?.locations,
+      [
+        Location(uri: uri, range: Range(positions["2️⃣"])),
+        Location(uri: uri, range: Range(positions["3️⃣"])),
+      ]
+    )
+  }
 }

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -249,9 +249,10 @@ final class ImplementationTests: SourceKitLSPTestCase {
   }
 
   func testOverrideProtocolFunc() async throws {
-    // TODO: We should not be reporting locations 4, 5 and 7 because they don't actually contain myFunc.
-    // We should, however, be reporting location 6. (https://github.com/swiftlang/sourcekit-lsp/issues/1600)
-
+    // https://github.com/swiftlang/sourcekit-lsp/issues/1600
+    // Report actual method implementations only: not subclass names (4, 5) or
+    // conformance-only extensions (7). Retroactive methods declared in the type
+    // body (6) must still be found via the conformance extension's index relation.
     try await testImplementation(
       """
       protocol MyProto {
@@ -277,7 +278,7 @@ final class ImplementationTests: SourceKitLSPTestCase {
         func 8️⃣myFunc() { }
       }
       """,
-      expectedLocations: ["2️⃣", "3️⃣", "4️⃣", "5️⃣", "7️⃣", "8️⃣"]
+      expectedLocations: ["2️⃣", "3️⃣", "6️⃣", "8️⃣"]
     )
   }
 

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -10,10 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKLogging
 import SKTestSupport
+import SwiftExtensions
 import TSCBasic
+import ToolchainRegistry
 import XCTest
 
 final class ImplementationTests: SourceKitLSPTestCase {
@@ -276,6 +279,71 @@ final class ImplementationTests: SourceKitLSPTestCase {
       """,
       expectedLocations: ["2️⃣", "3️⃣", "6️⃣", "8️⃣"]
     )
+  }
+
+  func testImplicitImplementationWithoutIndexedDefinitionIsReportedOnce() async throws {
+    guard let swiftc = await ToolchainRegistry.forTesting.default?.swiftc else {
+      throw XCTSkip("swiftc not found")
+    }
+
+    try await withTestScratchDir { binaryModuleDir in
+      let sourceFile = binaryModuleDir.appendingPathComponent("BinaryLib.swift")
+      try await """
+      open class BinaryType {
+        public init() {}
+        open func myFunc() {}
+      }
+      """.writeWithRetry(to: sourceFile)
+
+      var arguments = [
+        swiftc.path,
+        "-emit-module",
+        "-module-name", "BinaryLib",
+        "-emit-module-path", binaryModuleDir.appendingPathComponent("BinaryLib.swiftmodule").path,
+      ]
+      if let sdk = defaultSDKPath {
+        arguments += ["-sdk", sdk]
+      }
+      #if os(macOS)
+      #if arch(arm64)
+      arguments += ["-target", "arm64-apple-macosx10.13"]
+      #elseif arch(x86_64)
+      arguments += ["-target", "x86_64-apple-macosx10.13"]
+      #endif
+      #endif
+      arguments += [sourceFile.path]
+      try await Process.checkNonZeroExit(arguments: arguments)
+
+      let consumerDirectory = binaryModuleDir.appendingPathComponent("Consumer")
+      try FileManager.default.createDirectory(at: consumerDirectory, withIntermediateDirectories: true)
+      let project = try await IndexedSingleSwiftFileTestProject(
+        """
+        import BinaryLib
+
+        protocol MyProto {
+          func 1️⃣myFunc()
+        }
+
+        extension 2️⃣BinaryType: MyProto {}
+        class 3️⃣SubclassA: BinaryType {}
+        class 4️⃣SubclassB: BinaryType {}
+        """,
+        workspaceDirectory: consumerDirectory,
+        extraCompilerArguments: ["-I", binaryModuleDir.path]
+      )
+
+      let response = try await project.testClient.send(
+        ImplementationRequest(
+          textDocument: TextDocumentIdentifier(project.fileURI),
+          position: project.positions["1️⃣"]
+        )
+      )
+
+      XCTAssertEqual(
+        response?.locations,
+        [Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))]
+      )
+    }
   }
 
   func testCrossFile() async throws {

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -249,10 +249,6 @@ final class ImplementationTests: SourceKitLSPTestCase {
   }
 
   func testOverrideProtocolFunc() async throws {
-    // https://github.com/swiftlang/sourcekit-lsp/issues/1600
-    // Report actual method implementations only: not subclass names (4, 5) or
-    // conformance-only extensions (7). Retroactive methods declared in the type
-    // body (6) must still be found via the conformance extension's index relation.
     try await testImplementation(
       """
       protocol MyProto {

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -324,8 +324,9 @@ final class ImplementationTests: SourceKitLSPTestCase {
           func 1️⃣myFunc()
         }
 
-        extension 2️⃣BinaryType: MyProto {}
         class 3️⃣SubclassA: BinaryType {}
+        // Keep the extension between the subclasses to verify that the result doesn't depend on source order.
+        extension 2️⃣BinaryType: MyProto {}
         class 4️⃣SubclassB: BinaryType {}
         """,
         workspaceDirectory: consumerDirectory,


### PR DESCRIPTION
Fixes #1600

- Return actual method implementations instead of subclass and conformance locations
- Preserve C++ declarations and out-of-line definitions that share a USR
- Also includes Swift and C++ regression tests