### PR TITLE
Adopt renamed Parser.LanguageFeatures

### DIFF
--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -97,13 +97,13 @@ package struct SwiftCompileCommand: Sendable, Equatable, Hashable {
     self.isFallback = settings.isFallback
   }
 
-  /// Extract the `Parser.ExperimentalFeatures` from the compiler arguments.
+  /// Extract the `Parser.LanguageFeatures` from the compiler arguments.
   ///
   /// This scans the compiler arguments for `-enable-experimental-feature <name>` flags and maps them
-  /// to `Parser.ExperimentalFeatures` values so that the SwiftParser can parse the file correctly
+  /// to `Parser.LanguageFeatures` values so that the SwiftParser can parse the file correctly
   /// with the same experimental features that the compiler would use.
-  package var experimentalFeatures: Parser.ExperimentalFeatures {
-    var features: Parser.ExperimentalFeatures = []
+  package var experimentalFeatures: Parser.LanguageFeatures {
+    var features: Parser.LanguageFeatures = []
     var iterator = compilerArgs.makeIterator()
     while let arg = iterator.next() {
       if arg == "-enable-experimental-feature", let featureName = iterator.next() {
@@ -111,7 +111,7 @@ package struct SwiftCompileCommand: Sendable, Equatable, Hashable {
         // availability suffix (e.g. "FeatureName:adoption"). Strip it before
         // looking up the parser feature.
         let baseName = featureName.firstIndex(of: ":").map { String(featureName[..<$0]) } ?? featureName
-        if let feature = Parser.ExperimentalFeatures(name: baseName) {
+        if let feature = Parser.LanguageFeatures(name: baseName) {
           features.insert(feature)
         }
       }

--- a/Sources/SwiftLanguageService/SyntaxTreeManager.swift
+++ b/Sources/SwiftLanguageService/SyntaxTreeManager.swift
@@ -35,7 +35,7 @@ actor SyntaxTreeManager {
   ///
   /// When build settings are available for a file, the experimental features enabled in those build settings
   /// (via `-enable-experimental-feature` compiler flags) are stored here and passed to the Swift parser.
-  private var experimentalFeaturesPerDocument: [DocumentURI: Parser.ExperimentalFeatures] = [:]
+  private var experimentalFeaturesPerDocument: [DocumentURI: Parser.LanguageFeatures] = [:]
 
   /// - Important: For testing only
   private var reusedNodeCallback: ReusedNodeCallback?
@@ -51,7 +51,7 @@ actor SyntaxTreeManager {
   /// The features will be used for subsequent parse operations on that document.
   /// If the features differ from the previously stored ones, any cached syntax trees for the document are invalidated
   /// so that they will be re-parsed with the new features on next access.
-  func setExperimentalFeatures(_ features: Parser.ExperimentalFeatures, for uri: DocumentURI) {
+  func setExperimentalFeatures(_ features: Parser.LanguageFeatures, for uri: DocumentURI) {
     let previousFeatures = experimentalFeaturesPerDocument[uri] ?? []
     if previousFeatures != features {
       experimentalFeaturesPerDocument[uri] = features
@@ -61,7 +61,7 @@ actor SyntaxTreeManager {
   }
 
   /// Get the experimental features for the given document URI.
-  private func experimentalFeatures(for uri: DocumentURI) -> Parser.ExperimentalFeatures {
+  private func experimentalFeatures(for uri: DocumentURI) -> Parser.LanguageFeatures {
     return experimentalFeaturesPerDocument[uri] ?? []
   }
 
@@ -98,10 +98,10 @@ actor SyntaxTreeManager {
   /// Parse a source file incrementally, passing the given experimental features to the parser.
   private static func parseIncrementally(
     source: String,
-    experimentalFeatures: Parser.ExperimentalFeatures,
+    experimentalFeatures: Parser.LanguageFeatures,
     parseTransition: IncrementalParseTransition?
   ) -> IncrementalParseResult {
-    var parser = Parser(source, parseTransition: parseTransition, experimentalFeatures: experimentalFeatures)
+    var parser = Parser(source, parseTransition: parseTransition, languageFeatures: experimentalFeatures)
     return IncrementalParseResult(
       tree: SourceFileSyntax.parse(from: &parser),
       lookaheadRanges: parser.lookaheadRanges


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift-syntax/pull/3377

Update the SwiftParser usage in SwiftLanguageService for the swift-syntax rename of `Parser.ExperimentalFeatures` to `Parser.LanguageFeatures` and the `experimentalFeatures:` argument to `languageFeatures:`. SourceKit-LSP's own experimental-feature options are unaffected.