### PR TITLE
Re-enable `testPopularityForTypeFromSubmodule`

### DIFF
--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -1124,7 +1124,6 @@ final class SwiftSourceKitPluginTests: SourceKitLSPTestCase {
     #if !os(macOS)
     try XCTSkipIf(true, "AppKit is only defined on macOS")
     #endif
-    try XCTSkipIf(true, "Crashes sourcekitd with the macOS 27 SDK (rdar://184053015")
     try await SkipUnless.sourcekitdSupportsPlugin()
     let sourcekitd = try await getSourceKitD()
     let path = scratchFilePath()


### PR DESCRIPTION
Fixing the crasher in https://github.com/swiftlang/swift/pull/91307