### PR TITLE
Use '/' to separate group name levels in sourcekitd requests

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1674,7 +1674,10 @@ extension SourceKitLSPServer {
     guard fullModuleName.hasPrefix(swiftModulePrefix) else {
       return (fullModuleName, nil)
     }
-    return ("Swift", String(fullModuleName.dropFirst(swiftModulePrefix.count)))
+    // The index spells a group's levels with `.` (`Swift.Math.Integers`) but sourcekitd expects '/'
+    // separated group name.
+    let group = fullModuleName.dropFirst(swiftModulePrefix.count).replacing(".", with: "/")
+    return ("Swift", String(group))
   }
 
   /// For each distinct SDK interface (`.swiftinterface`/`.swiftmodule`) among `symbols`, resolve the main

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -13,6 +13,7 @@
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKLogging
 import SKTestSupport
+import SKUtilities
 import XCTest
 
 class WorkspaceSymbolsTests: SourceKitLSPTestCase {
@@ -412,6 +413,7 @@ class WorkspaceSymbolsTests: SourceKitLSPTestCase {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       let x: String = ""
+      let y: Int = 0
       """,
       capabilities: ClientCapabilities(
         workspace: .init(symbol: .init(resolveSupport: .init(properties: ["location"]))),
@@ -435,6 +437,39 @@ class WorkspaceSymbolsTests: SourceKitLSPTestCase {
     XCTAssertFalse(
       generatedInterfaceMembers.isEmpty,
       "Expected `String` members as generated-interface reference documents, got \(String(describing: response))"
+    )
+
+    // `Int` lives in the stdlib's `Math/Integers` group, whose levels the index spells with `.` in the module
+    // name `Swift.Math.Integers` while sourcekitd matches `key.groupname` with `/`. A member of it is only
+    // resolvable if the group name is translated back on the way into the request.
+    let nestedGroupResponse = try await project.testClient.send(WorkspaceSymbolsRequest(query: "Int.bitWidth"))
+    let nestedGroupSymbol = try XCTUnwrap(
+      (nestedGroupResponse ?? []).compactMap { item -> WorkspaceSymbol? in
+        guard case .workspaceSymbol(let symbol) = item, symbol.name == "Int.bitWidth" else { return nil }
+        return symbol
+      }.first,
+      "Expected `Int.bitWidth` as a generated-interface symbol, got \(String(describing: nestedGroupResponse))"
+    )
+
+    // Resolving opens the group's interface and points at the declaration inside it.
+    let resolved = try await project.testClient.send(
+      WorkspaceSymbolResolveRequest(workspaceSymbol: nestedGroupSymbol)
+    )
+    guard case .location(let location) = resolved.location else {
+      XCTFail("Expected .location after resolve, got \(resolved.location)")
+      return
+    }
+    let referenceDocument = try await project.testClient.send(GetReferenceDocumentRequest(uri: location.uri))
+    XCTAssert(
+      referenceDocument.content.contains("struct Int"),
+      "Interface of the group containing `Int` should contain `struct Int`"
+    )
+    let resolvedLine = try XCTUnwrap(
+      LineTable(referenceDocument.content).line(at: location.range.lowerBound.line)
+    )
+    XCTAssert(
+      resolvedLine.contains("bitWidth"),
+      "Line at the resolved position should declare `bitWidth`, got: '\(resolvedLine)'"
     )
   }
 


### PR DESCRIPTION
`workspace/symbol` and `workspace/symbolInfo` return SDK symbols as generated-interface reference documents whose module and group are derived from the module name that the index records. The index spells the levels of a group with `.`, recording the stdlib's `Math/Integers` group as the module name `Swift.Math.Integers`, but sourcekitd matches `key.groupname` against the group name as the module stores it, which separates levels with `/`. The dotted spelling matched no group, so the interface was generated without the group's declarations and `workspaceSymbol/resolve` could not locate the symbol in it, leaving the resolved position at the start of an interface that doesn't contain the symbol.

Translate `.` back to `/` when splitting the index module name into its module and group. Rendering a group for display keeps using `.`.
