### PR TITLE
Disable testPopularityForTypeFromSubmodule until a fix is found (#2742)

### DIFF
--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -1123,6 +1123,7 @@ final class SwiftSourceKitPluginTests: SourceKitLSPTestCase {
     #if !os(macOS)
     try XCTSkipIf(true, "AppKit is only defined on macOS")
     #endif
+    try XCTSkipIf(true, "Crashes sourcekitd with the macOS 27 SDK (rdar://184053015")
     try await SkipUnless.sourcekitdSupportsPlugin()
     let sourcekitd = try await getSourceKitD()
     let path = scratchFilePath()


### PR DESCRIPTION
- **Explanation**:
SwiftSourceKitPluginTests.testPopularityForTypeFromSubmodule crashes the out-of-process SourceKitService on MacOSX27.0.sdk. Disabling the test until a fix is found.
- **Scope**:
Disables one test.
- **Issues**:
A test failure on a new CI job being set up.
- **Original PRs**:
https://github.com/swiftlang/sourcekit-lsp/pull/2742
- **Risk**:
Low. This is test change only.
- **Testing**:
Ran the affected test to confirm that the disabling took effect.
- **Reviewers**:
@hamishknight @shahmishal 