### PR TITLE
Emit a stable generated-interface URI for SDK workspace symbols

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -406,7 +406,7 @@ Unlike the standard `workspace/symbol` request (which accepts a fuzzy query stri
 
 For each name the response contains zero or more `WorkspaceSymbolItem` values:
 - Source-file symbols carry a `SymbolInformation` with a `file://` URI and the exact position.
-- SDK/stdlib symbols carry a `WorkspaceSymbol` with `location: .uri(...)` pointing at the `file://` URI of the `.swiftinterface` or `.swiftmodule` file, with the fully-qualified module name as a `?module=` query parameter. The symbol's USR is stored in `data["usr"]`. Call `workspaceSymbol/resolve` to obtain the exact `Location` within the generated interface. The client must advertise `workspace.symbol.resolveSupport`; without it, the raw `file://` URI is returned as `SymbolInformation` instead.
+- SDK/stdlib symbols carry a `WorkspaceSymbol` with `location: .uri(...)` pointing at a `sourcekit-lsp://generated-swift-interface` reference-document URL (no range). Its `data` is a `SourceKitWorkspaceSymbolData` (see below). Call `workspaceSymbol/resolve` to fill in the exact `Location` range within the generated interface and `sourcekit/workspace/getReferenceDocument` to retrieve the interface's contents. The client must advertise both `workspace.symbol.resolveSupport` and the `sourcekit/workspace/getReferenceDocument` capability; without them, the raw `file://` URI of the `.swiftinterface`/`.swiftmodule` file is returned as `SymbolInformation` instead.
 
 Every requested name is present in the response as a flat array; items carry their name in the `name` field of the `SymbolInformation` or `WorkspaceSymbol`.
 
@@ -430,6 +430,23 @@ export interface WorkspaceSymbolInfoResult {
    * Each item carries the symbol name in its `name` field.
    */
   results: WorkspaceSymbolItem[];
+}
+
+/**
+ * For SDK/stdlib symbols, `WorkspaceSymbol.data` contains the following data.
+ */
+export interface SourceKitWorkspaceSymbolData {
+  /**
+   * The USR of the symbol, used by `workspaceSymbol/resolve` to find the symbol's position within the generated
+   * interface.
+   */
+  usr: string;
+
+  /** The `.swiftinterface`/`.swiftmodule` file the symbol is declared in. */
+  interfaceURI?: DocumentURI;
+
+  /** The fully-qualified module name recorded in the index (e.g. `Swift.String`). */
+  moduleName?: string;
 }
 ```
 

--- a/Contributor Documentation/Open Quickly.md
+++ b/Contributor Documentation/Open Quickly.md
@@ -44,13 +44,14 @@ The shape of each result item depends on the symbol's origin:
   }
 ```
 
-**SDK/stdlib symbols** — returned as `WorkspaceSymbol` with `location: .uri(file:// URL)` (no range) pointing to the
-`.swiftinterface` or `.swiftmodule` file from the index record, when the client advertises
-`workspace.symbol.resolveSupport.properties` containing `"location"` or both `"location.uri"` and `"location.range"`.
-The fully-qualified module name (e.g. `Swift.String`) is appended as a `?module=` query parameter on the location URL
-so clients can derive a display path without inspecting the `data` dictionary. The symbol's USR is stored in the
-`data` dictionary. The client must call `workspaceSymbol/resolve` to obtain the exact location within the generated
-interface.
+**SDK/stdlib symbols** — returned as `WorkspaceSymbol` with `location: .uri(sourcekit-lsp:// URL)` (no range) and a
+`data` payload. The `data` is a `SourceKitWorkspaceSymbolData` that clients decode via `WorkspaceSymbol.sourceKitData`,
+carrying the symbol's USR, the `.swiftinterface`/`.swiftmodule` path (`interfaceURI`), and the fully-qualified module
+name (`moduleName`, e.g. `Swift.String`) that clients can use to render the candidate. The URI is a
+fully-parameterized `sourcekit-lsp://generated-swift-interface/` reference-document URL: `workspaceSymbol/resolve`
+fills in its range and `workspace/getReferenceDocument` returns its content. This form is emitted when the client
+advertises **both** generated-interface reference documents (`GetReferenceDocumentRequest`) and
+`workspaceSymbol/resolve` support (see [Client Capabilities](#client-capabilities)).
 
 ```
 → WorkspaceSymbolInfoRequest { names: ["String"] }
@@ -59,37 +60,39 @@ interface.
       WorkspaceSymbol {
         name: "String",
         kind: .struct,
-        location: { uri: "file:///path/to/Swift.swiftmodule/arm64-apple-macosx.swiftinterface?module=Swift.String" },
-        data: { "usr": "s:SS" }
+        location: { uri: "sourcekit-lsp://generated-swift-interface/Swift.String.swiftinterface?moduleName=Swift&groupName=String&sourcekitdDocument=Swift.String.12345678&buildSettingsFrom=file:///path/to/Sources/main.swift" },
+        data: {
+          "usr": "s:SS",
+          "interfaceURI": "file:///path/to/Swift.swiftmodule/arm64-apple-macosx.swiftinterface",
+          "moduleName": "Swift.String"
+        }
       }
     ]
   }
 ```
 
-Without that capability, the raw `file://` URI of the `.swiftinterface` or `.swiftmodule` file from the index record
-is returned as `SymbolInformation` instead.
+Without those capabilities, the raw `file://` URI of the `.swiftinterface` or `.swiftmodule` file from the index
+record is returned as `SymbolInformation` instead.
+
+> [!NOTE]
+> The `data` payload is a typed SourceKit-LSP API (`SourceKitWorkspaceSymbolData`): clients should decode it via
+> `WorkspaceSymbol.sourceKitData` rather than reading raw JSON keys.
 
 The response is a flat array of `WorkspaceSymbolItem` values. Each item carries the symbol name in its `name` field.
 
-### `workspaceSymbol/resolve` — Location Resolution
+### `workspaceSymbol/resolve` — Range Resolution
 
-Resolves the lazy location of a `WorkspaceSymbol` returned by `sourcekit/workspace/symbolInfo`. The server parses
-`moduleName` and `groupName` from the `?module=` query parameter of the location URL, reads `usr` from the `data`
-dictionary, opens the generated Swift interface for the symbol's module, finds the symbol's position using the USR,
-and returns the same symbol with `location` replaced by a full `Location` (URI + range).
-
-> [!NOTE]
-> The LSP 3.17 spec defines `workspaceSymbol/resolve` as filling in a missing `range` for a URI-only location — it
-> does not anticipate replacing `location.uri` itself. SourceKit-LSP goes beyond the spec here: it substitutes the
-> `file://` module-file URL with a `sourcekit-lsp://` URI that the client can pass to `workspace/getReferenceDocument`
-> to retrieve the generated interface content.
+Fills in the range of a `WorkspaceSymbol` returned by `sourcekit/workspace/symbolInfo`. The server parses
+`moduleName`, `groupName`, and `buildSettingsFrom` from the location URI, reads `usr` from `sourceKitData`,
+opens the generated Swift interface for the symbol's module, finds the symbol's position using the USR, and returns
+the same symbol with `location` upgraded from a URI-only location to a full `Location` (URI + range).
 
 ```
 → WorkspaceSymbolResolveRequest {
     workspaceSymbol: WorkspaceSymbol {
       name: "String",
       kind: .struct,
-      location: { uri: "file:///path/to/Swift.swiftmodule/arm64-apple-macosx.swiftinterface?module=Swift.String" },
+      location: { uri: "sourcekit-lsp://generated-swift-interface/Swift.String.swiftinterface?moduleName=Swift&groupName=String&sourcekitdDocument=Swift.String.12345678&buildSettingsFrom=file:///path/to/Sources/main.swift" },
       data: { "usr": "s:SS" }
     }
   }
@@ -103,14 +106,10 @@ and returns the same symbol with `location` replaced by a full `Location` (URI +
   }
 ```
 
-The resolved URI is a fully-parameterized `sourcekit-lsp://generated-swift-interface/` URL containing
-`sourcekitdDocument` and `buildSettingsFrom` derived from a real source file in the workspace via
-`mainFiles(containing:)`.
-
-The client must treat the resolved `sourcekit-lsp://` URI as **opaque** — it should not parse or extract information
-from the query parameters. The path component (e.g. `Swift.String.swiftinterface`) may be used as the editor tab
-title. The URI is otherwise only valid as an input to `workspace/getReferenceDocument`; its query parameter structure
-is an implementation detail subject to change.
+The client must treat the `sourcekit-lsp://` URI as **opaque** — it should not parse or extract information from the
+query parameters. The path component (e.g. `Swift.String.swiftinterface`) may be used as the editor tab title. The URI
+is otherwise only valid as an input to `workspace/getReferenceDocument`; its query parameter structure is an
+implementation detail subject to change.
 
 ### `workspace/getReferenceDocument` — Content Retrieval
 
@@ -124,8 +123,8 @@ provider — it returns the document text and nothing else.
   }
 ```
 
-The URI passed here must be a fully resolved URI (with `sourcekitdDocument` set), as returned by
-`workspaceSymbol/resolve`.
+The URI passed here is the same one carried by the `WorkspaceSymbol` from `sourcekit/workspace/symbolInfo`; the client
+does not need to have resolved the range first.
 
 ## Workflow
 
@@ -140,13 +139,13 @@ Client                                            Server
   │── sourcekit/workspace/symbolInfo                 │
   │     {["String", "Stride", ...]} ────────────────▶│
   │◀─ [WorkspaceSymbol] ─────────────────────────────│
-  │     (location: "file://...?module=Swift.String") │
+  │     (location: "sourcekit-lsp://...")            │
   │                                                  │
   │  [user selects "String"]                         │
   │                                                  │
   │── workspaceSymbol/resolve ──────────────────────▶│
   │◀─ WorkspaceSymbol                                │
-  │     (url: "sourcekit-lsp://...", range: ...) ────│
+  │     (location: uri + range) ─────────────────────│
   │                                                  │
   │── workspace/getReferenceDocument ───────────────▶│
   │◀─ { content: "..." } ────────────────────────────│
@@ -158,90 +157,19 @@ Client                                            Server
 2. **Resolution** — send matching name(s) to populate the search result list; server returns symbol details (kind,
    container name, location) for display.
    - Source symbols: `SymbolInformation` with a `file://` URI and exact position. No further steps required.
-   - SDK/stdlib symbols: `WorkspaceSymbol` with `location: .uri(file:// URL?module=...)` pointing to the module file
-     and the USR in `data["usr"]`, when the client advertises `workspace.symbol.resolveSupport.properties` containing
-     `"location"` or both `"location.uri"` and `"location.range"`. Otherwise falls back to `SymbolInformation` with
-     the raw `file://` URI.
-3. **Location resolution** — call `workspaceSymbol/resolve` with the selected `WorkspaceSymbol` to open the generated
-   interface and resolve the symbol position. The server synthesizes the final `sourcekit-lsp://` URI and fills in
-   `location.range`.
+   - SDK/stdlib symbols: `WorkspaceSymbol` with a `location: .uri(sourcekit-lsp:// URL)` (no range) and a
+     `SourceKitWorkspaceSymbolData` payload in `data`, when the client advertises the required capabilities. Otherwise
+     falls back to `SymbolInformation` with the raw `file://` interface URI.
+3. **Range resolution** — call `workspaceSymbol/resolve` with the selected `WorkspaceSymbol` to open the generated
+   interface and resolve the symbol position. The server fills in `location.range`.
 4. **Content retrieval** — fetch the generated interface text. The editor scrolls to `location.range.start` from the
    resolve step.
 
-## Pre-resolve Location Design for SDK/stdlib Symbols
+## `sourcekit-lsp://` URI for SDK/stdlib Symbols
 
-When `sourcekit/workspace/symbolInfo` returns a `WorkspaceSymbol` for an SDK or stdlib symbol, the location is a
-`file://` URL pointing to the `.swiftinterface` or `.swiftmodule` file recorded in the index, with the
-fully-qualified module name appended as a `?module=` query parameter. The `data` field carries only the USR. There is
-no special URI scheme to parse.
-
-> [!NOTE]
-> The `file://path/to/module.{swiftinterface,swiftmodule}?module=<moduleName>` URL format is intended to become a
-> general-purpose format used throughout sourcekit-lsp wherever a module file location with associated module name
-> needs to be represented. It is currently only produced by `sourcekit/workspace/symbolInfo`.
->
-> In the future, `sourcekit/workspace/symbolInfo` may return other URL schemes. Clients should treat the location URI
-> as opaque and pass it back to the server via `workspaceSymbol/resolve` without attempting to parse or interpret it.
-
-`DocumentURI` equality and hashing use the filesystem path (via `withUnsafeFileSystemRepresentation`), which strips
-query parameters, so the URL with `?module=` compares equal to the clean path for all index and build-system lookups.
-
-### `WorkspaceSymbol` fields
-
-| Field | Value |
-|---|---|
-| `location` | `.uri(LocationURI)` — a `file://` URL to the `.swiftinterface` or `.swiftmodule` file, with `?module=<fullyQualifiedModuleName>` appended (e.g. `?module=Swift.String`) |
-| `data["usr"]` | Unified Symbol Reference string (e.g. `"s:SS"`) — used by `workspaceSymbol/resolve` to pinpoint the symbol's line/column within the generated interface |
-
-### `?module=` query parameter
-
-The `?module=` value is the fully-qualified dotted module name recorded in the index (e.g. `Swift.String`,
-`Foundation`). The server appends it when constructing the location URL:
-
-```swift
-var urlComponents = URLComponents(string: moduleFileURI.stringValue)!
-urlComponents.queryItems = [URLQueryItem(name: "module", value: fullModuleName)]
-```
-
-`workspaceSymbol/resolve` splits the value on the first `.` to derive `moduleName` and `groupName` for sourcekitd:
-
-```swift
-// fullModuleName = "Swift.String"
-moduleName = "Swift"    // passed to openGeneratedInterface
-groupName  = "String"   // passed to openGeneratedInterface
-```
-
-If there is no dot (e.g. `Foundation`), `groupName` is absent.
-
-### Example pre-resolve `WorkspaceSymbol`
-
-**`Swift.String`** (USR `s:SS`)
-
-```
-WorkspaceSymbol {
-  name: "String",
-  kind: .struct,
-  location: .uri("file:///path/to/Swift.swiftmodule/arm64-apple-macosx.swiftinterface?module=Swift.String"),
-  data: { "usr": "s:SS" }
-}
-```
-
-### `workspaceSymbol/resolve` transformation
-
-The resolve step parses the location URL, extracts the clean file path (query excluded via `urlComponents.path`) for
-`mainFiles(containing:)`, then opens the generated interface via sourcekitd:
-
-1. Parse `?module=Swift.String` from `uriOnly.uri.arbitrarySchemeURL`; split at first `.` → `moduleName`, `groupName`
-2. Read `usr` from `data["usr"]`
-3. Look up a real source file via `mainFiles(containing: moduleFileURI)`, sorted by URL string for determinism; pick
-   `.first`
-4. Call `openGeneratedInterface(document: primaryFile, moduleName:, groupName:, symbolUSR:)`
-5. Return the symbol with `location` replaced by a full `Location` (resolved `sourcekit-lsp://` URI + range)
-
-## `sourcekit-lsp://` URI for Resolved Locations
-
-After `workspaceSymbol/resolve`, the location URI is a fully-parameterized `sourcekit-lsp://generated-swift-interface/`
-URL.
+The location URI for an SDK/stdlib `WorkspaceSymbol` is a fully-parameterized
+`sourcekit-lsp://generated-swift-interface/` URL, built at `sourcekit/workspace/symbolInfo` time. The `data` field
+carries the USR and, for display, the interface path and module name.
 
 ### URL Structure
 
@@ -255,8 +183,11 @@ sourcekit-lsp://<document-type>/<display-name>?<parameters>
 | `display-name` | Human-readable filename shown in the editor tab/breadcrumb (e.g. `Swift.String.swiftinterface`). **Not used when parsing the URI** — all functional data is in the query parameters. |
 | `moduleName` | Top-level module name (e.g. `Swift`) |
 | `groupName` | Sub-module / group within the module, if any (e.g. `String`) |
-| `sourcekitdDocument` | Passed as `keys.name` to sourcekitd's `editor.open.interface` request — the buffer handle by which sourcekitd tracks the open interface. Synthesized by `workspaceSymbol/resolve` as `<moduleName>.<groupName>.<buildSettingsHash>` (e.g. `Swift.String.12345678`) to make the buffer name unique per build-settings context. |
+| `sourcekitdDocument` | Passed as `keys.name` to sourcekitd's `editor.open.interface` request — the buffer handle by which sourcekitd tracks the open interface. Derived as `<moduleName>.<groupName>.<buildSettingsHash>` (e.g. `Swift.String.12345678`) to make the buffer name unique per build-settings context. It is derived identically at the `symbolInfo` emission site and the open site so both refer to the same sourcekitd document. |
 | `buildSettingsFrom` | URI of a real source file in the workspace, obtained via `mainFiles(containing:)`. Used to derive build settings for the generated interface. |
+
+The index module name (e.g. `Swift.String`) is split on the first `.` to derive `moduleName` and `groupName`; if there
+is no dot (e.g. `Foundation`), `groupName` is absent.
 
 ### `display-name` derivation
 
@@ -268,9 +199,9 @@ sourcekit-lsp://<document-type>/<display-name>?<parameters>
 
 If `groupName` contains `/` (possible for nested groups), the slashes are replaced with `.` in the display name.
 
-### Example resolved URI
+### Example URI
 
-**`Swift.String`** after `workspaceSymbol/resolve`:
+**`Swift.String`** (USR `s:SS`):
 
 ```
 sourcekit-lsp://generated-swift-interface/Swift.String.swiftinterface
@@ -279,6 +210,19 @@ sourcekit-lsp://generated-swift-interface/Swift.String.swiftinterface
   &sourcekitdDocument=Swift.String.12345678
   &buildSettingsFrom=file:///path/to/MyProject/Sources/main.swift
 ```
+
+## Client Capabilities
+
+The `WorkspaceSymbol`/`.uri` path in `sourcekit/workspace/symbolInfo` is gated on the client advertising **both** of
+the following. When either is missing, `sourcekit/workspace/symbolInfo` falls back to `SymbolInformation` with the raw
+`file://` URI from the index record.
+
+- `GetReferenceDocumentRequest` support (an experimental client capability) — signals that the client can open the
+  `sourcekit-lsp://` reference document via `workspace/getReferenceDocument`.
+- `ClientCapabilities.workspace.symbol.resolveSupport.properties` containing `"location"` or `"location.range"` (LSP
+  3.17) — signals that the client can call `workspaceSymbol/resolve` to obtain a range-bearing location.
+
+The server advertises its side of the contract by reporting `workspaceSymbolProvider` with `resolveProvider: true`.
 
 ## Notes
 
@@ -292,14 +236,8 @@ sourcekit-lsp://generated-swift-interface/Swift.String.swiftinterface
   - *Non-resilient* system modules and the stdlib: indexed directly from the binary; symbol locations in the index
     point to the `.swiftmodule` file.
 - Both `.swiftinterface` and `.swiftmodule` location paths are handled identically in `workspaceSymbolItem` — both
-  produce a `WorkspaceSymbol` with a `file://` location URI (carrying `?module=`) and a `data` dictionary with the
-  USR, when the client has the required capabilities. sourcekitd can synthesize a textual interface from either form.
-- One client capability gates the `WorkspaceSymbol`/`.uri` path in `sourcekit/workspace/symbolInfo`:
-  - `ClientCapabilities.workspace.symbol.resolveSupport.properties` containing `"location"` or both `"location.uri"`
-    and `"location.range"` (LSP 3.17) — signals that the client can call `workspaceSymbol/resolve` to obtain a
-    range-bearing location.
-  - Without it, `sourcekit/workspace/symbolInfo` returns `SymbolInformation` with the raw `file://` URI from the
-    index record.
-- The resolved location URI from `workspaceSymbol/resolve` uses a `sourcekit-lsp://generated-swift-interface/` scheme
-  when the client advertises `GetReferenceDocumentRequest` support, or a temp `file://` path otherwise. Both forms can
-  be used to open the generated interface.
+  produce a `WorkspaceSymbol` with a `sourcekit-lsp://generated-swift-interface` location URI and a `data` dictionary
+  with the USR, when the client has the required capabilities. sourcekitd can synthesize a textual interface from
+  either form.
+- The standard `workspace/symbol` request is unaffected: it filters out system symbols, so none of its results point
+  into a generated interface.

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -128,15 +128,12 @@ package final actor CapabilityRegistry {
     return clientHasExperimentalCapability(GetReferenceDocumentRequest.method)
   }
 
-  /// Whether the client supports `workspaceSymbol/resolve` for lazy location resolution.
-  /// Requires `workspace.symbol.resolveSupport.properties` to contain `"location"` or
-  /// both `"location.uri"` and `"location.range"`.
+  /// Whether the client supports `workspaceSymbol/resolve` and will resolve `location` or `location.range`.
   package nonisolated var clientSupportsWorkspaceSymbolResolve: Bool {
     guard let properties = clientCapabilities.workspace?.symbol?.resolveSupport?.properties else {
       return false
     }
-    return properties.contains("location")
-      || (properties.contains("location.uri") && properties.contains("location.range"))
+    return properties.contains("location") || properties.contains("location.range")
   }
 
   package nonisolated func clientHasExperimentalCapability(_ name: String) -> Bool {

--- a/Sources/SourceKitLSP/GeneratedInterfaceDocumentURLData.swift
+++ b/Sources/SourceKitLSP/GeneratedInterfaceDocumentURLData.swift
@@ -70,6 +70,22 @@ package struct GeneratedInterfaceDocumentURLData: Hashable, ReferenceURLData {
     self.buildSettingsFrom = primaryFile.buildSettingsFile
   }
 
+  /// Create the URL data for a generated interface, deriving the `sourcekitdDocumentName` from the module
+  /// and the build-settings file of `primaryFile`. Both the `workspace/symbol` emission site and
+  /// `openGeneratedInterface` construct the data this way so they agree on the sourcekitd document name.
+  package init(moduleName: String, groupName: String?, primaryFile: DocumentURI) {
+    let buildSettingsFileHash = "\(abs(primaryFile.buildSettingsFile.stringValue.hashValue))"
+    let sourcekitdDocumentName = [moduleName, groupName, buildSettingsFileHash]
+      .compactMap(\.self)
+      .joined(separator: ".")
+    self.init(
+      moduleName: moduleName,
+      groupName: groupName,
+      sourcekitdDocumentName: sourcekitdDocumentName,
+      primaryFile: primaryFile
+    )
+  }
+
   init(queryItems: [URLQueryItem]) throws {
     guard let moduleName = queryItems.last(where: { $0.name == Parameters.moduleName })?.value,
       let sourcekitdDocumentName = queryItems.last(where: { $0.name == Parameters.sourcekitdDocumentName })?.value,

--- a/Sources/SourceKitLSP/MessageMetadata.swift
+++ b/Sources/SourceKitLSP/MessageMetadata.swift
@@ -33,12 +33,3 @@ struct ResolveItemData: Codable, Hashable, LSPAnyCodable {
     self.uri = uri
   }
 }
-
-/// Metadata stored in `WorkspaceSymbol.data` to support `workspaceSymbol/resolve` for SDK symbols.
-struct WorkspaceSymbolData: Codable, Hashable, LSPAnyCodable {
-  var usr: String
-
-  init(usr: String) {
-    self.usr = usr
-  }
-}

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1054,7 +1054,7 @@ extension SourceKitLSPServer {
       referencesProvider: .bool(true),
       documentHighlightProvider: .bool(true),
       documentSymbolProvider: .bool(true),
-      workspaceSymbolProvider: .bool(true),
+      workspaceSymbolProvider: .value(WorkspaceSymbolOptions(resolveProvider: true)),
       codeActionProvider: .value(
         CodeActionServerCapabilities(
           clientCapabilities: client.textDocument?.codeAction,
@@ -1576,13 +1576,21 @@ extension SourceKitLSPServer {
     return WorkspaceSymbolNamesResponse(names: symbols)
   }
 
-  /// Map a `SymbolOccurrence` from the index to a `WorkspaceSymbolItem` suitable for returning in a
-  /// `workspace/symbolInfo` response.
+  /// Map a `SymbolOccurrence` from the index to a `WorkspaceSymbolItem`, or `nil` if it has no
+  /// representable location.
+  ///
+  /// - Parameter referenceDocumentMainFile: The project file whose build settings are used to open the
+  ///   symbol's generated interface. **Passing a non-`nil` value changes the shape of the result**: the
+  ///   symbol is returned as a `WorkspaceSymbol` with a `sourcekit-lsp://generated-swift-interface`
+  ///   reference-document location (its range resolved lazily via `workspaceSymbol/resolve`) and the USR
+  ///   in `data`, instead of a `SymbolInformation` with a plain `file://` location. A non-`nil` value must
+  ///   therefore only be passed when the client supports **both** `workspace/getReferenceDocument` and
+  ///   `workspaceSymbol/resolve`; enforcing that is the caller's responsibility.
   private nonisolated func workspaceSymbolItem(
     for symbolOccurrence: SymbolOccurrence,
     in index: CheckedIndex,
     copiedFileMap: CopiedFileMap,
-    canUseWorkspaceSymbolResolve: Bool
+    referenceDocumentMainFile: DocumentURI?
   ) throws -> WorkspaceSymbolItem? {
     let containerNames = try index.containerNames(of: symbolOccurrence)
     let containerName: String? =
@@ -1595,38 +1603,28 @@ extension SourceKitLSPServer {
         nil
       }
 
-    // For SDK symbols (location in `.swiftinterface`/`.swiftmodule`), return a `WorkspaceSymbol`
-    // with a deferred location so the client can resolve it via `workspaceSymbol/resolve`.
-    // Falls through to `SymbolInformation` with regular file:// URL for clients without `workspace.symbol.resolveSupport`.
-    if canUseWorkspaceSymbolResolve,
-      symbolOccurrence.location.path.hasSuffix(".swiftinterface")
-        || symbolOccurrence.location.path.hasSuffix(".swiftmodule")
-    {
-      // URL: file://<path>.swiftinterface?module=<moduleName>
-      // Clients use `module` to show e.g. "Swift > String".
-      guard let documentURL = symbolOccurrence.location.uri?.fileURL else {
-        return nil
-      }
-      guard var urlComponents = URLComponents(url: documentURL, resolvingAgainstBaseURL: false) else {
-        return nil
-      }
-      urlComponents.queryItems = [
-        URLQueryItem(name: "module", value: symbolOccurrence.location.moduleName)
-      ]
-      guard let locationURL = urlComponents.url else {
-        return nil
-      }
-
+    if let referenceDocumentMainFile {
+      let (interfaceModuleName, groupName) = Self.splitModuleNameAndGroup(symbolOccurrence.location.moduleName)
+      let urlData = GeneratedInterfaceDocumentURLData(
+        moduleName: interfaceModuleName,
+        groupName: groupName,
+        primaryFile: referenceDocumentMainFile
+      )
       let usr = symbolOccurrence.symbol.usr
-      let data: LSPAny? = usr.isEmpty ? nil : WorkspaceSymbolData(usr: usr).encodeToLSPAny()
-
+      // Include the interface path and module name in `data` so clients can render the candidate without
+      // parsing the opaque location URI.
+      let data = SourceKitWorkspaceSymbolData(
+        usr: usr,
+        interfaceURI: symbolOccurrence.location.uri,
+        moduleName: symbolOccurrence.location.moduleName
+      )
       return WorkspaceSymbolItem.workspaceSymbol(
         WorkspaceSymbol(
           name: symbolOccurrence.symbol.name,
           kind: symbolOccurrence.symbol.kind.asLspSymbolKind(),
           containerName: containerName,
-          location: .uri(.init(uri: DocumentURI(locationURL))),
-          data: data
+          location: .uri(.init(uri: try urlData.uri)),
+          data: data.encodeToLSPAny()
         )
       )
     }
@@ -1644,6 +1642,51 @@ extension SourceKitLSPServer {
     )
   }
 
+  /// Split an index module name into its module and optional group components.
+  private nonisolated static func splitModuleNameAndGroup(
+    _ fullModuleName: String
+  ) -> (module: String, group: String?) {
+    // A dotted index module name is ambiguous: `Foo.Bar` could be module `Foo` with group `Bar`, or a real
+    // submodule named `Foo.Bar`, and SourceKit-LSP can't tell the two apart. In practice only the `Swift`
+    // module is divided into groups (and it has no submodules), so only there is the trailing component
+    // treated as a group; every other module name is kept whole.
+    let swiftModulePrefix = "Swift."
+    guard fullModuleName.hasPrefix(swiftModulePrefix) else {
+      return (fullModuleName, nil)
+    }
+    return ("Swift", String(fullModuleName.dropFirst(swiftModulePrefix.count)))
+  }
+
+  /// For each distinct SDK interface (`.swiftinterface`/`.swiftmodule`) among `symbols`, resolve the main
+  /// file — a project file that imports the module, found via `mainFiles(containing:)` — whose build
+  /// settings are used to open the generated interface. The lookup runs once per interface so a
+  /// `workspace/symbol` response with many members of the same module doesn't repeat it. Interfaces with no
+  /// main file are omitted, so callers skip those symbols.
+  private func generatedInterfaceMainFiles(
+    for symbols: [SymbolOccurrence],
+    in workspace: Workspace
+  ) async throws -> [DocumentURI: DocumentURI] {
+    var mainFiles: [DocumentURI: DocumentURI] = [:]
+    for symbol in symbols {
+      let path = symbol.location.path
+      guard path.hasSuffix(".swiftinterface") || path.hasSuffix(".swiftmodule"),
+        let interfaceURI = symbol.location.uri,
+        mainFiles[interfaceURI] == nil
+      else {
+        continue
+      }
+      try Task.checkCancellation()
+      let mainFile = await workspace.buildServerManager
+        .mainFiles(containing: interfaceURI)
+        .sorted(by: { $0.arbitrarySchemeURL.absoluteString < $1.arbitrarySchemeURL.absoluteString })
+        .first
+      if let mainFile {
+        mainFiles[interfaceURI] = mainFile
+      }
+    }
+    return mainFiles
+  }
+
   /// Handle a `workspace/symbolInfo` request.
   ///
   /// For each name in `req.names`, looks up all canonical occurrences in every workspace index and
@@ -1658,14 +1701,17 @@ extension SourceKitLSPServer {
   /// Every requested name is present as a key in the response, mapping to an empty array when there
   /// are no occurrences.
   func workspaceSymbolInfo(_ req: WorkspaceSymbolInfoRequest) async throws -> WorkspaceSymbolInfoResponse {
-    let canUseWorkspaceSymbolResolve = self.capabilityRegistry?.clientSupportsWorkspaceSymbolResolve ?? false
+    // Emitting a generated-interface reference document requires both that the client can open it and that
+    // it will call `workspaceSymbol/resolve` to fill in the range.
+    let canUseGeneratedInterfaceReferenceDocument =
+      (self.capabilityRegistry?.clientHasWorkspaceGetReferenceDocumentSupport ?? false)
+      && (self.capabilityRegistry?.clientSupportsWorkspaceSymbolResolve ?? false)
 
     let groupedResultPerWorkspace = await workspaces.concurrentMap { workspace -> [String: [WorkspaceSymbolItem]] in
       guard let index = await workspace.index(checkedFor: .deletedFiles) else {
         return [:]
       }
-      var result: [String: [WorkspaceSymbolItem]] = [:]
-      let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+      var occurrencesByName: [String: [SymbolOccurrence]] = [:]
       for name in req.names {
         if Task.isCancelled { return [:] }
         var symbols: [SymbolOccurrence] = []
@@ -1675,14 +1721,29 @@ extension SourceKitLSPServer {
             return true
           }
         }
-        if Task.isCancelled { return [:] }
-        result[name] = symbols.compactMap { symbol in
+        occurrencesByName[name] = symbols
+      }
+
+      var mainFiles: [DocumentURI: DocumentURI] = [:]
+      if canUseGeneratedInterfaceReferenceDocument {
+        let occurrences = occurrencesByName.values.flatMap { $0 }
+        mainFiles =
+          await orLog("Resolving generated interface main files") {
+            try await self.generatedInterfaceMainFiles(for: occurrences, in: workspace)
+          } ?? [:]
+      }
+      if Task.isCancelled { return [:] }
+
+      var result: [String: [WorkspaceSymbolItem]] = [:]
+      let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
+      for name in req.names {
+        result[name] = (occurrencesByName[name] ?? []).compactMap { symbol in
           orLog("Getting symbol information") {
             try self.workspaceSymbolItem(
               for: symbol,
               in: index,
               copiedFileMap: copiedFileMap,
-              canUseWorkspaceSymbolResolve: canUseWorkspaceSymbolResolve
+              referenceDocumentMainFile: symbol.location.uri.flatMap { mainFiles[$0] }
             )
           }
         }
@@ -1706,67 +1767,40 @@ extension SourceKitLSPServer {
 
   /// Handle a `workspaceSymbol/resolve` request.
   ///
-  /// If the symbol has a `location: .uri(moduleFileURL?module=...)` (as emitted by
-  /// `workspace/symbolInfo` for SDK/stdlib symbols), opens the generated Swift interface, resolves
-  /// the symbol position using `data["usr"]`, and returns the symbol with `location: .location(...)`.
-  /// Symbols with an already-resolved `location: .location(...)` are returned unchanged.
+  /// If the symbol has a `location: .uri(sourcekit-lsp://generated-swift-interface?...)` (as emitted by
+  /// `workspace/symbol` and `workspace/symbolInfo` for SDK/stdlib symbols), opens the generated Swift
+  /// interface, resolves the symbol position using `data["usr"]`, and returns the symbol with the exact
+  /// range. Symbols with an already-resolved `location: .location(...)` are returned unchanged.
   func workspaceSymbolResolve(_ req: WorkspaceSymbolResolveRequest) async throws -> WorkspaceSymbol {
     var symbol = req.workspaceSymbol
     guard
       case .uri(let uriOnly) = symbol.location,
-      let urlComponents = URLComponents(url: uriOnly.uri.arbitrarySchemeURL, resolvingAgainstBaseURL: false),
-      let fullModuleName = urlComponents.queryItems?.last(where: { $0.name == "module" })?.value
+      let referenceURL = try? ReferenceDocumentURL(from: uriOnly.uri),
+      case .generatedInterface(let urlData) = referenceURL
     else {
       return symbol
     }
 
-    let moduleName: String
-    let groupName: String?
-    if let dotIndex = fullModuleName.firstIndex(of: ".") {
-      moduleName = String(fullModuleName[fullModuleName.startIndex..<dotIndex])
-      groupName = String(fullModuleName[fullModuleName.index(after: dotIndex)...])
-    } else {
-      moduleName = fullModuleName
-      groupName = nil
-    }
-
-    let usr = WorkspaceSymbolData(fromLSPAny: symbol.data)?.usr
-
-    let moduleFileURI = DocumentURI(
-      {
-        var components = urlComponents
-        components.query = nil
-        return components.url!
-      }()
-    )
-    for workspace in workspaces {
-      let mainFile = await workspace.buildServerManager
-        .mainFiles(containing: moduleFileURI)
-        .sorted(by: { $0.arbitrarySchemeURL.absoluteString < $1.arbitrarySchemeURL.absoluteString })
-        .first
-      guard let mainFile else {
-        continue
-      }
-      let languageService = try await workspace.primaryLanguageService(for: mainFile, .swift)
-      let details = await orLog("Opening generated interface in workspaceSymbol/resolve") {
-        try await languageService.openGeneratedInterface(
-          document: mainFile,
-          moduleName: moduleName,
-          groupName: groupName,
-          symbolUSR: usr
-        )
-      }
-      if let details {
-        symbol.location = .location(
-          Location(uri: details.uri, range: Range(details.position ?? Position(line: 0, utf16index: 0)))
-        )
-      }
+    // A USR is always present in practice; this only guards against a malformed `data` payload with an
+    // empty USR string, treating it as absent so we don't run a position lookup that can't match.
+    let usr = (symbol.sourceKitData?.usr).flatMap { $0.isEmpty ? nil : $0 }
+    let buildSettingsFile = urlData.buildSettingsFrom
+    guard let workspace = await self.workspaceForDocument(uri: buildSettingsFile) else {
       return symbol
     }
-
-    throw ResponseError.requestFailed(
-      "No source file found that imports \(fullModuleName); cannot open generated interface"
+    let languageService = try await workspace.primaryLanguageService(for: buildSettingsFile, .swift)
+    let details = await orLog("Opening generated interface in workspaceSymbol/resolve") {
+      try await languageService.openGeneratedInterface(
+        document: buildSettingsFile,
+        moduleName: urlData.moduleName,
+        groupName: urlData.groupName,
+        symbolUSR: usr
+      )
+    }
+    symbol.location = .location(
+      Location(uri: uriOnly.uri, range: Range(details?.position ?? Position(line: 0, utf16index: 0)))
     )
+    return symbol
   }
 
   /// Handle a workspace/symbol request, returning the SymbolInformation.
@@ -1779,7 +1813,6 @@ extension SourceKitLSPServer {
     guard req.query.count >= minWorkspaceSymbolPatternLength else {
       return []
     }
-    let canUseWorkspaceSymbolResolve = self.capabilityRegistry?.clientSupportsWorkspaceSymbolResolve ?? false
     var items: [WorkspaceSymbolItem] = []
     for workspace in workspaces {
       guard let index = await workspace.index(checkedFor: .deletedFiles) else {
@@ -1804,12 +1837,14 @@ extension SourceKitLSPServer {
         return true
       }
       try Task.checkCancellation()
+      // `workspace/symbol` filters out system symbols above, so no result points into a generated
+      // interface and there is no main file to resolve.
       items += try symbols.sorted(by: <).compactMap {
         try self.workspaceSymbolItem(
           for: $0,
           in: index,
           copiedFileMap: copiedFileMap,
-          canUseWorkspaceSymbolResolve: canUseWorkspaceSymbolResolve
+          referenceDocumentMainFile: nil
         )
       }
     }

--- a/Sources/SwiftLanguageService/OpenInterface.swift
+++ b/Sources/SwiftLanguageService/OpenInterface.swift
@@ -24,13 +24,9 @@ extension SwiftLanguageService {
   ) async throws -> GeneratedInterfaceDetails? {
     // Include build settings context to distinguish different versions/configurations
     let buildSettingsFileHash = "\(abs(document.buildSettingsFile.stringValue.hashValue))"
-    let sourcekitdDocumentName = [moduleName, groupName, buildSettingsFileHash].compactMap(\.self)
-      .joined(separator: ".")
-
     let urlData = GeneratedInterfaceDocumentURLData(
       moduleName: moduleName,
       groupName: groupName,
-      sourcekitdDocumentName: sourcekitdDocumentName,
       primaryFile: document
     )
     let position: Position? =

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolInfoTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolInfoTests.swift
@@ -21,8 +21,8 @@ import ToolchainRegistry
 import XCTest
 
 final class WorkspaceSymbolInfoTests: XCTestCase {
-  /// Returns the first `WorkspaceSymbol` in a `workspaceSymbolInfo` response for `name` whose
-  /// location is a `file://` URI to a module file (`.swiftinterface` or `.swiftmodule`).
+  /// Returns the first `WorkspaceSymbol` in a `workspaceSymbolInfo` response for `name` whose location is a
+  /// URI-only `sourcekit-lsp://generated-swift-interface` reference-document location (no range).
   private func generatedInterfaceSymbol(
     for name: String,
     in response: WorkspaceSymbolInfoResponse
@@ -30,8 +30,9 @@ final class WorkspaceSymbolInfoTests: XCTestCase {
     for case .workspaceSymbol(let symbol) in response.results {
       if symbol.name == name,
         case .uri(let uriOnly) = symbol.location,
-        let path = uriOnly.uri.fileURL?.path,
-        path.hasSuffix(".swiftinterface") || path.hasSuffix(".swiftmodule")
+        let components = URLComponents(string: uriOnly.uri.arbitrarySchemeURL.absoluteString),
+        components.scheme == "sourcekit-lsp",
+        components.host == "generated-swift-interface"
       {
         return symbol
       }
@@ -70,31 +71,35 @@ final class WorkspaceSymbolInfoTests: XCTestCase {
 
     let response = try await project.testClient.send(WorkspaceSymbolInfoRequest(names: ["String"]))
 
-    // workspace/symbolInfo returns a deferred WorkspaceSymbol for SDK symbols:
-    // location is a file://<module-file>?module=<name> URI (no range), USR in data["usr"].
+    // workspace/symbolInfo returns SDK symbols as a `WorkspaceSymbol` whose location is the URI-only form of
+    // a `sourcekit-lsp://generated-swift-interface` reference document (no range), with a `sourceKitData`.
     let symbol = try XCTUnwrap(
       generatedInterfaceSymbol(for: "String", in: response),
-      "Expected a 'String' WorkspaceSymbol with a module file URI location"
+      "Expected a 'String' WorkspaceSymbol with a generated-interface reference-document URI"
     )
     guard case .uri(let uriOnly) = symbol.location else {
       XCTFail("Expected .uri location, got \(symbol.location)")
       return
     }
-    let path = try XCTUnwrap(uriOnly.uri.fileURL?.path)
-    XCTAssert(
-      path.hasSuffix(".swiftinterface") || path.hasSuffix(".swiftmodule"),
-      "Expected a .swiftinterface or .swiftmodule path, got: \(path)"
-    )
+    XCTAssertEqual(uriOnly.uri.scheme, "sourcekit-lsp")
     let urlComponents = try XCTUnwrap(URLComponents(string: uriOnly.uri.arbitrarySchemeURL.absoluteString))
-    let queryItems = urlComponents.queryItems
     let moduleParam = try XCTUnwrap(
-      queryItems?.first(where: { $0.name == "module" })?.value,
-      "URI should contain a ?module= query parameter"
+      urlComponents.queryItems?.first(where: { $0.name == "moduleName" })?.value,
+      "URI should contain a moduleName query parameter"
     )
-    XCTAssertFalse(moduleParam.isEmpty, "?module= query parameter should be non-empty")
-    XCTAssertNil(urlComponents.fragment, "URI should not contain a fragment")
+    XCTAssertFalse(moduleParam.isEmpty, "moduleName query parameter should be non-empty")
 
-    // workspaceSymbol/resolve turns the deferred URI into a sourcekit-lsp:// location with a range.
+    // The interface path and module name are also carried in `sourceKitData`.
+    let sourceKitData = try XCTUnwrap(symbol.sourceKitData, "Expected SourceKitWorkspaceSymbolData in data")
+    let dataModuleName = try XCTUnwrap(sourceKitData.moduleName, "Expected a moduleName in data")
+    XCTAssert(dataModuleName.hasPrefix("Swift"), "Expected module name starting with 'Swift', got \(dataModuleName)")
+    let dataInterfaceURI = try XCTUnwrap(sourceKitData.interfaceURI, "Expected an interfaceURI in data")
+    XCTAssert(
+      dataInterfaceURI.pseudoPath.hasSuffix(".swiftinterface") || dataInterfaceURI.pseudoPath.hasSuffix(".swiftmodule"),
+      "Expected interfaceURI to point at a .swiftinterface/.swiftmodule, got \(dataInterfaceURI)"
+    )
+
+    // workspaceSymbol/resolve fills in the range.
     let resolved = try await project.testClient.send(
       WorkspaceSymbolResolveRequest(workspaceSymbol: symbol)
     )
@@ -102,7 +107,7 @@ final class WorkspaceSymbolInfoTests: XCTestCase {
       XCTFail("Expected .location after resolve, got \(resolved.location)")
       return
     }
-    XCTAssertEqual(location.uri.scheme, "sourcekit-lsp")
+    XCTAssertEqual(location.uri, uriOnly.uri, "resolve must not change the URI, only fill in the range")
 
     // getReferenceDocument delivers the interface text; the resolved range points at the declaration.
     let refDoc = try await project.testClient.send(GetReferenceDocumentRequest(uri: location.uri))
@@ -116,6 +121,39 @@ final class WorkspaceSymbolInfoTests: XCTestCase {
     XCTAssert(
       line.contains("struct String"),
       "Line at resolved position should contain 'struct String', got: '\(line)'"
+    )
+  }
+
+  func testWorkspaceSymbolInfoStdlibSymbolFallsBackToFileLocationWithoutReferenceDocumentSupport() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      let x: String = ""
+      """,
+      // No `workspaceSymbol/resolve` and no generated-interface reference-document support.
+      capabilities: ClientCapabilities(),
+      indexSystemModules: true
+    )
+
+    let response = try await project.testClient.send(WorkspaceSymbolInfoRequest(names: ["String"]))
+
+    // Without reference-document + resolve support, the SDK symbol falls back to a plain
+    // `SymbolInformation` pointing directly at its `.swiftinterface`/`.swiftmodule` file.
+    let interfaceLocation = response.results.lazy.compactMap { item -> Location? in
+      guard case .symbolInformation(let info) = item, info.name == "String" else { return nil }
+      return info.location
+    }.first { location in
+      guard let path = location.uri.fileURL?.path else { return false }
+      return path.hasSuffix(".swiftinterface") || path.hasSuffix(".swiftmodule")
+    }
+    XCTAssertNotNil(
+      interfaceLocation,
+      "Expected a 'String' SymbolInformation with a .swiftinterface/.swiftmodule file:// location"
+    )
+
+    // No generated-interface reference-document URI should be emitted.
+    XCTAssertNil(
+      generatedInterfaceSymbol(for: "String", in: response),
+      "Should not emit a reference-document URI without reference-document support"
     )
   }
 


### PR DESCRIPTION
`workspace/symbolInfo` returned SDK/stdlib symbols with a deferred `file://<interface>?module=<name>` location that `workspaceSymbol/resolve` *replaced* with a `sourcekit-lsp://` reference-document URI. Replacing the URI on resolve requires the client to advertise `location.uri` resolution, so clients that resolve only `location.range` (e.g. VS Code) couldn't use it.

This emits the `sourcekit-lsp://generated-swift-interface` URI up front instead. It's self-describing, shared by every symbol of the module, and `workspaceSymbol/resolve` now leaves it untouched and only fills in the range, extending the feature to clients with `location.range`-only resolution and avoiding the percent-encoding issue via the custom scheme.

The interface's main file (for build settings) is resolved via `mainFiles(containing:)` and memoized per interface, so the number of `mainFiles(containing:)` calls is bounded by the distinct system modules imported in the workspace, not the number of symbols in the response.

The `WorkspaceSymbol`'s `data` now also carries the `.swiftinterface`/`.swiftmodule` path and the fully-qualified module name, so clients can render the candidate without parsing the opaque location URI.

The path is gated on the client supporting both generated-interface reference documents and `workspaceSymbol/resolve`; otherwise it falls back to a plain `file://` interface location. The server now advertises `workspaceSymbolProvider` with `resolveProvider: true`, and `clientSupportsWorkspaceSymbolResolve` is relaxed to accept `location` or `location.range`. Only `workspace/symbolInfo` is affected — `workspace/symbol` filters out system symbols.