### PR TITLE
Implement `DocCSymbolLinkDefinitionRequest` for documentation preview 

### DIFF
--- a/Sources/DocumentationLanguageService/DocCSymbolInformation.swift
+++ b/Sources/DocumentationLanguageService/DocCSymbolInformation.swift
@@ -38,10 +38,11 @@ struct DocCSymbolInformation {
   }
 
   func matches(_ link: DocCSymbolLink) -> Bool {
-    guard link.components.count == components.count else {
+    guard link.components.count <= components.count else {
       return false
     }
-    return zip(link.components, components).allSatisfy { linkComponent, symbolComponent in
+    let matchingSuffix = components.suffix(link.components.count)
+    return zip(link.components, matchingSuffix).allSatisfy { linkComponent, symbolComponent in
       linkComponent.name == symbolComponent.name && symbolComponent.information.matches(linkComponent.disambiguation)
     }
   }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -47,6 +47,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
   package static var experimentalCapabilities: [String: LSPAny] {
     return [
       DoccDocumentationRequest.method: ["version": 1],
+      DocCSymbolLinkDefinitionRequest.method: ["version": 1],
       "definitionProvider": .bool(true),
     ]
   }
@@ -686,5 +687,41 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
     let diagnostics = await symbolLinkDiagnostics(for: snapshot) ?? []
     return .full(RelatedFullDocumentDiagnosticReport(items: diagnostics))
+  }
+
+  package func symbolLinkDefinitionInPreview(
+    _ req: DocCSymbolLinkDefinitionRequest
+  ) async throws -> LocationsOrLocationLinksResponse? {
+    guard let symbolLink = DocCSymbolLink(linkString: req.symbolLink) else {
+      logger.debug("Failed to parse DocC symbol link from '\(req.symbolLink)'")
+      return nil
+    }
+    guard let sourceKitLSPServer else {
+      logger.debug("sourceKit-LSP server could not be resolved")
+      return nil
+    }
+    guard let workspace = await sourceKitLSPServer.workspaceForDocument(uri: req.textDocument.uri) else {
+      logger.debug("No workspace found for document \(req.textDocument.uri)")
+      return nil
+    }
+    guard let index = await workspace.index(checkedFor: .deletedFiles) else {
+      logger.debug("No index available for workspace")
+      return nil
+    }
+
+    let occurrence = try await sourceKitLSPServer.withOnDiskDocumentManager { onDiskDocumentManager in
+      try await resolveOccurrence(
+        for: symbolLink,
+        workspace: workspace,
+        index: index,
+        onDiskDocumentManager: onDiskDocumentManager
+      )
+    }
+
+    guard let targetLocation = occurrence?.location.lspLocation else {
+      return nil
+    }
+    return .locations([targetLocation])
+
   }
 }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -195,7 +195,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
         return
       }
 
-       // Symbol links are delimited by two backticks (``Foo/bar``),
+      // Symbol links are delimited by two backticks (``Foo/bar``),
       // so the destination starts two columns past the start of the link.
       let destinationStartColumn = range.lowerBound.column + 2
       let relativeColumn = target.column - destinationStartColumn
@@ -270,7 +270,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     return line.utf8.distance(from: line.startIndex, to: stringIndex)
   }
 
-  /// The inverse of `utf8Offset(inLine:forUTF16Offset:)`.
+  /// The inverse of `utf8Offset(inLine:forUTF16Offset:)`
   private func utf16Offset(inLine line: String, forUTF8Offset utf8Offset: Int) -> Int {
     let utf8View = line.utf8
     guard

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -10,12 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerIntegration
 import Foundation
 import IndexStoreDB
 @_spi(SourceKitLSP) package import LanguageServerProtocol
+import Markdown
+@_spi(SourceKitLSP) import SKLogging
 package import SKOptions
+import SemanticIndex
 package import SourceKitLSP
 import SwiftExtensions
+import SwiftParser
 package import SwiftSyntax
 package import ToolchainRegistry
 
@@ -36,7 +41,8 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
   package static var experimentalCapabilities: [String: LSPAny] {
     return [
-      DoccDocumentationRequest.method: ["version": 1]
+      DoccDocumentationRequest.method: ["version": 1],
+      "definitionProvider": .bool(true),
     ]
   }
 
@@ -48,7 +54,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     workspace: Workspace
   ) async throws {
     self.sourceKitLSPServer = sourceKitLSPServer
-    self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager)
+    self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager);
   }
 
   package nonisolated func canHandle(toolchain: Toolchain) -> Bool {
@@ -99,5 +105,319 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     edits: [SwiftSyntax.SourceEdit]
   ) async {
     // The DocumentationLanguageService does not do anything with document events
+  }
+
+  package func definition(_ req: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
+    let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
+    let clickedSymbol: String?
+    switch snapshot.language {
+    case .swift:
+      clickedSymbol = extractSymbolFromDocComment(snapshot: snapshot, at: req.position)
+    case .markdown, .tutorial:
+      clickedSymbol = extractSymbolFromText(snapshot.text, at: req.position)
+    default:
+      return nil
+    }
+
+    guard let clickedSymbol else {
+      logger.debug("No symbol link found at the cursor position")
+      return nil
+    }
+
+    guard let symbolLink = DocCSymbolLink(linkString: clickedSymbol) else {
+      logger.debug("Failed to parse DocC symbol link from '\(clickedSymbol)'")
+      return nil
+    }
+
+    guard let sourceKitLSPServer else {
+      logger.debug("sourceKit-LSP server could not be resolved")
+      return nil
+    }
+
+    guard let workspace = await sourceKitLSPServer.workspaceForDocument(uri: req.textDocument.uri) else {
+      logger.debug("No workspace found for document \(req.textDocument.uri)")
+      return nil
+    }
+
+    guard let index = await workspace.index(checkedFor: .deletedFiles) else {
+      logger.debug("No index available for workspace")
+      return nil
+    }
+
+    let occurrence = try await sourceKitLSPServer.withOnDiskDocumentManager { onDiskDocumentManager in
+      try await index.primaryDefinitionOrDeclarationOccurrence(
+        ofDocCSymbolLink: symbolLink,
+        fetchSymbolGraph: { location in
+          guard let uri = location.uri else { return nil }
+          return try await workspace.primaryLanguageService(
+            for: uri,
+            workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri)
+          ).symbolGraph(forOnDiskContentsAt: location, in: workspace, manager: onDiskDocumentManager)
+        }
+      )
+    }
+
+    guard let targetLocation = occurrence?.location.lspLocation else {
+      logger.debug("No definition occurrence found in the index for symbol link '\(clickedSymbol)'")
+      return nil
+    }
+    return .locations([targetLocation])
+  }
+
+  /// Walks the Markdown/DocC AST looking for symbol link
+  /// that contains a given source position.
+  private struct SymbolLocator: MarkupWalker {
+    let target: Markdown.SourceLocation
+    var found: String?
+
+    init(target: Markdown.SourceLocation) {
+      self.target = target
+    }
+
+    private func contains(_ range: Markdown.SourceRange?) -> Bool {
+      guard let range else { return false }
+      return range.lowerBound <= target && target < range.upperBound
+    }
+
+    mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
+      guard
+        found == nil,
+        contains(symbolLink.range),
+        let destination = symbolLink.destination,
+        let range = symbolLink.range
+      else {
+        return
+      }
+      // Symbol links are delimited by two backticks (``Foo/bar``),
+      // so the destination starts two columns past the start of the link.
+      let destinationStartColumn = range.lowerBound.column + 2
+      let relativeColumn = target.column - destinationStartColumn
+      guard relativeColumn >= 0 else {
+        return
+      }
+      let components = destination.split(separator: "/")
+      var currentLength = 0
+
+      for (index, component) in components.enumerated() {
+        let end = currentLength + component.utf8.count
+        if relativeColumn < end {
+          found = components[0...index].joined(separator: "/")
+          return
+        }
+        currentLength = end + 1  // Skip '/'
+      }
+      found = destination
+    }
+
+    mutating func defaultVisit(_ markup: any Markup) {
+      guard found == nil else { return }
+      descendInto(markup)
+    }
+  }
+
+  private func extractSymbolFromText(_ text: String, at position: Position) -> String? {
+    let lines = text.components(separatedBy: "\n")
+    var column = position.utf16index + 1
+    if position.line < lines.count {
+      column = utf8Offset(inLine: lines[position.line], forUTF16Offset: position.utf16index) + 1
+    }
+    // LSP positions are 0-based; swift-markdown SourceLocation is 1-based.
+    let target = Markdown.SourceLocation(
+      line: position.line + 1,
+      column: column,
+      source: nil
+    )
+
+    let document = Markdown.Document(parsing: text, options: [.parseSymbolLinks, .parseBlockDirectives])
+    var locator = SymbolLocator(target: target)
+    locator.visit(document)
+
+    guard let symbol = locator.found, !symbol.isEmpty else {
+      return nil
+    }
+    return symbol
+  }
+
+  private struct DocCCommentLine {
+    let text: String
+    let startLine: Int
+    let startColumn: Int
+  }
+
+  private enum DocTriviaGroup {
+    case lines(lines: [DocCCommentLine])
+    case block(text: String, startLine: Int, startColumn: Int)
+  }
+
+  /// Converts a UTF-16 offset within `line` into the corresponding UTF-8 byte offset.
+  /// Needed because DocumentSnapshot/LSP positions are UTF-16-based but
+  /// Markdown.SourceLocation.column is UTF-8-byte-based.
+  private func utf8Offset(inLine line: String, forUTF16Offset utf16Offset: Int) -> Int {
+    let utf16View = line.utf16
+    guard
+      let utf16Index = utf16View.index(utf16View.startIndex, offsetBy: utf16Offset, limitedBy: utf16View.endIndex),
+      let stringIndex = utf16Index.samePosition(in: line)
+    else {
+      return line.utf8.count
+    }
+    return line.utf8.distance(from: line.startIndex, to: stringIndex)
+  }
+
+  private func docCommentGroups(
+    in trivia: Trivia,
+    tokenStart: AbsolutePosition,
+    snapshot: DocumentSnapshot
+  ) -> [DocTriviaGroup] {
+    var groups: [DocTriviaGroup] = []
+    var pendingLines: [DocCCommentLine] = []
+    var offset = tokenStart.utf8Offset
+    var newlinesSinceLastDoc = 0
+
+    func flushPendingLines() {
+      guard !pendingLines.isEmpty else { return }
+      groups.append(.lines(lines: pendingLines))
+      pendingLines.removeAll()
+    }
+
+    for piece in trivia.pieces {
+      defer { offset += piece.sourceLength.utf8Length }
+      switch piece {
+      case .docLineComment(let text):
+        if newlinesSinceLastDoc > 1 { flushPendingLines() }
+        let position = snapshot.positionOf(utf8Offset: offset)
+        pendingLines.append(DocCCommentLine(text: text, startLine: position.line, startColumn: position.utf16index))
+        newlinesSinceLastDoc = 0
+      case .docBlockComment(let text):
+        flushPendingLines()
+        let position = snapshot.positionOf(utf8Offset: offset)
+        groups.append(.block(text: text, startLine: position.line, startColumn: position.utf16index))
+        newlinesSinceLastDoc = 0
+      case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
+        newlinesSinceLastDoc += n
+      case .spaces, .tabs:
+        break
+      default:
+        flushPendingLines()
+        newlinesSinceLastDoc = 0
+      }
+    }
+    flushPendingLines()
+    return groups
+  }
+
+  private struct StrippedLine {
+    let text: String
+    let strippedPrefixCount: Int
+  }
+
+  /// Strips `///` and any leading whitespace from each line comment piece.
+  private func stripLineCommentDelimiters(
+    _ lines: [DocCCommentLine]
+  ) -> [StrippedLine] {
+    return lines.map { line in
+      var text = Substring(line.text)
+      var stripped = 0
+
+      if text.hasPrefix("///") {
+        text.removeFirst(3)
+        stripped += 3
+      }
+      let beforeIndent = text.utf16.count
+      let trimmed = text.drop { $0 == " " || $0 == "\t" }
+      stripped += beforeIndent - trimmed.utf16.count
+      text = trimmed
+      return StrippedLine(text: String(text), strippedPrefixCount: stripped)
+    }
+  }
+  /// Strips `/**`, `*/`, and per-line leading `*`/whitespace from a block comment.
+  private func stripBlockCommentDelimiters(_ text: String) -> [StrippedLine] {
+    let lines = text.components(separatedBy: "\n")
+    return lines.enumerated().map { index, rawLine in
+      var line = Substring(rawLine)
+      var stripped = 0
+
+      if index == 0, line.hasPrefix("/**") {
+        line.removeFirst(3)
+        stripped += 3
+      }
+      if index == lines.count - 1, line.hasSuffix("*/") {
+        line.removeLast(2)
+      }
+      let beforeStar = line.utf16.count
+      var afterStar = line.drop { $0 == " " || $0 == "\t" }
+      if afterStar.hasPrefix("*") {
+        afterStar.removeFirst()
+        if afterStar.hasPrefix(" ") { afterStar.removeFirst() }
+        stripped += beforeStar - afterStar.utf16.count
+        line = afterStar
+      }
+      let beforeIndent = line.utf16.count
+      let trimmed = line.drop { $0 == " " || $0 == "\t" }
+      stripped += beforeIndent - trimmed.utf16.count
+      line = trimmed
+      return StrippedLine(text: String(line), strippedPrefixCount: stripped)
+    }
+  }
+
+  private func resolveTarget(
+    for group: DocTriviaGroup,
+    cursorPosition: Position
+  ) -> (strippedLines: [StrippedLine], lineIndex: Int, targetColumn: Int)? {
+    switch group {
+    case .lines(let lines):
+      guard let lineIndex = lines.firstIndex(where: { $0.startLine == cursorPosition.line }) else {
+        return nil
+      }
+      let strippedLines = stripLineCommentDelimiters(lines)
+      let rawLine = lines[lineIndex].text
+      let relativeUTF16 = cursorPosition.utf16index - lines[lineIndex].startColumn
+      let utf8Rel = utf8Offset(inLine: rawLine, forUTF16Offset: relativeUTF16)
+      let targetColumn = max(1, utf8Rel - strippedLines[lineIndex].strippedPrefixCount + 1)
+
+      return (strippedLines, lineIndex, targetColumn)
+
+    case .block(let text, let startLine, let startColumn):
+      let strippedLines = stripBlockCommentDelimiters(text)
+      let lineIndex = cursorPosition.line - startLine
+      guard strippedLines.indices.contains(lineIndex) else {
+        return nil
+      }
+
+      let rawLines = text.components(separatedBy: "\n")
+      let rawLine = rawLines[lineIndex]
+      let columnBase = lineIndex == 0 ? startColumn : 0
+      let relativeUTF16 = cursorPosition.utf16index - columnBase
+      let utf8Rel = utf8Offset(inLine: rawLine, forUTF16Offset: relativeUTF16)
+      let targetColumn = max(1, utf8Rel - strippedLines[lineIndex].strippedPrefixCount + 1)
+
+      return (strippedLines, lineIndex, targetColumn)
+    }
+  }
+
+  private func extractSymbolFromDocComment(snapshot: DocumentSnapshot, at position: Position) -> String? {
+    let sourceFile = SwiftParser.Parser.parse(source: snapshot.text)
+    let absolutePosition = snapshot.absolutePosition(of: position)
+
+    guard let token = sourceFile.token(at: absolutePosition) else {
+      return nil
+    }
+
+    let cursorPosition = snapshot.positionOf(utf8Offset: absolutePosition.utf8Offset)
+    let groups = docCommentGroups(in: token.leadingTrivia, tokenStart: token.position, snapshot: snapshot)
+
+    for group in groups {
+      guard let (strippedLines, lineIndex, targetColumn) = resolveTarget(for: group, cursorPosition: cursorPosition)
+      else {
+        continue
+      }
+
+      let combinedText = strippedLines.map(\.text).joined(separator: "\n")
+      let target = Markdown.SourceLocation(line: lineIndex + 1, column: targetColumn, source: nil)
+      let document = Markdown.Document(parsing: combinedText, options: [.parseSymbolLinks])
+      var locator = SymbolLocator(target: target)
+      locator.visit(document)
+      return locator.found
+    }
+    return nil
   }
 }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -39,6 +39,11 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     }
   }
 
+  /// In-flight debounce tasks for `publishSymbolLinkDiagnostics`, keyed by document.
+  /// Cancel-and-replace on every edit so we don't run diagnostics on every keystroke, and so an
+  /// older, now-stale run can never race a newer one and publish outdated results.
+  private var inFlightPublishDiagnosticsTasks: [DocumentURI: Task<Void, Never>] = [:]
+
   package static var experimentalCapabilities: [String: LSPAny] {
     return [
       DoccDocumentationRequest.method: ["version": 1],
@@ -75,11 +80,13 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     _ notification: DidOpenTextDocumentNotification,
     snapshot: DocumentSnapshot
   ) async {
-    // The DocumentationLanguageService does not do anything with document events
+    schedulePublishSymbolLinkDiagnostics(for: snapshot.uri)
   }
 
   package func closeDocument(_ notification: DidCloseTextDocumentNotification) async {
-    // The DocumentationLanguageService does not do anything with document events
+    cancelInFlightPublishDiagnosticsTask(for: notification.textDocument.uri)
+    inFlightPublishDiagnosticsTasks[notification.textDocument.uri] = nil
+    await sourceKitLSPServer?.clearDiagnostics(for: notification.textDocument.uri, from: .documentation)
   }
 
   package func reopenDocument(_ notification: ReopenTextDocumentNotification) async {
@@ -104,7 +111,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     postEditSnapshot: DocumentSnapshot,
     edits: [SwiftSyntax.SourceEdit]
   ) async {
-    // The DocumentationLanguageService does not do anything with document events
+    schedulePublishSymbolLinkDiagnostics(for: postEditSnapshot.uri)
   }
 
   package func definition(_ req: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
@@ -145,15 +152,11 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     }
 
     let occurrence = try await sourceKitLSPServer.withOnDiskDocumentManager { onDiskDocumentManager in
-      try await index.primaryDefinitionOrDeclarationOccurrence(
-        ofDocCSymbolLink: symbolLink,
-        fetchSymbolGraph: { location in
-          guard let uri = location.uri else { return nil }
-          return try await workspace.primaryLanguageService(
-            for: uri,
-            workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri)
-          ).symbolGraph(forOnDiskContentsAt: location, in: workspace, manager: onDiskDocumentManager)
-        }
+      try await resolveOccurrence(
+        for: symbolLink,
+        workspace: workspace,
+        index: index,
+        onDiskDocumentManager: onDiskDocumentManager
       )
     }
 
@@ -164,8 +167,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     return .locations([targetLocation])
   }
 
-  /// Walks the Markdown/DocC AST looking for symbol link
-  /// that contains a given source position.
+  /// Walks the Markdown/DocC AST looking for a symbol link that contains a given source position.
   private struct SymbolLocator: MarkupWalker {
     let target: Markdown.SourceLocation
     var found: String?
@@ -179,6 +181,10 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       return range.lowerBound <= target && target < range.upperBound
     }
 
+    /// Resolves a click inside a multi-component link like ``Sloth/energy`` to just the component under the cursor and
+    ///  everything before it: clicking `Sloth` goes to `Sloth`;
+    /// clicking `energy` goes to `Sloth/energy`. Without this, any click inside the link — including on
+    /// the first component — would always navigate to the full, most-nested destination.
     mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
       guard
         found == nil,
@@ -188,7 +194,8 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       else {
         return
       }
-      // Symbol links are delimited by two backticks (``Foo/bar``),
+
+       // Symbol links are delimited by two backticks (``Foo/bar``),
       // so the destination starts two columns past the start of the link.
       let destinationStartColumn = range.lowerBound.column + 2
       let relativeColumn = target.column - destinationStartColumn
@@ -261,6 +268,18 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       return line.utf8.count
     }
     return line.utf8.distance(from: line.startIndex, to: stringIndex)
+  }
+
+  /// The inverse of `utf8Offset(inLine:forUTF16Offset:)`.
+  private func utf16Offset(inLine line: String, forUTF8Offset utf8Offset: Int) -> Int {
+    let utf8View = line.utf8
+    guard
+      let utf8Index = utf8View.index(utf8View.startIndex, offsetBy: utf8Offset, limitedBy: utf8View.endIndex),
+      let stringIndex = utf8Index.samePosition(in: line)
+    else {
+      return line.utf16.count
+    }
+    return line.utf16.distance(from: line.startIndex, to: stringIndex)
   }
 
   private func docCommentGroups(
@@ -419,5 +438,251 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       return locator.found
     }
     return nil
+  }
+
+  /// Resolves a DocC symbol link to its definition occurrence via the index, fetching the symbol graph on demand
+  private func resolveOccurrence(
+    for symbolLink: DocCSymbolLink,
+    workspace: Workspace,
+    index: CheckedIndex,
+    onDiskDocumentManager: OnDiskDocumentManager
+  ) async throws -> SymbolOccurrence? {
+    try await index.primaryDefinitionOrDeclarationOccurrence(
+      ofDocCSymbolLink: symbolLink,
+      fetchSymbolGraph: { location in
+        guard let uri = location.uri else { return nil }
+        return try await workspace.primaryLanguageService(
+          for: uri,
+          workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri)
+        ).symbolGraph(forOnDiskContentsAt: location, in: workspace, manager: onDiskDocumentManager)
+      }
+    )
+  }
+
+  // MARK: - Symbol link diagnostics
+
+  private struct SymbolLinkReference {
+    let symbol: String
+    let range: Markdown.SourceRange
+  }
+
+  /// Walks a Markdown/DocC AST collecting every symbol link and its range.
+  private struct SymbolLinkCollector: MarkupWalker {
+    var found: [SymbolLinkReference] = []
+
+    mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
+      if let range = symbolLink.range, let destination = symbolLink.destination {
+        found.append(SymbolLinkReference(symbol: destination, range: range))
+      }
+    }
+  }
+
+  /// Maps a Markdown source location to an LSP position in the original source file.
+  private struct MappedLine {
+    let text: String
+    let absoluteLine: Int
+    let absoluteColumnBase: Int
+    let strippedPrefixCount: Int
+  }
+
+  private func mappedLines(for group: DocTriviaGroup) -> [MappedLine] {
+    switch group {
+    case .lines(let lines):
+      let strippedLines = stripLineCommentDelimiters(lines)
+      return zip(lines, strippedLines).map { raw, stripped in
+        MappedLine(
+          text: stripped.text,
+          absoluteLine: raw.startLine,
+          absoluteColumnBase: raw.startColumn,
+          strippedPrefixCount: stripped.strippedPrefixCount
+        )
+      }
+
+    case .block(let text, let startLine, let startColumn):
+      let strippedLines = stripBlockCommentDelimiters(text)
+      return strippedLines.enumerated().map { index, stripped in
+        MappedLine(
+          text: stripped.text,
+          absoluteLine: startLine + index,
+          absoluteColumnBase: index == 0 ? startColumn : 0,
+          strippedPrefixCount: stripped.strippedPrefixCount
+        )
+      }
+    }
+  }
+
+  private func position(for location: Markdown.SourceLocation, in lines: [MappedLine]) -> Position? {
+    let index = location.line - 1
+    guard lines.indices.contains(index) else { return nil }
+    let line = lines[index]
+    let utf16OffsetInStripped = utf16Offset(inLine: line.text, forUTF8Offset: location.column - 1)
+    let absoluteUTF16 = line.absoluteColumnBase + line.strippedPrefixCount + utf16OffsetInStripped
+    return Position(line: line.absoluteLine, utf16index: absoluteUTF16)
+  }
+
+  /// Collects every symbol link inside one doc-comment trivia group
+  private func symbolLinks(in group: DocTriviaGroup) -> [(symbol: String, range: Range<Position>)] {
+    let lines = mappedLines(for: group)
+    let combinedText = lines.map(\.text).joined(separator: "\n")
+
+    let document = Markdown.Document(parsing: combinedText, options: [.parseSymbolLinks])
+    var collector = SymbolLinkCollector()
+    collector.visit(document)
+
+    return collector.found.compactMap { link in
+      guard
+        let start = position(for: link.range.lowerBound, in: lines),
+        let end = position(for: link.range.upperBound, in: lines)
+      else {
+        return nil
+      }
+      return (link.symbol, start..<end)
+    }
+  }
+
+  private func collectSymbolLinksInSwiftDocComments(
+    _ snapshot: DocumentSnapshot
+  ) -> [(symbol: String, range: Range<Position>)] {
+    let sourceFile = SwiftParser.Parser.parse(source: snapshot.text)
+    var results: [(symbol: String, range: Range<Position>)] = []
+
+    for token in sourceFile.tokens(viewMode: .sourceAccurate) {
+      let groups = docCommentGroups(in: token.leadingTrivia, tokenStart: token.position, snapshot: snapshot)
+      for group in groups {
+        results.append(contentsOf: symbolLinks(in: group))
+      }
+    }
+    return results
+  }
+
+  private func collectSymbolLinksInMarkdown(_ text: String) -> [(symbol: String, range: Range<Position>)] {
+    let lines = text.components(separatedBy: "\n")
+    let document = Markdown.Document(parsing: text, options: [.parseSymbolLinks, .parseBlockDirectives])
+    var collector = SymbolLinkCollector()
+    collector.visit(document)
+
+    func position(for location: Markdown.SourceLocation) -> Position? {
+      let lineIndex = location.line - 1
+      guard lines.indices.contains(lineIndex) else { return nil }
+      let utf16Col = utf16Offset(inLine: lines[lineIndex], forUTF8Offset: location.column - 1)
+      return Position(line: lineIndex, utf16index: utf16Col)
+    }
+
+    return collector.found.compactMap { link in
+      guard let start = position(for: link.range.lowerBound), let end = position(for: link.range.upperBound) else {
+        return nil
+      }
+      return (link.symbol, start..<end)
+    }
+  }
+
+  private func collectSymbolLinks(in snapshot: DocumentSnapshot) -> [(symbol: String, range: Range<Position>)] {
+    switch snapshot.language {
+    case .swift:
+      return collectSymbolLinksInSwiftDocComments(snapshot)
+    case .markdown, .tutorial:
+      return collectSymbolLinksInMarkdown(snapshot.text)
+    default:
+      return []
+    }
+  }
+
+  private func cancelInFlightPublishDiagnosticsTask(for uri: DocumentURI) {
+    inFlightPublishDiagnosticsTasks[uri]?.cancel()
+  }
+
+  private func schedulePublishSymbolLinkDiagnostics(for uri: DocumentURI) {
+    cancelInFlightPublishDiagnosticsTask(for: uri)
+    inFlightPublishDiagnosticsTasks[uri] = Task(priority: .medium) { [weak self] in
+      do {
+        try await Task.sleep(for: .milliseconds(500))
+      } catch {
+        return  // cancelled by a newer edit
+      }
+      await self?.publishSymbolLinkDiagnostics(for: uri)
+    }
+  }
+
+  private func symbolLinkDiagnostics(for snapshot: DocumentSnapshot) async -> [Diagnostic]? {
+    guard let sourceKitLSPServer else { return nil }
+    guard let workspace = await sourceKitLSPServer.workspaceForDocument(uri: snapshot.uri) else { return nil }
+
+    await workspace.semanticIndexManagerTask.value?.waitForUpToDateIndex()
+    guard !Task.isCancelled else { return nil }
+    guard let index = await workspace.index(checkedFor: .deletedFiles) else { return nil }
+
+    let symbolLinks = collectSymbolLinks(in: snapshot)
+
+    return await sourceKitLSPServer.withOnDiskDocumentManager { onDiskDocumentManager in
+      var diagnostics: [Diagnostic] = []
+      for link in symbolLinks {
+        guard !Task.isCancelled else { break }
+        guard let symbolLink = DocCSymbolLink(linkString: link.symbol) else {
+          diagnostics.append(
+            Diagnostic(
+              range: link.range,
+              severity: .error,
+              source: "DocC",
+              message: "Failed to parse DocC symbol link '\(link.symbol)'"
+            )
+          )
+          continue
+        }
+        do {
+          let occurrence = try await resolveOccurrence(
+            for: symbolLink,
+            workspace: workspace,
+            index: index,
+            onDiskDocumentManager: onDiskDocumentManager
+          )
+          if occurrence == nil {
+            diagnostics.append(
+              Diagnostic(
+                range: link.range,
+                severity: .error,
+                source: "DocC",
+                message: "No symbol link resolved for '\(link.symbol)'"
+              )
+            )
+          }
+        } catch {
+          logger.debug("Failed to resolve DocC symbol link '\(link.symbol)': \(error.forLogging)")
+          continue
+        }
+      }
+      return diagnostics
+    }
+  }
+
+  private func publishSymbolLinkDiagnostics(for uri: DocumentURI) async {
+    guard let sourceKitLSPServer else { return }
+    guard let snapshot = try? self.documentManager.latestSnapshot(uri) else { return }
+
+    // Pull diagnostics are the first preference; only push if the client can't pull diagnostics for this document's language
+    let clientSupportsPull =
+      await sourceKitLSPServer.capabilityRegistry?.clientSupportsPullDiagnostics(for: snapshot.language) ?? false
+    guard !clientSupportsPull else { return }
+
+    guard !Task.isCancelled else { return }
+    guard let diagnostics = await symbolLinkDiagnostics(for: snapshot) else { return }
+    guard !Task.isCancelled else { return }
+
+    await sourceKitLSPServer.publishDiagnostics(diagnostics, for: uri, from: .documentation)
+  }
+
+  package func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport {
+    switch try? ReferenceDocumentURL(from: req.textDocument.uri) {
+    case .generatedInterface:
+      // Generated interfaces don't have diagnostics associated with them.
+      return .full(RelatedFullDocumentDiagnosticReport(items: []))
+    case .macroExpansion, nil: break
+    }
+
+    guard let snapshot = try? self.documentManager.latestSnapshot(req.textDocument.uri) else {
+      return .full(RelatedFullDocumentDiagnosticReport(items: []))
+    }
+
+    let diagnostics = await symbolLinkDiagnostics(for: snapshot) ?? []
+    return .full(RelatedFullDocumentDiagnosticReport(items: diagnostics))
   }
 }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -682,6 +682,8 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       return .full(RelatedFullDocumentDiagnosticReport(items: []))
     }
 
+    try Task.checkCancellation()
+
     let diagnostics = await symbolLinkDiagnostics(for: snapshot) ?? []
     return .full(RelatedFullDocumentDiagnosticReport(items: diagnostics))
   }

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -196,6 +196,9 @@ package protocol LanguageService: AnyObject, Sendable {
   func signatureHelp(_ req: SignatureHelpRequest) async throws -> SignatureHelp?
   func hover(_ req: HoverRequest) async throws -> HoverResponse?
   func doccDocumentation(_ req: DoccDocumentationRequest) async throws -> DoccDocumentationResponse
+  func symbolLinkDefinitionInPreview(
+    _ req: DocCSymbolLinkDefinitionRequest
+  ) async throws -> LocationsOrLocationLinksResponse?
   func symbolInfo(_ request: SymbolInfoRequest) async throws -> [SymbolDetails]
 
   /// Retrieve the symbol graph for the given position in the given snapshot, including the USR of the symbol at the
@@ -397,6 +400,12 @@ package extension LanguageService {
 
   func doccDocumentation(_ req: DoccDocumentationRequest) async throws -> DoccDocumentationResponse {
     throw ResponseError.requestNotImplemented(DoccDocumentationRequest.self)
+  }
+
+  func symbolLinkDefinitionInPreview(
+    _ req: DocCSymbolLinkDefinitionRequest
+  ) async throws -> LocationsOrLocationLinksResponse? {
+    throw ResponseError.requestNotImplemented(DocCSymbolLinkDefinitionRequest.self)
   }
 
   func symbolInfo(_ request: SymbolInfoRequest) async throws -> [SymbolDetails] {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -711,6 +711,8 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
       await self.handleRequest(for: request, requestHandler: self.typeDefinition)
     case let request as RequestAndReply<DoccDocumentationRequest>:
       await self.handleRequest(for: request, requestHandler: self.doccDocumentation)
+    case let request as RequestAndReply<DocCSymbolLinkDefinitionRequest>:
+      await self.handleRequest(for: request, requestHandler: self.doccSymbolLinkDefinition)
     case let request as RequestAndReply<DocumentColorRequest>:
       await self.handleRequest(for: request, requestHandler: self.documentColor)
     case let request as RequestAndReply<DocumentDiagnosticsRequest>:
@@ -1090,6 +1092,7 @@ extension SourceKitLSPServer {
     addCapabilities(WorkspaceTestsRefreshRequest.method, ["version": 1])
     addCapabilities(DocumentTestsRequest.method, ["version": 2])
     addCapabilities(DoccDocumentationRequest.method, ["version": 1])
+    addCapabilities(DocCSymbolLinkDefinitionRequest.method, ["version": 1])
     addCapabilities(TriggerReindexRequest.method, ["version": 1])
     addCapabilities(GetReferenceDocumentRequest.method, ["version": 1])
     addCapabilities(DidChangeActiveDocumentNotification.method, ["version": 1])
@@ -1614,6 +1617,14 @@ extension SourceKitLSPServer {
     languageService: any LanguageService
   ) async throws -> DoccDocumentationResponse {
     return try await languageService.doccDocumentation(req)
+  }
+
+  func doccSymbolLinkDefinition(
+    _ req: DocCSymbolLinkDefinitionRequest,
+    workspace: Workspace,
+    languageService: any LanguageService
+  ) async throws -> LocationsOrLocationLinksResponse? {
+    return try await languageService.symbolLinkDefinitionInPreview(req)
   }
 
   func hover(

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -135,6 +135,8 @@ package actor SourceKitLSPServer {
   /// the method of the request (ie. the value of `TextDocumentRequest.method`).
   private var inProgressTextDocumentRequests: [DocumentURI: [(id: RequestID, requestMethod: String)]] = [:]
 
+  private var diagnosticsByDocumentAndSource: [DocumentURI: [DiagnosticsSource: [Diagnostic]]] = [:]
+
   var onExit: () -> Void
 
   /// The files that we asked the client to watch.
@@ -392,7 +394,8 @@ package actor SourceKitLSPServer {
       @Sendable @escaping (
         RequestType, Workspace, any LanguageService
       ) async throws ->
-      RequestType.Response?
+      RequestType.Response?,
+    combine: (@Sendable ([RequestType.Response]) -> RequestType.Response)? = nil
   ) async {
     await request.reply {
       let request = request.params
@@ -404,18 +407,26 @@ package actor SourceKitLSPServer {
       if languageServices.isEmpty {
         throw ResponseError.unknown("No language service for '\(request.textDocument.uri)' found")
       }
-      // Return the results from the first language service that doesn't throw a `requestNotImplemented` error.
+
+      var responses: [RequestType.Response] = []
       for languageService in languageServices {
         do {
           guard let response = try await requestHandler(request, workspace, languageService) else {
             continue
           }
-          return response
+          guard let combine else {
+            // No `combine` supplied: first language service to answer wins,
+            return response
+          }
+          responses.append(response)
         } catch let error as ResponseError where error.code == .requestNotImplemented {
           continue
         }
       }
-      throw ResponseError.unknown("No language service implements \(type(of: request).method)")
+      guard let combine, !responses.isEmpty else {
+        throw ResponseError.unknown("No language service implements \(type(of: request).method)")
+      }
+      return combine(responses)
     }
   }
 
@@ -427,6 +438,25 @@ package actor SourceKitLSPServer {
   /// Send the given request to the editor.
   package func sendRequestToClient<R: RequestType>(_ request: R) async throws -> R.Response {
     return try await client.send(request)
+  }
+
+  package func publishDiagnostics(
+    _ diagnostics: [Diagnostic],
+    for uri: DocumentURI,
+    from source: DiagnosticsSource
+  ) {
+    diagnosticsByDocumentAndSource[uri, default: [:]][source] = diagnostics
+    let merged = diagnosticsByDocumentAndSource[uri]?.values.flatMap { $0 } ?? []
+    sendNotificationToClient(PublishDiagnosticsNotification(uri: uri, diagnostics: merged))
+  }
+
+  package func clearDiagnostics(for uri: DocumentURI, from source: DiagnosticsSource) {
+    guard diagnosticsByDocumentAndSource[uri]?.removeValue(forKey: source) != nil else { return }
+    let merged = diagnosticsByDocumentAndSource[uri]?.values.flatMap { $0 } ?? []
+    sendNotificationToClient(PublishDiagnosticsNotification(uri: uri, diagnostics: merged))
+    if diagnosticsByDocumentAndSource[uri]?.isEmpty == true {
+      diagnosticsByDocumentAndSource[uri] = nil
+    }
   }
 
   /// After the language service has crashed, send `DidOpenTextDocumentNotification`s to a newly instantiated language service for previously open documents.
@@ -664,7 +694,20 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
     case let request as RequestAndReply<DocumentColorRequest>:
       await self.handleRequest(for: request, requestHandler: self.documentColor)
     case let request as RequestAndReply<DocumentDiagnosticsRequest>:
-      await self.handleRequest(for: request, requestHandler: self.documentDiagnostic)
+      await self.handleRequest(
+        for: request,
+        requestHandler: self.documentDiagnostic,
+        combine: { responses in
+          .full(
+            RelatedFullDocumentDiagnosticReport(
+              items: responses.flatMap { report -> [Diagnostic] in
+                guard case .full(let full) = report else { return [] }
+                return full.items
+              }
+            )
+          )
+        }
+      )
     case let request as RequestAndReply<DocumentFormattingRequest>:
       await self.handleRequest(for: request, requestHandler: self.documentFormatting)
     case let request as RequestAndReply<DocumentRangeFormattingRequest>:
@@ -3015,6 +3058,11 @@ private let minWorkspaceSymbolPatternLength = 3
 private let maxWorkspaceSymbolResults = 4096
 
 package typealias Diagnostic = LanguageServerProtocol.Diagnostic
+
+package enum DiagnosticsSource: Hashable, Sendable {
+  case swift
+  case documentation
+}
 
 fileprivate extension CheckedIndex {
   /// Take the name of containers into account to form a fully-qualified name for the given symbol.

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -392,7 +392,7 @@ package actor SourceKitLSPServer {
       @Sendable @escaping (
         RequestType, Workspace, any LanguageService
       ) async throws ->
-      RequestType.Response
+      RequestType.Response?
   ) async {
     await request.reply {
       let request = request.params
@@ -407,7 +407,10 @@ package actor SourceKitLSPServer {
       // Return the results from the first language service that doesn't throw a `requestNotImplemented` error.
       for languageService in languageServices {
         do {
-          return try await requestHandler(request, workspace, languageService)
+          guard let response = try await requestHandler(request, workspace, languageService) else {
+            continue
+          }
+          return response
         } catch let error as ResponseError where error.code == .requestNotImplemented {
           continue
         }
@@ -2416,7 +2419,13 @@ extension SourceKitLSPServer {
     workspace: Workspace,
     languageService: any LanguageService
   ) async throws -> LocationsOrLocationLinksResponse? {
-    let indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
+    var indexBasedResponse: [Location] = []
+    do {
+      indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
+    } catch {
+      logger.info("indexBasedDefinition failed: \(error.forLogging)")
+      indexBasedResponse = []
+    }
     let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     // If we're unable to handle the definition request using our index, see if the
     // language service can handle it (e.g. clangd can provide AST based definitions).
@@ -2425,11 +2434,18 @@ extension SourceKitLSPServer {
     // `SwiftLanguageService` will always respond with `unsupported method`. Thus, only log such a failure instead of
     // returning it to the client.
     if indexBasedResponse.isEmpty {
-      return await orLog("Fallback definition request", level: .info) {
+      do {
         let result = try await languageService.definition(req)
         return result?.adjusted(for: copiedFileMap)
+      } catch let error as ResponseError where error.code == .requestNotImplemented {
+        // Signal to handleRequest's loop to try the next language service
+        throw error
+      } catch {
+        logger.info("Fallback definition request failed: \(error.forLogging)")
+        return nil
       }
     }
+
     let remappedLocations = indexBasedResponse.adjusted(for: copiedFileMap)
     return .locations(remappedLocations)
   }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -408,22 +408,42 @@ package actor SourceKitLSPServer {
         throw ResponseError.unknown("No language service for '\(request.textDocument.uri)' found")
       }
 
-      var responses: [RequestType.Response] = []
-      for languageService in languageServices {
-        do {
-          guard let response = try await requestHandler(request, workspace, languageService) else {
-            continue
+      guard let combine else {
+        // No `combine` supplied: first language service to answer wins, race them.
+        return try await withThrowingTaskGroup(of: RequestType.Response?.self) { group in
+          for languageService in languageServices {
+            group.addTask {
+              do {
+                return try await requestHandler(request, workspace, languageService)
+              } catch let error as ResponseError where error.code == .requestNotImplemented {
+                return nil
+              }
+            }
           }
-          guard let combine else {
-            // No `combine` supplied: first language service to answer wins,
-            return response
+          for try await response in group {
+            if let response { return response }
           }
-          responses.append(response)
-        } catch let error as ResponseError where error.code == .requestNotImplemented {
-          continue
+          throw ResponseError.unknown("No language service implements \(type(of: request).method)")
         }
       }
-      guard let combine, !responses.isEmpty else {
+
+      let responses = try await withThrowingTaskGroup(of: RequestType.Response?.self) { group in
+        for languageService in languageServices {
+          group.addTask {
+            do {
+              return try await requestHandler(request, workspace, languageService)
+            } catch let error as ResponseError where error.code == .requestNotImplemented {
+              return nil
+            }
+          }
+        }
+        var results: [RequestType.Response] = []
+        for try await response in group {
+          if let response { results.append(response) }
+        }
+        return results
+      }
+      guard !responses.isEmpty else {
         throw ResponseError.unknown("No language service implements \(type(of: request).method)")
       }
       return combine(responses)

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -795,6 +795,32 @@ extension SwiftLanguageService {
   // MARK: - Language features
 
   package func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
+
+    let snapshot = try await latestSnapshot(for: request.textDocument.uri)
+    let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    let absolutePosition = snapshot.absolutePosition(of: request.position)
+
+    if let token = tree.token(at: absolutePosition) {
+      var offset = token.position.utf8Offset
+      var isInDocComment = false
+
+      for piece in token.leadingTrivia.pieces {
+        let pieceLength = piece.sourceLength.utf8Length
+        switch piece {
+        case .docLineComment, .docBlockComment:
+          if absolutePosition.utf8Offset >= offset && absolutePosition.utf8Offset < offset + pieceLength {
+            isInDocComment = true
+          }
+        default:
+          break
+        }
+        offset += pieceLength
+      }
+
+      if isInDocComment {
+        return nil
+      }
+    }
     throw ResponseError.unknown("unsupported method")
   }
 

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -623,6 +623,7 @@ extension SwiftLanguageService {
     await syntaxTreeManager.clearSyntaxTrees(for: notification.textDocument.uri)
     await syntaxTreeManager.clearExperimentalFeatures(for: notification.textDocument.uri)
     await inlayHintManager.removeCachedInlayHints(for: notification.textDocument.uri)
+    await sourceKitLSPServer?.clearDiagnostics(for: notification.textDocument.uri, from: .swift)
     switch try? ReferenceDocumentURL(from: notification.textDocument.uri) {
     case .macroExpansion:
       break
@@ -716,12 +717,7 @@ extension SwiftLanguageService {
           throw CancellationError()
         }
 
-        sourceKitLSPServer.sendNotificationToClient(
-          PublishDiagnosticsNotification(
-            uri: document,
-            diagnostics: diagnosticReport.items
-          )
-        )
+        await sourceKitLSPServer.publishDiagnostics(diagnosticReport.items, for: document, from: .swift)
       } catch is CancellationError {
       } catch {
         logger.fault(

--- a/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SKTestSupport
+import XCTest
+
+final class DocumentationDefinitionTests: SourceKitLSPTestCase {
+
+  // MARK: Line comments (`///`)
+
+  func testJumpToDefinitionFromLineCommentSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+
+      /// See ``2️⃣Foo``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  /// Two `///` comment groups separated by a blank line are parsed as two separate
+  /// `DocTriviaGroup.lines` groups. Clicking in the second group should still resolve,
+  /// unaffected by the unrelated first group.
+  func testJumpToDefinitionIgnoresUnrelatedLineCommentGroup() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+      public struct Bar {}
+
+      /// Unrelated comment mentioning ``Bar``, detached by a blank line below.
+
+      /// See ``2️⃣Foo`` here instead.
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Block comments (`/** ... */`)
+
+  func testJumpToDefinitionFromBlockCommentSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+
+      /**
+       See ``2️⃣Foo`` for more information.
+       */
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  /// Symbol link on the same line as the opening `/**`.
+  func testJumpToDefinitionFromSingleLineBlockCommentSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+
+      /** See ``2️⃣Foo`` for more information. */
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Nested / multi-component links (``Foo/bar()``)
+
+  /// Clicking the parent component of a nested link resolves to the parent symbol.
+  func testJumpToDefinitionFromNestedSymbolLinkParentComponent() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {
+        public func bar() {}
+      }
+
+      /// See ``2️⃣Foo/bar()``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  /// Clicking the child component of a nested link resolves to the child symbol.
+  func testJumpToDefinitionFromNestedSymbolLinkChildComponent() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {
+        public func 1️⃣bar() {}
+      }
+
+      /// See ``Foo/2️⃣bar()``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Negative cases
+
+  func testDefinitionIsNilWhenNotOnSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {}
+
+      /// This 1️⃣comment has no symbol link.
+      public func useFoo() {}
+      """
+    )
+
+    await assertThrowsError(
+      try await project.testClient.send(
+        DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+      )
+    )
+  }
+
+  func testDefinitionIsNilForUnresolvedSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      /// See ``1️⃣DoesNotExist``
+      public func useFoo() {}
+      """
+    )
+
+    await assertThrowsError(
+      try await project.testClient.send(
+        DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+      )
+    )
+  }
+}


### PR DESCRIPTION
This PR adds implementation to `DocCSymbolLinkDefinitionRequest` to make symbol links clickable in the documentation preview of the editor. 

### Changes

- Add implementation to  `DocCSymbolLinkDefinitionRequest`.
- Resolve the symbol link via the index, fetching symbol graphs on demand.
- Return the definition location if found, or `nil` if the link can't be resolved.
- Expose support via experimental server capabilities as `sourcekit/textDocument/doccSymbolLinkDefinition`.

### User Impact
Symbol links are now clickable in the documentation preview, making the preview more interactive. Clicking a symbol link navigates to its definition if it's found, or shows an error if it can't be resolved. 
