### PR TITLE
Accept legacy GetReferenceDocumentRequest in client capabilities

### DIFF
--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -126,6 +126,9 @@ package final actor CapabilityRegistry {
 
   package nonisolated var clientHasWorkspaceGetReferenceDocumentSupport: Bool {
     return clientHasExperimentalCapability(GetReferenceDocumentRequest.method)
+      || MessageRegistry.lspLegacyNames[GetReferenceDocumentRequest.method].map {
+        clientHasExperimentalCapability($0)
+      } ?? false
   }
 
   /// Whether the client supports `workspaceSymbol/resolve` for lazy location resolution.

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -842,7 +842,12 @@ extension SourceKitLSPServer {
         DidChangeActiveDocumentNotification.method,
       ]
       for capabilityName in experimentalClientCapabilities {
-        guard let experimentalCapability = initializationOptions[capabilityName] else {
+        // Some clients still pass these under their legacy method names, so accept
+        // either the current name or the legacy name from `initializationOptions`.
+        let experimentalCapability =
+          initializationOptions[capabilityName]
+          ?? MessageRegistry.lspLegacyNames[capabilityName].flatMap { initializationOptions[$0] }
+        guard let experimentalCapability else {
           continue
         }
         var experimentalCapabilities: [String: LSPAny] =


### PR DESCRIPTION
The LSP server should accept `workspace/getReferenceDocument` in addition to `sourcekit/workspace/getReferenceDocument` for `clientHasWorkspaceGetReferenceDocumentSupport` capability. 04118be misseed this.