### PR TITLE
Fix clangd semantic token underflow handling

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -569,6 +569,9 @@ extension ClangLanguageService {
     guard var response = try await forwardRequestToClangd(req) else {
       return nil
     }
+    guard !response.data.containsInvalidDeltaLine else {
+      return nil
+    }
     if let semanticTokensTranslator {
       response.data = semanticTokensTranslator.translate(response.data)
     }
@@ -584,16 +587,24 @@ extension ClangLanguageService {
     if let semanticTokensTranslator {
       switch response {
       case .tokens(var tokens):
+        guard !tokens.data.containsInvalidDeltaLine else {
+          return nil
+        }
         tokens.data = semanticTokensTranslator.translate(tokens.data)
         response = .tokens(tokens)
       case .delta(var delta):
-        delta.edits = delta.edits.map {
-          var edit = $0
+        var translatedEdits: [SemanticTokensEdit] = []
+        translatedEdits.reserveCapacity(delta.edits.count)
+        for var edit in delta.edits {
           if let data = edit.data {
+            guard !data.containsInvalidDeltaLine else {
+              return nil
+            }
             edit.data = semanticTokensTranslator.translate(data)
           }
-          return edit
+          translatedEdits.append(edit)
         }
+        delta.edits = translatedEdits
         response = .delta(delta)
       }
     }
@@ -604,6 +615,9 @@ extension ClangLanguageService {
     _ req: DocumentSemanticTokensRangeRequest
   ) async throws -> DocumentSemanticTokensResponse? {
     guard var response = try await forwardRequestToClangd(req) else {
+      return nil
+    }
+    guard !response.data.containsInvalidDeltaLine else {
       return nil
     }
     if let semanticTokensTranslator {
@@ -793,5 +807,22 @@ private struct ClangBuildSettings: Equatable {
       compilationCommand: self.compilerArgs,
       workingDirectory: self.workingDirectory
     )
+  }
+}
+
+package extension Array where Element == UInt32 {
+  var containsInvalidDeltaLine: Bool {
+    guard count.isMultiple(of: 5) else {
+      return true
+    }
+
+    var i = 0
+    while i < count {
+      if self[i] == UInt32.max {
+        return true
+      }
+      i += 5
+    }
+    return false
   }
 }

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ClangLanguageService
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKLogging
 import SKTestSupport
@@ -390,5 +391,47 @@ final class LocalClangTests: SourceKitLSPTestCase {
     // Now we should get a diagnostic in main.c file because `Object` is no longer defined.
     let editedDiags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertFalse(editedDiags.diagnostics.isEmpty)
+  }
+
+  func testContainsInvalidDeltaLine() {
+    let validTokens: [UInt32] = [
+      0, 5, 3, 0, 0,
+      1, 0, 4, 1, 0,
+    ]
+    XCTAssertFalse(validTokens.containsInvalidDeltaLine, "Valid arrays should not flag as invalid.")
+
+    let invalidDeltaLineFirst: [UInt32] = [
+      UInt32.max, 5, 3, 0, 0,
+    ]
+    XCTAssertTrue(
+      invalidDeltaLineFirst.containsInvalidDeltaLine,
+      "Should detect UInt32.max at the 0th index of a tuple."
+    )
+
+    let invalidDeltaLineSecond: [UInt32] = [
+      0, 5, 3, 0, 0,
+      UInt32.max, 0, 4, 1, 0,
+    ]
+    XCTAssertTrue(
+      invalidDeltaLineSecond.containsInvalidDeltaLine,
+      "Should detect UInt32.max at subsequent deltaLine positions."
+    )
+
+    let safeDeltaStart: [UInt32] = [0, UInt32.max, 3, 0, 0]
+    XCTAssertFalse(safeDeltaStart.containsInvalidDeltaLine, "Should ignore UInt32.max if it occupies deltaStart.")
+
+    let safeLength: [UInt32] = [0, 5, UInt32.max, 0, 0]
+    XCTAssertFalse(safeLength.containsInvalidDeltaLine, "Should ignore UInt32.max if it occupies length.")
+
+    let safeModifier: [UInt32] = [0, 5, 3, 0, UInt32.max]
+    XCTAssertFalse(safeModifier.containsInvalidDeltaLine, "Should ignore UInt32.max if it occupies tokenModifiers.")
+
+    let malformedTokens: [UInt32] = [
+      0, 5, 3, 0,
+    ]
+    XCTAssertTrue(
+      malformedTokens.containsInvalidDeltaLine,
+      "Semantic token data must contain complete 5-element token entries."
+    )
   }
 }


### PR DESCRIPTION
Fixes #2736 

Prevent malformed semantic-token responses from clangd from reaching clients by detecting UInt32.max delta-line underflows and invalid token-array lengths. Drop affected full, range, and delta responses by returning nil, allowing clients to request valid semantic tokens again.