### PR TITLE
Disable testPopularityForTypeFromSubmodule until a fix is found

### DIFF
--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -1124,6 +1124,7 @@ final class SwiftSourceKitPluginTests: SourceKitLSPTestCase {
     #if !os(macOS)
     try XCTSkipIf(true, "AppKit is only defined on macOS")
     #endif
+    try XCTSkipIf(true, "Crashes sourcekitd with the macOS 27 SDK (rdar://184053015")
     try await SkipUnless.sourcekitdSupportsPlugin()
     let sourcekitd = try await getSourceKitD()
     let path = scratchFilePath()


### PR DESCRIPTION
SwiftSourceKitPluginTests.testPopularityForTypeFromSubmodule crashes the out-of-process SourceKitService on MacOSX27.0.sdk. Disabling the test until a fix is found.