### PR TITLE
Update the compiler diagnostic in `PullDiagnosticsTests.testNoteInSecondaryFile()`

### DIFF
--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -374,12 +374,11 @@ final class PullDiagnosticsTests: SourceKitLSPTestCase {
   func testNoteInSecondaryFile() async throws {
     let project = try await SwiftPMTestProject(files: [
       "FileA.swift": """
-      @available(*, unavailable)
-      struct 1️⃣Test {}
+      func 1️⃣foo(bar: Int) {}
       """,
       "FileB.swift": """
       func test() {
-          _ = Test()
+          foo()
       }
       """,
     ])


### PR DESCRIPTION
The location and highlights for Swift compiler diagnostics about unavailable declarations are changing in https://github.com/swiftlang/swift/pull/91369. The `PullDiagnosticsTests.testNoteInSecondaryFile()` test would start failing as a result, so update the test to verify the same fundamental behavior as it did before but using a different compiler diagnostic that isn't changing.