### PR TITLE
[WIP] Update test to account for updated SwiftPM handling of build tool dependencies

### DIFF
--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1090,6 +1090,9 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
       manifest: """
         let package = Package(
           name: "MyLibrary",
+          products: [
+            .executable(name: "MyExec", targets: ["MyExec"])
+          ],
           targets: [
            .target(name: "Lib"),
            .executableTarget(name: "MyExec", dependencies: ["Lib"]),


### PR DESCRIPTION
Update a test which looks like it was depending on slightly incorrect behavior. Add an explicit product to make it clear the executable is intended to build for the target and host