### PR TITLE
Use file names instead of full paths in the index log title

### DIFF
--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -602,10 +602,11 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
     let start = ContinuousClock.now
     let signposter = Logger(subsystem: LoggingScope.subsystem, category: "indexing").makeSignposter()
     let signpostID = signposter.makeSignpostID()
+    let indexFileNames = indexFiles.map { $0.fileURL?.lastPathComponent ?? $0.pseudoPath }
     let state = signposter.beginInterval(
       "Indexing",
       id: signpostID,
-      "Indexing \(indexFiles.map { $0.fileURL?.lastPathComponent ?? $0.pseudoPath })"
+      "Indexing \(indexFileNames)"
     )
     defer {
       signposter.endInterval("Indexing", state)
@@ -615,7 +616,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       processArguments.joined(separator: " "),
       .info,
       .begin(
-        StructuredLogBegin(title: "Indexing \(indexFiles.map(\.pseudoPath).joined(separator: ", "))", taskID: taskId)
+        StructuredLogBegin(title: "Indexing \(indexFileNames.joined(separator: ", "))", taskID: taskId)
       )
     )
 

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -737,7 +737,7 @@ final class BackgroundIndexingTests: SourceKitLSPTestCase {
     _ = try await project.testClient.nextNotification(
       ofType: LogMessageNotification.self,
       satisfying: { notification in
-        notification.message.contains("Indexing \(try project.uri(for: "MyFile.swift").pseudoPath)")
+        notification.message.contains("Indexing MyFile.swift")
       }
     )
     didReceiveIndexingLogMessage.signal()


### PR DESCRIPTION
The index log title listed the full path of every file in an indexing build. Since a single build can contain up to 25 files, the title grew extremely long. List only the file names; the full paths are still visible in the logged compiler invocation.