### PR TITLE
Allow extra SwiftPM build server arguments

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -33,6 +33,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `buildToolsSwiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files or plugins. Equivalent to SwiftPM's `-Xbuild-tools-swiftc` option.
   - `forceResolvedVersions: boolean`: Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.
   - `disableSandbox: boolean`: Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
+  - `extraArguments: string[]`: Additional arguments appended to SwiftPM when starting or preparing the build server.
   - `buildSystem: "native"|"swiftbuild"`: Which SwiftPM build system should be used when opening a package.
 - `compilationDatabase`: Dictionary with the following keys, defining options for workspaces with a compilation database.
   - `searchPaths: string[]`: Additional paths to search for a compilation database, relative to a workspace root.

--- a/Sources/BuildServerIntegration/ExternalBuildServerAdapter.swift
+++ b/Sources/BuildServerIntegration/ExternalBuildServerAdapter.swift
@@ -11,15 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(SourceKitLSP) import BuildServerProtocol
-import Foundation
+package import Foundation
 @_spi(SourceKitLSP) import LanguageServerProtocol
 @_spi(SourceKitLSP) import LanguageServerProtocolExtensions
 @_spi(SourceKitLSP) import LanguageServerProtocolTransport
 @_spi(SourceKitLSP) import SKLogging
-import SKOptions
+package import SKOptions
 import SwiftExtensions
 import TSCExtensions
-import ToolchainRegistry
+package import ToolchainRegistry
 @_spi(SourceKitLSP) import ToolsProtocolsSwiftExtensions
 
 import func TSCBasic.getEnvSearchPaths
@@ -63,7 +63,7 @@ enum BuildServerNotFoundError: Error {
 /// BSP configuration
 ///
 /// See https://build-server-protocol.github.io/docs/overview/server-discovery#the-bsp-connection-details
-struct BuildServerConfig: Codable {
+package struct BuildServerConfig: Codable {
   /// The name of the build tool.
   let name: String
 
@@ -77,7 +77,7 @@ struct BuildServerConfig: Codable {
   let languages: [String]
 
   /// Command arguments runnable via server processes to start a BSP server.
-  let argv: [String]
+  package let argv: [String]
 
   static func load(from path: URL) throws -> BuildServerConfig {
     let decoder = JSONDecoder()
@@ -89,7 +89,7 @@ struct BuildServerConfig: Codable {
     case unsupportedToolchainForSwiftPMBuildServerWithoutBackgroundIndexing
   }
 
-  static func forSwiftPMBuildServer(
+  package static func forSwiftPMBuildServer(
     projectRoot: URL,
     options: SourceKitLSPOptions,
     toolchainRegistry: ToolchainRegistry
@@ -191,6 +191,10 @@ struct BuildServerConfig: Codable {
     }
     if options.swiftPMOrDefault.disableSandbox == true {
       args.append("--disable-sandbox")
+    }
+    // Keep this last so extra arguments can override the options above.
+    if let extraArguments = options.swiftPMOrDefault.extraArguments {
+      args.append(contentsOf: extraArguments)
     }
     // The skipPlugins option isn't currently respected because the underlying build server does not support it.
     // We may want to reconsider this in the future, or remove the option entirely.

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -846,6 +846,8 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     case .noLazy: arguments += ["--experimental-prepare-for-indexing", "--experimental-prepare-for-indexing-no-lazy"]
     case .enabled: arguments.append("--experimental-prepare-for-indexing")
     }
+    // Keep this last so extra arguments can override the options above.
+    arguments += options.swiftPMOrDefault.extraArguments ?? []
     if Task.isCancelled {
       return
     }

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -86,6 +86,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
     ///   background indexing.
     public var skipPlugins: Bool?
 
+    /// Additional arguments appended to SwiftPM when starting or preparing the build server.
+    public var extraArguments: [String]?
+
     /// Which SwiftPM build system should be used when opening a package.
     public var buildSystem: SwiftPMBuildSystem?
 
@@ -107,6 +110,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
       forceResolvedVersions: Bool? = nil,
       disableSandbox: Bool? = nil,
       skipPlugins: Bool? = nil,
+      extraArguments: [String]? = nil,
       buildSystem: SwiftPMBuildSystem? = nil
     ) {
       self.configuration = configuration
@@ -125,6 +129,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
       self.buildToolsSwiftCompilerFlags = buildToolsSwiftCompilerFlags
       self.forceResolvedVersions = forceResolvedVersions
       self.disableSandbox = disableSandbox
+      self.extraArguments = extraArguments
       self.buildSystem = buildSystem
     }
 
@@ -147,6 +152,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, LSPAnyCodable {
         forceResolvedVersions: override?.forceResolvedVersions ?? base.forceResolvedVersions,
         disableSandbox: override?.disableSandbox ?? base.disableSandbox,
         skipPlugins: override?.skipPlugins ?? base.skipPlugins,
+        extraArguments: override?.extraArguments ?? base.extraArguments,
         buildSystem: override?.buildSystem ?? base.buildSystem
       )
     }

--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -187,6 +187,27 @@ struct SwiftPMBuildServerTests {
     }
   }
 
+  @Test
+  func testExtraArgumentsArePassedVerbatim() async throws {
+    try await withTestScratchDir { tempDir in
+      let extraArguments = [
+        "--experimental-prebuilts-download-url",
+        "file:swift-syntax-prebuilt/feed",
+        "--experimental-prebuilts-root-cert",
+        "swift-syntax-prebuilt/root.cer",
+      ]
+      let config = try await BuildServerConfig.forSwiftPMBuildServer(
+        projectRoot: tempDir,
+        options: SourceKitLSPOptions(
+          swiftPM: .init(extraArguments: extraArguments)
+        ),
+        toolchainRegistry: .forTesting
+      )
+
+      #expect(Array(config.argv.suffix(extraArguments.count)) == extraArguments)
+    }
+  }
+
   @Test(arguments: buildServerOptionsToTest)
   func testBasicSwiftArgs(options: SourceKitLSPOptions) async throws {
     try await withTestScratchDir { tempDir in

--- a/config.schema.json
+++ b/config.schema.json
@@ -282,6 +282,14 @@
           "markdownDescription" : "Disables running subprocesses from SwiftPM in a sandbox. Equivalent to SwiftPM's `--disable-sandbox` option. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.",
           "type" : "boolean"
         },
+        "extraArguments" : {
+          "description" : "Additional arguments appended to SwiftPM when starting or preparing the build server.",
+          "items" : {
+            "type" : "string"
+          },
+          "markdownDescription" : "Additional arguments appended to SwiftPM when starting or preparing the build server.",
+          "type" : "array"
+        },
         "forceResolvedVersions" : {
           "description" : "Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.",
           "markdownDescription" : "Equivalent to SwiftPM's `--force-resolved-versions` option. Makes all processes (including background indexing) treat Package.resolved as a lock file.",


### PR DESCRIPTION
SwiftPM's experimental build-server flags can evolve faster than SourceKit-LSP's typed configuration. There is currently no generic way to pass a newly introduced flag to `swift package experimental-build-server`.

This PR adds a `swiftPM.extraArguments` configuration option and appends its values verbatim to the builtin and external SwiftPM build-server invocation.