### PR TITLE
Replace SwiftPMTestHooks with more general build server test hooks

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerHooks.swift
+++ b/Sources/BuildServerIntegration/BuildServerHooks.swift
@@ -10,29 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SourceKitLSP) package import BuildServerProtocol
 package import Foundation
 @_spi(SourceKitLSP) package import LanguageServerProtocol
 
-package struct SwiftPMTestHooks: Sendable {
-  package var reloadPackageDidStart: (@Sendable () async -> Void)?
-  package var reloadPackageDidFinish: (@Sendable () async -> Void)?
-
-  package init(
-    reloadPackageDidStart: (@Sendable () async -> Void)? = nil,
-    reloadPackageDidFinish: (@Sendable () async -> Void)? = nil
-  ) {
-    self.reloadPackageDidStart = reloadPackageDidStart
-    self.reloadPackageDidFinish = reloadPackageDidFinish
-  }
-}
-
 package struct BuildServerHooks: Sendable {
-  package var swiftPMTestHooks: SwiftPMTestHooks
-
   /// A hook that will be executed before a request is handled by a `BuiltInBuildServer`.
   ///
   /// This allows requests to be artificially delayed.
   package var preHandleRequest: (@Sendable (any RequestType) async -> Void)?
+
+  /// A hook that will be executed before a notification received from the build server is handled.
+  package var preHandleNotificationFromBuildServer: (@Sendable (any NotificationType) async -> Void)?
 
   /// When running SourceKit-LSP in-process, allows the creator of `SourceKitLSPServer` to create a message handler that
   /// handles BSP requests instead of SourceKit-LSP creating build server as needed.
@@ -40,14 +29,14 @@ package struct BuildServerHooks: Sendable {
     (@Sendable (_ projectRoot: URL, _ connectionToSourceKitLSP: any Connection) async -> any Connection)?
 
   package init(
-    swiftPMTestHooks: SwiftPMTestHooks = SwiftPMTestHooks(),
     preHandleRequest: (@Sendable (any RequestType) async -> Void)? = nil,
+    preHandleNotificationFromBuildServer: (@Sendable (any NotificationType) async -> Void)? = nil,
     injectBuildServer: (
       @Sendable (_ projectRoot: URL, _ connectionToSourceKitLSP: any Connection) async -> any Connection
     )? = nil
   ) {
-    self.swiftPMTestHooks = swiftPMTestHooks
     self.preHandleRequest = preHandleRequest
+    self.preHandleNotificationFromBuildServer = preHandleNotificationFromBuildServer
     self.injectBuildServer = injectBuildServer
   }
 }

--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -310,8 +310,7 @@ private extension BuildServerSpec {
             projectRoot: projectRoot,
             toolchainRegistry: toolchainRegistry,
             options: options,
-            connectionToSourceKitLSP: connectionToSourceKitLSP,
-            testHooks: buildServerHooks.swiftPMTestHooks
+            connectionToSourceKitLSP: connectionToSourceKitLSP
           )
         }
         #else
@@ -397,6 +396,8 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   )
 
   package let messageHandlingQueue = AsyncQueue<BuildServerMessageDependencyTracker>()
+
+  private let buildServerHooks: BuildServerHooks
 
   /// The path to the main configuration file (or directory) that this build server manages.
   ///
@@ -578,6 +579,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
     self.options = options
     self.connectionToClient = connectionToClient
     self.configPath = buildServerSpec?.configPath
+    self.buildServerHooks = buildServerHooks
     self.buildServerAdapter = await buildServerSpec?.createBuildServerAdapter(
       toolchainRegistry: toolchainRegistry,
       options: options,
@@ -762,6 +764,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   // MARK: Handling messages from the build server
 
   package func handle(notification: some NotificationType) async {
+    await buildServerHooks.preHandleNotificationFromBuildServer?(notification)
     switch notification {
     case let notification as OnBuildTargetDidChangeNotification:
       await self.didChangeBuildTarget(notification: notification)

--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -93,12 +93,12 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     case cannotDetermineHostToolchain
   }
 
+  package static let packageReloadingTaskID = TaskId(id: "package-reloading")
+
   // MARK: Integration with SourceKit-LSP
 
   /// Options that allow the user to pass extra compiler flags.
   private let options: SourceKitLSPOptions
-
-  private let testHooks: SwiftPMTestHooks
 
   /// The queue on which we reload the package to ensure we don't reload it multiple times concurrently, which can cause
   /// issues in SwiftPM.
@@ -230,8 +230,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     projectRoot: URL,
     toolchainRegistry: ToolchainRegistry,
     options: SourceKitLSPOptions,
-    connectionToSourceKitLSP: any Connection,
-    testHooks: SwiftPMTestHooks
+    connectionToSourceKitLSP: any Connection
   ) async throws {
     self.projectRoot = projectRoot
     self.options = options
@@ -247,7 +246,6 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     }
 
     self.toolchain = toolchain
-    self.testHooks = testHooks
     self.connectionToSourceKitLSP = connectionToSourceKitLSP
 
     // Start an open-ended log for messages that we receive during package loading. We never end this log.
@@ -494,18 +492,16 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
 
     self.connectionToSourceKitLSP.send(
       TaskStartNotification(
-        taskId: TaskId(id: "package-reloading"),
+        taskId: Self.packageReloadingTaskID,
         data: WorkDoneProgressTask(title: "SourceKit-LSP: Reloading Package").encodeToLSPAny()
       )
     )
-    await testHooks.reloadPackageDidStart?()
     defer {
       signposter.endInterval("Reloading package", state)
       Task {
         self.connectionToSourceKitLSP.send(
-          TaskFinishNotification(taskId: TaskId(id: "package-reloading"), status: .ok)
+          TaskFinishNotification(taskId: Self.packageReloadingTaskID, status: .ok)
         )
-        await testHooks.reloadPackageDidFinish?()
       }
     }
 

--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -162,13 +162,15 @@ struct SwiftPMBuildServerTests {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
+      let connection = LocalConnection(receiverName: "dummy")
+      let handler = IgnoringMessageHandler()
+      connection.start(handler: handler)
       await expectThrowsError(
         try await SwiftPMBuildServer(
           projectRoot: packageRoot,
           toolchainRegistry: ToolchainRegistry(toolchains: []),
           options: SourceKitLSPOptions(),
-          connectionToSourceKitLSP: LocalConnection(receiverName: "dummy"),
-          testHooks: SwiftPMTestHooks()
+          connectionToSourceKitLSP: connection
         )
       )
     }
@@ -198,12 +200,14 @@ struct SwiftPMBuildServerTests {
         ),
         backgroundIndexing: false
       )
+      let connection = LocalConnection(receiverName: "dummy")
+      let handler = IgnoringMessageHandler()
+      connection.start(handler: handler)
       let swiftpmBuildServer = try await SwiftPMBuildServer(
         projectRoot: packageRoot,
         toolchainRegistry: .forTesting,
         options: options,
-        connectionToSourceKitLSP: LocalConnection(receiverName: "dummy"),
-        testHooks: SwiftPMTestHooks()
+        connectionToSourceKitLSP: connection
       )
 
       let dataPath = await swiftpmBuildServer.destinationBuildParameters.dataPath
@@ -1151,11 +1155,11 @@ struct SwiftPMBuildServerTests {
       ],
       capabilities: ClientCapabilities(window: WindowClientCapabilities(workDoneProgress: true)),
       hooks: Hooks(
-        buildServerHooks: BuildServerHooks(
-          swiftPMTestHooks: SwiftPMTestHooks(reloadPackageDidStart: {
+        buildServerHooks: BuildServerHooks(preHandleNotificationFromBuildServer: { notification in
+          if notification is TaskFinishNotification {
             didReceiveWorkDoneProgressNotification.waitOrXCTFail()
-          })
-        )
+          }
+        })
       ),
       pollIndex: false,
       preInitialization: { testClient in
@@ -1165,7 +1169,12 @@ struct SwiftPMBuildServerTests {
       }
     )
     let begin = try await project.testClient.nextNotification(ofType: WorkDoneProgress.self)
-    #expect(begin.value == .begin(WorkDoneProgressBegin(title: "SourceKit-LSP: Reloading Package")))
+    guard case .begin(let beginValue) = begin.value else {
+      Issue.record("Expected a 'begin' work done progress, got \(begin.value)")
+      return
+    }
+    #expect(beginValue.title.hasSuffix("Reloading Package"))
+
     didReceiveWorkDoneProgressNotification.signal()
 
     let end = try await project.testClient.nextNotification(ofType: WorkDoneProgress.self)
@@ -1386,7 +1395,7 @@ struct SwiftPMBuildServerTests {
   private func makeServerWithBinaryTargetAndWaitForInitialLoad(
     in tempDir: URL,
     options: SourceKitLSPOptions = SourceKitLSPOptions(),
-    reloadPackageDidStart: (@Sendable () async -> Void)? = nil
+    connectionToSourceKitLSP: any Connection
   ) async throws -> (server: SwiftPMBuildServer, projectRoot: URL) {
     let artifactBundleName = "MyBinaryTool.artifactbundle"
     let zipName = "\(artifactBundleName).zip"
@@ -1435,8 +1444,7 @@ struct SwiftPMBuildServerTests {
       projectRoot: projectRoot,
       toolchainRegistry: .forTesting,
       options: options,
-      connectionToSourceKitLSP: LocalConnection(receiverName: "dummy"),
-      testHooks: SwiftPMTestHooks(reloadPackageDidStart: reloadPackageDidStart)
+      connectionToSourceKitLSP: connectionToSourceKitLSP
     )
     _ = await server.waitForBuildSystemUpdates(request: WorkspaceWaitForBuildSystemUpdatesRequest())
     return (server, projectRoot)
@@ -1453,18 +1461,13 @@ struct SwiftPMBuildServerTests {
   @Test
   func testBinaryTargetArtifactEventsDoNotTriggerPackageReload() async throws {
     try await withTestScratchDir { tempDir in
-      let packageInitialized = ThreadSafeBox<Bool>(initialValue: false)
-      let unexpectedReloadStarted = ThreadSafeBox<Bool>(initialValue: false)
+      let packageReloads = PackageReloadCountingMessageHandler()
 
       let (server, projectRoot) = try await makeServerWithBinaryTargetAndWaitForInitialLoad(
         in: tempDir,
-        reloadPackageDidStart: {
-          if packageInitialized.value {
-            unexpectedReloadStarted.withLock { $0 = true }
-          }
-        }
+        connectionToSourceKitLSP: LocalConnection(receiverName: "dummy", handler: packageReloads)
       )
-      packageInitialized.withLock { $0 = true }
+      let reloadsAfterInitialLoad = packageReloads.count
 
       // SwiftPM extracts the artifact bundle to:
       //   <scratch>/artifacts/<package-identity>/<target-name>/<artifact-name>/
@@ -1489,7 +1492,7 @@ struct SwiftPMBuildServerTests {
       )
 
       _ = await server.waitForBuildSystemUpdates(request: WorkspaceWaitForBuildSystemUpdatesRequest())
-      #expect(!unexpectedReloadStarted.value)
+      #expect(packageReloads.count == reloadsAfterInitialLoad)
     }
   }
 
@@ -1506,19 +1509,14 @@ struct SwiftPMBuildServerTests {
     try await withTestScratchDir { tempDir in
       let customScratch = tempDir.appending(component: "custom-scratch")
 
-      let packageInitialized = ThreadSafeBox<Bool>(initialValue: false)
-      let unexpectedReloadStarted = ThreadSafeBox<Bool>(initialValue: false)
+      let packageReloads = PackageReloadCountingMessageHandler()
 
       let (server, projectRoot) = try await makeServerWithBinaryTargetAndWaitForInitialLoad(
         in: tempDir,
         options: SourceKitLSPOptions(swiftPM: .init(scratchPath: try customScratch.filePath)),
-        reloadPackageDidStart: {
-          if packageInitialized.value {
-            unexpectedReloadStarted.withLock { $0 = true }
-          }
-        }
+        connectionToSourceKitLSP: LocalConnection(receiverName: "dummy", handler: packageReloads)
       )
-      packageInitialized.withLock { $0 = true }
+      let reloadsAfterInitialLoad = packageReloads.count
 
       // With a custom scratch path, SwiftPM extracts to <custom-scratch>/artifacts/.
       // Simulate the delete-and-re-expand cycle for those paths.
@@ -1556,7 +1554,7 @@ struct SwiftPMBuildServerTests {
       )
 
       _ = await server.waitForBuildSystemUpdates(request: WorkspaceWaitForBuildSystemUpdatesRequest())
-      #expect(!unexpectedReloadStarted.value)
+      #expect(packageReloads.count == reloadsAfterInitialLoad)
     }
   }
 
@@ -1874,3 +1872,38 @@ fileprivate extension BuildServerSpec {
   }
 }
 #endif
+
+private final class PackageReloadCountingMessageHandler: MessageHandler {
+  private let reloads = ThreadSafeBox<Int>(initialValue: 0)
+
+  var count: Int { reloads.value }
+
+  func handle(_ notification: some NotificationType) {
+    guard let notification = notification as? TaskStartNotification,
+      notification.taskId == SwiftPMBuildServer.packageReloadingTaskID
+    else {
+      return
+    }
+    reloads.withLock { $0 += 1 }
+  }
+
+  func handle<Request: RequestType>(
+    _ request: Request,
+    id: RequestID,
+    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+  ) {
+    reply(.failure(.methodNotFound(Request.method)))
+  }
+}
+
+private final class IgnoringMessageHandler: MessageHandler {
+  func handle(_ notification: some NotificationType) {
+  }
+
+  func handle<Request: RequestType>(
+    _ request: Request,
+    id: RequestID,
+    reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+  ) {
+  }
+}

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1374,8 +1374,11 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     let packageInitialized = ThreadSafeBox<Bool>(initialValue: false)
 
     var testHooks = Hooks()
-    testHooks.buildServerHooks.swiftPMTestHooks.reloadPackageDidStart = {
-      if packageInitialized.value {
+    testHooks.buildServerHooks.preHandleNotificationFromBuildServer = { notification in
+      if let notification = notification as? TaskStartNotification,
+        notification.taskId == SwiftPMBuildServer.packageReloadingTaskID,
+        packageInitialized.value
+      {
         XCTFail("Build graph should not get reloaded when random file gets added")
       }
     }
@@ -1762,16 +1765,6 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
 
   func testPauseBackgroundIndexing() async throws {
     try SkipUnless.longTestsEnabled()
-    let backgroundIndexingPaused = WrappedSemaphore(name: "Background indexing was paused")
-    let hooks = Hooks(
-      buildServerHooks: BuildServerHooks(
-        swiftPMTestHooks: SwiftPMTestHooks(
-          reloadPackageDidFinish: {
-            backgroundIndexingPaused.waitOrXCTFail()
-          }
-        )
-      )
-    )
     let project = try await SwiftPMTestProject(
       files: [
         "Test.swift": """
@@ -1779,14 +1772,12 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         """
       ],
       options: .testDefault(experimentalFeatures: [.setOptionsRequest]),
-      hooks: hooks,
       enableBackgroundIndexing: true,
       // pollIndex increases the background indexing priority from `low` to `medium`, which thus won't be affected by
       // `workspace/_setBackgroundIndexingPaused` anymore
       pollIndex: false
     )
     try await project.testClient.send(SetOptionsRequest(backgroundIndexingPaused: true))
-    backgroundIndexingPaused.signal()
 
     // Give SwiftPM sufficient time to run background indexing if it was not paused.
     try await Task.sleep(for: .seconds(5))
@@ -1804,16 +1795,6 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
   }
 
   func testBackgroundIndexingRunsOnSynchronizeRequestEvenIfPaused() async throws {
-    let backgroundIndexingPaused = WrappedSemaphore(name: "Background indexing was paused")
-    let hooks = Hooks(
-      buildServerHooks: BuildServerHooks(
-        swiftPMTestHooks: SwiftPMTestHooks(
-          reloadPackageDidFinish: {
-            backgroundIndexingPaused.waitOrXCTFail()
-          }
-        )
-      )
-    )
     let project = try await SwiftPMTestProject(
       files: [
         "Test.swift": """
@@ -1821,14 +1802,12 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         """
       ],
       options: .testDefault(experimentalFeatures: [.setOptionsRequest]),
-      hooks: hooks,
       enableBackgroundIndexing: true,
       // pollIndex increases the background indexing priority from `low` to `medium`, which thus won't be affected by
       // `workspace/_setBackgroundIndexingPaused` anymore
       pollIndex: false
     )
     try await project.testClient.send(SetOptionsRequest(backgroundIndexingPaused: true))
-    backgroundIndexingPaused.signal()
 
     // Running a `SynchronizeRequest` elevates the background indexing tasks to `medium` priority. We thus no longer
     // consider the indexing to happen in the background and hence it is not affected by the paused background indexing
@@ -1840,16 +1819,6 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
   }
 
   func testPausingBackgroundIndexingDoesNotStopPreparation() async throws {
-    let backgroundIndexingPaused = WrappedSemaphore(name: "Background indexing was paused")
-    let hooks = Hooks(
-      buildServerHooks: BuildServerHooks(
-        swiftPMTestHooks: SwiftPMTestHooks(
-          reloadPackageDidFinish: {
-            backgroundIndexingPaused.waitOrXCTFail()
-          }
-        )
-      )
-    )
     let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
@@ -1875,14 +1844,12 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
         )
         """,
       options: .testDefault(experimentalFeatures: [.setOptionsRequest]),
-      hooks: hooks,
       enableBackgroundIndexing: true,
       // pollIndex increases the background indexing priority from `low` to `medium`, which thus won't be affected by
       // `workspace/_setBackgroundIndexingPaused` anymore
       pollIndex: false
     )
     try await project.testClient.send(SetOptionsRequest(backgroundIndexingPaused: true))
-    backgroundIndexingPaused.signal()
 
     let (uri, positions) = try project.openDocument("LibB.swift")
 

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import BuildServerIntegration
+@_spi(SourceKitLSP) import BuildServerProtocol
 import Foundation
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKLogging
@@ -287,16 +288,18 @@ final class SwiftPMIntegrationTests: SourceKitLSPTestCase {
   }
 
   func testProvideSyntacticFunctionalityWhilePackageIsLoading() async throws {
-    let receivedDocumentSymbolsReply = WrappedSemaphore(name: "Received document symbols reply")
+    let receivedDocumentSymbolsReply = MultiEntrySemaphore(name: "Received document symbols reply")
     let project = try await SwiftPMTestProject(
       files: [
         "Test.swift": ""
       ],
       hooks: Hooks(
         buildServerHooks: BuildServerHooks(
-          swiftPMTestHooks: SwiftPMTestHooks(reloadPackageDidStart: {
-            receivedDocumentSymbolsReply.waitOrXCTFail()
-          })
+          preHandleRequest: { request in
+            if request is TextDocumentSourceKitOptionsRequest {
+              await receivedDocumentSymbolsReply.waitOrXCTFail()
+            }
+          }
         )
       ),
       pollIndex: false
@@ -307,7 +310,7 @@ final class SwiftPMIntegrationTests: SourceKitLSPTestCase {
   }
 
   func testDiagnosticsGetRefreshedAfterPackageLoadingFinishes() async throws {
-    let receivedInitialDiagnosticsReply = WrappedSemaphore(name: "Received initial diagnostics reply")
+    let receivedInitialDiagnosticsReply = MultiEntrySemaphore(name: "Received initial diagnostics reply")
     let project = try await SwiftPMTestProject(
       files: [
         "Test.swift": """
@@ -319,9 +322,11 @@ final class SwiftPMIntegrationTests: SourceKitLSPTestCase {
       ),
       hooks: Hooks(
         buildServerHooks: BuildServerHooks(
-          swiftPMTestHooks: SwiftPMTestHooks(reloadPackageDidStart: {
-            receivedInitialDiagnosticsReply.waitOrXCTFail()
-          })
+          preHandleRequest: { request in
+            if request is TextDocumentSourceKitOptionsRequest {
+              await receivedInitialDiagnosticsReply.waitOrXCTFail()
+            }
+          }
         )
       ),
       pollIndex: false

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1194,12 +1194,12 @@ final class WorkspaceTests: SourceKitLSPTestCase {
   func testSourceKitOptionsAllowingFallback() async throws {
     let hooks = Hooks(
       buildServerHooks: BuildServerHooks(
-        swiftPMTestHooks: SwiftPMTestHooks(
-          reloadPackageDidStart: {
-            // Essentially make sure that the package never loads, so we are forced to return fallback arguments.
+        preHandleRequest: { request in
+          if request is TextDocumentSourceKitOptionsRequest {
+            // Essentially make sure that build settings never arrive, so we are forced to return fallback arguments.
             try? await Task.sleep(for: .seconds(defaultTimeout * 2))
           }
-        )
+        }
       )
     )
     let project = try await SwiftPMTestProject(


### PR DESCRIPTION
The SwiftPM test hooks were relatively tightly coupled to the builtin build server. This PR replaces them with the more general build server test hooks that are also supported by the SwiftPM BSP backend, and updates tests accordingly. A few of the test updates might need some scrutiny, I'll leave some comments below. 