### PR TITLE
Add support for pkgconfig option when using Swift Build BSP backend

### DIFF
--- a/Sources/BuildServerIntegration/ExternalBuildServerAdapter.swift
+++ b/Sources/BuildServerIntegration/ExternalBuildServerAdapter.swift
@@ -161,6 +161,11 @@ package struct BuildServerConfig: Codable {
     if let sdk = options.swiftPMOrDefault.sdk {
       args.append(contentsOf: ["--sdk", try resolvedRelativeToProjectRoot(sdk)])
     }
+    if let pkgConfigPaths = options.swiftPMOrDefault.pkgConfigPaths {
+      for pkgConfigPath in pkgConfigPaths {
+        args.append(contentsOf: ["--pkg-config-path", try resolvedRelativeToProjectRoot(pkgConfigPath)])
+      }
+    }
     if let traits = options.swiftPMOrDefault.traits {
       args.append(contentsOf: ["--traits", traits.joined(separator: ",")])
     }

--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -1299,8 +1299,10 @@ struct SwiftPMBuildServerTests {
     #expect(diagnostics.isEmpty)
   }
 
-  @Test func testPkgConfigDirectories() async throws {
-    var options = try await SourceKitLSPOptions.testDefault(experimentalFeatures: [.sourceKitOptionsRequest])
+  @Test(arguments: buildServerOptionsToTest)
+  func testPkgConfigDirectories(options: SourceKitLSPOptions) async throws {
+    var options = options
+    options.experimentalFeatures = [.sourceKitOptionsRequest]
     options.swiftPMOrDefault.pkgConfigPaths = ["pcfiles"]
     let project = try await SwiftPMTestProject(
       files: [


### PR DESCRIPTION
I forgot to add this when the option was initially added, we just need to forward --pkg-config-path along when we launch the build server