### PR TITLE
Add missing semantic token modifier `parameterLabel` to documentation

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -59,6 +59,8 @@ functionScope = 'functionScope'
 classScope = 'classScope'
 fileScope = 'fileScope'
 globalScope = 'globalScope'
+//  Marks a token as a parameter label in a function signature or call.
+parameterLabel = 'parameterLabel'
 ```
 
 ## Semantic token types

--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -59,7 +59,14 @@ functionScope = 'functionScope'
 classScope = 'classScope'
 fileScope = 'fileScope'
 globalScope = 'globalScope'
-//  Marks a token as a parameter label in a function signature or call.
+```
+
+Added case
+
+```ts
+/**
+ * Marks a token as a parameter label in a function signature or call.
+ */
 parameterLabel = 'parameterLabel'
 ```
 


### PR DESCRIPTION
Sync the semantic token modifiers with https://github.com/swiftlang/swift-tools-protocols/blob/main/Sources/LanguageServerProtocol/SupportTypes/SemanticTokenModifiers.swift

A commit in swift-tools-protocols added `parameterLabel`, which is not yet documented here.

As far as I understand, both should be in sync.
I was unable to actually see `parameterLabel` being returned in the list of available modifiers with Swift 6.3.3. But that may be caused by just testing with Objective-C files?